### PR TITLE
Added Volume filtering, Fixes #137

### DIFF
--- a/commands/volumes_test.go
+++ b/commands/volumes_test.go
@@ -51,6 +51,28 @@ func TestVolumesList(t *testing.T) {
 	})
 }
 
+func TestVolumesListID(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.volumes.On("List").Return(testVolumeList, nil)
+
+		config.Args = append(config.Args, testVolume.ID)
+
+		err := RunVolumeList(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestVolumesListName(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.volumes.On("List").Return(testVolumeList, nil)
+
+		config.Args = append(config.Args, "test-volume")
+
+		err := RunVolumeList(config)
+		assert.NoError(t, err)
+	})
+}
+
 func TestVolumeCreate(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tcr := godo.VolumeCreateRequest{


### PR DESCRIPTION
Fixes #137 

I've followed pattern from `droplets.go` and I successfully created Volume filtering.
I hope it's right way to do it, when I test, it's working flawless.

Beyond that, I added Region filtering and ID filtering. Region filtering is present in `droplets.go` but ID one is addition in `volumes.go`.

Output of `doctl compute volume list`:

```
ID                  Name        Size    Region  Droplet IDs
42db5324-9ad6-11e6-aef4-000f53315a41    volume-nyc1-01  1 GiB   nyc1    
5e17d1c0-9ad6-11e6-bd40-000f53315820    volume-nyc1-02  1 GiB   nyc1    
442a1a5f-9ae5-11e6-b290-000f5339d321    volume-sfo2-01  1 GiB   sfo2    [30553301]
```

Output of `doctl compute volume list volume-nyc1-01`:

```
ID                  Name        Size    Region  Droplet IDs
42db5324-9ad6-11e6-aef4-000f53315a41    volume-nyc1-01  1 GiB   nyc1    
```

Output of `doctl compute volume list 442a1a5f-9ae5-11e6-b290-000f5339d321`:

```
ID                  Name        Size    Region  Droplet IDs
442a1a5f-9ae5-11e6-b290-000f5339d321    volume-sfo2-01  1 GiB   sfo2    [30553301]
```

Output of `doctl compute volume list --region nyc1`:

```
ID                  Name        Size    Region  Droplet IDs
42db5324-9ad6-11e6-aef4-000f53315a41    volume-nyc1-01  1 GiB   nyc1    
5e17d1c0-9ad6-11e6-bd40-000f53315820    volume-nyc1-02  1 GiB   nyc1    
```

I've created test units for this actions, you should check is it OK.
