### PR TITLE
Ability to delete multiple snapshots and confirmation before delete

### DIFF
--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -30,7 +30,12 @@ var (
 		Slug:    "slug",
 		Regions: []string{"test0"},
 	}}
-	testImageList = do.Images{testImage}
+	testImageSecondary = do.Image{Image: &godo.Image{
+		ID:      2,
+		Slug:    "slug-secondary",
+		Regions: []string{"test0"},
+	}}
+	testImageList = do.Images{testImage, testImageSecondary}
 )
 
 func TestDropletCommand(t *testing.T) {

--- a/commands/images_test.go
+++ b/commands/images_test.go
@@ -108,6 +108,21 @@ func TestImagesDelete(t *testing.T) {
 		tm.images.On("Delete", testImage.ID).Return(nil)
 
 		config.Args = append(config.Args, strconv.Itoa(testImage.ID))
+		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+
+		err := RunImagesDelete(config)
+		assert.NoError(t, err)
+	})
+
+}
+
+func TestImagesDeleteS(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.images.On("Delete", testImage.ID).Return(nil)
+		tm.images.On("Delete", testImageSecondary.ID).Return(nil)
+
+		config.Args = append(config.Args, strconv.Itoa(testImage.ID), strconv.Itoa(testImageSecondary.ID))
+		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
 
 		err := RunImagesDelete(config)
 		assert.NoError(t, err)

--- a/commands/images_test.go
+++ b/commands/images_test.go
@@ -116,7 +116,7 @@ func TestImagesDelete(t *testing.T) {
 
 }
 
-func TestImagesDeleteS(t *testing.T) {
+func TestImagesDeleteMultiple(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.images.On("Delete", testImage.ID).Return(nil)
 		tm.images.On("Delete", testImageSecondary.ID).Return(nil)


### PR DESCRIPTION
Fixs #133 
This is continued work on #139, which was closed because I pushed commits to it instead of another branch. 

# Ability to delete multiple snapshots
Problem with last PR was test units. At that time, I didn't know how to make test units and it was in TODO state.
This is not the case anymore, I learned more about `doctl` & `go` and it's here. Test passes successfully, I hope test changes will not make another problem.
Multiple delete has been tested, it is working flawless.

Beside that, confirmation like on droplets are added (incl. `force` flag). I don't know is it problem, or no, but I can revert it if it is not good place for it.