### PR TITLE
Allow untagging droplets

### DIFF
--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -94,7 +94,7 @@ func Droplet() *Command {
 
 	cmdRunDropletUntag := CmdBuilder(cmd, RunDropletUntag, "untag <droplet id or name>", "untag", Writer,
 		docCategories("droplet"))
-	AddStringSliceFlag(cmdRunDropletUntag, doctl.ArgDropletName, []string{}, "Droplet names")
+	AddStringSliceFlag(cmdRunDropletUntag, doctl.ArgTagName, []string{}, "tag names")
 
 	return cmd
 }
@@ -110,6 +110,9 @@ func RunDropletActions(c *CmdConfig) error {
 	}
 
 	list, err := ds.Actions(id)
+	if err != nil {
+		return err
+	}
 	item := &action{actions: list}
 	return c.Display(item)
 }
@@ -198,13 +201,16 @@ func RunDropletCreate(c *CmdConfig) error {
 		return err
 	}
 
-	var createImage godo.DropletCreateImage
-
 	imageStr, err := c.Doit.GetString(c.NS, doctl.ArgImage)
-	if i, err := strconv.Atoi(imageStr); err == nil {
+	if err != nil {
+		return err
+	}
+
+	createImage := godo.DropletCreateImage{Slug: imageStr}
+
+	i, err := strconv.Atoi(imageStr)
+	if err == nil {
 		createImage = godo.DropletCreateImage{ID: i}
-	} else {
-		createImage = godo.DropletCreateImage{Slug: imageStr}
 	}
 
 	wait, err := c.Doit.GetBool(c.NS, doctl.ArgCommandWait)
@@ -306,13 +312,13 @@ func RunDropletUntag(c *CmdConfig) error {
 	ds := c.Droplets()
 	ts := c.Tags()
 
-	if len(c.Args) != 1 {
+	if len(c.Args) < 1 {
 		return doctl.NewMissingArgsErr(c.NS)
 	}
 
-	tagName := c.Args[0]
+	dropletIDStrs := c.Args
 
-	dropletIDStrs, err := c.Doit.GetStringSlice(c.NS, doctl.ArgDropletName)
+	tagNames, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTagName)
 	if err != nil {
 		return err
 	}
@@ -321,15 +327,22 @@ func RunDropletUntag(c *CmdConfig) error {
 		urr := &godo.UntagResourcesRequest{}
 
 		for _, id := range ids {
-			r := godo.Resource{
-				ID:   strconv.Itoa(id),
-				Type: godo.DropletResourceType,
-			}
+			for _, tagName := range tagNames {
+				r := godo.Resource{
+					ID:   strconv.Itoa(id),
+					Type: godo.DropletResourceType,
+				}
 
-			urr.Resources = append(urr.Resources, r)
+				urr.Resources = append(urr.Resources, r)
+
+				err := ts.UntagResources(tagName, urr)
+				if err != nil {
+					return err
+				}
+			}
 		}
 
-		return ts.UntagResources(tagName, urr)
+		return nil
 	}
 
 	return matchDroplets(dropletIDStrs, ds, fn)
@@ -338,23 +351,16 @@ func RunDropletUntag(c *CmdConfig) error {
 func extractSSHKeys(keys []string) []godo.DropletCreateSSHKey {
 	sshKeys := []godo.DropletCreateSSHKey{}
 
-	for _, rawKey := range keys {
-		rawKey = strings.TrimPrefix(rawKey, "[")
-		rawKey = strings.TrimSuffix(rawKey, "]")
-
-		keys := strings.Split(rawKey, ",")
-
-		for _, k := range keys {
-			if i, err := strconv.Atoi(k); err == nil {
-				if i > 0 {
-					sshKeys = append(sshKeys, godo.DropletCreateSSHKey{ID: i})
-				}
-				continue
+	for _, k := range keys {
+		if i, err := strconv.Atoi(k); err == nil {
+			if i > 0 {
+				sshKeys = append(sshKeys, godo.DropletCreateSSHKey{ID: i})
 			}
+			continue
+		}
 
-			if k != "" {
-				sshKeys = append(sshKeys, godo.DropletCreateSSHKey{Fingerprint: k})
-			}
+		if k != "" {
+			sshKeys = append(sshKeys, godo.DropletCreateSSHKey{Fingerprint: k})
 		}
 	}
 
@@ -375,24 +381,19 @@ func extractUserData(userData, filename string) (string, error) {
 
 func extractVolumes(volumeList []string) []godo.DropletCreateVolume {
 	var volumes []godo.DropletCreateVolume
-	for _, rawVolume := range volumeList {
-		rawVolume = strings.TrimPrefix(rawVolume, "[")
-		rawVolume = strings.TrimSuffix(rawVolume, "]")
 
-		list := strings.Split(rawVolume, ",")
-		for _, v := range list {
-			if v == "" {
-				continue
-			}
-			var req godo.DropletCreateVolume
-			if uuid.Parse(v) != nil {
-				req.ID = v
-			} else {
-				req.Name = v
-			}
-			volumes = append(volumes, req)
+	fmt.Printf("extracting volumes from %#v\n", volumeList)
+
+	for _, v := range volumeList {
+		var req godo.DropletCreateVolume
+		if uuid.Parse(v) != nil {
+			req.ID = v
+		} else {
+			req.Name = v
 		}
+		volumes = append(volumes, req)
 	}
+
 	return volumes
 }
 

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package commands
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 
@@ -88,7 +87,7 @@ func TestDropletCreate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgSizeSlug, "1gb")
 		config.Doit.Set(config.NS, doctl.ArgImage, "image")
 		config.Doit.Set(config.NS, doctl.ArgUserData, "#cloud-config")
-		config.Doit.Set(config.NS, doctl.ArgVolumeList, fmt.Sprintf("[test-volume, %s]", volumeUUID))
+		config.Doit.Set(config.NS, doctl.ArgVolumeList, []string{"test-volume", volumeUUID})
 
 		err := RunDropletCreate(config)
 		assert.NoError(t, err)
@@ -360,8 +359,8 @@ func TestDropletsUntag(t *testing.T) {
 		tm.tags.On("UntagResources", "my-tag", urr).Return(nil)
 		tm.droplets.On("List").Return(testDropletList, nil)
 
-		config.Args = append(config.Args, "my-tag")
-		config.Doit.Set(config.NS, doctl.ArgDropletName, testDroplet.Name)
+		config.Args = []string{testDroplet.Name}
+		config.Doit.Set(config.NS, doctl.ArgTagName, "my-tag")
 
 		err := RunDropletUntag(config)
 		assert.NoError(t, err)
@@ -370,29 +369,29 @@ func TestDropletsUntag(t *testing.T) {
 
 func Test_extractSSHKey(t *testing.T) {
 	cases := []struct {
-		in       string
+		in       []string
 		expected []godo.DropletCreateSSHKey
 	}{
 		{
-			in:       "1",
+			in:       []string{"1"},
 			expected: []godo.DropletCreateSSHKey{{ID: 1}},
 		},
 		{
-			in:       "fingerprint",
+			in:       []string{"fingerprint"},
 			expected: []godo.DropletCreateSSHKey{{Fingerprint: "fingerprint"}},
 		},
 		{
-			in:       "1,2",
+			in:       []string{"1", "2"},
 			expected: []godo.DropletCreateSSHKey{{ID: 1}, {ID: 2}},
 		},
 		{
-			in:       "1,fingerprint",
+			in:       []string{"1", "fingerprint"},
 			expected: []godo.DropletCreateSSHKey{{ID: 1}, {Fingerprint: "fingerprint"}},
 		},
 	}
 
 	for _, c := range cases {
-		got := extractSSHKeys([]string{fmt.Sprintf("[%s]", c.in)})
+		got := extractSSHKeys(c.in)
 		assert.Equal(t, c.expected, got)
 	}
 }

--- a/doit.go
+++ b/doit.go
@@ -275,5 +275,21 @@ func (c *LiveConfig) GetStringSlice(ns, key string) ([]string, error) {
 		}
 	}
 
-	return viper.GetStringSlice(nskey), nil
+	out := []string{}
+	for _, item := range viper.GetStringSlice(nskey) {
+
+		item = strings.TrimPrefix(item, "[")
+		item = strings.TrimSuffix(item, "]")
+
+		list := strings.Split(item, ",")
+		for _, str := range list {
+			if str == "" {
+				continue
+			}
+
+			out = append(out, str)
+		}
+	}
+
+	return out, nil
 }


### PR DESCRIPTION
* Change command for untagging to `doctl compute untag <droplet id or
name> [droplet id or name] —tag-name foo`
* Catch broken pflags earlier in the chain, so string slice fetching
works sanely

fixes: #119 