### PR TITLE
Deprecate tag rename (PUT /v2/tags/:name)

### DIFF
--- a/commands/tags.go
+++ b/commands/tags.go
@@ -43,11 +43,6 @@ func Tags() *Command {
 	CmdBuilder(cmd, RunCmdTagList, "list", "list tags", Writer,
 		aliasOpt("ls"), docCategories("tag"))
 
-	cmdTagUpdate := CmdBuilder(cmd, RunCmdTagUpdate, "update <tag-name>", "update tag", Writer,
-		docCategories("tag"))
-	AddStringFlag(cmdTagUpdate, doctl.ArgTagName, "", "", "Tag name",
-		requiredOpt())
-
 	cmdRunTagDelete := CmdBuilder(cmd, RunCmdTagDelete, "delete <tag-name> [tag-name ...]", "delete tag", Writer,
 		docCategories("tag"))
 	AddBoolFlag(cmdRunTagDelete, doctl.ArgDeleteForce, doctl.ArgShortDeleteForce, false, "Force tag delete")
@@ -98,24 +93,6 @@ func RunCmdTagList(c *CmdConfig) error {
 	}
 
 	return c.Display(&tag{tags: tags})
-}
-
-// RunCmdTagUpdate runs tag update.
-func RunCmdTagUpdate(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
-	}
-
-	name := c.Args[0]
-
-	newName, err := c.Doit.GetString(c.NS, doctl.ArgTagName)
-	if err != nil {
-		return err
-	}
-
-	ts := c.Tags()
-	tur := &godo.TagUpdateRequest{Name: newName}
-	return ts.Update(name, tur)
 }
 
 // RunCmdTagDelete runs tag delete.

--- a/commands/tags_test.go
+++ b/commands/tags_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package commands
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/digitalocean/doctl"
@@ -41,7 +40,7 @@ var (
 func TestTTagCommand(t *testing.T) {
 	cmd := Tags()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "create", "get", "update", "delete", "list")
+	assertCommandNames(t, cmd, "create", "get", "delete", "list")
 }
 
 func TestTagGet(t *testing.T) {
@@ -97,29 +96,5 @@ func TestTagDeleteMultiple(t *testing.T) {
 
 		err := RunCmdTagDelete(config)
 		assert.NoError(t, err)
-	})
-}
-
-func TestTagUpdate(t *testing.T) {
-	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tur := &godo.TagUpdateRequest{Name: "new-name"}
-		tm.tags.On("Update", "my-tag", tur).Return(nil)
-		config.Args = append(config.Args, "my-tag")
-
-		config.Doit.Set(config.NS, doctl.ArgTagName, "new-name")
-
-		err := RunCmdTagUpdate(config)
-		assert.NoError(t, err)
-	})
-}
-
-func TestTagUpdateMissingName(t *testing.T) {
-	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tur := &godo.TagUpdateRequest{Name: ""}
-		tm.tags.On("Update", "my-tag", tur).Return(errors.New("boom"))
-		config.Args = append(config.Args, "my-tag")
-
-		err := RunCmdTagUpdate(config)
-		assert.Error(t, err)
 	})
 }

--- a/do/mocks/TagsService.go
+++ b/do/mocks/TagsService.go
@@ -121,17 +121,3 @@ func (_m *TagsService) UntagResources(_a0 string, _a1 *godo.UntagResourcesReques
 
 	return r0
 }
-
-// Update provides a mock function with given fields: _a0, _a1
-func (_m *TagsService) Update(_a0 string, _a1 *godo.TagUpdateRequest) error {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *godo.TagUpdateRequest) error); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}

--- a/do/tags.go
+++ b/do/tags.go
@@ -32,7 +32,6 @@ type TagsService interface {
 	List() (Tags, error)
 	Get(string) (*Tag, error)
 	Create(*godo.TagCreateRequest) (*Tag, error)
-	Update(string, *godo.TagUpdateRequest) error
 	Delete(string) error
 	TagResources(string, *godo.TagResourcesRequest) error
 	UntagResources(string, *godo.UntagResourcesRequest) error
@@ -96,11 +95,6 @@ func (ts *tagsService) Create(tcr *godo.TagCreateRequest) (*Tag, error) {
 	}
 
 	return &Tag{Tag: t}, nil
-}
-
-func (ts *tagsService) Update(name string, tur *godo.TagUpdateRequest) error {
-	_, err := ts.client.Tags.Update(context.TODO(), name, tur)
-	return err
 }
 
 func (ts *tagsService) Delete(name string) error {


### PR DESCRIPTION
Per [our changelog](https://developers.digitalocean.com/documentation/changelog/api-v2/deprecating-update-tag/), tag rename will be deprecated on April 26, 2017.

cc @mauricio @hugocorbucci @magicgrl111 