### PR TITLE
Invalid type on --add-region parameter

### DIFF
--- a/droplet.go
+++ b/droplet.go
@@ -139,7 +139,7 @@ func dropletCreate(ctx *cli.Context) {
 
 	// Add domain to end if available.
 	dropletName := ctx.Args().First()
-	if ctx.String("add-region") != "" {
+	if ctx.Bool("add-region") {
 		dropletName = fmt.Sprintf("%s.%s", dropletName, ctx.String("region"))
 	}
 	if ctx.String("domain") != "" {


### PR DESCRIPTION
This was automatically appending the region on the end of the droplet. The logic was broken due to a type mismatch between the arg definition and the check.