### PR TITLE
Add tags commands

### DIFF
--- a/args.go
+++ b/args.go
@@ -104,6 +104,8 @@ const (
 	ArgNoHeader = "no-header"
 	// ArgPollTime is how long before the next poll argument.
 	ArgPollTime = "poll-timeout"
+	// ArgTagName is a tag name
+	ArgTagName = "tag-name"
 
 	// ArgOutput is an output type argument.
 	ArgOutput = "output"

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -138,6 +138,7 @@ type tcMocks struct {
 	domains           domocks.DomainsService
 	actions           domocks.ActionsService
 	account           domocks.AccountService
+	tags              domocks.TagsService
 }
 
 func withTestClient(t *testing.T, tFn testFn) {
@@ -168,6 +169,7 @@ func withTestClient(t *testing.T, tFn testFn) {
 		Domains:           func() do.DomainsService { return &tm.domains },
 		Actions:           func() do.ActionsService { return &tm.actions },
 		Account:           func() do.AccountService { return &tm.account },
+		Tags:              func() do.TagsService { return &tm.tags },
 	}
 
 	tFn(config, tm)
@@ -184,6 +186,7 @@ func withTestClient(t *testing.T, tFn testFn) {
 	assert.True(t, tm.regions.AssertExpectations(t))
 	assert.True(t, tm.sizes.AssertExpectations(t))
 	assert.True(t, tm.keys.AssertExpectations(t))
+	assert.True(t, tm.tags.AssertExpectations(t))
 }
 
 type TestConfig struct {

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -112,6 +112,7 @@ func computeCmd() *Command {
 	cmd.AddCommand(Region())
 	cmd.AddCommand(Size())
 	cmd.AddCommand(SSHKeys())
+	cmd.AddCommand(Tags())
 
 	// SSH is different since it doesn't have any subcommands. In this case, let's
 	// give it a parent at init time.
@@ -249,6 +250,7 @@ type CmdConfig struct {
 	Domains           func() do.DomainsService
 	Actions           func() do.ActionsService
 	Account           func() do.AccountService
+	Tags              func() do.TagsService
 }
 
 // NewCmdConfig creates an instance of a CmdConfig.
@@ -273,6 +275,7 @@ func NewCmdConfig(ns string, dc doit.Config, out io.Writer, args []string) *CmdC
 		Domains:           func() do.DomainsService { return do.NewDomainsService(godoClient) },
 		Actions:           func() do.ActionsService { return do.NewActionsService(godoClient) },
 		Account:           func() do.AccountService { return do.NewAccountService(godoClient) },
+		Tags:              func() do.TagsService { return do.NewTagsService(godoClient) },
 	}
 }
 

--- a/commands/tags.go
+++ b/commands/tags.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2016 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/do"
+	"github.com/digitalocean/godo"
+	"github.com/spf13/cobra"
+)
+
+// Tags creates the tag commands heirarchy.
+func Tags() *Command {
+	cmd := &Command{
+		Command: &cobra.Command{
+			Use:   "tag",
+			Short: "tag commands",
+			Long:  "tag is used to access tag commands",
+		},
+		DocCategories: []string{"tag"},
+		IsIndex:       true,
+	}
+
+	CmdBuilder(cmd, RunCmdTagCreate, "create NAME", "create tag", Writer,
+		docCategories("tag"))
+
+	CmdBuilder(cmd, RunCmdTagGet, "get NAME", "get tag", Writer,
+		docCategories("tag"))
+
+	CmdBuilder(cmd, RunCmdTagList, "list", "list tags", Writer,
+		aliasOpt("ls"), docCategories("tag"))
+
+	cmdTagUpdate := CmdBuilder(cmd, RunCmdTagUpdate, "update NAME", "update tag", Writer,
+		docCategories("tag"))
+	AddStringFlag(cmdTagUpdate, doit.ArgTagName, "", "Tag name",
+		requiredOpt())
+
+	CmdBuilder(cmd, RunCmdTagDelete, "delete NAME", "delete tag", Writer,
+		docCategories("tag"))
+
+	return cmd
+}
+
+// RunCmdTagCreate runs tag create.
+func RunCmdTagCreate(c *CmdConfig) error {
+	if len(c.Args) != 1 {
+		return doit.NewMissingArgsErr(c.NS)
+	}
+
+	name := c.Args[0]
+	ts := c.Tags()
+
+	tcr := &godo.TagCreateRequest{Name: name}
+	t, err := ts.Create(tcr)
+	if err != nil {
+		return err
+	}
+
+	return c.Display(&tag{tags: do.Tags{*t}})
+}
+
+// RunCmdTagGet runs tag get.
+func RunCmdTagGet(c *CmdConfig) error {
+	if len(c.Args) != 1 {
+		return doit.NewMissingArgsErr(c.NS)
+	}
+
+	name := c.Args[0]
+	ts := c.Tags()
+	t, err := ts.Get(name)
+	if err != nil {
+		return err
+	}
+
+	return c.Display(&tag{tags: do.Tags{*t}})
+}
+
+// RunCmdTagList runs tag list.
+func RunCmdTagList(c *CmdConfig) error {
+	ts := c.Tags()
+	tags, err := ts.List()
+	if err != nil {
+		return err
+	}
+
+	return c.Display(&tag{tags: tags})
+}
+
+// RunCmdTagUpdate runs tag update.
+func RunCmdTagUpdate(c *CmdConfig) error {
+	if len(c.Args) != 1 {
+		return doit.NewMissingArgsErr(c.NS)
+	}
+
+	name := c.Args[0]
+
+	newName, err := c.Doit.GetString(c.NS, doit.ArgTagName)
+	if err != nil {
+		return err
+	}
+
+	ts := c.Tags()
+	tur := &godo.TagUpdateRequest{Name: newName}
+	return ts.Update(name, tur)
+}
+
+// RunCmdTagDelete runs tag delete.
+func RunCmdTagDelete(c *CmdConfig) error {
+	if len(c.Args) != 1 {
+		return doit.NewMissingArgsErr(c.NS)
+	}
+
+	name := c.Args[0]
+	ts := c.Tags()
+	return ts.Delete(name)
+}

--- a/commands/tags_test.go
+++ b/commands/tags_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2016 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/do"
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testTag = do.Tag{
+		Tag: &godo.Tag{
+			Name: "mytag",
+			Resources: &godo.TaggedResources{
+				Droplets: &godo.TaggedDropletsResources{
+					Count:      5,
+					LastTagged: testDroplet.Droplet,
+				},
+			}}}
+	testTagList = do.Tags{
+		testTag,
+	}
+)
+
+func TestTTagCommand(t *testing.T) {
+	cmd := Tags()
+	assert.NotNil(t, cmd)
+	assertCommandNames(t, cmd, "create", "get", "update", "delete", "list")
+}
+
+func TestTagGet(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.tags.On("Get", "mytag").Return(&testTag, nil)
+
+		config.Args = append(config.Args, "mytag")
+
+		err := RunCmdTagGet(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestTagList(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.tags.On("List").Return(testTagList, nil)
+
+		err := RunCmdTagList(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestTagCreate(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tcr := godo.TagCreateRequest{Name: "new-tag"}
+		tm.tags.On("Create", &tcr).Return(&testTag, nil)
+		config.Args = append(config.Args, "new-tag")
+
+		err := RunCmdTagCreate(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestTagDelete(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.tags.On("Delete", "my-tag").Return(nil)
+		config.Args = append(config.Args, "my-tag")
+
+		err := RunCmdTagDelete(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestTagUpdate(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tur := &godo.TagUpdateRequest{Name: "new-name"}
+		tm.tags.On("Update", "my-tag", tur).Return(nil)
+		config.Args = append(config.Args, "my-tag")
+
+		config.Doit.Set(config.NS, doit.ArgTagName, "new-name")
+
+		err := RunCmdTagUpdate(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestTagUpdateMissingName(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tur := &godo.TagUpdateRequest{Name: ""}
+		tm.tags.On("Update", "my-tag", tur).Return(errors.New("boom"))
+		config.Args = append(config.Args, "my-tag")
+
+		err := RunCmdTagUpdate(config)
+		assert.Error(t, err)
+	})
+}

--- a/do/mocks/DropletsService.go
+++ b/do/mocks/DropletsService.go
@@ -1,17 +1,3 @@
-
-/*
-Copyright 2016 The Doctl Authors All rights reserved.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package mocks
 
 import "github.com/digitalocean/doctl/do"
@@ -37,6 +23,27 @@ func (_m *DropletsService) List() (do.Droplets, error) {
 	var r1 error
 	if rf, ok := ret.Get(1).(func() error); ok {
 		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListByTag provides a mock function with given fields: _a0
+func (_m *DropletsService) ListByTag(_a0 string) (do.Droplets, error) {
+	ret := _m.Called(_a0)
+
+	var r0 do.Droplets
+	if rf, ok := ret.Get(0).(func(string) do.Droplets); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(do.Droplets)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -117,6 +124,20 @@ func (_m *DropletsService) Delete(_a0 int) error {
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(int) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteByTag provides a mock function with given fields: _a0
+func (_m *DropletsService) DeleteByTag(_a0 string) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
 		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)

--- a/do/mocks/TagsService.go
+++ b/do/mocks/TagsService.go
@@ -1,0 +1,133 @@
+package mocks
+
+import "github.com/digitalocean/doctl/do"
+import "github.com/stretchr/testify/mock"
+
+import "github.com/digitalocean/godo"
+
+type TagsService struct {
+	mock.Mock
+}
+
+// List provides a mock function with given fields:
+func (_m *TagsService) List() (do.Tags, error) {
+	ret := _m.Called()
+
+	var r0 do.Tags
+	if rf, ok := ret.Get(0).(func() do.Tags); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(do.Tags)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Get provides a mock function with given fields: _a0
+func (_m *TagsService) Get(_a0 string) (*do.Tag, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *do.Tag
+	if rf, ok := ret.Get(0).(func(string) *do.Tag); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*do.Tag)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Create provides a mock function with given fields: _a0
+func (_m *TagsService) Create(_a0 *godo.TagCreateRequest) (*do.Tag, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *do.Tag
+	if rf, ok := ret.Get(0).(func(*godo.TagCreateRequest) *do.Tag); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*do.Tag)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*godo.TagCreateRequest) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Update provides a mock function with given fields: _a0, _a1
+func (_m *TagsService) Update(_a0 string, _a1 *godo.TagUpdateRequest) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *godo.TagUpdateRequest) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Delete provides a mock function with given fields: _a0
+func (_m *TagsService) Delete(_a0 string) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// TagResources provides a mock function with given fields: _a0, _a1
+func (_m *TagsService) TagResources(_a0 string, _a1 *godo.TagResourcesRequest) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *godo.TagResourcesRequest) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UntagResources provides a mock function with given fields: _a0, _a1
+func (_m *TagsService) UntagResources(_a0 string, _a1 *godo.UntagResourcesRequest) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *godo.UntagResourcesRequest) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/do/tags.go
+++ b/do/tags.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2016 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import "github.com/digitalocean/godo"
+
+// Tag is a wrapper for godo.Tag
+type Tag struct {
+	*godo.Tag
+}
+
+// Tags is a slice of Tag.
+type Tags []Tag
+
+// TagsService is an interface for interacting with DigitalOcean's tags api.
+type TagsService interface {
+	List() (Tags, error)
+	Get(string) (*Tag, error)
+	Create(*godo.TagCreateRequest) (*Tag, error)
+	Update(string, *godo.TagUpdateRequest) error
+	Delete(string) error
+	TagResources(string, *godo.TagResourcesRequest) error
+	UntagResources(string, *godo.UntagResourcesRequest) error
+}
+
+type tagsService struct {
+	client *godo.Client
+}
+
+var _ TagsService = (*tagsService)(nil)
+
+// NewTagsService builds a TagsService instance.
+func NewTagsService(godoClient *godo.Client) TagsService {
+	return &tagsService{
+		client: godoClient,
+	}
+}
+
+func (ts *tagsService) List() (Tags, error) {
+	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+		list, resp, err := ts.client.Tags.List(opt)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		si := make([]interface{}, len(list))
+		for i := range list {
+			si[i] = list[i]
+		}
+
+		return si, resp, err
+	}
+
+	si, err := PaginateResp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	list := make(Tags, len(si))
+	for i := range si {
+		a := si[i].(godo.Tag)
+		list[i] = Tag{Tag: &a}
+	}
+
+	return list, nil
+}
+
+func (ts *tagsService) Get(name string) (*Tag, error) {
+	t, _, err := ts.client.Tags.Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Tag{Tag: t}, nil
+}
+
+func (ts *tagsService) Create(tcr *godo.TagCreateRequest) (*Tag, error) {
+	t, _, err := ts.client.Tags.Create(tcr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Tag{Tag: t}, nil
+}
+
+func (ts *tagsService) Update(name string, tur *godo.TagUpdateRequest) error {
+	_, err := ts.client.Tags.Update(name, tur)
+	return err
+}
+
+func (ts *tagsService) Delete(name string) error {
+	_, err := ts.client.Tags.Delete(name)
+	return err
+}
+
+func (ts *tagsService) TagResources(name string, trr *godo.TagResourcesRequest) error {
+	_, err := ts.client.Tags.TagResources(name, trr)
+	return err
+}
+
+func (ts *tagsService) UntagResources(name string, urr *godo.UntagResourcesRequest) error {
+	_, err := ts.client.Tags.UntagResources(name, urr)
+	return err
+}

--- a/vendor/github.com/digitalocean/godo/droplets.go
+++ b/vendor/github.com/digitalocean/godo/droplets.go
@@ -53,7 +53,8 @@ type Droplet struct {
 	Status      string    `json:"status,omitempty"`
 	Networks    *Networks `json:"networks,omitempty"`
 	Created     string    `json:"created_at,omitempty"`
-	Kernel      *Kernel   `json:"kernel, omitempty"`
+	Kernel      *Kernel   `json:"kernel,omitempty"`
+	Tags        []string  `json:"tags,ommitempty"`
 }
 
 // PublicIPv4 returns the public IPv4 address for the Droplet.

--- a/vendor/github.com/digitalocean/godo/droplets_test.go
+++ b/vendor/github.com/digitalocean/godo/droplets_test.go
@@ -408,66 +408,6 @@ func TestNetworkV6_String(t *testing.T) {
 	}
 }
 
-func TestDroplet_String(t *testing.T) {
-
-	region := &Region{
-		Slug:      "region",
-		Name:      "Region",
-		Sizes:     []string{"1", "2"},
-		Available: true,
-	}
-
-	image := &Image{
-		ID:           1,
-		Name:         "Image",
-		Type:         "snapshot",
-		Distribution: "Ubuntu",
-		Slug:         "image",
-		Public:       true,
-		Regions:      []string{"one", "two"},
-		MinDiskSize:  20,
-		Created:      "2013-11-27T09:24:55Z",
-	}
-
-	size := &Size{
-		Slug:         "size",
-		PriceMonthly: 123,
-		PriceHourly:  456,
-		Regions:      []string{"1", "2"},
-	}
-	network := &NetworkV4{
-		IPAddress: "192.168.1.2",
-		Netmask:   "255.255.255.0",
-		Gateway:   "192.168.1.1",
-	}
-	networks := &Networks{
-		V4: []NetworkV4{*network},
-	}
-
-	droplet := &Droplet{
-		ID:          1,
-		Name:        "droplet",
-		Memory:      123,
-		Vcpus:       456,
-		Disk:        789,
-		Region:      region,
-		Image:       image,
-		Size:        size,
-		BackupIDs:   []int{1},
-		SnapshotIDs: []int{1},
-		Locked:      false,
-		Status:      "active",
-		Networks:    networks,
-		SizeSlug:    "1gb",
-	}
-
-	stringified := droplet.String()
-	expected := `godo.Droplet{ID:1, Name:"droplet", Memory:123, Vcpus:456, Disk:789, Region:godo.Region{Slug:"region", Name:"Region", Sizes:["1" "2"], Available:true}, Image:godo.Image{ID:1, Name:"Image", Type:"snapshot", Distribution:"Ubuntu", Slug:"image", Public:true, Regions:["one" "two"], MinDiskSize:20, Created:"2013-11-27T09:24:55Z"}, Size:godo.Size{Slug:"size", Memory:0, Vcpus:0, Disk:0, PriceMonthly:123, PriceHourly:456, Regions:["1" "2"], Available:false, Transfer:0}, SizeSlug:"1gb", BackupIDs:[1], SnapshotIDs:[1], Locked:false, Status:"active", Networks:godo.Networks{V4:[godo.NetworkV4{IPAddress:"192.168.1.2", Netmask:"255.255.255.0", Gateway:"192.168.1.1", Type:""}]}, Created:""}`
-	if expected != stringified {
-		t.Errorf("Droplet.String returned %+v, expected %+v", stringified, expected)
-	}
-}
-
 func TestDroplets_IPMethods(t *testing.T) {
 	var d Droplet
 

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -61,7 +61,7 @@
 		{
 			"importpath": "github.com/digitalocean/godo",
 			"repository": "https://github.com/digitalocean/godo",
-			"revision": "859ab8f9253710399c0bc0f481a236f8285d5d4f",
+			"revision": "d5eb35143cad86edbe7136512921790fada64222",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
Allow `doctl` to access functionality exposed by DigitalOcean [tags](https://developers.digitalocean.com/documentation/v2/#tags). 

Adds the following new commands:

* create a new tag: `doctl compute tag create <tag name>`
* retrieve a tag: `doctl compute tag get <tag name>`
* list all tags: `doctl compute tag list`
* list droplets by tag: `doctl compute droplet list --tag-name <tag name>`
* update a tag: `doctl compute tag update <tag name> --name <new tag name>`
* tag a resource (droplet): `doctl compute droplet tag <droplet name or id> --tag-name <tag name>`
* untag a resource (droplet): `doctl compute droplet untag <tag name or id>`
* delete a tag: `doctl compute tag delete <tag name>`
* delete droplets by tags `doctl compute droplet delete --tag-name <tag name>`