### PR TITLE
Minimize Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile


### PR DESCRIPTION
As currently the whole directory is sent to the docker socket including the `.git` directory the build context keeps growing with every commit.

As the Dockerfile downloads everything from external sources ignore the whole repository besides the Dockerfile itself, minimized the build context sent to docker.sock from >80MB to 3.072 kB.