### PR TITLE
Allow certificate-chain-path to be optional.

### DIFF
--- a/commands/certificates.go
+++ b/commands/certificates.go
@@ -40,7 +40,7 @@ func Certificate() *Command {
 	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateName, "", "", "certificate name", requiredOpt())
 	AddStringFlag(cmdCertificateCreate, doctl.ArgPrivateKeyPath, "", "", "path to a private key for the certificate", requiredOpt())
 	AddStringFlag(cmdCertificateCreate, doctl.ArgLeafCertificatePath, "", "", "path to a certificate leaf", requiredOpt())
-	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateChainPath, "", "", "path to a certificate chain", requiredOpt())
+	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateChainPath, "", "", "path to a certificate chain")
 
 	CmdBuilder(cmd, RunCertificateList, "list", "list certificates", Writer, aliasOpt("ls"))
 
@@ -94,24 +94,27 @@ func RunCertificateCreate(c *CmdConfig) error {
 		return err
 	}
 
+	r := &godo.CertificateRequest{
+		Name:            name,
+		PrivateKey:      pc,
+		LeafCertificate: lc,
+	}
+
 	ccPath, err := c.Doit.GetString(c.NS, doctl.ArgCertificateChainPath)
 	if err != nil {
 		return err
 	}
 
-	cc, err := readInputFromFile(ccPath)
-	if err != nil {
-		return err
+	if len(ccPath) > 0 {
+		cc, err := readInputFromFile(ccPath)
+		if err != nil {
+			return err
+		}
+
+		r.CertificateChain = cc
 	}
 
 	cs := c.Certificates()
-	r := &godo.CertificateRequest{
-		Name:             name,
-		PrivateKey:       pc,
-		LeafCertificate:  lc,
-		CertificateChain: cc,
-	}
-
 	cer, err := cs.Create(r)
 	if err != nil {
 		return err


### PR DESCRIPTION
```
$ doctl compute certificate create --help
create new certificate

Usage:
  doctl compute certificate create [flags]

Aliases:
  create, c


Flags:
      --certificate-chain-path string   path to a certificate chain
      --leaf-certificate-path string    path to a certificate leaf (required)
      --name string                     certificate name (required)
      --private-key-path string         path to a private key for the certificate (required)
```

`$ doctl compute certificate create --name web-cert-01 --private-key-path ~/my-secrets/priv-key.pem --leaf-certificate-path ~/my-secrets/leaf-cer.crt`

```
ID                                      Name           SHA-1 Fingerprint                           Expiration Date         Created At
cf0d1458-0809-4d41-a70c-eb7b76363db6    web-cert-01    6a70e706ec245cfb66956b150c56befcf12a5d5a    2022-01-26T15:50:00Z    2017-04-17T16:54:52Z
```