### PR TITLE
doctl/snap: bash/zsh completions on install

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,3 +16,8 @@ parts:
     go-importpath: github.com/digitalocean/doctl
     build-packages: [git]
     go-packages: [github.com/digitalocean/doctl/cmd/doctl]
+    install: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bash_completions
+      mkdir -p $SNAPCRAFT_PART_INSTALL/zsh_completions
+      doctl completion bash > $SNAPCRAFT_PART_INSTALL/bash_completions/doctl
+      doctl completion zsh > $SNAPCRAFT_PART_INSTALL/zsh_completions/doctl


### PR DESCRIPTION
Automatically install bash and zsh completions on doctl install via snap.
To be in effect, doctl needs to be re-released with new script.
It's not guaranteed to work, but we will see results once we build doctl with new script. It appears to work for juju, so I hope it will work for us as well.

/cc @mauricio @lxfontes 