### PR TITLE
Add snapcraft packaging.

### DIFF
--- a/parts/plugins/x-build-sh.yaml
+++ b/parts/plugins/x-build-sh.yaml
@@ -1,0 +1,6 @@
+options:
+    source:
+        required: true
+    source-type:
+    source-tag:
+    source-branch:

--- a/parts/plugins/x_build_sh.py
+++ b/parts/plugins/x_build_sh.py
@@ -1,0 +1,14 @@
+import os
+import shutil
+import snapcraft
+
+class DoctlBuildPlugin(snapcraft.BasePlugin):
+
+    def __init__(self, name, options, project):
+        super().__init__(name, options, project)
+
+    def build(self):
+        result = self.run([os.path.join(self.sourcedir, 'scripts/build.sh')])
+        shutil.move(os.path.join(self.sourcedir, "out"), self.installdir)
+        return result
+            

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: doctl
+version: 0
+summary: A command line tool for DigitalOcean services
+description: doctl is a command line interface for the DigitalOcean API.
+confinement: strict
+
+apps:
+    doctl:
+        command: bin/doctl
+        plugs:
+            - network
+ 
+parts:
+    doctl-build:
+        plugin: x-build-sh
+        source: .
+        organize:
+            out/doctl: bin/doctl


### PR DESCRIPTION
This patch adds [snap](http://snapcraft.io/) packaging for the doctl command. A custom plugin is used to invoke the build.sh script.

To build the snap, with [snapcraft installed](http://snapcraft.io/create/), just run
`snapcraft`.

If this looks useful, I'd be happy to assist with
[publishing](https://snapcraft.io/docs/build-snaps/publish) the snap.