### PR TITLE
Don't report new release available when already installed.

### DIFF
--- a/doit.go
+++ b/doit.go
@@ -104,6 +104,10 @@ func (v Version) Complete(lv LatestVersioner) string {
 		v0, err1 := semver.Make(tagName)
 		v1, err2 := semver.Make(v.String())
 
+		if len(v0.Build) == 0 {
+			v0, err1 = semver.Make(tagName + "-release")
+		}
+
 		if err1 == nil && err2 == nil && v0.GT(v1) {
 			buffer.WriteString(fmt.Sprintf("\nrelease %s is available, check it out! ", tagName))
 		}

--- a/doit_test.go
+++ b/doit_test.go
@@ -60,6 +60,20 @@ func TestVersion(t *testing.T) {
 			ver: `0.1.2`,
 			slr: slr2,
 		},
+		// version with dev label and released version
+		{
+			v:   Version{Major: 1, Minor: 0, Patch: 0, Label: "dev"},
+			s:   "doctl version 1.0.0-dev\nrelease 1.0.0 is available, check it out! ",
+			ver: `1.0.0-dev`,
+			slr: slr2,
+		},
+		// version with release label and released version available
+		{
+			v:   Version{Major: 1, Minor: 0, Patch: 0, Label: "release"},
+			s:   "doctl version 1.0.0-release",
+			ver: `1.0.0-release`,
+			slr: slr2,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
`doctl` reports that there is a new version available even though the most recent release is installed:

```
$ doctl version
doctl version 1.2.0-release
Git commit hash: 4d9207c
release 1.2.0 is available, check it out!
```

This is because the release process adds the `release` label while the git tag for the release does not contain that. See:

https://github.com/digitalocean/doctl/blob/master/scripts/stage.sh#L34

`github.com/blang/semver` is used to compare the versions and `1.2.0` is considered a higher version than `1.2.0-release`. You can test this with:

```go
package main

import (
	"fmt"
	"github.com/blang/semver"
)

func main() {
	v0, err1 := semver.Make("1.0.0")
	v1, err2 := semver.Make("1.0.0-release")

	if err1 == nil && err2 == nil && v0.GT(v1) == true {
		fmt.Printf("%q gt %q", v0.String(), v1.String())
	}
}
```

This PR compensates for that by internally adding the `release` label to the tag if no other is already assigned. This ensures things still correctly function for releases labeled `beta`, `dev`, etc... 

Of course, the alternative is to tag the release in git differently...
