### PR TITLE
Introduce `doctl auth init`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ dist
 public
 docs/content
 
-out/doctl
+/out

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ You can download the archive from your browser, or copy its URL and retrieve it 
 cd ~
 
 # OS X
-curl -L https://github.com/digitalocean/doctl/releases/download/v1.1.0/doctl-1.1.0-darwin-10.6-amd64.tar.gz | tar xz
+curl -L https://github.com/digitalocean/doctl/releases/download/v1.4.0/doctl-1.4.0-darwin-10.6-amd64.tar.gz | tar xz
 
 # linux (with wget)
-wget -qO- https://github.com/digitalocean/doctl/releases/download/v1.1.0/doctl-1.1.0-linux-amd64.tar.gz  | tar xz
+wget -qO- https://github.com/digitalocean/doctl/releases/download/v1.4.0/doctl-1.4.0-linux-amd64.tar.gz  | tar xz
 # linux (with curl)
-curl -L https://github.com/digitalocean/doctl/releases/download/v1.1.0/doctl-1.1.0-linux-amd64.tar.gz  | tar xz
+curl -L https://github.com/digitalocean/doctl/releases/download/v1.4.0/doctl-1.4.0-linux-amd64.tar.gz  | tar xz
 ```
 
 Move the `doctl` binary to somewhere in your path.  For example:
@@ -79,14 +79,18 @@ go get github.com/digitalocean/doctl/cmd/doctl
 
 ## Initialization
 
-To automatically retrieve your access token from DigitalOcean, run `doctl auth login`. This process will authenticate
-you with DigitalOcean and retrieve an access token. If your shell does not have access to a web browser
-(because of a remote Linux shell with no DISPLAY environment variable or you've specified the CLIAUTH=1 flag), `doctl`
-will give you a link for offline authentication.
+To use `doctl`, a DigitalOcean access token is required. [Generate](https://cloud.digitalocean.com/settings/api/tokens)
+a new token and run `doctl auth init`, or set the environment variable, `DIGITALOCEAN_ACCESS_TOKEN`, with your new
+token.
 
 ## Configuration
 
-By default, `doctl` will load a configuration file from `$HOME/.doctlcfg` if found.
+By default, `doctl` will load a configuration file from `$XDG_CONFIG_HOME/doctl/config.yaml` if found. If
+the `XDG_CONFIG_HOME` environment variable is not, the path will default to `$HOME/.config/doctl/config.yaml` on
+Unix like systems, and `%APPDATA%/doctl/config/config.yaml` on Windows.
+
+The configuration file has changed locations in recent versions, and a warning will be displayed if your configuration
+exists at the legacy location.
 
 ### Configuration OPTIONS
 
@@ -143,4 +147,4 @@ repository is required.
 
 [tutorial]: https://www.digitalocean.com/community/tutorials/how-to-use-doctl-the-official-digitalocean-command-line-client
 [doctl-releases]: https://github.com/digitalocean/doctl/releases
-[windows-release]: https://github.com/digitalocean/doctl/releases/download/v1.1.0/doctl-1.1.0-windows-4.0-amd64.zip
+[windows-release]: https://github.com/digitalocean/doctl/releases/download/v1.4.0/doctl-1.4.0-windows-4.0-amd64.zip

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -15,21 +15,13 @@ package commands
 
 import (
 	"bufio"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
 	"os"
-	"runtime"
+	"strings"
 
 	"golang.org/x/crypto/ssh/terminal"
 
-	"github.com/bryanl/doit-server"
-	"github.com/bryanl/webbrowser"
-	"github.com/gorilla/websocket"
-	"github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -46,7 +38,7 @@ var retrieveUserTokenFunc = func() (string, error) {
 	}
 
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("Enter token: ")
+	fmt.Print("DigitalOcean access token: ")
 	return reader.ReadString('\n')
 }
 
@@ -71,187 +63,39 @@ func Auth() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunAuthLogin, "login", "login to DigitalOcean account", Writer, docCategories("account"))
+	CmdBuilder(cmd, RunAuthInit, "init", "initialize configuration", Writer, docCategories("account"))
 
 	return cmd
 }
 
-// RunAuthLogin runs auth login. It communicates with doit-server to perform auth.
-func RunAuthLogin(c *CmdConfig) error {
-	dsa := newDoitServerAuth()
-
-	ac, err := dsa.retrieveAuthCredentials()
+// RunAuthInit initializes the doctl config. Configuring is stored in $XDG_CONFIG_HOME/doctl. On Unix, if
+// XDG_CONFIG_HOME is not set, use $HOME/.config. On Windows use %APPDATA%/doctl/config.
+func RunAuthInit(c *CmdConfig) error {
+	in, err := retrieveUserTokenFunc()
 	if err != nil {
-		return err
+		return errors.New("unable to read input")
 	}
 
-	token, err := dsa.initAuth(ac)
-	if err != nil {
-		return err
+	token := strings.TrimSpace(in)
+
+	viper.Set("access-token", string(token))
+
+	fmt.Fprintln(c.Out)
+	fmt.Fprint(c.Out, "Validating token: ")
+
+	// need to initial the godo client since we've changed the configuration.
+	if err := c.initServices(c); err != nil {
+		return fmt.Errorf("unable to initialize DigitalOcean API client with new token: %s", err)
 	}
 
-	viper.Set("access-token", token)
-
-	fmt.Println("updated access token")
-
-	return nil
-}
-
-type doitServerAuth struct {
-	url         string
-	browserOpen func(u string) error
-	isCLI       func() bool
-	monitorAuth func(u string, ac *doitserver.AuthCredentials) (*doitserver.TokenResponse, error)
-}
-
-func newDoitServerAuth() *doitServerAuth {
-	return &doitServerAuth{
-		url: "http://doit-server.apps.pifft.com",
-		browserOpen: func(u string) error {
-			return webbrowser.Open(u, webbrowser.NewTab, true)
-		},
-		isCLI: func() bool {
-			return (runtime.GOOS == "linux" && os.Getenv("DISPLAY") == "") || os.Getenv("CLIAUTH") != ""
-		},
-		monitorAuth: monitorAuthWS,
-	}
-}
-
-func (dsa *doitServerAuth) initAuth(ac *doitserver.AuthCredentials) (string, error) {
-	if dsa.isCLI() {
-		return dsa.initAuthCLI(ac)
+	if _, err := c.Account().Get(); err != nil {
+		fmt.Fprintln(c.Out, "invalid token")
+		fmt.Fprintln(c.Out)
+		return errors.New("unable to use supplied token to access API")
 	}
 
-	return dsa.initAuthBrowser(ac)
-}
+	fmt.Fprintln(c.Out, "OK")
+	fmt.Fprintln(c.Out)
 
-func (dsa *doitServerAuth) initAuthCLI(ac *doitserver.AuthCredentials) (string, error) {
-	u, err := dsa.createAuthURL(ac, keyPair{k: "cliauth", v: "1"})
-	if err != nil {
-		return "", err
-	}
-
-	fmt.Printf("Visit the following URL in your browser: %s\n", u)
-
-	return retrieveUserTokenFunc()
-}
-
-func (dsa *doitServerAuth) initAuthBrowser(ac *doitserver.AuthCredentials) (string, error) {
-	u, err := dsa.createAuthURL(ac)
-	if err != nil {
-		return "", err
-	}
-
-	err = dsa.browserOpen(u)
-	if err != nil {
-		return "", err
-	}
-
-	tr, err := dsa.monitorAuth(dsa.url, ac)
-	if err != nil {
-		return "", err
-	}
-
-	return tr.AccessToken, nil
-}
-
-func (dsa *doitServerAuth) retrieveAuthCredentials() (*doitserver.AuthCredentials, error) {
-	u, err := url.Parse(dsa.url)
-	if err != nil {
-		return nil, err
-	}
-
-	u.Path = "/token"
-	v := u.Query()
-	v.Set("id", uuid.NewV4().String())
-	u.RawQuery = v.Encode()
-
-	r, err := http.Get(u.String())
-	if err != nil {
-		return nil, err
-	}
-	defer r.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if r.StatusCode != 200 {
-		return nil, errors.New("it's broke, Jim")
-	}
-
-	var m doitserver.AuthCredentials
-	err = json.Unmarshal(body, &m)
-	if err != nil {
-		return nil, err
-	}
-
-	return &m, nil
-}
-
-type keyPair struct {
-	k, v string
-}
-
-func (dsa *doitServerAuth) createAuthURL(ac *doitserver.AuthCredentials, kps ...keyPair) (string, error) {
-	authURL, err := url.Parse(dsa.url)
-	if err != nil {
-		return "", err
-	}
-
-	authURL.Path = "/auth/digitalocean"
-
-	q := authURL.Query()
-	q.Set("id", ac.ID)
-	q.Set("cs", ac.CS)
-
-	for _, kp := range kps {
-		q.Set(kp.k, kp.v)
-	}
-
-	authURL.RawQuery = q.Encode()
-
-	return authURL.String(), nil
-
-}
-
-func monitorAuthWS(serverURL string, ac *doitserver.AuthCredentials) (*doitserver.TokenResponse, error) {
-	u, err := url.Parse(serverURL)
-	if err != nil {
-		return nil, err
-	}
-
-	switch u.Scheme {
-	case "http":
-		u.Scheme = "ws"
-	case "https":
-		u.Scheme = "wss"
-	default:
-		return nil, &UnknownSchemeError{Scheme: u.Scheme}
-	}
-
-	u.Path = "/status"
-
-	conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	err = conn.WriteJSON(ac)
-	if err != nil {
-		return nil, err
-	}
-
-	var tr doitserver.TokenResponse
-
-	err = conn.ReadJSON(&tr)
-	if err != nil {
-		return nil, err
-	}
-
-	return &tr, nil
+	return writeConfig()
 }

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -63,17 +63,17 @@ func Auth() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunAuthInit, "init", "initialize configuration", Writer, docCategories("account"))
+	cmdBuilderWithInit(cmd, RunAuthInit, "init", "initialize configuration", Writer, false, docCategories("auth"))
 
 	return cmd
 }
 
-// RunAuthInit initializes the doctl config. Configuring is stored in $XDG_CONFIG_HOME/doctl. On Unix, if
+// RunAuthInit initializes the doctl config. Configuration is stored in $XDG_CONFIG_HOME/doctl. On Unix, if
 // XDG_CONFIG_HOME is not set, use $HOME/.config. On Windows use %APPDATA%/doctl/config.
 func RunAuthInit(c *CmdConfig) error {
 	in, err := retrieveUserTokenFunc()
 	if err != nil {
-		return errors.New("unable to read input")
+		return fmt.Errorf("unable to read DigitalOcean access token: %s", err)
 	}
 
 	token := strings.TrimSpace(in)
@@ -91,7 +91,7 @@ func RunAuthInit(c *CmdConfig) error {
 	if _, err := c.Account().Get(); err != nil {
 		fmt.Fprintln(c.Out, "invalid token")
 		fmt.Fprintln(c.Out)
-		return errors.New("unable to use supplied token to access API")
+		return fmt.Errorf("unable to use supplied token to access API: %s", err)
 	}
 
 	fmt.Fprintln(c.Out, "OK")

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -14,228 +14,49 @@ limitations under the License.
 package commands
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"reflect"
+	"io"
 	"testing"
 
-	"github.com/bryanl/doit-server"
-	"github.com/gorilla/websocket"
+	"github.com/digitalocean/doctl/do"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthCommand(t *testing.T) {
 	cmd := Auth()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "login")
+	assertCommandNames(t, cmd, "init")
 }
 
-func TestAuth_retrieveCredentials(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ac := doitserver.AuthCredentials{ID: "abc", CS: "def"}
-		err := json.NewEncoder(w).Encode(&ac)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}))
-	defer ts.Close()
-
-	dsa := newDoitServerAuth()
-	dsa.url = ts.URL
-	ac, err := dsa.retrieveAuthCredentials()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedAC := &doitserver.AuthCredentials{ID: "abc", CS: "def"}
-	if got, want := ac, expectedAC; !reflect.DeepEqual(got, expectedAC) {
-		t.Fatalf("retrieveAuthCredentials() = %#v; got %#v", got, want)
-	}
-}
-
-func TestAuth_createAuthURL(t *testing.T) {
-	dsa := newDoitServerAuth()
-	dsa.url = "http://example.com"
-
-	ac := &doitserver.AuthCredentials{
-		ID: "id",
-		CS: "cs",
-	}
-	u, err := dsa.createAuthURL(ac)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	newU, err := url.Parse(u)
-
-	if got, want := newU.Host, "example.com"; got != want {
-		t.Fatalf("createAuthURL() Host = %q, want = %q", got, want)
-	}
-
-	if got, want := newU.Path, "/auth/digitalocean"; got != want {
-		t.Fatalf("createAuthURL() Path = %q, want = %q", got, want)
-	}
-
-	q := newU.Query()
-
-	if got, want := q.Get("cs"), "cs"; got != want {
-		t.Fatalf("createAuthURL() cs param = %q, want = %q", got, want)
-	}
-
-	if got, want := q.Get("id"), "id"; got != want {
-		t.Fatalf("createAuthURL() id param = %q, want = %q", got, want)
-	}
-}
-
-func TestAuth_createAuthURL_with_keypairs(t *testing.T) {
-	dsa := newDoitServerAuth()
-	dsa.url = "http://example.com"
-	ac := &doitserver.AuthCredentials{
-		ID: "id",
-		CS: "cs",
-	}
-	u, err := dsa.createAuthURL(ac, keyPair{k: "foo", v: "bar"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	newU, err := url.Parse(u)
-
-	if got, want := newU.Host, "example.com"; got != want {
-		t.Fatalf("createAuthURL() Host = %q, want = %q", got, want)
-	}
-
-	if got, want := newU.Path, "/auth/digitalocean"; got != want {
-		t.Fatalf("createAuthURL() Path = %q, want = %q", got, want)
-	}
-
-	q := newU.Query()
-
-	if got, want := q.Get("cs"), "cs"; got != want {
-		t.Fatalf("createAuthURL() cs param = %q, want = %q", got, want)
-	}
-
-	if got, want := q.Get("id"), "id"; got != want {
-		t.Fatalf("createAuthURL() id param = %q, want = %q", got, want)
-	}
-
-	if got, want := q.Get("foo"), "bar"; got != want {
-		t.Fatalf("createAuthURL() foo param = %q, want = %q", got, want)
-	}
-}
-
-func TestAuth_initAuthCLI(t *testing.T) {
-	ogRUTF := retrieveUserTokenFunc
+func TestAuthInit(t *testing.T) {
+	rtf := retrieveUserTokenFunc
+	cfw := cfgFileWriter
 	defer func() {
-		retrieveUserTokenFunc = ogRUTF
+		retrieveUserTokenFunc = rtf
+		cfgFileWriter = cfw
 	}()
 
 	retrieveUserTokenFunc = func() (string, error) {
-		return "token", nil
+		return "valid-token", nil
 	}
 
-	dsa := newDoitServerAuth()
+	cfgFileWriter = func() (io.WriteCloser, error) { return &discardCloser{}, nil }
 
-	ac := &doitserver.AuthCredentials{
-		ID: "id",
-		CS: "cs",
-	}
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.account.On("Get").Return(&do.Account{}, nil)
 
-	done := make(chan struct{})
-
-	go func() {
-		defer close(done)
-		s, err := dsa.initAuthCLI(ac)
-		if err != nil {
-			t.Fatalf("initAuthCLI() unexpected error: %v", err)
-		}
-
-		if got, want := s, "token"; got != want {
-			t.Fatalf("initAuthCLI() = %q; want = %q", got, want)
-		}
-	}()
-
-	<-done
+		err := RunAuthInit(config)
+		assert.NoError(t, err)
+	})
 }
 
-func TestAuth_initAuth(t *testing.T) {
-	dsa := newDoitServerAuth()
-	dsa.url = "http://example.com"
-	dsa.browserOpen = func(u string) error {
-		return nil
-	}
-	dsa.monitorAuth = func(u string, ac *doitserver.AuthCredentials) (*doitserver.TokenResponse, error) {
-		return &doitserver.TokenResponse{
-			AccessToken: "access-token",
-		}, nil
-	}
-	ac := &doitserver.AuthCredentials{
-		ID: "id",
-		CS: "cs",
-	}
+type discardCloser struct{}
 
-	token, err := dsa.initAuth(ac)
-	if err != nil && err != ErrUnknownTerminal {
-		t.Fatalf("initAuth() unexpected error: %v", err)
-	} else if err == ErrUnknownTerminal {
-		return
-	}
+var _ io.WriteCloser = (*discardCloser)(nil)
 
-	if got, want := token, "access-token"; got != want {
-		t.Fatalf("initAuth() token = %q; want = %q", got, want)
-	}
+func (d *discardCloser) Write(p []byte) (n int, err error) {
+	return len(p), nil
 }
 
-func TestAuth_monitorAuthWS(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upgrader := websocket.Upgrader{}
-		ws, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			t.Fatalf("websocket upgrade error: %v", err)
-		}
-
-		var readAC doitserver.AuthCredentials
-		err = ws.ReadJSON(&readAC)
-		if err != nil {
-			t.Fatalf("read auth credentials error: %v", err)
-		}
-
-		if got, want := readAC.CS, "cs"; got != want {
-			t.Fatalf("server AuthCredentials CS = %q; want = %q", got, want)
-		}
-
-		if got, want := readAC.ID, "id"; got != want {
-			t.Fatalf("server AuthCredentials ID = %q; want = %q", got, want)
-		}
-
-		writeTR := doitserver.TokenResponse{
-			AccessToken: "access-token",
-		}
-
-		err = ws.WriteJSON(&writeTR)
-		if err != nil {
-			t.Fatalf("write token respose error: %v", err)
-		}
-
-		err = ws.Close()
-		if err != nil {
-			t.Fatalf("websock close: %v", err)
-		}
-	}))
-
-	ac := &doitserver.AuthCredentials{
-		ID: "id",
-		CS: "cs",
-	}
-
-	tr, err := monitorAuthWS(ts.URL, ac)
-	if err != nil {
-		t.Fatalf("monitorAuthWS() unexpected error: %v", err)
-	}
-
-	if got, want := tr.AccessToken, "access-token"; got != want {
-		t.Fatalf("monitorAuthWS() AccessToken = %q; want = %q", got, want)
-	}
+func (d *discardCloser) Close() error {
+	return nil
 }

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -15,6 +15,7 @@ package commands
 
 import (
 	"io"
+	"io/ioutil"
 	"testing"
 
 	"github.com/digitalocean/doctl/do"
@@ -39,7 +40,7 @@ func TestAuthInit(t *testing.T) {
 		return "valid-token", nil
 	}
 
-	cfgFileWriter = func() (io.WriteCloser, error) { return &discardCloser{}, nil }
+	cfgFileWriter = func() (io.WriteCloser, error) { return &nopWriteCloser{Writer: ioutil.Discard}, nil }
 
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.account.On("Get").Return(&do.Account{}, nil)
@@ -49,14 +50,12 @@ func TestAuthInit(t *testing.T) {
 	})
 }
 
-type discardCloser struct{}
-
-var _ io.WriteCloser = (*discardCloser)(nil)
-
-func (d *discardCloser) Write(p []byte) (n int, err error) {
-	return len(p), nil
+type nopWriteCloser struct {
+	io.Writer
 }
 
-func (d *discardCloser) Close() error {
+var _ io.WriteCloser = (*nopWriteCloser)(nil)
+
+func (d *nopWriteCloser) Close() error {
 	return nil
 }

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -160,6 +160,9 @@ func withTestClient(t *testing.T, tFn testFn) {
 		Doit: cfg,
 		Out:  ioutil.Discard,
 
+		// can stub this out, since the return is dictated by the mocks.
+		initServices: func(c *CmdConfig) error { return nil },
+
 		Keys:              func() do.KeysService { return &tm.keys },
 		Sizes:             func() do.SizesService { return &tm.sizes },
 		Regions:           func() do.RegionsService { return &tm.regions },

--- a/commands/errors.go
+++ b/commands/errors.go
@@ -33,6 +33,10 @@ var (
 	}
 )
 
+func init() {
+	color.Output = os.Stderr
+}
+
 type outputErrors struct {
 	Errors []outputError `json:"errors"`
 }
@@ -69,5 +73,5 @@ func checkErr(err error, cmd ...*cobra.Command) {
 }
 
 func warn(msg string) {
-	fmt.Fprintf(color.Output, "%s: %s\n", colorWarn, msg)
+	fmt.Fprintf(color.Output, "%s: %s\n\n", colorWarn, msg)
 }

--- a/commands/xdg.go
+++ b/commands/xdg.go
@@ -1,0 +1,39 @@
+// Copyright 2016 The Doctl Authors All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func configHome() string {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		configHome = filepath.Join(homeDir(), ".config", "doctl")
+	}
+
+	return configHome
+}
+
+func legacyConfigCheck() {
+	fi, err := os.Stat(cfgFile)
+	expectedPerms := os.FileMode(0600)
+	if err == nil && fi.Mode() != expectedPerms {
+		msg := fmt.Sprintf("Configuration %q permissions are %#o. Should be set to %#o",
+			cfgFile, fi.Mode(), expectedPerms)
+		warn(msg)
+	}
+}

--- a/commands/xdg_windows.go
+++ b/commands/xdg_windows.go
@@ -1,0 +1,35 @@
+// Copyright 2016 The Doctl Authors All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func configHome() string {
+	// is this even a thing on windows?
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		userName := os.Getenv("USERNAME")
+		configHome = filepath.Join("C:/", "Users", userName, "AppData", "Local", "doctl", "config")
+	}
+
+	return configHome
+}
+
+// legacyConfigCheck is a no-op on windows since go doesn't have a chmod
+// on this platform.
+func legacyConfigCheck() {
+}

--- a/commands/xdg_windows_test.go
+++ b/commands/xdg_windows_test.go
@@ -1,0 +1,30 @@
+// Copyright 2016 The Doctl Authors All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package commands
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigHome(t *testing.T) {
+	os.Setenv("USERNAME", "testuser")
+	defer os.Unsetenv("USERNAME")
+
+	ch := configHome()
+	expected := `C:\Users\testuser\AppData\Local\doctl\config`
+	assert.Equal(t, expected, ch)
+}

--- a/do/account.go
+++ b/do/account.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2016 The Doctl Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,11 @@ limitations under the License.
 
 package do
 
-import "github.com/digitalocean/godo"
+import (
+	"fmt"
+
+	"github.com/digitalocean/godo"
+)
 
 // Account is a wrapper for godo.Account.
 type Account struct {
@@ -46,6 +49,7 @@ func NewAccountService(godoClient *godo.Client) AccountService {
 }
 
 func (as *accountService) Get() (*Account, error) {
+	fmt.Printf("as: %#v\n", as)
 	godoAccount, _, err := as.client.Account.Get()
 	if err != nil {
 		return nil, err

--- a/do/account.go
+++ b/do/account.go
@@ -13,11 +13,7 @@ limitations under the License.
 
 package do
 
-import (
-	"fmt"
-
-	"github.com/digitalocean/godo"
-)
+import "github.com/digitalocean/godo"
 
 // Account is a wrapper for godo.Account.
 type Account struct {
@@ -49,7 +45,6 @@ func NewAccountService(godoClient *godo.Client) AccountService {
 }
 
 func (as *accountService) Get() (*Account, error) {
-	fmt.Printf("as: %#v\n", as)
 	godoAccount, _, err := as.client.Account.Get()
 	if err != nil {
 		return nil, err

--- a/do/sshkeys.go
+++ b/do/sshkeys.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2016 The Doctl Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/doit.go
+++ b/doit.go
@@ -173,7 +173,7 @@ var _ Config = &LiveConfig{}
 func (c *LiveConfig) GetGodoClient(trace bool) (*godo.Client, error) {
 	token := viper.GetString("access-token")
 	if token == "" {
-		return nil, fmt.Errorf("access token is required")
+		return nil, fmt.Errorf("access token is required. (hint: run 'doctl auth init')")
 	}
 
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})

--- a/doit.go
+++ b/doit.go
@@ -171,16 +171,12 @@ var _ Config = &LiveConfig{}
 
 // GetGodoClient returns a GodoClient.
 func (c *LiveConfig) GetGodoClient(trace bool) (*godo.Client, error) {
-	if c.godoClient != nil {
-		return c.godoClient, nil
-	}
-
 	token := viper.GetString("access-token")
 	if token == "" {
 		return nil, fmt.Errorf("access token is required")
 	}
 
-	tokenSource := &TokenSource{AccessToken: token}
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	oauthClient := oauth2.NewClient(oauth2.NoContext, tokenSource)
 
 	if trace {

--- a/util.go
+++ b/util.go
@@ -13,15 +13,7 @@ limitations under the License.
 
 package doctl
 
-import (
-	"github.com/digitalocean/doctl/pkg/runner"
-	"golang.org/x/oauth2"
-)
-
-// TokenSource holds an oauth token.
-type TokenSource struct {
-	AccessToken string
-}
+import "github.com/digitalocean/doctl/pkg/runner"
 
 // MockRunner is an implemenation of Runner for mocking.
 type MockRunner struct {
@@ -33,11 +25,4 @@ var _ runner.Runner = &MockRunner{}
 // Run mock runs things.
 func (tr *MockRunner) Run() error {
 	return tr.Err
-}
-
-// Token returns an oauth token.
-func (t *TokenSource) Token() (*oauth2.Token, error) {
-	return &oauth2.Token{
-		AccessToken: t.AccessToken,
-	}, nil
 }


### PR DESCRIPTION
Introduces `dolt auth init` command which replaces `dolt auth login`.

Instead of trying to fetch the token from the API, the user will have to manually enter it instead.

Also moves the default configuration location to `$XDG_CONFIG_HOME/doctl/doctlcfg`. On Windows, the default location is `%APPDATA%/doctl/config` and on other platform without the environment variable set, it will look in `$HOME/.config/doctl`. 

If the legacy location is detected, a warning will be displayed.

Fixes #59 
Fixes #94