### PR TITLE
[Fixs #109] Adding confirmation on delete actions

### DIFF
--- a/args.go
+++ b/args.go
@@ -122,4 +122,7 @@ const (
 	ArgVolumeRegion = "region"
 	// ArgVolumeList is the IDs of many volumes.
 	ArgVolumeList = "volumes"
+
+	// ArgDeleteForce forces deletion actions
+	ArgDeleteForce = "force"
 )

--- a/commands/confirmation.go
+++ b/commands/confirmation.go
@@ -1,0 +1,23 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+)
+
+func askForConfirm(message string) bool {
+	var answer string
+	warn("Are you sure you want to " + message + " (y/N) ? ")
+	_, err := fmt.Scanln(&answer)
+	if err != nil {
+		return false
+	}
+	return verifyAnswer(answer)
+}
+
+func verifyAnswer(answer string) bool {
+	if strings.ToLower(answer) == "y" || strings.ToLower(answer) == "yes" {
+		return true
+	}
+	return false
+}

--- a/commands/confirmation.go
+++ b/commands/confirmation.go
@@ -2,17 +2,29 @@ package commands
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"strings"
 )
 
-func AskForConfirm(message string) bool {
+var retrieveUserInput = func(message string) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
 	warnConfirm("Are you sure you want to " + message + " (y/N) ? ")
 	answer, err := reader.ReadString('\n')
 	if err != nil {
-		return false
+		return "", err
 	}
-	answer = strings.ToLower(strings.Replace(answer, "\n", "", 1))
-	return answer == "y" || answer == "ye" || answer == "yes"
+	return strings.ToLower(strings.Replace(answer, "\n", "", 1)), nil
+}
+
+func AskForConfirm(message string) error {
+	answer, err := retrieveUserInput(message)
+	if err != nil {
+		return fmt.Errorf("unable to parse users input: %s", err)
+	}
+	if answer == "y" || answer == "ye" || answer == "yes" {
+		return nil
+	} else {
+		return fmt.Errorf("invaild user input")
+	}
 }

--- a/commands/confirmation.go
+++ b/commands/confirmation.go
@@ -1,23 +1,18 @@
 package commands
 
 import (
-	"fmt"
+	"bufio"
+	"os"
 	"strings"
 )
 
