### PR TITLE
commands: implement command aliases

### DIFF
--- a/commands/alias.go
+++ b/commands/alias.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2017 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/digitalocean/doctl"
+	"github.com/gobwas/glob"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type aliasDesc struct {
+	Alias        string `json:"alias"`
+	AliasCommand string `json:"alias_command"`
+}
+
+// Alias creates a alias command.
+func Alias() *Command {
+	cmd := &Command{
+		Command: &cobra.Command{
+			Use:   "alias",
+			Short: "alias commands",
+			Long:  "alias is used to manage aliases",
+		},
+	}
+
+	CmdBuilder(cmd, RunAliasList, "list", "list [glob]", Writer, aliasOpt("ls"))
+
+	CmdBuilder(cmd, RunAliasGet, "get", "get <alias-name>", Writer, aliasOpt("g"))
+
+	CmdBuilder(cmd, RunAliasAdd, "add", "add <alias-name> <alias-command>", Writer, aliasOpt("a"))
+
+	cmdRunAliasDelete := CmdBuilder(cmd, RunAliasDelete, "delete", "delete <alias-name> [alias-name ...]",
+		Writer, aliasOpt("d"))
+	AddBoolFlag(cmdRunAliasDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force alias delete")
+
+	return cmd
+}
+
+// RunAliasList returns the list of all aliases
+func RunAliasList(c *CmdConfig) error {
+
+	list := AliasReader.AllKeys()
+	var al []aliasDesc
+
+	matches := []glob.Glob{}
+	for _, globStr := range c.Args {
+		g, err := glob.Compile(globStr)
+		if err != nil {
+			return fmt.Errorf("unknown glob %q", globStr)
+		}
+
+		matches = append(matches, g)
+	}
+
+	for _, a := range list {
+		var skip = true
+		if len(matches) == 0 {
+			skip = false
+		} else {
+			for _, m := range matches {
+				if m.Match(a) {
+					skip = false
+				}
+			}
+		}
+
+		if !skip {
+			al = append(al, aliasDesc{a, AliasReader.GetString(a)})
+		}
+	}
+
+	item := &alias{aliases: al}
+	return c.Display(item)
+
+}
+
+// RunAliasGet returns alias details
+func RunAliasGet(c *CmdConfig) error {
+
+	if len(c.Args) != 1 {
+		return doctl.NewMissingArgsErr(c.NS)
+	}
+
+	ali := c.Args[0]
+	var a []aliasDesc
+
+	if value := AliasReader.GetString(ali); value != "" {
+		a = append(a, aliasDesc{ali, AliasReader.GetString(ali)})
+	} else {
+		return fmt.Errorf("alias %s not found", ali)
+	}
+
+	item := &alias{aliases: a}
+	return c.Display(item)
+
+}
+
+// RunAliasSet creates new alias
+func RunAliasAdd(c *CmdConfig) error {
+
+	if len(c.Args) != 2 {
+		return doctl.NewMissingArgsErr(c.NS)
+	}
+
+	alias := c.Args[0]
+	command := c.Args[1]
+
+	AliasReader.Set(alias, command)
+
+	return writeAlias()
+}
+
+// RunAliasDelete deletes an existing alias
+func RunAliasDelete(c *CmdConfig) error {
+
+	if len(c.Args) < 1 {
+		return doctl.NewMissingArgsErr(c.NS)
+	}
+
+	force, err := c.Doit.GetBool(c.NS, doctl.ArgForce)
+	if err != nil {
+		return err
+	}
+
+	if force || AskForConfirm("delete alias(es)") == nil {
+		newAliasReader := viper.New()
+		keys := AliasReader.AllKeys()
+		var match bool
+
+		for _, key := range keys {
+			for _, alias := range c.Args {
+				if key == alias {
+					match = true
+					break
+				}
+			}
+			if !match {
+				newAliasReader.Set(key, AliasReader.GetString(key))
+			} else {
+				match = false
+			}
+		}
+
+		AliasReader = newAliasReader
+
+		return writeAlias()
+	}
+
+	return nil
+}

--- a/commands/output.go
+++ b/commands/output.go
@@ -154,6 +154,44 @@ func (a *action) KV() []map[string]interface{} {
 	return out
 }
 
+type alias struct {
+	aliases []aliasDesc
+}
+
+var _ Displayable = &alias{}
+
+func (al *alias) JSON(out io.Writer) error {
+	return writeJSON(al.aliases, out)
+}
+
+func (al *alias) Cols() []string {
+	return []string{
+		"Alias", "AliasCommand",
+	}
+}
+
+func (al *alias) ColMap() map[string]string {
+	return map[string]string{
+		"Alias":        "Alias",
+		"AliasCommand": "Command",
+	}
+}
+
+func (al *alias) KV() []map[string]interface{} {
+	out := []map[string]interface{}{}
+
+	for _, ali := range al.aliases {
+		o := map[string]interface{}{
+			"Alias":        ali.Alias,
+			"AliasCommand": ali.AliasCommand,
+		}
+
+		out = append(out, o)
+	}
+
+	return out
+}
+
 type domain struct {
 	domains do.Domains
 }

--- a/commands/xdg.go
+++ b/commands/xdg.go
@@ -28,6 +28,15 @@ func configHome() string {
 	return configHome
 }
 
+func aliasHome() string {
+	aliasHome := os.Getenv("XDG_CONFIG_HOME")
+	if aliasHome == "" {
+		aliasHome = filepath.Join(homeDir(), ".config", "doctl")
+	}
+
+	return aliasHome
+}
+
 func legacyConfigCheck() {
 	fi, err := os.Stat(cfgFile)
 	expectedPerms := os.FileMode(0600)

--- a/commands/xdg_windows.go
+++ b/commands/xdg_windows.go
@@ -29,6 +29,16 @@ func configHome() string {
 	return configHome
 }
 
+func aliasHome() string {
+	aliasHome := os.Getenv("XDG_CONFIG_HOME")
+	if aliasHome == "" {
+		userName := os.Getenv("USERNAME")
+		aliasHome = filepath.Join("C:/", "Users", userName, "AppData", "Local", "doctl", "alias")
+	}
+
+	return aliasHome
+}
+
 // legacyConfigCheck is a no-op on windows since go doesn't have a chmod
 // on this platform.
 func legacyConfigCheck() {

--- a/commands/xdg_windows_test.go
+++ b/commands/xdg_windows_test.go
@@ -28,3 +28,12 @@ func TestConfigHome(t *testing.T) {
 	expected := `C:\Users\testuser\AppData\Local\doctl\config`
 	assert.Equal(t, expected, ch)
 }
+
+func TestAliasHome(t *testing.T) {
+	os.Setenv("USERNAME", "testuser")
+	defer os.Unsetenv("USERNAME")
+
+	ch := aliasHome()
+	expected := `C:\Users\testuser\AppData\Local\doctl\alias`
+	assert.Equal(t, expected, ch)
+}


### PR DESCRIPTION
# Aliases
Fixes #67 

## What
Allow aliases in doctl

## Why
Some commands are used more than others. This will allow you to alias commands so you have better experience using doctl.

## How does this work
This works by rewriting `os.Args` before initializing `cobra`. It tries to find pattern in aliases file and assembles it as one command.

## Where are aliases stored
In `~/.config/doctl/alias.yaml`.

## How does this file should look
Format for alias file is `yaml`. Type of key is string (written in `''`).
Example:
```yaml
'dls': compute droplet list
'dg': compute droplet get
'r': account ratelimit
```

## Why is `alias.yaml` separate file from `config.yaml`
Separating it form config can help sharing and versioning your aliases. Many of us have `dotfiles` repository where we store stuff like this (config, aliases...). As `config.yaml` is not supposed to be shared, as it contains sensitive data such as `access-token`, I believe it's the best idea to use a separate file for aliases..

## What's the status of this PR
This Pull Request is ready to be merged feature wise. It's fully working on both Linux and Windows.