### PR TITLE
Display list of droplets before deleting

### DIFF
--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -475,9 +475,26 @@ func RunDropletDelete(c *CmdConfig) error {
 		return nil
 	}
 
-	if force || AskForConfirm("delete droplet(s)") == nil {
-
-		fn := func(ids []int) error {
+	fn := func(ids []int) error {
+		if !force {
+		
+			// If we aren't forcing, print out the list
+			fmt.Printf("Following Droplet(s) will be deleted:\n")
+			
+			var list do.Droplets
+			for _, id := range ids {
+				d, err := ds.Get(id)
+				if err != nil {
+					return err
+				}
+				list = append(list, *d)	
+			}
+			
+			item := &droplet{droplets: list}
+			c.Display(item)
+		}
+			
+		if force || AskForConfirm("delete droplet(s)") == nil {
 			for _, id := range ids {
 				if err := ds.Delete(id); err != nil {
 					return fmt.Errorf("unable to delete droplet %d: %v", id, err)
@@ -485,9 +502,12 @@ func RunDropletDelete(c *CmdConfig) error {
 			}
 			return nil
 		}
-		return matchDroplets(c.Args, ds, fn)
+		return fmt.Errorf("operation aborted")
+			
+			
 	}
-	return fmt.Errorf("operation aborted")
+	return matchDroplets(c.Args, ds, fn)
+	
 
 	return nil
 

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -479,7 +479,7 @@ func RunDropletDelete(c *CmdConfig) error {
 		if !force {
 		
 			// If we aren't forcing, print out the list
-			fmt.Printf("Following Droplet(s) will be deleted:\n")
+			fmt.Println("Following Droplet(s) will be deleted")
 			
 			var list do.Droplets
 			for _, id := range ids {

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -74,7 +74,7 @@ func Droplet() *Command {
 		aliasOpt("d", "del", "rm"), docCategories("droplet"))
 	AddBoolFlag(cmdRunDropletDelete, doctl.ArgDeleteForce, doctl.ArgShortDeleteForce, false, "Force droplet delete")
 	AddStringFlag(cmdRunDropletDelete, doctl.ArgTagName, "", "", "Tag name")
-	
+
 	cmdRunDropletGet := CmdBuilder(cmd, RunDropletGet, "get", "get droplet", Writer,
 		aliasOpt("g"), displayerType(&droplet{}), docCategories("droplet"))
 	AddStringFlag(cmdRunDropletGet, doctl.ArgTemplate, "", "", "Go template format. Few sample values:{{.ID}} {{.Name}} {{.Memory}} {{.Region.Name}} {{.Image}} {{.Tags}}")
@@ -467,23 +467,23 @@ func RunDropletDelete(c *CmdConfig) error {
 
 	deleteFn := func(ids []int) error {
 		if !force {
-		
+
 			// If we aren't forcing, print out the list
 			fmt.Println("Following Droplet(s) will be deleted:")
-			
+
 			var list do.Droplets
 			for _, id := range ids {
 				d, err := ds.Get(id)
 				if err != nil {
 					return err
 				}
-				list = append(list, *d)	
+				list = append(list, *d)
 			}
-			
+
 			item := &droplet{droplets: list}
 			c.Display(item)
 		}
-			
+
 		if force || AskForConfirm("delete droplet(s)") == nil {
 			for _, id := range ids {
 				if err := ds.Delete(id); err != nil {
@@ -493,7 +493,7 @@ func RunDropletDelete(c *CmdConfig) error {
 			return nil
 		}
 		return fmt.Errorf("operation aborted")
-			
+
 	}
 
 	if len(c.Args) < 1 && tagName == "" {
@@ -503,19 +503,19 @@ func RunDropletDelete(c *CmdConfig) error {
 	} else if tagName != "" {
 		var list do.Droplets
 		list, err := ds.ListByTag(tagName)
-	    if err != nil {
-		    return err
-	    }
-	    
-	    var extractedIDs []int
-	    for _, droplet := range list {
-	    	extractedIDs = append(extractedIDs, droplet.ID)
-	    }
-	    
-	    if len(extractedIDs) < 1 {
-	    	return fmt.Errorf("droplet(s) with tag %q could not be found",tagName)
-	    }
-	    return deleteFn(extractedIDs)
+		if err != nil {
+			return err
+		}
+
+		var extractedIDs []int
+		for _, droplet := range list {
+			extractedIDs = append(extractedIDs, droplet.ID)
+		}
+
+		if len(extractedIDs) < 1 {
+			return fmt.Errorf("droplet(s) with tag %q could not be found", tagName)
+		}
+		return deleteFn(extractedIDs)
 	}
 
 	return matchDroplets(c.Args, ds, deleteFn)

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -160,7 +160,9 @@ func TestDropletDelete(t *testing.T) {
 
 func TestDropletDeleteByTag(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.droplets.On("DeleteByTag", "my-tag").Return(nil)
+		tm.droplets.On("ListByTag", "my-tag").Return(testDropletList, nil)
+		tm.droplets.On("Delete", 1).Return(nil)
+		tm.droplets.On("Delete", 3).Return(nil)
 
 		config.Doit.Set(config.NS, doctl.ArgTagName, "my-tag")
 		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)


### PR DESCRIPTION
For issue #172, this will show the list of droplets being deleted if we
aren’t forcing so that the confirmation has more information for us.
Note: does not handle printing the list when doing a DeleteByTag.

We want to make sure that the list shown before the confirmation is actually the list that will be deleted which is why we retrieve the list once and use the same list before and after the confirmation. That way if the confirmation had been up and someone else deletes and recreates droplet "test" as a different one, since it is working off of IDs we don't delete one that was not shown.
If we wanted to do deleteByTag as well we would probably want a similar mechanism to do ListByTag, show the confirmation, and then loop through the same list after the confirmation doing the ds.Delete from the original list rather than ds.DeleteByTag directly.