### PR TITLE
Add snap package creation script

### DIFF
--- a/scripts/snap.sh
+++ b/scripts/snap.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+OUT_DIR="$DIR/../out"
+
+# Build the package
+/bin/bash build.sh
+
+# Create the package
+version="$(git rev-parse --short HEAD)"
+sed -i "s/edge/$version/g" snapcraft.yaml
+
+cp $OUT_DIR/doctl .
+snapcraft
+
+# Clean temp stuff
+snapcraft clean
+

--- a/scripts/snapcraft.yaml
+++ b/scripts/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: doctl
+version: edge
+confinement: strict
+summary: DigitalOcean's command line interface for the API
+description: doctl is a command line interface for the DigitalOcean API. Use "doctl [command] --help" for more information about a command.
+
+apps:
+  doctl:
+    command: doctl
+    plugs: [network, network-bind]
+
+parts:
+  doctl:
+    plugin: nil
+
+    organize: 
+        ../../../doctl: doctl


### PR DESCRIPTION
The PR shows that is easy to integrate (snap) package creation in DigitalOcean workflow:
- I mean, if one can run your 'build.sh' script, he/she can also run the new 'snap.sh'.
- **Everything works as usual**. Only IF desired one can create a package. 
- Naturally, the packaging tool has to be installed (on Ubuntu, easy as sudo apt-get install snapcraft).

See #136 

*****
In fact, anyone can do something like this to create now an stable package. 
```
$ cd /tmp
$ wget https://raw.githubusercontent.com/claudioandre/doctl/a7b070dac1c39b1873c0dbf3c3cc0d96cc06040a/scripts/snapcraft.yaml # using mine since it is not merged.
$ wget -qO- https://github.com/digitalocean/doctl/releases/download/v1.4.0/doctl-1.4.0-linux-amd64.tar.gz  | tar xz
$ snapcraft
```

And you will have a '.snap' package in the current directory. 
