### PR TITLE
docs: improve package manager part in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ You can use [snap](https://snapcraft.io) to install `doctl` on Ubuntu and [snap 
 snap install doctl
 ```
 
-#### Windows and GNU/Linux
+#### Windows
 
-Integrations with package managers for GNU/Linux and Windows are to come.
+Integrations with package managers for Windows are to come.
 
 ### Option 2 – Download a Release from GitHub
 


### PR DESCRIPTION
@mauricio :100: 

~By the way, maybe you should check, but I think snap is containing 1.5.0 instead of 1.6.0.
This is what I get when I execute find (`snap find doctl`) on my box:~
**It has been updated to 1.6.0 in meanwhile:**
```
Name   Version  Developer  Notes  Summary
doctl  1.6.0    joeborg    -      Digital Ocean command line tool
```
