### PR TITLE
Change default config location from $HOME/.doctlcfg to $HOME/.config/doctl/config.yaml

### DIFF
--- a/commands/doit.go
+++ b/commands/doit.go
@@ -73,7 +73,7 @@ var ErrNoAccessToken = errors.New("no access token has been configured")
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	DoitCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.doctlcfg)")
+	DoitCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.config/doctl/config.yaml)")
 	DoitCmd.PersistentFlags().StringVarP(&Token, "access-token", "t", "", "API V2 Access Token")
 	DoitCmd.PersistentFlags().StringVarP(&Output, "output", "o", "text", "output format [text|json]")
 	DoitCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")


### PR DESCRIPTION
When you type doctl in your terminal, this will fire up:
```
doctl is a command line interface for the DigitalOcean API.

Usage:
  doctl [command]

Available Commands:
  account     account commands
  auth        auth commands
  compute     compute commands
  version     show the current version

Flags:
  -t, --access-token string   API V2 Access Token
  -c, --config string         config file (default is $HOME/.doctlcfg)
  -h, --help                  help for doctl
  -o, --output string         output format [text|json] (default "text")
      --trace                 trace api access
  -v, --verbose               verbose output

Use "doctl [command] --help" for more information about a command.
```

Opening `$HOME/.doctlcfg` in your favorite text editor will open empty/no-existing file.
Writing anything in it, and executing `doctl` will show this:
`Warning: Configuration detected at "/home/mudri/.doctlcfg". Please move .doctlcfg to /home/mudri/.config/doctl/config.yaml`.

If $HOME/.doctlcfg is getting deprecated and it by default uses $HOME/.config/doctl/config.yaml, mine idea is to change config file default from $HOME/.doctlcfg to $HOME/.config/doctl/config.yaml