### PR TITLE
commands/output: adds features and volumes to droplet's list output

### DIFF
--- a/commands/output.go
+++ b/commands/output.go
@@ -235,10 +235,7 @@ func (d *droplet) JSON(out io.Writer) error {
 
 func (d *droplet) Cols() []string {
 	cols := []string{
-		"ID", "Name", "PublicIPv4", "PrivateIPv4", "PublicIPv6", "Memory", "VCPUs", "Disk", "Region", "Image", "Status", "Tags",
-	}
-	if isBeta() {
-		cols = append(cols, "Volumes")
+		"ID", "Name", "PublicIPv4", "PrivateIPv4", "PublicIPv6", "Memory", "VCPUs", "Disk", "Region", "Image", "Status", "Tags", "Features", "Volumes",
 	}
 	return cols
 }
@@ -248,7 +245,7 @@ func (d *droplet) ColMap() map[string]string {
 		"ID": "ID", "Name": "Name", "PublicIPv4": "Public IPv4", "PrivateIPv4": "Private IPv4", "PublicIPv6": "Public IPv6",
 		"Memory": "Memory", "VCPUs": "VCPUs", "Disk": "Disk",
 		"Region": "Region", "Image": "Image", "Status": "Status",
-		"Tags": "Tags", "Volumes": "Volumes",
+		"Tags": "Tags", "Features": "Features", "Volumes": "Volumes",
 	}
 }
 
@@ -260,12 +257,13 @@ func (d *droplet) KV() []map[string]interface{} {
 		ip, _ := d.PublicIPv4()
 		privIP, _ := d.PrivateIPv4()
 		ip6, _ := d.PublicIPv6()
+		features := strings.Join(d.Features, ",")
 		volumes := strings.Join(d.VolumeIDs, ",")
 		m := map[string]interface{}{
 			"ID": d.ID, "Name": d.Name, "PublicIPv4": ip, "PrivateIPv4": privIP, "PublicIPv6": ip6,
 			"Memory": d.Memory, "VCPUs": d.Vcpus, "Disk": d.Disk,
 			"Region": d.Region.Slug, "Image": image, "Status": d.Status,
-			"Tags": tags, "Volumes": volumes,
+			"Tags": tags, "Features": features, "Volumes": volumes,
 		}
 		out = append(out, m)
 	}


### PR DESCRIPTION
This PR adds Features list and Volumes list to the Droplet's list output.
Volumes list was there before, but under `isBeta()` flag. As volumes are in beta phase, I removed this and it appeared back in the output.

Fixes #213 

/cc @mauricio @viola 