### PR TITLE
consistency changes: ask for confirm added to all delete actions

### DIFF
--- a/args.go
+++ b/args.go
@@ -161,6 +161,6 @@ const (
 	// ArgForwardingRules is a list of forwarding rules for the load balancer.
 	ArgForwardingRules = "forwarding-rules"
 
-	// ArgDeleteForce forces deletion actions
-	ArgDeleteForce = "force"
+	// ArgForce forces confirmation on actions
+	ArgForce = "force"
 )

--- a/args_short.go
+++ b/args_short.go
@@ -14,6 +14,6 @@ limitations under the License.
 package doctl
 
 const (
-	// ArgShortDeleteForce forces deletion actions
-	ArgShortDeleteForce = "f"
+	// ArgShortForce forces confirmation on actions
+	ArgShortForce = "f"
 )

--- a/commands/certificates.go
+++ b/commands/certificates.go
@@ -45,7 +45,7 @@ func Certificate() *Command {
 	CmdBuilder(cmd, RunCertificateList, "list", "list certificates", Writer, aliasOpt("ls"))
 
 	cmdCertificateDelete := CmdBuilder(cmd, RunCertificateDelete, "delete <id>", "delete certificate", Writer, aliasOpt("d", "rm"))
-	AddBoolFlag(cmdCertificateDelete, doctl.ArgDeleteForce, doctl.ArgShortDeleteForce, false, "Force certificate delete")
+	AddBoolFlag(cmdCertificateDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force certificate delete")
 
 	return cmd
 }
@@ -143,7 +143,7 @@ func RunCertificateDelete(c *CmdConfig) error {
 	}
 	cID := c.Args[0]
 
-	force, err := c.Doit.GetBool(c.NS, doctl.ArgDeleteForce)
+	force, err := c.Doit.GetBool(c.NS, doctl.ArgForce)
 	if err != nil {
 		return err
 	}

--- a/commands/certificates_test.go
+++ b/commands/certificates_test.go
@@ -131,7 +131,7 @@ func TestCertificateDelete(t *testing.T) {
 		tm.certificates.On("Delete", cID).Return(nil)
 
 		config.Args = append(config.Args, cID)
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunCertificateDelete(config)
 		assert.NoError(t, err)

--- a/commands/domains_test.go
+++ b/commands/domains_test.go
@@ -81,6 +81,8 @@ func TestDomainsDelete(t *testing.T) {
 
 		config.Args = append(config.Args, testDomain.Name)
 
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
+
 		err := RunDomainDelete(config)
 		assert.NoError(t, err)
 	})
@@ -139,6 +141,8 @@ func TestRecordsDelete(t *testing.T) {
 		tm.domains.On("DeleteRecord", "example.com", 1).Return(nil)
 
 		config.Args = append(config.Args, "example.com", "1")
+
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunRecordDelete(config)
 		assert.NoError(t, err)

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -72,7 +72,7 @@ func Droplet() *Command {
 
 	cmdRunDropletDelete := CmdBuilder(cmd, RunDropletDelete, "delete <droplet-id|droplet-name> [droplet-id|droplet-name ...]", "Delete droplet by id or name", Writer,
 		aliasOpt("d", "del", "rm"), docCategories("droplet"))
-	AddBoolFlag(cmdRunDropletDelete, doctl.ArgDeleteForce, doctl.ArgShortDeleteForce, false, "Force droplet delete")
+	AddBoolFlag(cmdRunDropletDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force droplet delete")
 
 	cmdRunDropletGet := CmdBuilder(cmd, RunDropletGet, "get <droplet-id>", "get droplet", Writer,
 		aliasOpt("g"), displayerType(&droplet{}), docCategories("droplet"))
@@ -452,7 +452,7 @@ func allInt(in []string) ([]int, error) {
 func RunDropletDelete(c *CmdConfig) error {
 	ds := c.Droplets()
 
-	force, err := c.Doit.GetBool(c.NS, doctl.ArgDeleteForce)
+	force, err := c.Doit.GetBool(c.NS, doctl.ArgForce)
 	if err != nil {
 		return err
 	}

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -150,7 +150,7 @@ func TestDropletDelete(t *testing.T) {
 		tm.droplets.On("Delete", 1).Return(nil)
 
 		config.Args = append(config.Args, strconv.Itoa(testDroplet.ID))
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)
@@ -163,7 +163,7 @@ func TestDropletDeleteByTag(t *testing.T) {
 		tm.droplets.On("DeleteByTag", "my-tag").Return(nil)
 
 		config.Doit.Set(config.NS, doctl.ArgTagName, "my-tag")
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)
@@ -177,7 +177,7 @@ func TestDropletDeleteRepeatedID(t *testing.T) {
 
 		id := strconv.Itoa(testDroplet.ID)
 		config.Args = append(config.Args, id, id)
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)
@@ -190,7 +190,7 @@ func TestDropletDeleteByName(t *testing.T) {
 		tm.droplets.On("Delete", 1).Return(nil)
 
 		config.Args = append(config.Args, testDroplet.Name)
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)
@@ -203,7 +203,7 @@ func TestDropletDeleteByName_Ambiguous(t *testing.T) {
 		tm.droplets.On("List").Return(list, nil)
 
 		config.Args = append(config.Args, testDroplet.Name)
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunDropletDelete(config)
 		t.Log(err)
@@ -218,7 +218,7 @@ func TestDropletDelete_MixedNameAndType(t *testing.T) {
 
 		id := strconv.Itoa(testDroplet.ID)
 		config.Args = append(config.Args, id, testDroplet.Name)
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunDropletDelete(config)
 		assert.NoError(t, err)

--- a/commands/floating_ips.go
+++ b/commands/floating_ips.go
@@ -48,7 +48,8 @@ func FloatingIP() *Command {
 	CmdBuilder(cmd, RunFloatingIPGet, "get <floating-ip>", "get the details of a floating IP", Writer,
 		aliasOpt("g"), displayerType(&floatingIP{}), docCategories("floatingip"))
 
-	CmdBuilder(cmd, RunFloatingIPDelete, "delete <floating-ip>", "delete a floating IP address", Writer, aliasOpt("d"))
+	cmdRunFloatingIPDelete := CmdBuilder(cmd, RunFloatingIPDelete, "delete <floating-ip>", "delete a floating IP address", Writer, aliasOpt("d"))
+	AddBoolFlag(cmdRunFloatingIPDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force floating IP delete")
 
 	cmdFloatingIPList := CmdBuilder(cmd, RunFloatingIPList, "list", "list all floating IP addresses", Writer,
 		aliasOpt("ls"), displayerType(&floatingIP{}), docCategories("floatingip"))
@@ -119,9 +120,18 @@ func RunFloatingIPDelete(c *CmdConfig) error {
 		return doctl.NewMissingArgsErr(c.NS)
 	}
 
-	ip := c.Args[0]
+	force, err := c.Doit.GetBool(c.NS, doctl.ArgForce)
+	if err != nil {
+		return err
+	}
 
-	return fis.Delete(ip)
+	if force || AskForConfirm("delete floating IP") == nil {
+		ip := c.Args[0]
+		return fis.Delete(ip)
+	} else {
+		return fmt.Errorf("operation aborted")
+	}
+	return nil
 }
 
 // RunFloatingIPList runs floating IP create.

--- a/commands/floating_ips_test.go
+++ b/commands/floating_ips_test.go
@@ -92,6 +92,8 @@ func TestFloatingIPsDelete(t *testing.T) {
 
 		config.Args = append(config.Args, "127.0.0.1")
 
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
+
 		RunFloatingIPDelete(config)
 	})
 }

--- a/commands/images.go
+++ b/commands/images.go
@@ -63,7 +63,7 @@ func Images() *Command {
 
 	cmdRunImagesDelete := CmdBuilder(cmd, RunImagesDelete, "delete <image-id>", "Delete image", Writer,
 		docCategories("image"))
-	AddBoolFlag(cmdRunImagesDelete, doctl.ArgDeleteForce, doctl.ArgShortDeleteForce, false, "Force image delete")
+	AddBoolFlag(cmdRunImagesDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force image delete")
 
 	return cmd
 }
@@ -208,7 +208,7 @@ func RunImagesDelete(c *CmdConfig) error {
 		return doctl.NewMissingArgsErr(c.NS)
 	}
 
-	force, err := c.Doit.GetBool(c.NS, doctl.ArgDeleteForce)
+	force, err := c.Doit.GetBool(c.NS, doctl.ArgForce)
 	if err != nil {
 		return err
 	}

--- a/commands/images_test.go
+++ b/commands/images_test.go
@@ -108,7 +108,7 @@ func TestImagesDelete(t *testing.T) {
 		tm.images.On("Delete", testImage.ID).Return(nil)
 
 		config.Args = append(config.Args, strconv.Itoa(testImage.ID))
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunImagesDelete(config)
 		assert.NoError(t, err)
@@ -122,7 +122,7 @@ func TestImagesDeleteMultiple(t *testing.T) {
 		tm.images.On("Delete", testImageSecondary.ID).Return(nil)
 
 		config.Args = append(config.Args, strconv.Itoa(testImage.ID), strconv.Itoa(testImageSecondary.ID))
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunImagesDelete(config)
 		assert.NoError(t, err)

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -63,7 +63,7 @@ func LoadBalancer() *Command {
 	CmdBuilder(cmd, RunLoadBalancerList, "list", "list load balancers", Writer, aliasOpt("ls"))
 
 	cmdRunRecordDelete := CmdBuilder(cmd, RunLoadBalancerDelete, "delete <id>", "delete load balancer", Writer, aliasOpt("d", "rm"))
-	AddBoolFlag(cmdRunRecordDelete, doctl.ArgDeleteForce, doctl.ArgShortDeleteForce, false, "Force load balancer delete")
+	AddBoolFlag(cmdRunRecordDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force load balancer delete")
 
 	cmdAddDroplets := CmdBuilder(cmd, RunLoadBalancerAddDroplets, "add-droplets <id>", "add droplets to the load balancer", Writer)
 	AddStringSliceFlag(cmdAddDroplets, doctl.ArgDropletIDs, "", []string{}, "comma-separated list of droplet IDs, example valus: 12,33")
@@ -155,7 +155,7 @@ func RunLoadBalancerDelete(c *CmdConfig) error {
 	}
 	lbID := c.Args[0]
 
-	force, err := c.Doit.GetBool(c.NS, doctl.ArgDeleteForce)
+	force, err := c.Doit.GetBool(c.NS, doctl.ArgForce)
 	if err != nil {
 		return err
 	}

--- a/commands/load_balancers_test.go
+++ b/commands/load_balancers_test.go
@@ -177,7 +177,7 @@ func TestLoadBalancerDelete(t *testing.T) {
 		tm.loadBalancers.On("Delete", lbID).Return(nil)
 
 		config.Args = append(config.Args, lbID)
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunLoadBalancerDelete(config)
 		assert.NoError(t, err)

--- a/commands/snapshots.go
+++ b/commands/snapshots.go
@@ -45,7 +45,7 @@ func Snapshot() *Command {
 
 	cmdRunSnapshotDelete := CmdBuilder(cmd, RunSnapshotDelete, "delete <snapshot-id> [snapshot-id ...]", "delete snapshot", Writer,
 		aliasOpt("d"), displayerType(&droplet{}), docCategories("snapshot"))
-	AddBoolFlag(cmdRunSnapshotDelete, doctl.ArgDeleteForce, doctl.ArgShortDeleteForce, false, "Force snapshot delete")
+	AddBoolFlag(cmdRunSnapshotDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force snapshot delete")
 
 	return cmd
 }
@@ -159,7 +159,7 @@ func RunSnapshotDelete(c *CmdConfig) error {
 		return doctl.NewMissingArgsErr(c.NS)
 	}
 
-	force, err := c.Doit.GetBool(c.NS, doctl.ArgDeleteForce)
+	force, err := c.Doit.GetBool(c.NS, doctl.ArgForce)
 	if err != nil {
 		return err
 	}

--- a/commands/snapshots_test.go
+++ b/commands/snapshots_test.go
@@ -107,7 +107,7 @@ func TestSnapshotDelete(t *testing.T) {
 		tm.snapshots.On("Delete", testSnapshot.ID).Return(nil)
 
 		config.Args = append(config.Args, testSnapshot.ID)
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunSnapshotDelete(config)
 		assert.NoError(t, err)

--- a/commands/sshkeys_test.go
+++ b/commands/sshkeys_test.go
@@ -87,6 +87,8 @@ func TestKeysDeleteByID(t *testing.T) {
 
 		config.Args = append(config.Args, "1")
 
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
+
 		err := RunKeyDelete(config)
 		assert.NoError(t, err)
 	})
@@ -97,6 +99,8 @@ func TestKeysDeleteByFingerprint(t *testing.T) {
 		tm.keys.On("Delete", "fingerprint").Return(nil)
 
 		config.Args = append(config.Args, "fingerprint")
+
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunKeyDelete(config)
 		assert.NoError(t, err)

--- a/commands/tags.go
+++ b/commands/tags.go
@@ -45,7 +45,7 @@ func Tags() *Command {
 
 	cmdRunTagDelete := CmdBuilder(cmd, RunCmdTagDelete, "delete <tag-name> [tag-name ...]", "delete tag", Writer,
 		docCategories("tag"))
-	AddBoolFlag(cmdRunTagDelete, doctl.ArgDeleteForce, doctl.ArgShortDeleteForce, false, "Force tag delete")
+	AddBoolFlag(cmdRunTagDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force tag delete")
 
 	return cmd
 }
@@ -101,7 +101,7 @@ func RunCmdTagDelete(c *CmdConfig) error {
 		return doctl.NewMissingArgsErr(c.NS)
 	}
 
-	force, err := c.Doit.GetBool(c.NS, doctl.ArgDeleteForce)
+	force, err := c.Doit.GetBool(c.NS, doctl.ArgForce)
 	if err != nil {
 		return err
 	}

--- a/commands/tags_test.go
+++ b/commands/tags_test.go
@@ -79,7 +79,7 @@ func TestTagDelete(t *testing.T) {
 		tm.tags.On("Delete", "my-tag").Return(nil)
 		config.Args = append(config.Args, "my-tag")
 
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunCmdTagDelete(config)
 		assert.NoError(t, err)
@@ -92,7 +92,7 @@ func TestTagDeleteMultiple(t *testing.T) {
 		tm.tags.On("Delete", "my-tag-secondary").Return(nil)
 		config.Args = append(config.Args, "my-tag", "my-tag-secondary")
 
-		config.Doit.Set(config.NS, doctl.ArgDeleteForce, true)
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
 
 		err := RunCmdTagDelete(config)
 		assert.NoError(t, err)

--- a/commands/volumes_test.go
+++ b/commands/volumes_test.go
@@ -113,6 +113,8 @@ func TestVolumesDelete(t *testing.T) {
 
 		config.Args = append(config.Args, "test-volume")
 
+		config.Doit.Set(config.NS, doctl.ArgForce, true)
+
 		err := RunVolumeDelete(config)
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
This PR adds Ask for confirm on all delete actions.

Currently, AskForConfirm is implemented only for Droplets and functions added after confirmation was implemented. Inconsistency can cause confusion and I like keeping up with one pattern. 

This PR also renames `ArgDeleteForce` to `ArgForce` because AskForConfirm can be used for other actions as well, it's not limited to delete actions so `ArgDeleteForce` name can be inappropriate.

/cc @mauricio 