### PR TITLE
Remove dev label from release builds

### DIFF
--- a/scripts/stage.sh
+++ b/scripts/stage.sh
@@ -30,7 +30,8 @@ rm -f $STAGE_DIR/doctl $STAGE_DIR/doctl.exe
 if [[ -z $SKIPBUILD ]]; then
   echo "building doctl"
   baseFlag="-X github.com/digitalocean/doctl"
-  ldflags="${baseFlag}.Build=$(git rev-parse --short HEAD) $baseFlag.Major=${major} $baseFlag.Minor=${minor} $baseFlag.Patch=${patch}"
+  ldflags="${baseFlag}.Build=$(git rev-parse --short HEAD)"
+  ldflags="${ldflags} $baseFlag.Major=${major} $baseFlag.Minor=${minor} $baseFlag.Patch=${patch} $baseFlag.Label=release"
   if [[ -n "$label" ]]; then
     ldflags="${ldflags} $baseFlag.Label=${label}"
   fi


### PR DESCRIPTION
Release builds will now have a version string that looks like: `doctl version 1.0.0-release`

Fixes: #22