### PR TITLE
Add snapcraft.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ public
 docs/content
 
 /out
+
+# Snapcraft
+parts/
+prime/
+stage/
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: doctl
+version: "1.5.0"
+summary: A command line tool for DigitalOcean services
+description: doctl is a command line tool for DigitalOcean servics using the API.
+confinement: strict
+
+apps:
+  doctl:
+    command: bin/doctl
+    plugs: [network]
+
+parts:
+  doctl:
+    source: ..
+    plugin: go
+    go-importpath: github.com/digitalocean/doctl
+    build-packages: [git]
+    go-packages: [github.com/digitalocean/doctl/cmd/doctl]


### PR DESCRIPTION
This adds snapcraft.yaml which can be used with the snapcraft command to create snap packages. snap is the "new" packaging format that will work across all major Linux distros. 

snaps can be easily created with one command: `cd snap && snapcraft`
snaps can then be easily installed with: `snap install doctl_*_amd64.snap`

And even better, it can be uploaded to the ubuntu store, and users just need to run one to install: `snap install doctl`

Read more:
- http://snapcraft.io/