### PR TITLE
allow "tags" attribute for droplet create

### DIFF
--- a/args.go
+++ b/args.go
@@ -110,6 +110,8 @@ const (
 	ArgPollTime = "poll-timeout"
 	// ArgTagName is a tag name
 	ArgTagName = "tag-name"
+	// ArgTagNames is a slice of possible tag names
+	ArgTagNames = "tag-names"
 	//ArgTemplate is template format
 	ArgTemplate = "template"
 

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -65,6 +65,7 @@ func Droplet() *Command {
 	AddStringFlag(cmdDropletCreate, doctl.ArgImage, "", "Droplet image",
 		requiredOpt())
 	AddStringFlag(cmdDropletCreate, doctl.ArgTagName, "", "Tag name")
+	AddStringSliceFlag(cmdDropletCreate, doctl.ArgTagNames, []string{}, "Tag names")
 
 	AddStringSliceFlag(cmdDropletCreate, doctl.ArgVolumeList, []string{}, "Volumes to attach")
 
@@ -181,6 +182,11 @@ func RunDropletCreate(c *CmdConfig) error {
 		return err
 	}
 
+	tagNames, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTagNames)
+	if err != nil {
+		return err
+	}
+
 	sshKeys := extractSSHKeys(keys)
 
 	userData, err := c.Doit.GetString(c.NS, doctl.ArgUserData)
@@ -239,6 +245,7 @@ func RunDropletCreate(c *CmdConfig) error {
 			PrivateNetworking: privateNetworking,
 			SSHKeys:           sshKeys,
 			UserData:          userData,
+			Tags:              tagNames,
 		}
 
 		wg.Add(1)

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -83,6 +83,7 @@ func TestDropletCreate(t *testing.T) {
 			IPv6:              false,
 			PrivateNetworking: false,
 			UserData:          "#cloud-config",
+			Tags:              []string{"one", "two"},
 		}
 		tm.droplets.On("Create", dcr, false).Return(&testDroplet, nil)
 
@@ -93,6 +94,7 @@ func TestDropletCreate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgImage, "image")
 		config.Doit.Set(config.NS, doctl.ArgUserData, "#cloud-config")
 		config.Doit.Set(config.NS, doctl.ArgVolumeList, []string{"test-volume", volumeUUID})
+		config.Doit.Set(config.NS, doctl.ArgTagNames, []string{"one", "two"})
 
 		err := RunDropletCreate(config)
 		assert.NoError(t, err)

--- a/vendor/github.com/digitalocean/godo/droplets.go
+++ b/vendor/github.com/digitalocean/godo/droplets.go
@@ -147,6 +147,16 @@ type DropletCreateImage struct {
 	Slug string
 }
 
+// MarshalJSON returns either the slug or id of the image. It returns the id
+// if the slug is empty.
+func (d DropletCreateImage) MarshalJSON() ([]byte, error) {
+	if d.Slug != "" {
+		return json.Marshal(d.Slug)
+	}
+
+	return json.Marshal(d.ID)
+}
+
 // DropletCreateVolume identifies a volume to attach for the create request. It
 // prefers Name over ID,
 type DropletCreateVolume struct {
@@ -166,16 +176,6 @@ func (d DropletCreateVolume) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		ID string `json:"id"`
 	}{ID: d.ID})
-}
-
-// MarshalJSON returns either the slug or id of the image. It returns the id
-// if the slug is empty.
-func (d DropletCreateImage) MarshalJSON() ([]byte, error) {
-	if d.Slug != "" {
-		return json.Marshal(d.Slug)
-	}
-
-	return json.Marshal(d.ID)
 }
 
 // DropletCreateSSHKey identifies a SSH Key for the create request. It prefers fingerprint over ID.
@@ -206,6 +206,7 @@ type DropletCreateRequest struct {
 	PrivateNetworking bool                  `json:"private_networking"`
 	UserData          string                `json:"user_data,omitempty"`
 	Volumes           []DropletCreateVolume `json:"volumes,omitempty"`
+	Tags              []string              `json:"tags"`
 }
 
 // DropletMultiCreateRequest is a request to create multiple droplets.
