### PR TITLE
make new-version message appeal to action

### DIFF
--- a/doit.go
+++ b/doit.go
@@ -105,7 +105,7 @@ func (v Version) Complete(lv LatestVersioner) string {
 		v1, err2 := semver.Make(v.String())
 
 		if err1 == nil && err2 == nil && v0.GT(v1) {
-			buffer.WriteString(fmt.Sprintf("\n%q is a newer release than %q", tagName, v.String()))
+			buffer.WriteString(fmt.Sprintf("\nrelease %s is available, check it out! ", tagName))
 		}
 	}
 

--- a/doit_test.go
+++ b/doit_test.go
@@ -56,7 +56,7 @@ func TestVersion(t *testing.T) {
 		// version with no label and higher released version
 		{
 			v:   Version{Major: 0, Minor: 1, Patch: 2},
-			s:   "doctl version 0.1.2\n\"1.0.0\" is a newer release than \"0.1.2\"",
+			s:   "doctl version 0.1.2\nrelease 1.0.0 is available, check it out! ",
 			ver: `0.1.2`,
 			slr: slr2,
 		},


### PR DESCRIPTION
The current message reads kind of weird. When I saw it, I found
it a bit confusing, because it just states "x is greater than y".
It took me a couple seconds parse the information and understand
"oh you mean there's a newer version and I should update?".
```
doctl version 1.0.0-dev
"1.0.2" is a newer release than "1.0.0-dev"
```

Since the current version is already printed, we don't need to
repeat "this is version x, version y is greater than version x".
We can just say "this is version x, version y is available!".

Then we can make the message a bit less impersonal, and try to encourage
users to perform an action "hey this version is avail, try it!".

So it ends up like this:
```
doctl version 1.0.0-dev
release 1.0.2 is available, check it out!
```

r: @bryanl 