### PR TITLE
use image instead of image id when rebuilding droplets

### DIFF
--- a/commands/droplet_actions.go
+++ b/commands/droplet_actions.go
@@ -129,7 +129,7 @@ func DropletAction() *Command {
 	cmdDropletActionRebuild := CmdBuilder(cmd, RunDropletActionRebuild,
 		"rebuild <droplet-id>", "rebuild droplet", Writer,
 		displayerType(&action{}), docCategories("droplet"))
-	AddIntFlag(cmdDropletActionRebuild, doit.ArgImageID, 0, "Image ID", requiredOpt())
+	AddStringFlag(cmdDropletActionRebuild, doit.ArgImage, "", "Image ID or Slug", requiredOpt())
 	AddBoolFlag(cmdDropletActionRebuild, doit.ArgCommandWait, false, "Wait for action to complete")
 
 	cmdDropletActionRename := CmdBuilder(cmd, RunDropletActionRename,

--- a/commands/droplet_actions_test.go
+++ b/commands/droplet_actions_test.go
@@ -146,6 +146,8 @@ func TestDropletActionsRebuildByImageID(t *testing.T) {
 
 		err := RunDropletActionRebuild(config)
 		assert.NoError(t, err)
+
+		assert.True(t, tm.dropletActions.AssertExpectations(t))
 	})
 }
 
@@ -159,6 +161,8 @@ func TestDropletActionsRebuildByImageSlug(t *testing.T) {
 
 		err := RunDropletActionRebuild(config)
 		assert.NoError(t, err)
+
+		assert.True(t, tm.dropletActions.AssertExpectations(t))
 	})
 
 }


### PR DESCRIPTION
Use image instead of image id when rebuilding droplets. The argument was tagged with `ArgImage` when it should have been tagged with `ArgImage`. Since doctl has to be GIGO, it was happy to pass the blank string upstring to the API.