### PR TITLE
Add a --ssh-agent-forwarding flag

### DIFF
--- a/args.go
+++ b/args.go
@@ -82,6 +82,8 @@ const (
 	ArgSSHKeys = "ssh-keys"
 	// ArgsSSHPort is a ssh argument.
 	ArgsSSHPort = "ssh-port"
+	// ArgsSSHAgentForwarding is a ssh argument.
+	ArgsSSHAgentForwarding = "ssh-agent-forwarding"
 	// ArgUserData is a user data argument.
 	ArgUserData = "user-data"
 	// ArgUserDataFile is a user data file location argument.

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/digitalocean/doctl/do"
 	domocks "github.com/digitalocean/doctl/do/mocks"
 	"github.com/digitalocean/doctl/pkg/runner"
+	"github.com/digitalocean/doctl/pkg/ssh"
 	"github.com/digitalocean/godo"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -196,7 +197,7 @@ func withTestClient(t *testing.T, tFn testFn) {
 }
 
 type TestConfig struct {
-	SSHFn func(user, host, keyPath string, port int, agentForwarding bool) runner.Runner
+	SSHFn func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner
 	v     *viper.Viper
 }
 
@@ -204,7 +205,7 @@ var _ doctl.Config = &TestConfig{}
 
 func NewTestConfig() *TestConfig {
 	return &TestConfig{
-		SSHFn: func(u, h, kp string, p int, a bool) runner.Runner {
+		SSHFn: func(u, h, kp string, p int, opts ssh.Options) runner.Runner {
 			return &doctl.MockRunner{}
 		},
 		v: viper.New(),
@@ -217,8 +218,8 @@ func (c *TestConfig) GetGodoClient(trace bool) (*godo.Client, error) {
 	return &godo.Client{}, nil
 }
 
-func (c *TestConfig) SSH(user, host, keyPath string, port int, agentForwarding bool) runner.Runner {
-	return c.SSHFn(user, host, keyPath, port, agentForwarding)
+func (c *TestConfig) SSH(user, host, keyPath string, port int, opts ssh.Options) runner.Runner {
+	return c.SSHFn(user, host, keyPath, port, opts)
 }
 
 func (c *TestConfig) Set(ns, key string, val interface{}) {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -196,7 +196,7 @@ func withTestClient(t *testing.T, tFn testFn) {
 }
 
 type TestConfig struct {
-	SSHFn func(user, host, keyPath string, port int) runner.Runner
+	SSHFn func(user, host, keyPath string, port int, agentForwarding bool) runner.Runner
 	v     *viper.Viper
 }
 
@@ -204,7 +204,7 @@ var _ doctl.Config = &TestConfig{}
 
 func NewTestConfig() *TestConfig {
 	return &TestConfig{
-		SSHFn: func(u, h, kp string, p int) runner.Runner {
+		SSHFn: func(u, h, kp string, p int, a bool) runner.Runner {
 			return &doctl.MockRunner{}
 		},
 		v: viper.New(),
@@ -217,8 +217,8 @@ func (c *TestConfig) GetGodoClient(trace bool) (*godo.Client, error) {
 	return &godo.Client{}, nil
 }
 
-func (c *TestConfig) SSH(user, host, keyPath string, port int) runner.Runner {
-	return c.SSHFn(user, host, keyPath, port)
+func (c *TestConfig) SSH(user, host, keyPath string, port int, agentForwarding bool) runner.Runner {
+	return c.SSHFn(user, host, keyPath, port, agentForwarding)
 }
 
 func (c *TestConfig) Set(ns, key string, val interface{}) {

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -41,6 +41,7 @@ func SSH(parent *Command) *Command {
 	AddStringFlag(cmdSSH, doctl.ArgSSHUser, "root", "ssh user")
 	AddStringFlag(cmdSSH, doctl.ArgsSSHKeyPath, path, "path to private ssh key")
 	AddIntFlag(cmdSSH, doctl.ArgsSSHPort, 22, "port sshd is running on")
+	AddBoolFlag(cmdSSH, doctl.ArgsSSHAgentForwarding, false, "enable ssh agent forwarding")
 
 	return cmdSSH
 }
@@ -72,6 +73,11 @@ func RunSSH(c *CmdConfig) error {
 		return err
 	}
 
+	agentForwarding, err := c.Doit.GetBool(c.NS, doctl.ArgsSSHAgentForwarding)
+	if err != nil {
+		return err
+	}
+
 	var droplet *do.Droplet
 
 	ds := c.Droplets()
@@ -93,7 +99,7 @@ func RunSSH(c *CmdConfig) error {
 
 		shi := extractHostInfo(dropletID)
 
-		if (shi.user != "") {
+		if shi.user != "" {
 			user = shi.user
 		}
 
@@ -131,7 +137,7 @@ func RunSSH(c *CmdConfig) error {
 		return errors.New("could not find droplet address")
 	}
 
-	runner := c.Doit.SSH(user, ip, keyPath, port)
+	runner := c.Doit.SSH(user, ip, keyPath, port, agentForwarding)
 	return runner.Run()
 }
 

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/do"
+	"github.com/digitalocean/doctl/pkg/ssh"
 )
 
 var (
@@ -73,7 +74,8 @@ func RunSSH(c *CmdConfig) error {
 		return err
 	}
 
-	agentForwarding, err := c.Doit.GetBool(c.NS, doctl.ArgsSSHAgentForwarding)
+	var opts = make(ssh.Options)
+	opts[doctl.ArgsSSHAgentForwarding], err = c.Doit.GetBool(c.NS, doctl.ArgsSSHAgentForwarding)
 	if err != nil {
 		return err
 	}
@@ -137,7 +139,7 @@ func RunSSH(c *CmdConfig) error {
 		return errors.New("could not find droplet address")
 	}
 
-	runner := c.Doit.SSH(user, ip, keyPath, port, agentForwarding)
+	runner := c.Doit.SSH(user, ip, keyPath, port, opts)
 	return runner.Run()
 }
 

--- a/commands/ssh_test.go
+++ b/commands/ssh_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/pkg/runner"
 	"github.com/digitalocean/doctl/pkg/runner/mocks"
+	"github.com/digitalocean/doctl/pkg/ssh"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -83,7 +84,7 @@ func TestSSH_CustomPort(t *testing.T) {
 		rm.On("Run").Return(nil)
 
 		tc := config.Doit.(*TestConfig)
-		tc.SSHFn = func(user, host, keyPath string, port int, agentForwarding bool) runner.Runner {
+		tc.SSHFn = func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner {
 			assert.Equal(t, 2222, port)
 			return rm
 		}
@@ -104,7 +105,7 @@ func TestSSH_CustomUser(t *testing.T) {
 		rm.On("Run").Return(nil)
 
 		tc := config.Doit.(*TestConfig)
-		tc.SSHFn = func(user, host, keyPath string, port int, agentForwarding bool) runner.Runner {
+		tc.SSHFn = func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner {
 			assert.Equal(t, "foobar", user)
 			return rm
 		}
@@ -125,8 +126,8 @@ func TestSSH_AgentForwarding(t *testing.T) {
 		rm.On("Run").Return(nil)
 
 		tc := config.Doit.(*TestConfig)
-		tc.SSHFn = func(user, host, keyPath string, port int, agentForwarding bool) runner.Runner {
-			assert.Equal(t, true, agentForwarding)
+		tc.SSHFn = func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner {
+			assert.Equal(t, true, opts[doctl.ArgsSSHAgentForwarding])
 			return rm
 		}
 

--- a/commands/ssh_test.go
+++ b/commands/ssh_test.go
@@ -83,7 +83,7 @@ func TestSSH_CustomPort(t *testing.T) {
 		rm.On("Run").Return(nil)
 
 		tc := config.Doit.(*TestConfig)
-		tc.SSHFn = func(user, host, keyPath string, port int) runner.Runner {
+		tc.SSHFn = func(user, host, keyPath string, port int, agentForwarding bool) runner.Runner {
 			assert.Equal(t, 2222, port)
 			return rm
 		}
@@ -104,7 +104,7 @@ func TestSSH_CustomUser(t *testing.T) {
 		rm.On("Run").Return(nil)
 
 		tc := config.Doit.(*TestConfig)
-		tc.SSHFn = func(user, host, keyPath string, port int) runner.Runner {
+		tc.SSHFn = func(user, host, keyPath string, port int, agentForwarding bool) runner.Runner {
 			assert.Equal(t, "foobar", user)
 			return rm
 		}
@@ -112,6 +112,27 @@ func TestSSH_CustomUser(t *testing.T) {
 		tm.droplets.On("List").Return(testDropletList, nil)
 
 		config.Doit.Set(config.NS, doctl.ArgSSHUser, "foobar")
+		config.Args = append(config.Args, testDroplet.Name)
+
+		err := RunSSH(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestSSH_AgentForwarding(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		rm := &mocks.Runner{}
+		rm.On("Run").Return(nil)
+
+		tc := config.Doit.(*TestConfig)
+		tc.SSHFn = func(user, host, keyPath string, port int, agentForwarding bool) runner.Runner {
+			assert.Equal(t, true, agentForwarding)
+			return rm
+		}
+
+		tm.droplets.On("List").Return(testDropletList, nil)
+
+		config.Doit.Set(config.NS, doctl.ArgsSSHAgentForwarding, true)
 		config.Args = append(config.Args, testDroplet.Name)
 
 		err := RunSSH(config)

--- a/doit.go
+++ b/doit.go
@@ -154,7 +154,7 @@ func (glv *GithubLatestVersioner) LatestVersion() (string, error) {
 // Config is an interface that represent doit's config.
 type Config interface {
 	GetGodoClient(trace bool) (*godo.Client, error)
-	SSH(user, host, keyPath string, port int) runner.Runner
+	SSH(user, host, keyPath string, port int, agentForwarding bool) runner.Runner
 	Set(ns, key string, val interface{})
 	GetString(ns, key string) (string, error)
 	GetBool(ns, key string) (bool, error)
@@ -205,14 +205,14 @@ func (c *LiveConfig) GetGodoClient(trace bool) (*godo.Client, error) {
 }
 
 // SSH creates a ssh connection to a host.
-func (c *LiveConfig) SSH(user, host, keyPath string, port int) runner.Runner {
+func (c *LiveConfig) SSH(user, host, keyPath string, port int, agentForwarding bool) runner.Runner {
 	return &ssh.Runner{
-		User:    user,
-		Host:    host,
-		KeyPath: keyPath,
-		Port:    port,
+		User:            user,
+		Host:            host,
+		KeyPath:         keyPath,
+		Port:            port,
+		AgentForwarding: agentForwarding,
 	}
-
 }
 
 // Set sets a config key.

--- a/doit.go
+++ b/doit.go
@@ -154,7 +154,7 @@ func (glv *GithubLatestVersioner) LatestVersion() (string, error) {
 // Config is an interface that represent doit's config.
 type Config interface {
 	GetGodoClient(trace bool) (*godo.Client, error)
-	SSH(user, host, keyPath string, port int, agentForwarding bool) runner.Runner
+	SSH(user, host, keyPath string, port int, opts ssh.Options) runner.Runner
 	Set(ns, key string, val interface{})
 	GetString(ns, key string) (string, error)
 	GetBool(ns, key string) (bool, error)
@@ -205,13 +205,13 @@ func (c *LiveConfig) GetGodoClient(trace bool) (*godo.Client, error) {
 }
 
 // SSH creates a ssh connection to a host.
-func (c *LiveConfig) SSH(user, host, keyPath string, port int, agentForwarding bool) runner.Runner {
+func (c *LiveConfig) SSH(user, host, keyPath string, port int, opts ssh.Options) runner.Runner {
 	return &ssh.Runner{
 		User:            user,
 		Host:            host,
 		KeyPath:         keyPath,
 		Port:            port,
-		AgentForwarding: agentForwarding,
+		AgentForwarding: opts[ArgsSSHAgentForwarding].(bool),
 	}
 }
 

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -96,10 +96,11 @@ func sshConnect(user string, host string, method ssh.AuthMethod) error {
 
 // Runner runs ssh commands.
 type Runner struct {
-	User    string
-	Host    string
-	KeyPath string
-	Port    int
+	User            string
+	Host            string
+	KeyPath         string
+	Port            int
+	AgentForwarding bool
 }
 
 var _ runner.Runner = &Runner{}

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -23,6 +23,9 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// Options is the type used to specify options passed to the SSH command
+type Options map[string]interface{}
+
 func sshConnect(user string, host string, method ssh.AuthMethod) error {
 	sshc := &ssh.ClientConfig{
 		User: user,

--- a/pkg/ssh/ssh_external.go
+++ b/pkg/ssh/ssh_external.go
@@ -34,6 +34,10 @@ func runExternalSSH(r *Runner) error {
 		args = append(args, "-p", strconv.Itoa(r.Port))
 	}
 
+	if r.AgentForwarding {
+		args = append(args, "-A")
+	}
+
 	args = append(args, sshHost)
 
 	cmd := exec.Command("ssh", args...)


### PR DESCRIPTION
It doesn't work on Windows, since the custom ssh client for Windows
doesn't have agent support yet, as stated in issue #65.

This feature has been requested in issue #77.

That's my first contribution to doctl, comments are welcome!