### PR TITLE
Add more logic around droplet deletes

### DIFF
--- a/commands/errors.go
+++ b/commands/errors.go
@@ -24,7 +24,8 @@ import (
 )
 
 var (
-	colorErr = color.New(color.FgRed).SprintFunc()("Error")
+	colorErr  = color.New(color.FgRed).SprintFunc()("Error")
+	colorWarn = color.New(color.FgYellow).SprintFunc()("Warning")
 
 	// errAction specifies what should happen when an error occurs
 	errAction = func() {
@@ -65,4 +66,8 @@ func checkErr(err error, cmd ...*cobra.Command) {
 	}
 
 	errAction()
+}
+
+func warn(msg string) {
+	fmt.Fprintf(color.Output, "%s: %s\n", colorWarn, msg)
 }


### PR DESCRIPTION
When deleting droplets, cycle through the following logic:

* check for ambiguous names. e.g. multiple droplets named ubuntu
* build a list of droplets to delete and execute them all at once
* don't allow deleting the same droplet twice (by name or id)

Fixes #18