### PR TITLE
Rename DetachByDropletID function to Detach

### DIFF
--- a/commands/volume_actions.go
+++ b/commands/volume_actions.go
@@ -61,8 +61,11 @@ func VolumeAction() *Command {
 	CmdBuilder(cmd, RunVolumeAttach, "attach <volume-id> <droplet-id>", "attach a volume", Writer,
 		aliasOpt("a"))
 
-	CmdBuilder(cmd, RunVolumeDetachByDropletID, "detach-by-droplet-id <volume-id> <droplet-id>", "detach a volume by droplet ID", Writer,
-		aliasOpt("dd"))
+	CmdBuilder(cmd, RunVolumeDetach, "detach <volume-id> <droplet-id>", "detach a volume", Writer,
+		aliasOpt("d"))
+
+	CmdBuilder(cmd, RunVolumeDetach, "detach-by-droplet-id <volume-id> <droplet-id>", "detach a volume (deprecated - use detach instead)",
+		Writer)
 
 	cmdRunVolumeResize := CmdBuilder(cmd, RunVolumeResize, "resize <volume-id>", "resize a volume", Writer,
 		aliasOpt("r"))
@@ -94,7 +97,7 @@ func RunVolumeAttach(c *CmdConfig) error {
 }
 
 // RunVolumeDetachByDropletID detaches a volume by droplet ID
-func RunVolumeDetachByDropletID(c *CmdConfig) error {
+func RunVolumeDetach(c *CmdConfig) error {
 	fn := func(das do.VolumeActionsService) (*do.Action, error) {
 		if len(c.Args) != 2 {
 			return nil, doctl.NewMissingArgsErr(c.NS)
@@ -104,7 +107,7 @@ func RunVolumeDetachByDropletID(c *CmdConfig) error {
 		if err != nil {
 			return nil, err
 		}
-		a, err := das.DetachByDropletID(volumeID, dropletID)
+		a, err := das.Detach(volumeID, dropletID)
 		return a, err
 	}
 	return performVolumeAction(c, fn)

--- a/commands/volume_actions_test.go
+++ b/commands/volume_actions_test.go
@@ -24,7 +24,7 @@ import (
 func TestVolumeActionCommand(t *testing.T) {
 	cmd := VolumeAction()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "attach", "detach-by-droplet-id", "resize")
+	assertCommandNames(t, cmd, "attach", "detach", "detach-by-droplet-id", "resize")
 }
 
 func TestVolumeActionsAttach(t *testing.T) {
@@ -38,13 +38,13 @@ func TestVolumeActionsAttach(t *testing.T) {
 	})
 }
 
-func TestVolumeDetachByDropletID(t *testing.T) {
+func TestVolumeDetach(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.volumeActions.On("DetachByDropletID", testVolume.ID, testDroplet.ID).Return(&testAction, nil)
+		tm.volumeActions.On("Detach", testVolume.ID, testDroplet.ID).Return(&testAction, nil)
 		config.Args = append(config.Args, testVolume.ID)
 		config.Args = append(config.Args, fmt.Sprintf("%d", testDroplet.ID))
 
-		err := RunVolumeDetachByDropletID(config)
+		err := RunVolumeDetach(config)
 		assert.NoError(t, err)
 	})
 }

--- a/do/mocks/VolumeActionsService.go
+++ b/do/mocks/VolumeActionsService.go
@@ -34,31 +34,8 @@ func (_m *VolumeActionsService) Attach(_a0 string, _a1 int) (*do.Action, error) 
 	return r0, r1
 }
 
-// Detach provides a mock function with given fields: _a0
-func (_m *VolumeActionsService) Detach(_a0 string) (*do.Action, error) {
-	ret := _m.Called(_a0)
-
-	var r0 *do.Action
-	if rf, ok := ret.Get(0).(func(string) *do.Action); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*do.Action)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(_a0)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// DetachByDropletID provides a mock function with given fields: _a0, _a1
-func (_m *VolumeActionsService) DetachByDropletID(_a0 string, _a1 int) (*do.Action, error) {
+// Detach provides a mock function with given fields: _a0, _a1
+func (_m *VolumeActionsService) Detach(_a0 string, _a1 int) (*do.Action, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *do.Action

--- a/do/volume_actions.go
+++ b/do/volume_actions.go
@@ -9,7 +9,7 @@ import (
 // VolumeActionsService is an interface for interacting with DigitalOcean's volume-action api.
 type VolumeActionsService interface {
 	Attach(string, int) (*Action, error)
-	DetachByDropletID(string, int) (*Action, error)
+	Detach(string, int) (*Action, error)
 	Get(string, int) (*Action, error)
 	List(string, *godo.ListOptions) ([]Action, error)
 	Resize(string, int, string) (*Action, error)
@@ -43,7 +43,7 @@ func (vas *volumeActionsService) Attach(volumeID string, dropletID int) (*Action
 
 }
 
-func (vas *volumeActionsService) DetachByDropletID(volumeID string, dropletID int) (*Action, error) {
+func (vas *volumeActionsService) Detach(volumeID string, dropletID int) (*Action, error) {
 	a, _, err := vas.client.StorageActions.DetachByDropletID(context.TODO(), volumeID, dropletID)
 	return vas.handleActionResponse(a, err)
 


### PR DESCRIPTION
This PR renames function `detach-by-droplet-id` to `detach`. Providing Droplet ID is as of [April 4th, 2017](https://github.com/digitalocean/godo/pull/136#issuecomment-291612894) required and it's not possible to detach without anymore.
`detach-by-droplet-id` is long for a function and makes its usage inconvenient.

This PR also regenerates mocks as it was forgotten in #208.

cc @mauricio @hugocorbucci @mchitten @magicgrl111 