### PR TITLE
ssh: respect ssh-user flag

### DIFF
--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -93,7 +93,10 @@ func RunSSH(c *CmdConfig) error {
 
 		shi := extractHostInfo(dropletID)
 
-		user = shi.user
+		if (shi.user != "") {
+			user = shi.user
+		}
+
 		if i, err := strconv.Atoi(shi.port); shi.port != "" && err != nil {
 			port = i
 		}

--- a/commands/ssh_test.go
+++ b/commands/ssh_test.go
@@ -98,6 +98,27 @@ func TestSSH_CustomPort(t *testing.T) {
 	})
 }
 
+func TestSSH_CustomUser(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		rm := &mocks.Runner{}
+		rm.On("Run").Return(nil)
+
+		tc := config.Doit.(*TestConfig)
+		tc.SSHFn = func(user, host, keyPath string, port int) runner.Runner {
+			assert.Equal(t, "foobar", user)
+			return rm
+		}
+
+		tm.droplets.On("List").Return(testDropletList, nil)
+
+		config.Doit.Set(config.NS, doctl.ArgSSHUser, "foobar")
+		config.Args = append(config.Args, testDroplet.Name)
+
+		err := RunSSH(config)
+		assert.NoError(t, err)
+	})
+}
+
 func Test_extractHostInfo(t *testing.T) {
 	cases := []struct {
 		s string


### PR DESCRIPTION
Currently `ssh-user` is always overwritten by user extracted from droplet id. I'm not sure even that there are cases where droplet id contains user, so it's almost always an empty string.