### PR TITLE
[Fixes #168] Implementing command forwarding for external SSH

### DIFF
--- a/args.go
+++ b/args.go
@@ -92,6 +92,8 @@ const (
 	ArgsSSHAgentForwarding = "ssh-agent-forwarding"
 	// ArgsSSHPrivateIP is a ssh argument.
 	ArgsSSHPrivateIP = "ssh-private-ip"
+	// ArgSSHCommand is a ssh argument.
+	ArgSSHCommand = "ssh-command"
 	// ArgUserData is a user data argument.
 	ArgUserData = "user-data"
 	// ArgUserDataFile is a user data file location argument.

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -44,6 +44,7 @@ func SSH(parent *Command) *Command {
 	AddIntFlag(cmdSSH, doctl.ArgsSSHPort, "", 22, "port sshd is running on")
 	AddBoolFlag(cmdSSH, doctl.ArgsSSHAgentForwarding, "", false, "enable ssh agent forwarding")
 	AddBoolFlag(cmdSSH, doctl.ArgsSSHPrivateIP, "", false, "ssh to private ip instead of public ip")
+	AddStringFlag(cmdSSH, doctl.ArgSSHCommand, "", "", "command to execute")
 
 	return cmdSSH
 }
@@ -79,6 +80,11 @@ func RunSSH(c *CmdConfig) error {
 	opts[doctl.ArgsSSHAgentForwarding], err = c.Doit.GetBool(c.NS, doctl.ArgsSSHAgentForwarding)
 	if err != nil {
 		return err
+	}
+
+	opts[doctl.ArgSSHCommand], err = c.Doit.GetString(c.NS, doctl.ArgSSHCommand)
+	if err != nil {
+		return nil
 	}
 
 	privateIPChoice, err := c.Doit.GetBool(c.NS, doctl.ArgsSSHPrivateIP)

--- a/commands/ssh_test.go
+++ b/commands/ssh_test.go
@@ -141,6 +141,26 @@ func TestSSH_AgentForwarding(t *testing.T) {
 	})
 }
 
+func TestSSH_CommandExecuting(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		rm := &mocks.Runner{}
+		rm.On("Run").Return(nil)
+
+		tc := config.Doit.(*TestConfig)
+		tc.SSHFn = func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner {
+			assert.Equal(t, "uptime", opts[doctl.ArgSSHCommand])
+			return rm
+		}
+
+		tm.droplets.On("List").Return(testDropletList, nil)
+		config.Doit.Set(config.NS, doctl.ArgSSHCommand, "uptime")
+		config.Args = append(config.Args, testDroplet.Name)
+
+		err := RunSSH(config)
+		assert.NoError(t, err)
+	})
+}
+
 func Test_extractHostInfo(t *testing.T) {
 	cases := []struct {
 		s string

--- a/doit.go
+++ b/doit.go
@@ -217,6 +217,7 @@ func (c *LiveConfig) SSH(user, host, keyPath string, port int, opts ssh.Options)
 		KeyPath:         keyPath,
 		Port:            port,
 		AgentForwarding: opts[ArgsSSHAgentForwarding].(bool),
+		Command:         opts[ArgSSHCommand].(string),
 	}
 }
 

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -29,6 +29,7 @@ type Runner struct {
 	KeyPath         string
 	Port            int
 	AgentForwarding bool
+	Command         string
 }
 
 var _ runner.Runner = &Runner{}

--- a/pkg/ssh/ssh_external.go
+++ b/pkg/ssh/ssh_external.go
@@ -39,6 +39,9 @@ func runExternalSSH(r *Runner) error {
 	}
 
 	args = append(args, sshHost)
+	if r.Command != "" {
+		args = append(args, r.Command)
+	}
 
 	cmd := exec.Command("ssh", args...)
 


### PR DESCRIPTION
With this PR, we should fix #168. However, this is not really same idea as it's in issue.
Issue is proposing following implementation:
```
doctl compute ssh mydroplet uptime
```
I decided to follow template of SSH unit, so I went with flag (`--ssh-command`).
When I execute `doctl compute ssh mydroplet`, I'll work as usual.
When I execute `doctl compute ssh test1 --ssh-command uptime`, it'll will only return output of command, as expected:
```
 22:32:26 up  1:07,  0 users,  load average: 0.00, 0.00, 0.00
```
I want to know do you like it, how it looks and could it be done better.
Just to note, this is only implemented for external SSH (OS X & Linux). I need to look more in Windows implementation of SSH client, but first I want to know is this one OK. If this is right, I'll do the same for internal if possible.

cc @nanzhong @aybabtme 