### PR TITLE
Ensure all 'list' commands are aliased to 'ls'

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -26,9 +26,9 @@ import (
 
 	"golang.org/x/crypto/ssh/terminal"
 
-	"github.com/digitalocean/doctl"
 	"github.com/bryanl/doit-server"
 	"github.com/bryanl/webbrowser"
+	"github.com/digitalocean/doctl"
 	"github.com/gorilla/websocket"
 	"github.com/satori/go.uuid"
 	"github.com/spf13/cobra"

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -113,6 +113,9 @@ func assertCommandNames(t *testing.T, cmd *Command, expected ...string) {
 
 	for _, c := range cmd.Commands() {
 		names = append(names, c.Name())
+		if c.Name() == "list" {
+			assert.Contains(t, c.Aliases, "ls", "Missing 'ls' alias for 'list' command.")
+		}
 	}
 
 	sort.Strings(expected)

--- a/commands/images.go
+++ b/commands/images.go
@@ -36,7 +36,7 @@ func Images() *Command {
 	}
 
 	cmdImagesList := CmdBuilder(cmd, RunImagesList, "list", "list images", Writer,
-		displayerType(&image{}), docCategories("image"))
+		aliasOpt("ls"), displayerType(&image{}), docCategories("image"))
 	AddBoolFlag(cmdImagesList, doit.ArgImagePublic, false, "List public images")
 
 	cmdImagesListDistribution := CmdBuilder(cmd, RunImagesListDistribution,

--- a/commands/regions.go
+++ b/commands/regions.go
@@ -25,8 +25,8 @@ func Region() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunRegionList, "list", "list regions", Writer, displayerType(&region{}),
-		docCategories("compute"))
+	CmdBuilder(cmd, RunRegionList, "list", "list regions", Writer, aliasOpt("ls"),
+		displayerType(&region{}), docCategories("compute"))
 
 	return cmd
 }

--- a/commands/sizes.go
+++ b/commands/sizes.go
@@ -25,8 +25,8 @@ func Size() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunSizeList, "list", "list sizes", Writer, displayerType(&size{}),
-		docCategories("compute"))
+	CmdBuilder(cmd, RunSizeList, "list", "list sizes", Writer, aliasOpt("ls"),
+		displayerType(&size{}), docCategories("compute"))
 
 	return cmd
 }


### PR DESCRIPTION
I noticed a number of commands with a `list` subcommand do not have the `ls` alias. For the sake of consistency, this adds those where missing. It also adds a check to the `assertCommandNames` function to ensure future `list` commands are given the alias. 