### PR TITLE
[Fixes #192] Added type transfer to image-action transfer

### DIFF
--- a/commands/image_actions.go
+++ b/commands/image_actions.go
@@ -93,6 +93,7 @@ func RunImageActionsTransfer(c *CmdConfig) error {
 	}
 
 	req := &godo.ActionRequest{
+		"type":   "transfer",
 		"region": region,
 	}
 

--- a/commands/image_actions_test.go
+++ b/commands/image_actions_test.go
@@ -43,7 +43,7 @@ func TestImageActionsGet(t *testing.T) {
 
 func TestImageActionsTransfer(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		ar := &godo.ActionRequest{"region": "dev0"}
+		ar := &godo.ActionRequest{"type": "transfer", "region": "dev0"}
 		tm.imageActions.On("Transfer", 1, ar).Return(&testAction, nil)
 
 		config.Args = append(config.Args, "1")


### PR DESCRIPTION
This Pull Request addresses issue #192.

Executing Transfer command like:
```
$ doctl compute image-action transfer -o json --region sgp1 12345
```
would result in error that Action Type is not available:
```
{"errors":[{"detail":"could not transfer image: POST https://api.digitalocean.com/v2/images/12345/actions: 404 The specified action type is not available."}]}
```

By the [API docs](https://developers.digitalocean.com/documentation/v2/#transfer-an-image), it's also required to send type in the request. This PR implements it.
Response after change:
```
[
  {
    "id": 12345,
    "status": "in-progress",
    "type": "transfer",
    "started_at": "2017-03-04T18:49:16Z",
    "completed_at": null,
    "resource_id": 12345,
    "resource_type": "image"
  }
]
```

cc @viola @caueguerra @aybabtme 