### PR TITLE
Remove Detach function

### DIFF
--- a/commands/volume_actions.go
+++ b/commands/volume_actions.go
@@ -61,9 +61,6 @@ func VolumeAction() *Command {
 	CmdBuilder(cmd, RunVolumeAttach, "attach <volume-id> <droplet-id>", "attach a volume", Writer,
 		aliasOpt("a"))
 
-	CmdBuilder(cmd, RunVolumeDetach, "detach <volume-id>", "detach a volume", Writer,
-		aliasOpt("d"))
-
 	CmdBuilder(cmd, RunVolumeDetachByDropletID, "detach-by-droplet-id <volume-id> <droplet-id>", "detach a volume by droplet ID", Writer,
 		aliasOpt("dd"))
 
@@ -91,19 +88,6 @@ func RunVolumeAttach(c *CmdConfig) error {
 
 		}
 		a, err := das.Attach(volumeID, dropletID)
-		return a, err
-	}
-	return performVolumeAction(c, fn)
-}
-
-// RunVolumeDetach detaches a volume from the droplet it's attached to.
-func RunVolumeDetach(c *CmdConfig) error {
-	fn := func(das do.VolumeActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
-		}
-		volumeID := c.Args[0]
-		a, err := das.Detach(volumeID)
 		return a, err
 	}
 	return performVolumeAction(c, fn)

--- a/commands/volume_actions_test.go
+++ b/commands/volume_actions_test.go
@@ -24,7 +24,7 @@ import (
 func TestVolumeActionCommand(t *testing.T) {
 	cmd := VolumeAction()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "attach", "detach", "detach-by-droplet-id", "resize")
+	assertCommandNames(t, cmd, "attach", "detach-by-droplet-id", "resize")
 }
 
 func TestVolumeActionsAttach(t *testing.T) {

--- a/commands/volume_actions_test.go
+++ b/commands/volume_actions_test.go
@@ -38,16 +38,6 @@ func TestVolumeActionsAttach(t *testing.T) {
 	})
 }
 
-func TestVolumeActionsDetach(t *testing.T) {
-	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.volumeActions.On("Detach", testVolume.ID).Return(&testAction, nil)
-		config.Args = append(config.Args, testVolume.ID)
-
-		err := RunVolumeDetach(config)
-		assert.NoError(t, err)
-	})
-}
-
 func TestVolumeDetachByDropletID(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.volumeActions.On("DetachByDropletID", testVolume.ID, testDroplet.ID).Return(&testAction, nil)

--- a/do/volume_actions.go
+++ b/do/volume_actions.go
@@ -9,7 +9,6 @@ import (
 // VolumeActionsService is an interface for interacting with DigitalOcean's volume-action api.
 type VolumeActionsService interface {
 	Attach(string, int) (*Action, error)
-	Detach(string) (*Action, error)
 	DetachByDropletID(string, int) (*Action, error)
 	Get(string, int) (*Action, error)
 	List(string, *godo.ListOptions) ([]Action, error)
@@ -40,12 +39,6 @@ func (vas *volumeActionsService) handleActionResponse(a *godo.Action, err error)
 
 func (vas *volumeActionsService) Attach(volumeID string, dropletID int) (*Action, error) {
 	a, _, err := vas.client.StorageActions.Attach(context.TODO(), volumeID, dropletID)
-	return vas.handleActionResponse(a, err)
-
-}
-
-func (vas *volumeActionsService) Detach(volumeID string) (*Action, error) {
-	a, _, err := vas.client.StorageActions.Detach(context.TODO(), volumeID)
 	return vas.handleActionResponse(a, err)
 
 }

--- a/vendor/github.com/digitalocean/godo/storage.go
+++ b/vendor/github.com/digitalocean/godo/storage.go
@@ -73,6 +73,7 @@ type VolumeCreateRequest struct {
 	Name          string `json:"name"`
 	Description   string `json:"description"`
 	SizeGigaBytes int64  `json:"size_gigabytes"`
+	SnapshotID    string `json:"snapshot_id"`
 }
 
 // ListVolumes lists all storage volumes.

--- a/vendor/github.com/digitalocean/godo/storage_actions.go
+++ b/vendor/github.com/digitalocean/godo/storage_actions.go
@@ -10,7 +10,6 @@ import (
 // See: https://developers.digitalocean.com/documentation/v2#storage-actions
 type StorageActionsService interface {
 	Attach(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)
-	Detach(ctx context.Context, volumeID string) (*Action, *Response, error)
 	DetachByDropletID(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)
 	Get(ctx context.Context, volumeID string, actionID int) (*Action, *Response, error)
 	List(ctx context.Context, volumeID string, opt *ListOptions) ([]Action, *Response, error)
@@ -34,14 +33,6 @@ func (s *StorageActionsServiceOp) Attach(ctx context.Context, volumeID string, d
 	request := &ActionRequest{
 		"type":       "attach",
 		"droplet_id": dropletID,
-	}
-	return s.doAction(ctx, volumeID, request)
-}
-
-// Detach a storage volume from a Droplet.
-func (s *StorageActionsServiceOp) Detach(ctx context.Context, volumeID string) (*Action, *Response, error) {
-	request := &ActionRequest{
-		"type": "detach",
 	}
 	return s.doAction(ctx, volumeID, request)
 }

--- a/vendor/github.com/digitalocean/godo/storage_actions_test.go
+++ b/vendor/github.com/digitalocean/godo/storage_actions_test.go
@@ -42,36 +42,6 @@ func TestStoragesActions_Attach(t *testing.T) {
 	}
 }
 
-func TestStoragesActions_Detach(t *testing.T) {
-	setup()
-	defer teardown()
-	volumeID := "98d414c6-295e-4e3a-ac58-eb9456c1e1d1"
-
-	detachRequest := &ActionRequest{
-		"type": "detach",
-	}
-
-	mux.HandleFunc("/v2/volumes/"+volumeID+"/actions", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ActionRequest)
-		err := json.NewDecoder(r.Body).Decode(v)
-		if err != nil {
-			t.Fatalf("decode json: %v", err)
-		}
-
-		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, detachRequest) {
-			t.Errorf("want=%#v", detachRequest)
-			t.Errorf("got=%#v", v)
-		}
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
-	})
-
-	_, _, err := client.StorageActions.Detach(ctx, volumeID)
-	if err != nil {
-		t.Errorf("StoragesActions.Detach returned error: %v", err)
-	}
-}
-
 func TestStoragesActions_DetachByDropletID(t *testing.T) {
 	setup()
 	defer teardown()

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -80,7 +80,7 @@
 			"importpath": "github.com/digitalocean/godo",
 			"repository": "https://github.com/digitalocean/godo",
 			"vcs": "git",
-			"revision": "84099941ba2381607e1b05ffd4822781af86675e",
+			"revision": "dfa802149cae7e4b8eb8bdd7cbbf619dab60bea4",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
This PR removes Detach function which was removed from API.
Proposal: Rename `detach-by-droplet-id` to `detach`. As there is only one detach function (there is by name also in API too) I think we could rename it to Detach only.
I would love to hear opinions.

Fixes #207.

cc @mauricio 