### PR TITLE
Fixed typos in README.md and domains.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ exists at the legacy location.
 ### Configuration OPTIONS
 
 * `access-token` - The DigitalOcean access token. You can generate a token in the
-[Apps & API](https://cloud.digitalocean.com/settings/applications) section of the DigitalOcean control panel or use
+[Apps & API](https://cloud.digitalocean.com/settings/api/tokens) section of the DigitalOcean control panel or use
 `doctl auth login`.
 * `output` - Type of output to display results in. Choices are `json` or `text`. If not supplied, `doctl` will default
  to `text`.
@@ -142,7 +142,7 @@ By default, it assumes you are using the `root` user. If you want to SSH as a sp
 ## Releasing
 
 To build `doctl` for all its platforms, run `script/build.sh <version>`. To upload `doctl` to Github,
-run `script/release.sh <version>`. A valid `GITHUB_TOKEN` environment variable with access to the `bryanl/doctl`
+run `script/release.sh <version>`. A valid `GITHUB_TOKEN` environment variable with access to the `digitalocean/doctl`
 repository is required.
 
 [tutorial]: https://www.digitalocean.com/community/tutorials/how-to-use-doctl-the-official-digitalocean-command-line-client

--- a/commands/domains.go
+++ b/commands/domains.go
@@ -46,7 +46,7 @@ func Domain() *Command {
 	CmdBuilder(cmd, RunDomainGet, "get <domain>", "get domain", Writer,
 		aliasOpt("g"), displayerType(&domain{}), docCategories("domain"))
 
-	CmdBuilder(cmd, RunDomainDelete, "delete <domain>", "delete droplet", Writer, aliasOpt("g"))
+	CmdBuilder(cmd, RunDomainDelete, "delete <domain>", "delete domain", Writer, aliasOpt("g"))
 
 	cmdRecord := &Command{
 		Command: &cobra.Command{


### PR DESCRIPTION
@bryanl I found some typos over project.
At `README.md` I updated link as old one redirects to this. 
Also I think project is now @ `digitalocean/doctl` instead of `bryanl/digitalocean`. Not sure is it indeed but I will revert back if it is really `bryanl/digitalocean`.

About `domains.go`, well it's really not droplet :D

Found something more but gonna make issue to ask something first