### PR TITLE
Fix the submodules error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,11 @@
+[submodule "github.com/vektra/errors"]
+  path = vendor/github.com/vektra/errors
+  url = git@github.com:vektra/errors.git
+
+[submodule "github.com/vektra/mockery"]
+  path = vendor/github.com/vektra/mockery
+  url = git@github.com:vektra/mockery.git
+
+[submodule "golang.org/x/tools"]
+  path = vendor/golang.org/x/tools
+  url = https://go.googlesource.com/tools


### PR DESCRIPTION
With this .gitmodules file, I am able to successfully `git submodule update --init --recursive`, which is where `go get` is presently hung up.

In theory, this _may_ solve #42 entirely, but I cannot figure out how to test if it does, as `go get` on my fork still installs from the DigitalOcean repo.