### PR TITLE
Extract cli.App building and add tests for global flags.

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"errors"
 	"fmt"
-	"os"
 
 	"github.com/digitalocean/doctl/Godeps/_workspace/src/github.com/codegangsta/cli"
 
@@ -26,6 +26,11 @@ func (t *TokenSource) Token() (*oauth2.Token, error) {
 }
 
 func main() {
+	app := buildApp()
+	app.RunAndExitOnError()
+}
+
+func buildApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "doctl"
 	app.Version = AppVersion
@@ -45,10 +50,8 @@ func main() {
 			APIKey = ctx.String("api-key")
 		}
 
-		if APIKey == "" && ctx.BoolT("help") != false {
-			cli.ShowAppHelp(ctx)
-			fmt.Println("Must provide API Key via DIGITALOCEAN_API_KEY environment variable or via CLI argument.")
-			os.Exit(1)
+		if APIKey == "" && !ctx.Bool("help") && !ctx.Bool("version") {
+			return errors.New("must provide API Key via DIGITALOCEAN_API_KEY environment variable or via CLI argument")
 		}
 
 		switch ctx.String("format") {
@@ -57,8 +60,7 @@ func main() {
 		case "yaml":
 			OutputFormat = ctx.String("format")
 		default:
-			fmt.Printf("Invalid output format: %s. Available output options: json, yaml.\n", ctx.String("format"))
-			os.Exit(64)
+			return fmt.Errorf("invalid output format: %s, available output options: json, yaml", ctx.String("format"))
 		}
 
 		return nil
@@ -73,5 +75,5 @@ func main() {
 		SSHCommand,
 	}
 
-	app.Run(os.Args)
+	return app
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,61 @@
 package main
 
-import ()
+import (
+	"errors"
+	"io/ioutil"
+	"testing"
+)
 
 func setup() {
 }
 
 func teardown() {
+}
+
+func TestAppWithoutApiKey(t *testing.T) {
+	app := buildApp()
+	app.Writer = ioutil.Discard
+
+	// test with other global flags
+	tests := []struct {
+		args    []string
+		wantErr error
+	}{
+		{
+			args:    []string{"doctl"},
+			wantErr: errors.New("must provide API Key via DIGITALOCEAN_API_KEY environment variable or via CLI argument"),
+		},
+		{
+			args:    []string{"doctl", "--version"},
+			wantErr: nil,
+		},
+		{
+			args:    []string{"doctl", "--help"},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		err := app.Run(tt.args)
+		if tt.wantErr == nil {
+			if err != nil {
+				t.Errorf("Expected nil error")
+			}
+		} else if err.Error() != tt.wantErr.Error() {
+			t.Errorf("app.Run(%v) = %#v, want %#v", tt.args, err, tt.wantErr)
+		}
+	}
+}
+
+func TestGlobalFormatFlag(t *testing.T) {
+	app := buildApp()
+	app.Writer = ioutil.Discard
+
+	args := []string{"doctl", "-k", "key", "-f", "invalid"}
+	err := app.Run(args)
+
+	expected := "invalid output format: invalid, available output options: json, yaml"
+	if err.Error() != expected {
+		t.Errorf("app.Run(%v) = %#v, want %#v", err.Error(), expected)
+	}
 }


### PR DESCRIPTION
Hooks into cli's `Before` error handling for global flags and adds tests!

cc @aybabtme @bryanl @macb