### PR TITLE
Fixes #198 - Hide public images by default

### DIFF
--- a/do/images.go
+++ b/do/images.go
@@ -111,7 +111,7 @@ func (is *imagesService) listImages(lFn listFn, public bool) (Images, error) {
 
 		si := []interface{}{}
 		for _, i := range list {
-			if (public && i.Public) || !public {
+			if (public && i.Public) || !i.Public {
 				si = append(si, i)
 			}
 		}


### PR DESCRIPTION
This PR fixes #198.

Looking by the code, I think this was unintended behavior, as on [L40/images.go](https://github.com/digitalocean/doctl/blob/master/commands/images.go#L40) it states that default for Public Images is `false`.

If it is indeed to show all images, including public ones, this change should be kept with changing default flag value to `true`.

cc @viola @caueguerra @lxfontes 