### PR TITLE
Update README.md with latest Release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ You can download the archive from your browser, or copy its URL and retrieve it 
 cd ~
 
 # OS X
-curl -L https://github.com/digitalocean/doctl/releases/download/v1.3.1/doctl-1.3.1-darwin-10.6-amd64.tar.gz | tar xz
+curl -L https://github.com/digitalocean/doctl/releases/download/v1.4.0/doctl-1.4.0-darwin-10.6-amd64.tar.gz | tar xz
 
 # linux (with wget)
-wget -qO- https://github.com/digitalocean/doctl/releases/download/v1.3.1/doctl-1.3.1-linux-amd64.tar.gz  | tar xz
+wget -qO- https://github.com/digitalocean/doctl/releases/download/v1.4.0/doctl-1.4.0-linux-amd64.tar.gz  | tar xz
 # linux (with curl)
-curl -L https://github.com/digitalocean/doctl/releases/download/v1.3.1/doctl-1.3.1-linux-amd64.tar.gz  | tar xz
+curl -L https://github.com/digitalocean/doctl/releases/download/v1.4.0/doctl-1.4.0-linux-amd64.tar.gz  | tar xz
 ```
 
 Move the `doctl` binary to somewhere in your path.  For example:


### PR DESCRIPTION
This is result of bug report #131

Myself I had problem using `doctl auth init` that would make me Auth my PC and DigitalOcean on easy way. 

As far as I noticed that feature is missing in v1.3.1.

Because I think some people will just copy link if they have OS X or Linux x64, it would not be bad to update links in README.md.
This could be applied to [DigitalOcean Community Tutorial](https://www.digitalocean.com/community/tutorials/how-to-use-doctl-the-official-digitalocean-command-line-client) too