### PR TITLE
Update Travis-CI Go version to 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.7
+  - 1.x
   - tip
 sudo: false
 install: true


### PR DESCRIPTION
This PR updates Go version for Travis-CI.
`1.x` represents latest major or minor Go version.

cc @mauricio 