### PR TITLE
Added multiple tag delete, tag delete confirmation

### DIFF
--- a/commands/tags_test.go
+++ b/commands/tags_test.go
@@ -80,6 +80,21 @@ func TestTagDelete(t *testing.T) {
 		tm.tags.On("Delete", "my-tag").Return(nil)
 		config.Args = append(config.Args, "my-tag")
 
+		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+
+		err := RunCmdTagDelete(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestTagDeleteMultiple(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.tags.On("Delete", "my-tag").Return(nil)
+		tm.tags.On("Delete", "my-tag-secondary").Return(nil)
+		config.Args = append(config.Args, "my-tag", "my-tag-secondary")
+
+		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+
 		err := RunCmdTagDelete(config)
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
Droplet Tagging is released today, tags are more relevant.

First change is that you have possibility to delete multiple tags.
Second one is thing I add one by one is delete confirmation. Now you're asked are you sure or you have to specify `--force` flag.

Also test for multiple delete is added.
