### PR TITLE
README.md installation section:  tweak go get path

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ sudo mv ./doctl /usr/local/bin
 Alternatively, if you have a Go environment configured, you can install the development version of `doctl` from the command line like so:
 
 ```
-go get github.com/digitalocean/doctl
+go get github.com/digitalocean/doctl/cmd/doctl
 ```
 
 ## Initialization


### PR DESCRIPTION
So, per #24:

    go get github.com/digitalocean/doctl/cmd/doctl

...seems to be the one-liner that works here, but let me know if this should be something different.