### PR TITLE
Don't require API key if no args were passed

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func buildApp() *cli.App {
 			APIKey = ctx.String("api-key")
 		}
 
-		if APIKey == "" && !ctx.Bool("help") && !ctx.Bool("version") {
+		if APIKey == "" && !ctx.Bool("help") && !ctx.Bool("version") && !(ctx.NumFlags() == 0) {
 			return errors.New("must provide API Key via DIGITALOCEAN_API_KEY environment variable or via CLI argument.")
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"io/ioutil"
 	"testing"
 )
@@ -23,7 +22,7 @@ func TestAppWithoutApiKey(t *testing.T) {
 	}{
 		{
 			args:    []string{"doctl"},
-			wantErr: errors.New("must provide API Key via DIGITALOCEAN_API_KEY environment variable or via CLI argument."),
+			wantErr: nil,
 		},
 		{
 			args:    []string{"doctl", "--version"},


### PR DESCRIPTION
Typing `doctl` on its own should not produce an error when `doctl
--help` would not.