### PR TITLE
confirmation: fix confirmation behavior on windows cmd and powershell

### DIFF
--- a/commands/confirmation.go
+++ b/commands/confirmation.go
@@ -16,7 +16,11 @@ var retrieveUserInput = func(message string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.ToLower(strings.Replace(answer, "\n", "", 1)), nil
+
+	answer = strings.Replace(answer, "\r", "", 1)
+	answer = strings.Replace(answer, "\n", "", 1)
+
+	return strings.ToLower(answer), nil
 }
 
 // AskForConfirm parses and verifies user input for confirmation.


### PR DESCRIPTION
This PR fixes confirmation behavior on Command Prompt and PowerShell for Windows users.

Currently, confirmation doesn't work for Windows users. If you try command such as:
```
doctl compute droplet delete 1
```
and type `y` or `yes`, you would get `operation aborted` error.

This is because Windows shells use `\r\n` instead `\n` for new line, which makes answer verification to fail.
This PR appears to work on both Linux and Windows, so it should be good to go.

/cc @mauricio 