### PR TITLE
add support for doctl config file

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -1,0 +1,15 @@
+# Configuration
+
+By default `doctl` will load a configuration file from `$HOME/.docfg` if found.
+
+## Configuration Options
+
+* `api_key` - The Digital Ocean API key.
+
+Example:
+
+```
+{
+  "api_key": "digital-ocean-api-key"
+}
+```

--- a/config.go
+++ b/config.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+)
+
+// Config holds the Digital Ocean config.
+type Config struct {
+	APIKey string `json:"api_key"`
+}
+
+func getConfig(configPath string) (*Config, error) {
+	c := &Config{}
+
+	data, err := ioutil.ReadFile(configPath)
+
+	// The configuration file is optional so just return an empty config.
+	if os.IsNotExist(err) && configPath == defaultConfigPath {
+		return c, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("Unable to load configuration file: %s", err)
+	}
+	return c, nil
+}
+
+func getHomeDir() string {
+	u, err := user.Current()
+	if err != nil {
+		return ""
+	}
+	return u.HomeDir
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestGetConfig(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "get-config")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldDefaultConfigPath := defaultConfigPath
+	defaultConfigPath = filepath.Join(tempDir, "/.docfg")
+	defer func() {
+		defaultConfigPath = oldDefaultConfigPath
+	}()
+
+	var want *Config
+
+	// default config does not exist.
+	config, err := getConfig(defaultConfigPath)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	want = &Config{}
+	if !reflect.DeepEqual(config, want) {
+		t.Errorf("want %v, got %v", want, config)
+	}
+
+	// default config exist with a valid API key.
+	configFile, err := os.Create(defaultConfigPath)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if _, err := configFile.Write([]byte("{\"api_key\": \"apikey\"}")); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	config, err = getConfig(defaultConfigPath)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	want = &Config{APIKey: "apikey"}
+
+	if !reflect.DeepEqual(config, want) {
+		t.Errorf("want %v, got %v", want, config)
+	}
+}


### PR DESCRIPTION
doctl now supports a config file for setting the Digital Ocean
APIKey. By default doctl will search for a .docfg config file in
the users home directory and load it if present.

Fixes issue #2.