@@ -219,6 +220,7 @@ type DropletMultiCreateRequest struct {
 	IPv6              bool                  `json:"ipv6"`
 	PrivateNetworking bool                  `json:"private_networking"`
 	UserData          string                `json:"user_data,omitempty"`
+	Tags              []string              `json:"tags"`
 }
 
 func (d DropletCreateRequest) String() string {

--- a/vendor/github.com/digitalocean/godo/droplets_test.go
+++ b/vendor/github.com/digitalocean/godo/droplets_test.go
@@ -152,6 +152,7 @@ func TestDroplets_Create(t *testing.T) {
 			{ID: "hello-im-another-volume"},
 			{Name: "hello-im-still-a-volume", ID: "should be ignored due to Name"},
 		},
+		Tags: []string{"one", "two"},
 	}
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
@@ -169,6 +170,7 @@ func TestDroplets_Create(t *testing.T) {
 				map[string]interface{}{"id": "hello-im-another-volume"},
 				map[string]interface{}{"name": "hello-im-still-a-volume"},
 			},
+			"tags": []interface{}{"one", "two"},
 		}
 
 		var v map[string]interface{}
@@ -209,6 +211,7 @@ func TestDroplets_CreateMultiple(t *testing.T) {
 		Image: DropletCreateImage{
 			ID: 1,
 		},
+		Tags: []string{"one", "two"},
 	}
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
@@ -221,6 +224,7 @@ func TestDroplets_CreateMultiple(t *testing.T) {
 			"backups":            false,
 			"ipv6":               false,
 			"private_networking": false,
+			"tags":               []interface{}{"one", "two"},
 		}
 
 		var v map[string]interface{}

--- a/vendor/github.com/digitalocean/godo/floating_ips_actions_test.go
+++ b/vendor/github.com/digitalocean/godo/floating_ips_actions_test.go
@@ -112,7 +112,7 @@ func TestFloatingIPsActions_List(t *testing.T) {
 		t.Errorf("FloatingIPsActions.List returned error: %v", err)
 	}
 
-	expected := []Action{Action{Status: "in-progress"}}
+	expected := []Action{{Status: "in-progress"}}
 	if !reflect.DeepEqual(actions, expected) {
 		t.Errorf("FloatingIPsActions.List returned %+v, expected %+v", actions, expected)
 	}

--- a/vendor/github.com/digitalocean/godo/godo_test.go
+++ b/vendor/github.com/digitalocean/godo/godo_test.go
@@ -133,7 +133,7 @@ func TestNewRequest(t *testing.T) {
 	inBody, outBody := &DropletCreateRequest{Name: "l"},
 		`{"name":"l","region":"","size":"","image":0,`+
 			`"ssh_keys":null,"backups":false,"ipv6":false,`+
-			`"private_networking":false}`+"\n"
+			`"private_networking":false,"tags":null}`+"\n"
 	req, _ := c.NewRequest("GET", inURL, inBody)
 
 	// test relative URL was expanded
@@ -161,7 +161,7 @@ func TestNewRequest_withUserData(t *testing.T) {
 	inBody, outBody := &DropletCreateRequest{Name: "l", UserData: "u"},
 		`{"name":"l","region":"","size":"","image":0,`+
 			`"ssh_keys":null,"backups":false,"ipv6":false,`+
-			`"private_networking":false,"user_data":"u"}`+"\n"
+			`"private_networking":false,"user_data":"u","tags":null}`+"\n"
 	req, _ := c.NewRequest("GET", inURL, inBody)
 
 	// test relative URL was expanded

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -87,7 +87,7 @@
 			"importpath": "github.com/digitalocean/godo",
 			"repository": "https://github.com/digitalocean/godo",
 			"vcs": "git",
-			"revision": "27d2cca254e40de87ef3d247d0cb29fa57cd8303",
+			"revision": "a2c1274e95421d0450d178e0ecdbf278915b7260",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
This allows `tag-names` as an attribute for droplet create, in accordance with https://developers.digitalocean.com/documentation/changelog/api-v2/tagging-in-droplet-create/.

cc @hugocorbucci @daveworth 