### PR TITLE
Add the option to run doctl within a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.4
+
+ENV DOCTL_VERSION=1.4.0
+
+RUN apk add --update curl && \
+    rm -rf /var/cache/apk/*
+
+RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+
+WORKDIR /app
+
+RUN curl -L https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz  | tar xz
+
+ENTRYPOINT ["./doctl"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ Alternatively, if you have a Go environment configured, you can install the deve
 go get github.com/digitalocean/doctl/cmd/doctl
 ```
 
+### Option 4 – Build with Docker
+
+If you have Docker installed, you can build with the Dockerfile a Docker image and run `doctl` within a Docker container.
+
+```
+# build Docker image
+docker build -t doctl .
+
+# usage
+docker run -e DIGITALOCEAN_ACCESS_TOKEN doctl <followed by doctl commands>
+```
+
 ## Initialization
 
 To use `doctl`, a DigitalOcean access token is required. [Generate](https://cloud.digitalocean.com/settings/api/tokens)


### PR DESCRIPTION
Hi,

I added a Dockerfile, so doctl can be used within a docker container. This can be useful if you are in a container environment, like CoreOS.