### PR TITLE
Issues with listing droplet kernels

### DIFF
--- a/commands/droplet_actions.go
+++ b/commands/droplet_actions.go
@@ -140,7 +140,7 @@ func DropletAction() *Command {
 
 	cmdDropletActionChangeKernel := CmdBuilder(cmd, RunDropletActionChangeKernel,
 		"change-kernel <droplet-id>", "change kernel", Writer,
-		docCategories("droplet"))
+		displayerType(&action{}), docCategories("droplet"))
 	AddIntFlag(cmdDropletActionChangeKernel, doit.ArgKernelID, 0, "Kernel ID", requiredOpt())
 	AddBoolFlag(cmdDropletActionChangeKernel, doit.ArgCommandWait, false, "Wait for action to complete")
 


### PR DESCRIPTION
* Kernel lists had no formating or header options.
* Pagination skipped the second page of results.

Fixes #33