### PR TITLE
Add explicit parent to SSH command

### DIFF
--- a/commands/doit.go
+++ b/commands/doit.go
@@ -112,7 +112,10 @@ func computeCmd() *Command {
 	cmd.AddCommand(Region())
 	cmd.AddCommand(Size())
 	cmd.AddCommand(SSHKeys())
-	cmd.AddCommand(SSH())
+
+	// SSH is different since it doesn't have any subcommands. In this case, let's
+	// give it a parent at init time.
+	SSH(cmd)
 
 	return cmd
 }

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -36,13 +36,13 @@ var (
 )
 
 // SSH creates the ssh commands heirarchy
-func SSH() *Command {
+func SSH(parent *Command) *Command {
 	usr, err := user.Current()
 	checkErr(err)
 
 	path := filepath.Join(usr.HomeDir, ".ssh", "id_rsa")
 
-	cmdSSH := CmdBuilder(nil, RunSSH, "ssh <droplet-id | host>", "ssh to droplet", Writer,
+	cmdSSH := CmdBuilder(parent, RunSSH, "ssh <droplet-id | host>", "ssh to droplet", Writer,
 		docCategories("droplet"))
 	AddStringFlag(cmdSSH, doit.ArgSSHUser, "root", "ssh user")
 	AddStringFlag(cmdSSH, doit.ArgsSSHKeyPath, path, "path to private ssh key")

--- a/pkg/runner/mocks/Runner.go
+++ b/pkg/runner/mocks/Runner.go
@@ -1,0 +1,21 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+type Runner struct {
+	mock.Mock
+}
+
+// Run provides a mock function with given fields:
+func (_m *Runner) Run() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}


### PR DESCRIPTION
Add explicit parent to SSH command, so it can create configuration keys in the proper place. This solves the problem of ssh flags not working since they were be being searched for in `doit.ssh.*` instead of `compute.ssh.*`.

Fixes #30