### PR TITLE
completion: make completion code generation independent on auth status

### DIFF
--- a/commands/completion.go
+++ b/commands/completion.go
@@ -70,11 +70,8 @@ func Completion() *Command {
 		IsIndex: true,
 	}
 
-	CmdBuilder(cmd, RunCompletionBash, "bash", "generate bash completion code",
-		Writer, aliasOpt("b"))
-
-	CmdBuilder(cmd, RunCompletionZsh, "zsh", "generate zsh completion code",
-		Writer, aliasOpt("z"))
+	cmdBuilderWithInit(cmd, RunCompletionBash, "bash", "generate bash completion code", Writer, false)
+	cmdBuilderWithInit(cmd, RunCompletionZsh, "zsh", "generate zsh completion code", Writer, false)
 
 	return cmd
 }


### PR DESCRIPTION
This PR makes completion code generation independent on auth status.
With current code, if you try to generate completion code before you authenticate with doctl and DO, it will show following error:
```
Error: unable to initialize DigitalOcean api client: access token is required. (hint: run 'doctl auth init')
```

This makes problem in case we want to integrate code generation into package managers such as brew and snap.

Using `cmdBuilderWithInit` seems to fix the problem if it's appropriate use for that builder.

/cc @mauricio 
