### PR TITLE
Bumping Dockerfile doctl version to 1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-ENV DOCTL_VERSION=1.4.0
+ENV DOCTL_VERSION=1.5.0
 
 RUN apk add --update curl && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
Changed `Dockerfile` to use version `1.5.0` instead of `1.4.0`.

cc @nanzhong 