-func askForConfirm(message string) bool {
-	var answer string
-	warn("Are you sure you want to " + message + " (y/N) ? ")
-	_, err := fmt.Scanln(&answer)
+func AskForConfirm(message string) bool {
+	reader := bufio.NewReader(os.Stdin)
+	warnConfirm("Are you sure you want to " + message + " (y/N) ? ")
+	answer, err := reader.ReadString('\n')
 	if err != nil {
 		return false
 	}
-	return verifyAnswer(answer)
-}
-
-func verifyAnswer(answer string) bool {
-	if strings.ToLower(answer) == "y" || strings.ToLower(answer) == "yes" {
-		return true
-	}
-	return false
+	answer = strings.ToLower(strings.Replace(answer, "\n", "", 1))
+	return answer == "y" || answer == "ye" || answer == "yes"
 }

--- a/commands/confirmation_test.go
+++ b/commands/confirmation_test.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAskForConfirmYes(t *testing.T) {
+	rui := retrieveUserInput
+	defer func() {
+		retrieveUserInput = rui
+	}()
+
+	retrieveUserInput = func(string) (string, error) {
+		return "yes", nil
+	}
+
+	err := AskForConfirm("test")
+	assert.NoError(t, err)
+}
+
+func TestAskForConfirmNo(t *testing.T) {
+	rui := retrieveUserInput
+	defer func() {
+		retrieveUserInput = rui
+	}()
+
+	retrieveUserInput = func(string) (string, error) {
+		return "no", nil
+	}
+
+	err := AskForConfirm("test")
+	assert.Error(t, err)
+}
+
+func TestAskForConfirmAny(t *testing.T) {
+	rui := retrieveUserInput
+	defer func() {
+		retrieveUserInput = rui
+	}()
+
+	retrieveUserInput = func(string) (string, error) {
+		return "some-random-message", nil
+	}
+
+	err := AskForConfirm("test")
+	assert.Error(t, err)
+}
+
+func TestAskForConfirmError(t *testing.T) {
+	rui := retrieveUserInput
+	defer func() {
+		retrieveUserInput = rui
+	}()
+
+	retrieveUserInput = func(string) (string, error) {
+		return "", fmt.Errorf("test-error")
+	}
+
+	err := AskForConfirm("test")
+	assert.Error(t, err)
+}

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -53,9 +53,6 @@ var Output string
 // Verbose toggles verbose output.
 var Verbose bool
 
-// Force froces command execution.
-var Force bool
-
 var requiredColor = color.New(color.Bold, color.FgWhite).SprintfFunc()
 
 // Writer is where output should be written to.
@@ -80,7 +77,6 @@ func init() {
 	DoitCmd.PersistentFlags().StringVarP(&Token, "access-token", "t", "", "API V2 Access Token")
 	DoitCmd.PersistentFlags().StringVarP(&Output, "output", "o", "text", "output format [text|json]")
 	DoitCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
-	DoitCmd.PersistentFlags().BoolVarP(&Force, "force", "f", false, "force execution")
 	DoitCmd.PersistentFlags().BoolVarP(&Trace, "trace", "", false, "trace api access")
 
 	viper.SetEnvPrefix("DIGITALOCEAN")

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -53,6 +53,9 @@ var Output string
 // Verbose toggles verbose output.
 var Verbose bool
 
+// Force froces command execution.
+var Force bool
+
 var requiredColor = color.New(color.Bold, color.FgWhite).SprintfFunc()
 
 // Writer is where output should be written to.
@@ -77,6 +80,7 @@ func init() {
 	DoitCmd.PersistentFlags().StringVarP(&Token, "access-token", "t", "", "API V2 Access Token")
 	DoitCmd.PersistentFlags().StringVarP(&Output, "output", "o", "text", "output format [text|json]")
 	DoitCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+	DoitCmd.PersistentFlags().BoolVarP(&Force, "force", "f", false, "force execution")
 	DoitCmd.PersistentFlags().BoolVarP(&Trace, "trace", "", false, "trace api access")
 
 	viper.SetEnvPrefix("DIGITALOCEAN")

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -69,7 +69,7 @@ func Droplet() *Command {
 
 	cmdRunDropletDelete := CmdBuilder(cmd, RunDropletDelete, "delete ID [ID|Name ...]", "Delete droplet by id or name", Writer,
 		aliasOpt("d", "del", "rm"), docCategories("droplet"))
-	AddBoolFlag(cmdRunDropletDelete, doctl.ArgDeleteForce, false, "Froce droplet delete")
+	AddBoolFlag(cmdRunDropletDelete, doctl.ArgDeleteForce, false, "Force droplet delete")
 
 	CmdBuilder(cmd, RunDropletGet, "get", "get droplet", Writer,
 		aliasOpt("g"), displayerType(&droplet{}), docCategories("droplet"))

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -267,7 +267,7 @@ func RunDropletCreate(c *CmdConfig) error {
 
 	wg.Wait()
 	close(errs)
-	
+
 	item := &droplet{droplets: createdList}
 	c.Display(item)
 
@@ -434,20 +434,31 @@ func RunDropletDelete(c *CmdConfig) error {
 	} else if len(c.Args) > 0 && tagName != "" {
 		return fmt.Errorf("please specify droplets identifiers or a tag name")
 	} else if tagName != "" {
-		return ds.DeleteByTag(tagName)
-	}
-
-	fn := func(ids []int) error {
-		for _, id := range ids {
-			if err := ds.Delete(id); err != nil {
-				return fmt.Errorf("unable to delete droplet %d: %v", id, err)
-			}
+		if Force || askForConfirm("delete droplet by \""+tagName+"\" tag") {
+			return ds.DeleteByTag(tagName)
+		} else {
+			return fmt.Errorf("Operation aborted.")
 		}
-
 		return nil
 	}
 
-	return matchDroplets(c.Args, ds, fn)
+	if Force || askForConfirm("delete droplet(s)") {
+
+		fn := func(ids []int) error {
+			for _, id := range ids {
+				if err := ds.Delete(id); err != nil {
+					return fmt.Errorf("unable to delete droplet %d: %v", id, err)
+				}
+			}
+			return nil
+		}
+		return matchDroplets(c.Args, ds, fn)
+	} else {
+		return fmt.Errorf("Operation aborted.")
+	}
+
+	return nil
+
 }
 
 type matchDropletsFn func(ids []int) error

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -434,7 +434,7 @@ func RunDropletDelete(c *CmdConfig) error {
 	} else if len(c.Args) > 0 && tagName != "" {
 		return fmt.Errorf("please specify droplets identifiers or a tag name")
 	} else if tagName != "" {
-		if Force || askForConfirm("delete droplet by \""+tagName+"\" tag") {
+		if Force || AskForConfirm("delete droplet by \""+tagName+"\" tag") {
 			return ds.DeleteByTag(tagName)
 		} else {
 			return fmt.Errorf("Operation aborted.")
@@ -442,7 +442,7 @@ func RunDropletDelete(c *CmdConfig) error {
 		return nil
 	}
 
-	if Force || askForConfirm("delete droplet(s)") {
+	if Force || AskForConfirm("delete droplet(s)") {
 
 		fn := func(ids []int) error {
 			for _, id := range ids {

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -434,7 +434,7 @@ func RunDropletDelete(c *CmdConfig) error {
 	} else if len(c.Args) > 0 && tagName != "" {
 		return fmt.Errorf("please specify droplets identifiers or a tag name")
 	} else if tagName != "" {
-		if Force || AskForConfirm("delete droplet by \""+tagName+"\" tag") {
+		if Force || AskForConfirm("delete droplet by \""+tagName+"\" tag") == nil {
 			return ds.DeleteByTag(tagName)
 		} else {
 			return fmt.Errorf("Operation aborted.")
@@ -442,7 +442,7 @@ func RunDropletDelete(c *CmdConfig) error {
 		return nil
 	}
 
-	if Force || AskForConfirm("delete droplet(s)") {
+	if Force || AskForConfirm("delete droplet(s)") == nil {
 
 		fn := func(ids []int) error {
 			for _, id := range ids {

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -140,10 +140,12 @@ func TestDropletDelete(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.droplets.On("Delete", 1).Return(nil)
 
+		Force = true
 		config.Args = append(config.Args, strconv.Itoa(testDroplet.ID))
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)
+
 	})
 }
 
@@ -151,6 +153,7 @@ func TestDropletDeleteByTag(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.droplets.On("DeleteByTag", "my-tag").Return(nil)
 
+		Force = true
 		config.Doit.Set(config.NS, doctl.ArgTagName, "my-tag")
 
 		err := RunDropletDelete(config)
@@ -163,6 +166,7 @@ func TestDropletDeleteRepeatedID(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.droplets.On("Delete", 1).Return(nil).Once()
 
+		Force = true
 		id := strconv.Itoa(testDroplet.ID)
 		config.Args = append(config.Args, id, id)
 
@@ -206,6 +210,7 @@ func TestDropletDelete_MixedNameAndType(t *testing.T) {
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)
+		Force = false
 	})
 
 }

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -140,8 +140,8 @@ func TestDropletDelete(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.droplets.On("Delete", 1).Return(nil)
 
-		Force = true
 		config.Args = append(config.Args, strconv.Itoa(testDroplet.ID))
+		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)
@@ -153,8 +153,8 @@ func TestDropletDeleteByTag(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.droplets.On("DeleteByTag", "my-tag").Return(nil)
 
-		Force = true
 		config.Doit.Set(config.NS, doctl.ArgTagName, "my-tag")
+		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)
@@ -166,9 +166,9 @@ func TestDropletDeleteRepeatedID(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.droplets.On("Delete", 1).Return(nil).Once()
 
-		Force = true
 		id := strconv.Itoa(testDroplet.ID)
 		config.Args = append(config.Args, id, id)
+		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)
@@ -181,6 +181,7 @@ func TestDropletDeleteByName(t *testing.T) {
 		tm.droplets.On("Delete", 1).Return(nil)
 
 		config.Args = append(config.Args, testDroplet.Name)
+		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)
@@ -193,6 +194,7 @@ func TestDropletDeleteByName_Ambiguous(t *testing.T) {
 		tm.droplets.On("List").Return(list, nil)
 
 		config.Args = append(config.Args, testDroplet.Name)
+		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
 
 		err := RunDropletDelete(config)
 		t.Log(err)
@@ -207,10 +209,10 @@ func TestDropletDelete_MixedNameAndType(t *testing.T) {
 
 		id := strconv.Itoa(testDroplet.ID)
 		config.Args = append(config.Args, id, testDroplet.Name)
+		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)
-		Force = false
 	})
 
 }

--- a/commands/errors.go
+++ b/commands/errors.go
@@ -77,6 +77,9 @@ func checkErr(err error, cmd ...*cobra.Command) {
 func warn(msg string) {
 	fmt.Fprintf(color.Output, "%s: %s\n\n", colorWarn, msg)
 }
+func warnConfirm(msg string) {
+	fmt.Fprintf(color.Output, "%s: %s", colorWarn, msg)
+}
 
 func notice(msg string) {
 	fmt.Fprintf(color.Output, "%s: %s\n\n", colorNotice, msg)


### PR DESCRIPTION
Fixs #109 
Continues work from #110 
@bryanl I would like review if possible, in free time ofc. :D

# Adding confirmation on delete actions

This is basic yes/no confirmation. User need to answer `y`, `ye` or `yes`. For every other answer, command will be stopped.
For now it is only implemented for Droplet delete action.

List of done things that are working:
- [x] Created `confirmation.go` 
- [x] Added confirmation before Droplet delete (both on ID & Tag name)
- [x] Added local force flag
- [x] Added special function for improved output
- [x] Created test units for `confirmation.go`
- [x] Updated test units for `droplets.go`
- [x] Fixed Travis CI errors

Things could be done:
- [ ] Add confirmation on delete for other actions

## Explanation

First of all I created confirmation.go because of reusability. It would not be bad to extend it on volume delete, images delete, but this is something we will discuss later. Anyways I decided to make it reusable from beginning.

It is working like, you have to answer `y` or `yes` (case doesn't matters as I convert it to lower). If you answer anything other, operation will be aborted.

I added Force flag to `doit`, but I'm not sure is it right way, I would like some suggestion on this.