### PR TITLE
Imply that doctl is actively doing something

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -81,7 +81,7 @@ func RunAuthInit(c *CmdConfig) error {
 	viper.Set("access-token", string(token))
 
 	fmt.Fprintln(c.Out)
-	fmt.Fprint(c.Out, "Validating token: ")
+	fmt.Fprint(c.Out, "Validating token... ")
 
 	// need to initial the godo client since we've changed the configuration.
 	if err := c.initServices(c); err != nil {


### PR DESCRIPTION
The "Validating token: " message used to end with ": ", which looks like a prompt for more info. The ellipsis implies that doctl itself is doing something instead of waiting for more user input.

This is a really small change. I needed to re-`auth init` on a slow connection and had that "prompt" sitting in for more than a few seconds. I then pasted the access token again because I though it was waiting for something. The error really is on my part, but I think this makes things clearer.