### PR TITLE
xdg: fix path when XDG_CONFIG_HOME is present

### DIFF
--- a/commands/xdg.go
+++ b/commands/xdg.go
@@ -22,8 +22,9 @@ import (
 func configHome() string {
 	configHome := os.Getenv("XDG_CONFIG_HOME")
 	if configHome == "" {
-		configHome = filepath.Join(homeDir(), ".config", "doctl")
+		configHome = filepath.Join(homeDir(), ".config")
 	}
+	configHome = filepath.Join(configHome, "doctl")
 
 	return configHome
 }


### PR DESCRIPTION
Closes #246 

This should fix #246 and make config location more consistent. Should we check is there config in old location as well or we can assume it's not that frequently used?

/cc @viola @mauricio 