### PR TITLE
Add support for creating CAA records

### DIFF
--- a/args.go
+++ b/args.go
@@ -82,6 +82,10 @@ const (
 	ArgRecordTTL = "record-ttl"
 	// ArgRecordWeight is a record weight argument.
 	ArgRecordWeight = "record-weight"
+	// ArgRecordFlags is a record flags argument.
+	ArgRecordFlags = "record-flags"
+	// ArgRecordTag is a record tag argument.
+	ArgRecordTag = "record-tag"
 	// ArgRegionSlug is a region slug argument.
 	ArgRegionSlug = "region"
 	// ArgSizeSlug is a size slug argument.

--- a/commands/domains.go
+++ b/commands/domains.go
@@ -71,6 +71,8 @@ func Domain() *Command {
 	AddIntFlag(cmdRecordCreate, doctl.ArgRecordPort, "", 0, "Record port")
 	AddIntFlag(cmdRecordCreate, doctl.ArgRecordTTL, "", 1800, "Record TTL")
 	AddIntFlag(cmdRecordCreate, doctl.ArgRecordWeight, "", 0, "Record weight")
+	AddIntFlag(cmdRecordCreate, doctl.ArgRecordFlags, "", 0, "Record flags")
+	AddStringFlag(cmdRecordCreate, doctl.ArgRecordTag, "", "", "Record tag")
 
 	cmdRunRecordDelete := CmdBuilder(cmdRecord, RunRecordDelete, "delete <domain> <record id...>", "delete record", Writer,
 		aliasOpt("d"), docCategories("domain"))
@@ -86,6 +88,8 @@ func Domain() *Command {
 	AddIntFlag(cmdRecordUpdate, doctl.ArgRecordPort, "", 0, "Record port")
 	AddIntFlag(cmdRecordUpdate, doctl.ArgRecordTTL, "", 1800, "Record TTL")
 	AddIntFlag(cmdRecordUpdate, doctl.ArgRecordWeight, "", 0, "Record weight")
+	AddIntFlag(cmdRecordUpdate, doctl.ArgRecordFlags, "", 0, "Record flags")
+	AddStringFlag(cmdRecordUpdate, doctl.ArgRecordTag, "", "", "Record tag")
 
 	return cmd
 }
@@ -248,6 +252,16 @@ func RunRecordCreate(c *CmdConfig) error {
 		return err
 	}
 
+	rFlags, err := c.Doit.GetInt(c.NS, doctl.ArgRecordFlags)
+	if err != nil {
+		return err
+	}
+
+	rTag, err := c.Doit.GetString(c.NS, doctl.ArgRecordTag)
+	if err != nil {
+		return err
+	}
+
 	drcr := &godo.DomainRecordEditRequest{
 		Type:     rType,
 		Name:     rName,
@@ -256,6 +270,8 @@ func RunRecordCreate(c *CmdConfig) error {
 		Port:     rPort,
 		TTL:      rTTL,
 		Weight:   rWeight,
+		Flags:    rFlags,
+		Tag:      rTag,
 	}
 
 	if len(drcr.Type) == 0 {
@@ -359,6 +375,16 @@ func RunRecordUpdate(c *CmdConfig) error {
 		return err
 	}
 
+	rFlags, err := c.Doit.GetInt(c.NS, doctl.ArgRecordFlags)
+	if err != nil {
+		return err
+	}
+
+	rTag, err := c.Doit.GetString(c.NS, doctl.ArgRecordTag)
+	if err != nil {
+		return err
+	}
+
 	drcr := &godo.DomainRecordEditRequest{
 		Type:     rType,
 		Name:     rName,
@@ -367,6 +393,8 @@ func RunRecordUpdate(c *CmdConfig) error {
 		Port:     rPort,
 		TTL:      rTTL,
 		Weight:   rWeight,
+		Flags:    rFlags,
+		Tag:      rTag,
 	}
 
 	r, err := ds.EditRecord(domainName, recordID, drcr)

--- a/vendor/github.com/digitalocean/godo/account.go
+++ b/vendor/github.com/digitalocean/godo/account.go
@@ -1,6 +1,10 @@
 package godo
 
-import "github.com/digitalocean/godo/context"
+import (
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
 
 // AccountService is an interface for interfacing with the Account
 // endpoints of the DigitalOcean API
@@ -41,7 +45,7 @@ func (s *AccountServiceOp) Get(ctx context.Context) (*Account, *Response, error)
 
 	path := "v2/account"
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/account_test.go
+++ b/vendor/github.com/digitalocean/godo/account_test.go
@@ -12,7 +12,7 @@ func TestAccountGet(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/account", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 
 		response := `
 		{ "account": {

--- a/vendor/github.com/digitalocean/godo/action.go
+++ b/vendor/github.com/digitalocean/godo/action.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo/context"
 )
@@ -61,7 +62,7 @@ func (s *ActionsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Action
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -85,7 +86,7 @@ func (s *ActionsServiceOp) Get(ctx context.Context, id int) (*Action, *Response,
 	}
 
 	path := fmt.Sprintf("%s/%d", actionsBasePath, id)
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/action_test.go
+++ b/vendor/github.com/digitalocean/godo/action_test.go
@@ -14,7 +14,7 @@ func TestAction_List(t *testing.T) {
 
 	mux.HandleFunc("/v2/actions", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"actions": [{"id":1},{"id":2}]}`)
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 	})
 
 	actions, _, err := client.Actions.List(ctx, nil)
@@ -34,7 +34,7 @@ func TestAction_ListActionMultiplePages(t *testing.T) {
 
 	mux.HandleFunc("/v2/actions", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"actions": [{"id":1},{"id":2}], "links":{"pages":{"next":"http://example.com/v2/droplets/?page=2"}}}`)
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 	})
 
 	_, resp, err := client.Actions.List(ctx, nil)
@@ -63,7 +63,7 @@ func TestAction_RetrievePageByNumber(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/actions", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -82,7 +82,7 @@ func TestAction_Get(t *testing.T) {
 
 	mux.HandleFunc("/v2/actions/12345", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"action": {"id":12345,"region":{"name":"name","slug":"slug","available":true,"sizes":["512mb"],"features":["virtio"]},"region_slug":"slug"}}`)
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 	})
 
 	action, _, err := client.Actions.Get(ctx, 12345)

--- a/vendor/github.com/digitalocean/godo/certificates.go
+++ b/vendor/github.com/digitalocean/godo/certificates.go
@@ -1,6 +1,7 @@
 package godo
 
 import (
+	"net/http"
 	"path"
 
 	"github.com/digitalocean/godo/context"
@@ -54,7 +55,7 @@ var _ CertificatesService = &CertificatesServiceOp{}
 func (c *CertificatesServiceOp) Get(ctx context.Context, cID string) (*Certificate, *Response, error) {
 	urlStr := path.Join(certificatesBasePath, cID)
 
-	req, err := c.client.NewRequest(ctx, "GET", urlStr, nil)
+	req, err := c.client.NewRequest(ctx, http.MethodGet, urlStr, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +76,7 @@ func (c *CertificatesServiceOp) List(ctx context.Context, opt *ListOptions) ([]C
 		return nil, nil, err
 	}
 
-	req, err := c.client.NewRequest(ctx, "GET", urlStr, nil)
+	req, err := c.client.NewRequest(ctx, http.MethodGet, urlStr, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -94,7 +95,7 @@ func (c *CertificatesServiceOp) List(ctx context.Context, opt *ListOptions) ([]C
 
 // Create a new certificate with provided configuration.
 func (c *CertificatesServiceOp) Create(ctx context.Context, cr *CertificateRequest) (*Certificate, *Response, error) {
-	req, err := c.client.NewRequest(ctx, "POST", certificatesBasePath, cr)
+	req, err := c.client.NewRequest(ctx, http.MethodPost, certificatesBasePath, cr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -112,7 +113,7 @@ func (c *CertificatesServiceOp) Create(ctx context.Context, cr *CertificateReque
 func (c *CertificatesServiceOp) Delete(ctx context.Context, cID string) (*Response, error) {
 	urlStr := path.Join(certificatesBasePath, cID)
 
-	req, err := c.client.NewRequest(ctx, "DELETE", urlStr, nil)
+	req, err := c.client.NewRequest(ctx, http.MethodDelete, urlStr, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/certificates_test.go
+++ b/vendor/github.com/digitalocean/godo/certificates_test.go
@@ -55,7 +55,7 @@ func TestCertificates_Get(t *testing.T) {
 	cID := "892071a0-bb95-49bc-8021-3afd67a210bf"
 	urlStr = path.Join(urlStr, cID)
 	mux.HandleFunc(urlStr, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, certJSONResponse)
 	})
 
@@ -81,7 +81,7 @@ func TestCertificates_List(t *testing.T) {
 
 	urlStr := "/v2/certificates"
 	mux.HandleFunc(urlStr, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, certsJSONResponse)
 	})
 
@@ -130,7 +130,7 @@ func TestCertificates_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		assert.Equal(t, createRequest, v)
 
 		fmt.Fprint(w, certJSONResponse)
@@ -160,7 +160,7 @@ func TestCertificates_Delete(t *testing.T) {
 	urlStr := "/v2/certificates"
 	urlStr = path.Join(urlStr, cID)
 	mux.HandleFunc(urlStr, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Certificates.Delete(ctx, cID)

--- a/vendor/github.com/digitalocean/godo/domains.go
+++ b/vendor/github.com/digitalocean/godo/domains.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo/context"
 )
@@ -76,6 +77,8 @@ type DomainRecord struct {
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight,omitempty"`
+	Flags    int    `json:"flags"`
+	Tag      string `json:"tag,omitempty"`
 }
 
 // DomainRecordEditRequest represents a request to update a domain record.
@@ -87,6 +90,8 @@ type DomainRecordEditRequest struct {
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight,omitempty"`
+	Flags    int    `json:"flags"`
+	Tag      string `json:"tag,omitempty"`
 }
 
 func (d Domain) String() string {
@@ -101,7 +106,7 @@ func (s DomainsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Domain,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,7 +131,7 @@ func (s *DomainsServiceOp) Get(ctx context.Context, name string) (*Domain, *Resp
 
 	path := fmt.Sprintf("%s/%s", domainsBasePath, name)
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -148,7 +153,7 @@ func (s *DomainsServiceOp) Create(ctx context.Context, createRequest *DomainCrea
 
 	path := domainsBasePath
 
-	req, err := s.client.NewRequest(ctx, "POST", path, createRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -169,7 +174,7 @@ func (s *DomainsServiceOp) Delete(ctx context.Context, name string) (*Response, 
 
 	path := fmt.Sprintf("%s/%s", domainsBasePath, name)
 
-	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +206,7 @@ func (s *DomainsServiceOp) Records(ctx context.Context, domain string, opt *List
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -230,7 +235,7 @@ func (s *DomainsServiceOp) Record(ctx context.Context, domain string, id int) (*
 
 	path := fmt.Sprintf("%s/%s/records/%d", domainsBasePath, domain, id)
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -256,7 +261,7 @@ func (s *DomainsServiceOp) DeleteRecord(ctx context.Context, domain string, id i
 
 	path := fmt.Sprintf("%s/%s/records/%d", domainsBasePath, domain, id)
 
-	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -313,7 +318,7 @@ func (s *DomainsServiceOp) CreateRecord(ctx context.Context,
 	}
 
 	path := fmt.Sprintf("%s/%s/records", domainsBasePath, domain)
-	req, err := s.client.NewRequest(ctx, "POST", path, createRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
 
 	if err != nil {
 		return nil, nil, err

--- a/vendor/github.com/digitalocean/godo/domains_test.go
+++ b/vendor/github.com/digitalocean/godo/domains_test.go
@@ -13,7 +13,7 @@ func TestDomains_ListDomains(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/domains", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"domains": [{"name":"foo.com"},{"name":"bar.com"}]}`)
 	})
 
@@ -33,7 +33,7 @@ func TestDomains_ListDomainsMultiplePages(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/domains", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"domains": [{"id":1},{"id":2}], "links":{"pages":{"next":"http://example.com/v2/domains/?page=2"}}}`)
 	})
 
@@ -63,7 +63,7 @@ func TestDomains_RetrievePageByNumber(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/domains", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -81,7 +81,7 @@ func TestDomains_GetDomain(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/domains/example.com", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"domain":{"name":"example.com"}}`)
 	})
 
@@ -112,7 +112,7 @@ func TestDomains_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, createRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 		}
@@ -136,7 +136,7 @@ func TestDomains_Destroy(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/domains/example.com", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Domains.Delete(ctx, "example.com")
@@ -150,7 +150,7 @@ func TestDomains_AllRecordsForDomainName(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/domains/example.com/records", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"domain_records":[{"id":1},{"id":2}]}`)
 	})
 
@@ -195,7 +195,7 @@ func TestDomains_GetRecordforDomainName(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/domains/example.com/records/1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"domain_record":{"id":1}}`)
 	})
 
@@ -215,7 +215,7 @@ func TestDomains_DeleteRecordForDomainName(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/domains/example.com/records/1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Domains.DeleteRecord(ctx, "example.com", 1)
@@ -236,6 +236,8 @@ func TestDomains_CreateRecordForDomainName(t *testing.T) {
 		Port:     10,
 		TTL:      1800,
 		Weight:   10,
+		Flags:    1,
+		Tag:      "test",
 	}
 
 	mux.HandleFunc("/v2/domains/example.com/records",
@@ -247,7 +249,7 @@ func TestDomains_CreateRecordForDomainName(t *testing.T) {
 				t.Fatalf("decode json: %v", err)
 			}
 
-			testMethod(t, r, "POST")
+			testMethod(t, r, http.MethodPost)
 			if !reflect.DeepEqual(v, createRequest) {
 				t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 			}
@@ -278,6 +280,8 @@ func TestDomains_EditRecordForDomainName(t *testing.T) {
 		Port:     10,
 		TTL:      1800,
 		Weight:   10,
+		Flags:    1,
+		Tag:      "test",
 	}
 
 	mux.HandleFunc("/v2/domains/example.com/records/1", func(w http.ResponseWriter, r *http.Request) {
@@ -316,10 +320,12 @@ func TestDomainRecord_String(t *testing.T) {
 		Port:     10,
 		TTL:      1800,
 		Weight:   10,
+		Flags:    1,
+		Tag:      "test",
 	}
 
 	stringified := record.String()
-	expected := `godo.DomainRecord{ID:1, Type:"CNAME", Name:"example", Data:"@", Priority:10, Port:10, TTL:1800, Weight:10}`
+	expected := `godo.DomainRecord{ID:1, Type:"CNAME", Name:"example", Data:"@", Priority:10, Port:10, TTL:1800, Weight:10, Flags:1, Tag:"test"}`
 	if expected != stringified {
 		t.Errorf("DomainRecord.String returned %+v, expected %+v", stringified, expected)
 	}
@@ -334,10 +340,12 @@ func TestDomainRecordEditRequest_String(t *testing.T) {
 		Port:     10,
 		TTL:      1800,
 		Weight:   10,
+		Flags:    1,
+		Tag:      "test",
 	}
 
 	stringified := record.String()
-	expected := `godo.DomainRecordEditRequest{Type:"CNAME", Name:"example", Data:"@", Priority:10, Port:10, TTL:1800, Weight:10}`
+	expected := `godo.DomainRecordEditRequest{Type:"CNAME", Name:"example", Data:"@", Priority:10, Port:10, TTL:1800, Weight:10, Flags:1, Tag:"test"}`
 	if expected != stringified {
 		t.Errorf("DomainRecordEditRequest.String returned %+v, expected %+v", stringified, expected)
 	}

--- a/vendor/github.com/digitalocean/godo/droplet_actions.go
+++ b/vendor/github.com/digitalocean/godo/droplet_actions.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/digitalocean/godo/context"
@@ -247,7 +248,7 @@ func (s *DropletActionsServiceOp) doAction(ctx context.Context, id int, request 
 
 	path := dropletActionPath(id)
 
-	req, err := s.client.NewRequest(ctx, "POST", path, request)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -272,7 +273,7 @@ func (s *DropletActionsServiceOp) doActionByTag(ctx context.Context, tag string,
 
 	path := dropletActionPathByTag(tag)
 
-	req, err := s.client.NewRequest(ctx, "POST", path, request)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -312,7 +313,7 @@ func (s *DropletActionsServiceOp) GetByURI(ctx context.Context, rawurl string) (
 }
 
 func (s *DropletActionsServiceOp) get(ctx context.Context, path string) (*Action, *Response, error) {
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/droplet_actions_test.go
+++ b/vendor/github.com/digitalocean/godo/droplet_actions_test.go
@@ -23,7 +23,7 @@ func TestDropletActions_Shutdown(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
@@ -61,7 +61,7 @@ func TestDropletActions_ShutdownByTag(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
@@ -95,7 +95,7 @@ func TestDropletAction_PowerOff(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
@@ -133,7 +133,7 @@ func TestDropletAction_PowerOffByTag(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
@@ -167,7 +167,7 @@ func TestDropletAction_PowerOn(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
@@ -205,7 +205,7 @@ func TestDropletAction_PowerOnByTag(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
@@ -238,7 +238,7 @@ func TestDropletAction_Reboot(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
@@ -274,7 +274,7 @@ func TestDropletAction_Restore(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -312,7 +312,7 @@ func TestDropletAction_Resize(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -349,7 +349,7 @@ func TestDropletAction_Rename(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -384,7 +384,7 @@ func TestDropletAction_PowerCycle(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
@@ -423,7 +423,7 @@ func TestDropletAction_PowerCycleByTag(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
@@ -458,7 +458,7 @@ func TestDropletAction_Snapshot(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -498,7 +498,7 @@ func TestDropletAction_SnapshotByTag(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -533,7 +533,7 @@ func TestDropletAction_EnableBackups(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -572,7 +572,7 @@ func TestDropletAction_EnableBackupsByTag(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -607,7 +607,7 @@ func TestDropletAction_DisableBackups(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -646,7 +646,7 @@ func TestDropletAction_DisableBackupsByTag(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -681,7 +681,7 @@ func TestDropletAction_PasswordReset(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -717,7 +717,7 @@ func TestDropletAction_RebuildByImageID(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = \n%#v, expected \n%#v", v, request)
@@ -753,7 +753,7 @@ func TestDropletAction_RebuildByImageSlug(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -789,7 +789,7 @@ func TestDropletAction_ChangeKernel(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -824,7 +824,7 @@ func TestDropletAction_EnableIPv6(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -863,7 +863,7 @@ func TestDropletAction_EnableIPv6ByTag(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -898,7 +898,7 @@ func TestDropletAction_EnablePrivateNetworking(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -937,7 +937,7 @@ func TestDropletAction_EnablePrivateNetworkingByTag(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -972,7 +972,7 @@ func TestDropletAction_Upgrade(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 
 		if !reflect.DeepEqual(v, request) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
@@ -997,7 +997,7 @@ func TestDropletActions_Get(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/droplets/123/actions/456", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 

--- a/vendor/github.com/digitalocean/godo/droplets.go
+++ b/vendor/github.com/digitalocean/godo/droplets.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo/context"
 )
@@ -275,7 +276,7 @@ func (n NetworkV6) String() string {
 
 // Performs a list request given a path.
 func (s *DropletsServiceOp) list(ctx context.Context, path string) ([]Droplet, *Response, error) {
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -322,7 +323,7 @@ func (s *DropletsServiceOp) Get(ctx context.Context, dropletID int) (*Droplet, *
 
 	path := fmt.Sprintf("%s/%d", dropletBasePath, dropletID)
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -344,7 +345,7 @@ func (s *DropletsServiceOp) Create(ctx context.Context, createRequest *DropletCr
 
 	path := dropletBasePath
 
-	req, err := s.client.NewRequest(ctx, "POST", path, createRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -369,7 +370,7 @@ func (s *DropletsServiceOp) CreateMultiple(ctx context.Context, createRequest *D
 
 	path := dropletBasePath
 
-	req, err := s.client.NewRequest(ctx, "POST", path, createRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -388,7 +389,7 @@ func (s *DropletsServiceOp) CreateMultiple(ctx context.Context, createRequest *D
 
 // Performs a delete request given a path
 func (s *DropletsServiceOp) delete(ctx context.Context, path string) (*Response, error) {
-	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +433,7 @@ func (s *DropletsServiceOp) Kernels(ctx context.Context, dropletID int, opt *Lis
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -458,7 +459,7 @@ func (s *DropletsServiceOp) Actions(ctx context.Context, dropletID int, opt *Lis
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -487,7 +488,7 @@ func (s *DropletsServiceOp) Backups(ctx context.Context, dropletID int, opt *Lis
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -516,7 +517,7 @@ func (s *DropletsServiceOp) Snapshots(ctx context.Context, dropletID int, opt *L
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -541,7 +542,7 @@ func (s *DropletsServiceOp) Neighbors(ctx context.Context, dropletID int) ([]Dro
 
 	path := fmt.Sprintf("%s/%d/neighbors", dropletBasePath, dropletID)
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/droplets_test.go
+++ b/vendor/github.com/digitalocean/godo/droplets_test.go
@@ -13,7 +13,7 @@ func TestDroplets_ListDroplets(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"droplets": [{"id":1},{"id":2}]}`)
 	})
 
@@ -37,7 +37,7 @@ func TestDroplets_ListDropletsByTag(t *testing.T) {
 			t.Errorf("Droplets.ListByTag did not request with a tag parameter")
 		}
 
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"droplets": [{"id":1},{"id":2}]}`)
 	})
 
@@ -57,7 +57,7 @@ func TestDroplets_ListDropletsMultiplePages(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 
 		dr := dropletsRoot{
 			Droplets: []Droplet{
@@ -103,7 +103,7 @@ func TestDroplets_RetrievePageByNumber(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -121,7 +121,7 @@ func TestDroplets_GetDroplet(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/droplets/12345", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"droplet":{"id":12345}}`)
 	})
 
@@ -265,7 +265,7 @@ func TestDroplets_Destroy(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/droplets/12345", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Droplets.Delete(ctx, 12345)
@@ -283,7 +283,7 @@ func TestDroplets_DestroyByTag(t *testing.T) {
 			t.Errorf("Droplets.DeleteByTag did not request with a tag parameter")
 		}
 
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Droplets.DeleteByTag(ctx, "testing-1")
@@ -297,7 +297,7 @@ func TestDroplets_Kernels(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/droplets/12345/kernels", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"kernels": [{"id":1},{"id":2}]}`)
 	})
 
@@ -318,7 +318,7 @@ func TestDroplets_Snapshots(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/droplets/12345/snapshots", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"snapshots": [{"id":1},{"id":2}]}`)
 	})
 
@@ -339,7 +339,7 @@ func TestDroplets_Backups(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/droplets/12345/backups", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"backups": [{"id":1},{"id":2}]}`)
 	})
 
@@ -360,7 +360,7 @@ func TestDroplets_Actions(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/droplets/12345/actions", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"actions": [{"id":1},{"id":2}]}`)
 	})
 
@@ -381,7 +381,7 @@ func TestDroplets_Neighbors(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/droplets/12345/neighbors", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"droplets": [{"id":1},{"id":2}]}`)
 	})
 

--- a/vendor/github.com/digitalocean/godo/firewalls.go
+++ b/vendor/github.com/digitalocean/godo/firewalls.go
@@ -1,6 +1,7 @@
 package godo
 
 import (
+	"net/http"
 	"path"
 	"strconv"
 
@@ -107,7 +108,7 @@ var _ FirewallsService = &FirewallsServiceOp{}
 func (fw *FirewallsServiceOp) Get(ctx context.Context, fID string) (*Firewall, *Response, error) {
 	path := path.Join(firewallsBasePath, fID)
 
-	req, err := fw.client.NewRequest(ctx, "GET", path, nil)
+	req, err := fw.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -123,7 +124,7 @@ func (fw *FirewallsServiceOp) Get(ctx context.Context, fID string) (*Firewall, *
 
 // Create a new Firewall with a given configuration.
 func (fw *FirewallsServiceOp) Create(ctx context.Context, fr *FirewallRequest) (*Firewall, *Response, error) {
-	req, err := fw.client.NewRequest(ctx, "POST", firewallsBasePath, fr)
+	req, err := fw.client.NewRequest(ctx, http.MethodPost, firewallsBasePath, fr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -158,7 +159,7 @@ func (fw *FirewallsServiceOp) Update(ctx context.Context, fID string, fr *Firewa
 // Delete a Firewall by its identifier.
 func (fw *FirewallsServiceOp) Delete(ctx context.Context, fID string) (*Response, error) {
 	path := path.Join(firewallsBasePath, fID)
-	return fw.createAndDoReq(ctx, "DELETE", path, nil)
+	return fw.createAndDoReq(ctx, http.MethodDelete, path, nil)
 }
 
 // List Firewalls.
@@ -185,37 +186,37 @@ func (fw *FirewallsServiceOp) ListByDroplet(ctx context.Context, dID int, opt *L
 // AddDroplets to a Firewall.
 func (fw *FirewallsServiceOp) AddDroplets(ctx context.Context, fID string, dropletIDs ...int) (*Response, error) {
 	path := path.Join(firewallsBasePath, fID, "droplets")
-	return fw.createAndDoReq(ctx, "POST", path, &dropletsRequest{IDs: dropletIDs})
+	return fw.createAndDoReq(ctx, http.MethodPost, path, &dropletsRequest{IDs: dropletIDs})
 }
 
 // RemoveDroplets from a Firewall.
 func (fw *FirewallsServiceOp) RemoveDroplets(ctx context.Context, fID string, dropletIDs ...int) (*Response, error) {
 	path := path.Join(firewallsBasePath, fID, "droplets")
-	return fw.createAndDoReq(ctx, "DELETE", path, &dropletsRequest{IDs: dropletIDs})
+	return fw.createAndDoReq(ctx, http.MethodDelete, path, &dropletsRequest{IDs: dropletIDs})
 }
 
 // AddTags to a Firewall.
 func (fw *FirewallsServiceOp) AddTags(ctx context.Context, fID string, tags ...string) (*Response, error) {
 	path := path.Join(firewallsBasePath, fID, "tags")
-	return fw.createAndDoReq(ctx, "POST", path, &tagsRequest{Tags: tags})
+	return fw.createAndDoReq(ctx, http.MethodPost, path, &tagsRequest{Tags: tags})
 }
 
 // RemoveTags from a Firewall.
 func (fw *FirewallsServiceOp) RemoveTags(ctx context.Context, fID string, tags ...string) (*Response, error) {
 	path := path.Join(firewallsBasePath, fID, "tags")
-	return fw.createAndDoReq(ctx, "DELETE", path, &tagsRequest{Tags: tags})
+	return fw.createAndDoReq(ctx, http.MethodDelete, path, &tagsRequest{Tags: tags})
 }
 
 // AddRules to a Firewall.
 func (fw *FirewallsServiceOp) AddRules(ctx context.Context, fID string, rr *FirewallRulesRequest) (*Response, error) {
 	path := path.Join(firewallsBasePath, fID, "rules")
-	return fw.createAndDoReq(ctx, "POST", path, rr)
+	return fw.createAndDoReq(ctx, http.MethodPost, path, rr)
 }
 
 // RemoveRules from a Firewall.
 func (fw *FirewallsServiceOp) RemoveRules(ctx context.Context, fID string, rr *FirewallRulesRequest) (*Response, error) {
 	path := path.Join(firewallsBasePath, fID, "rules")
-	return fw.createAndDoReq(ctx, "DELETE", path, rr)
+	return fw.createAndDoReq(ctx, http.MethodDelete, path, rr)
 }
 
 type dropletsRequest struct {
@@ -245,7 +246,7 @@ func (fw *FirewallsServiceOp) createAndDoReq(ctx context.Context, method, path s
 }
 
 func (fw *FirewallsServiceOp) listHelper(ctx context.Context, path string) ([]Firewall, *Response, error) {
-	req, err := fw.client.NewRequest(ctx, "GET", path, nil)
+	req, err := fw.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/firewalls_test.go
+++ b/vendor/github.com/digitalocean/godo/firewalls_test.go
@@ -224,7 +224,7 @@ func TestFirewalls_Get(t *testing.T) {
 	urlStr = path.Join(urlStr, fID)
 
 	mux.HandleFunc(urlStr, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, firewallJSONResponse)
 	})
 
@@ -333,7 +333,7 @@ func TestFirewalls_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, expectedFirewallRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, expectedFirewallRequest)
 		}
@@ -481,7 +481,7 @@ func TestFirewalls_Delete(t *testing.T) {
 	fID := "fe6b88f2-b42b-4bf7-bbd3-5ae20208f0b0"
 	urlStr = path.Join(urlStr, fID)
 	mux.HandleFunc(urlStr, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Firewalls.Delete(ctx, fID)
@@ -496,7 +496,7 @@ func TestFirewalls_List(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/firewalls", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, firewallListJSONResponse)
 	})
 
@@ -517,7 +517,7 @@ func TestFirewalls_ListByDroplet(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/droplets/123/firewalls", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, firewallListJSONResponse)
 	})
 
@@ -550,7 +550,7 @@ func TestFirewalls_AddDroplets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, dRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, dRequest)
 		}
@@ -589,7 +589,7 @@ func TestFirewalls_RemoveDroplets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 		if !reflect.DeepEqual(v, dRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, dRequest)
 		}
@@ -628,7 +628,7 @@ func TestFirewalls_AddTags(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, tRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, tRequest)
 		}
@@ -666,7 +666,7 @@ func TestFirewalls_RemoveTags(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 		if !reflect.DeepEqual(v, tRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, tRequest)
 		}
@@ -721,7 +721,7 @@ func TestFirewalls_AddRules(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, rr) {
 			t.Errorf("Request body = %+v, expected %+v", v, rr)
 		}
@@ -776,7 +776,7 @@ func TestFirewalls_RemoveRules(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 		if !reflect.DeepEqual(v, rr) {
 			t.Errorf("Request body = %+v, expected %+v", v, rr)
 		}

--- a/vendor/github.com/digitalocean/godo/floating_ips.go
+++ b/vendor/github.com/digitalocean/godo/floating_ips.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo/context"
 )
@@ -63,7 +64,7 @@ func (f *FloatingIPsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Fl
 		return nil, nil, err
 	}
 
-	req, err := f.client.NewRequest(ctx, "GET", path, nil)
+	req, err := f.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -84,7 +85,7 @@ func (f *FloatingIPsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Fl
 func (f *FloatingIPsServiceOp) Get(ctx context.Context, ip string) (*FloatingIP, *Response, error) {
 	path := fmt.Sprintf("%s/%s", floatingBasePath, ip)
 
-	req, err := f.client.NewRequest(ctx, "GET", path, nil)
+	req, err := f.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -103,7 +104,7 @@ func (f *FloatingIPsServiceOp) Get(ctx context.Context, ip string) (*FloatingIP,
 func (f *FloatingIPsServiceOp) Create(ctx context.Context, createRequest *FloatingIPCreateRequest) (*FloatingIP, *Response, error) {
 	path := floatingBasePath
 
-	req, err := f.client.NewRequest(ctx, "POST", path, createRequest)
+	req, err := f.client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -124,7 +125,7 @@ func (f *FloatingIPsServiceOp) Create(ctx context.Context, createRequest *Floati
 func (f *FloatingIPsServiceOp) Delete(ctx context.Context, ip string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", floatingBasePath, ip)
 
-	req, err := f.client.NewRequest(ctx, "DELETE", path, nil)
+	req, err := f.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/floating_ips_actions.go
+++ b/vendor/github.com/digitalocean/godo/floating_ips_actions.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo/context"
 )
@@ -57,7 +58,7 @@ func (s *FloatingIPActionsServiceOp) List(ctx context.Context, ip string, opt *L
 func (s *FloatingIPActionsServiceOp) doAction(ctx context.Context, ip string, request *ActionRequest) (*Action, *Response, error) {
 	path := floatingIPActionPath(ip)
 
-	req, err := s.client.NewRequest(ctx, "POST", path, request)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -72,7 +73,7 @@ func (s *FloatingIPActionsServiceOp) doAction(ctx context.Context, ip string, re
 }
 
 func (s *FloatingIPActionsServiceOp) get(ctx context.Context, path string) (*Action, *Response, error) {
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -87,7 +88,7 @@ func (s *FloatingIPActionsServiceOp) get(ctx context.Context, path string) (*Act
 }
 
 func (s *FloatingIPActionsServiceOp) list(ctx context.Context, path string) ([]Action, *Response, error) {
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/floating_ips_actions_test.go
+++ b/vendor/github.com/digitalocean/godo/floating_ips_actions_test.go
@@ -24,7 +24,7 @@ func TestFloatingIPsActions_Assign(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, assignRequest) {
 			t.Errorf("Request body = %#v, expected %#v", v, assignRequest)
 		}
@@ -59,7 +59,7 @@ func TestFloatingIPsActions_Unassign(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, unassignRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, unassignRequest)
 		}
@@ -83,7 +83,7 @@ func TestFloatingIPsActions_Get(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/floating_ips/192.168.0.1/actions/456", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
@@ -103,7 +103,7 @@ func TestFloatingIPsActions_List(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/floating_ips/192.168.0.1/actions", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprintf(w, `{"actions":[{"status":"in-progress"}]}`)
 	})
 
@@ -123,7 +123,7 @@ func TestFloatingIPsActions_ListMultiplePages(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/floating_ips/192.168.0.1/actions", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"actions":[{"status":"in-progress"}], "links":{"pages":{"next":"http://example.com/v2/floating_ips/192.168.0.1/actions?page=2"}}}`)
 	})
 
@@ -153,7 +153,7 @@ func TestFloatingIPsActions_ListPageByNumber(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/floating_ips/192.168.0.1/actions", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 

--- a/vendor/github.com/digitalocean/godo/floating_ips_test.go
+++ b/vendor/github.com/digitalocean/godo/floating_ips_test.go
@@ -13,7 +13,7 @@ func TestFloatingIPs_ListFloatingIPs(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/floating_ips", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"floating_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}]}`)
 	})
 
@@ -36,7 +36,7 @@ func TestFloatingIPs_ListFloatingIPsMultiplePages(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/floating_ips", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"floating_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}], "links":{"pages":{"next":"http://example.com/v2/floating_ips/?page=2"}}}`)
 	})
 
@@ -66,7 +66,7 @@ func TestFloatingIPs_RetrievePageByNumber(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/floating_ips", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -84,7 +84,7 @@ func TestFloatingIPs_Get(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/floating_ips/192.168.0.1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"floating_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"}}`)
 	})
 
@@ -115,7 +115,7 @@ func TestFloatingIPs_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, createRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 		}
@@ -139,7 +139,7 @@ func TestFloatingIPs_Destroy(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/floating_ips/192.168.0.1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.FloatingIPs.Delete(ctx, "192.168.0.1")

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -210,7 +210,7 @@ func SetBaseURL(bu string) ClientOpt {
 // SetUserAgent is a client option for setting the user agent.
 func SetUserAgent(ua string) ClientOpt {
 	return func(c *Client) error {
-		c.UserAgent = fmt.Sprintf("%s+%s", ua, c.UserAgent)
+		c.UserAgent = fmt.Sprintf("%s %s", ua, c.UserAgent)
 		return nil
 	}
 }

--- a/vendor/github.com/digitalocean/godo/image_actions.go
+++ b/vendor/github.com/digitalocean/godo/image_actions.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo/context"
 )
@@ -35,7 +36,7 @@ func (i *ImageActionsServiceOp) Transfer(ctx context.Context, imageID int, trans
 
 	path := fmt.Sprintf("v2/images/%d/actions", imageID)
 
-	req, err := i.client.NewRequest(ctx, "POST", path, transferRequest)
+	req, err := i.client.NewRequest(ctx, http.MethodPost, path, transferRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -61,7 +62,7 @@ func (i *ImageActionsServiceOp) Convert(ctx context.Context, imageID int) (*Acti
 		"type": "convert",
 	}
 
-	req, err := i.client.NewRequest(ctx, "POST", path, convertRequest)
+	req, err := i.client.NewRequest(ctx, http.MethodPost, path, convertRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -87,7 +88,7 @@ func (i *ImageActionsServiceOp) Get(ctx context.Context, imageID, actionID int) 
 
 	path := fmt.Sprintf("v2/images/%d/actions/%d", imageID, actionID)
 
-	req, err := i.client.NewRequest(ctx, "GET", path, nil)
+	req, err := i.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/image_actions_test.go
+++ b/vendor/github.com/digitalocean/godo/image_actions_test.go
@@ -21,7 +21,7 @@ func TestImageActions_Transfer(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, transferRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, transferRequest)
 		}
@@ -56,7 +56,7 @@ func TestImageActions_Convert(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, convertRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, convertRequest)
 		}
@@ -81,7 +81,7 @@ func TestImageActions_Get(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/images/123/actions/456", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 

--- a/vendor/github.com/digitalocean/godo/images.go
+++ b/vendor/github.com/digitalocean/godo/images.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo/context"
 )
@@ -140,7 +141,7 @@ func (s *ImagesServiceOp) Delete(ctx context.Context, imageID int) (*Response, e
 
 	path := fmt.Sprintf("%s/%d", imageBasePath, imageID)
 
-	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +155,7 @@ func (s *ImagesServiceOp) Delete(ctx context.Context, imageID int) (*Response, e
 func (s *ImagesServiceOp) get(ctx context.Context, ID interface{}) (*Image, *Response, error) {
 	path := fmt.Sprintf("%s/%v", imageBasePath, ID)
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -180,7 +181,7 @@ func (s *ImagesServiceOp) list(ctx context.Context, opt *ListOptions, listOpt *l
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/images_test.go
+++ b/vendor/github.com/digitalocean/godo/images_test.go
@@ -13,7 +13,7 @@ func TestImages_List(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/images", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"images":[{"id":1},{"id":2}]}`)
 	})
 
@@ -33,7 +33,7 @@ func TestImages_ListDistribution(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/images", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		expected := "distribution"
 		actual := r.URL.Query().Get("type")
 		if actual != expected {
@@ -58,7 +58,7 @@ func TestImages_ListApplication(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/images", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		expected := "application"
 		actual := r.URL.Query().Get("type")
 		if actual != expected {
@@ -83,7 +83,7 @@ func TestImages_ListUser(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/images", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		expected := "true"
 		actual := r.URL.Query().Get("private")
 		if actual != expected {
@@ -109,7 +109,7 @@ func TestImages_ListImagesMultiplePages(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/images", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"images": [{"id":1},{"id":2}], "links":{"pages":{"next":"http://example.com/v2/images/?page=2"}}}`)
 	})
 
@@ -138,7 +138,7 @@ func TestImages_RetrievePageByNumber(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/images", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -156,7 +156,7 @@ func TestImages_GetImageByID(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/images/12345", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"image":{"id":12345}}`)
 	})
 
@@ -176,7 +176,7 @@ func TestImages_GetImageBySlug(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/images/ubuntu", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"image":{"id":12345}}`)
 	})
 
@@ -232,7 +232,7 @@ func TestImages_Destroy(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/images/12345", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Images.Delete(ctx, 12345)

--- a/vendor/github.com/digitalocean/godo/keys.go
+++ b/vendor/github.com/digitalocean/godo/keys.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo/context"
 )
@@ -70,7 +71,7 @@ func (s *KeysServiceOp) List(ctx context.Context, opt *ListOptions) ([]Key, *Res
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -89,7 +90,7 @@ func (s *KeysServiceOp) List(ctx context.Context, opt *ListOptions) ([]Key, *Res
 
 // Performs a get given a path
 func (s *KeysServiceOp) get(ctx context.Context, path string) (*Key, *Response, error) {
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -129,7 +130,7 @@ func (s *KeysServiceOp) Create(ctx context.Context, createRequest *KeyCreateRequ
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
 
-	req, err := s.client.NewRequest(ctx, "POST", keysBasePath, createRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, keysBasePath, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -195,7 +196,7 @@ func (s *KeysServiceOp) UpdateByFingerprint(ctx context.Context, fingerprint str
 
 // Delete key using a path
 func (s *KeysServiceOp) delete(ctx context.Context, path string) (*Response, error) {
-	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/keys_test.go
+++ b/vendor/github.com/digitalocean/godo/keys_test.go
@@ -13,7 +13,7 @@ func TestKeys_List(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/account/keys", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"ssh_keys":[{"id":1},{"id":2}]}`)
 	})
 
@@ -33,7 +33,7 @@ func TestKeys_ListKeysMultiplePages(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/account/keys", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"droplets": [{"id":1},{"id":2}], "links":{"pages":{"next":"http://example.com/v2/account/keys/?page=2"}}}`)
 	})
 
@@ -62,7 +62,7 @@ func TestKeys_RetrievePageByNumber(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/account/keys", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -79,7 +79,7 @@ func TestKeys_GetByID(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/account/keys/12345", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"ssh_key": {"id":12345}}`)
 	})
 
@@ -99,7 +99,7 @@ func TestKeys_GetByFingerprint(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/account/keys/aa:bb:cc", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"ssh_key": {"fingerprint":"aa:bb:cc"}}`)
 	})
 
@@ -130,7 +130,7 @@ func TestKeys_Create(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, createRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 		}
@@ -226,7 +226,7 @@ func TestKeys_DestroyByID(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/account/keys/12345", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Keys.DeleteByID(ctx, 12345)
@@ -240,7 +240,7 @@ func TestKeys_DestroyByFingerprint(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/account/keys/aa:bb:cc", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Keys.DeleteByFingerprint(ctx, "aa:bb:cc")

--- a/vendor/github.com/digitalocean/godo/load_balancers_test.go
+++ b/vendor/github.com/digitalocean/godo/load_balancers_test.go
@@ -272,7 +272,7 @@ var lbUpdateJSONResponse = `
 }
 `
 
-func TestLoadBlanacers_Get(t *testing.T) {
+func TestLoadBalancers_Get(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -280,7 +280,7 @@ func TestLoadBlanacers_Get(t *testing.T) {
 	loadBalancerId := "37e6be88-01ec-4ec7-9bc6-a514d4719057"
 	path = fmt.Sprintf("%s/%s", path, loadBalancerId)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, lbGetJSONResponse)
 	})
 
@@ -333,7 +333,7 @@ func TestLoadBlanacers_Get(t *testing.T) {
 	assert.Equal(t, expected, loadBalancer)
 }
 
-func TestLoadBlanacers_Create(t *testing.T) {
+func TestLoadBalancers_Create(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -377,7 +377,7 @@ func TestLoadBlanacers_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		assert.Equal(t, createRequest, v)
 
 		fmt.Fprint(w, lbCreateJSONResponse)
@@ -440,7 +440,7 @@ func TestLoadBlanacers_Create(t *testing.T) {
 	assert.Equal(t, expected, loadBalancer)
 }
 
-func TestLoadBlanacers_Update(t *testing.T) {
+func TestLoadBalancers_Update(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -547,13 +547,13 @@ func TestLoadBlanacers_Update(t *testing.T) {
 	assert.Equal(t, expected, loadBalancer)
 }
 
-func TestLoadBlanacers_List(t *testing.T) {
+func TestLoadBalancers_List(t *testing.T) {
 	setup()
 	defer teardown()
 
 	path := "/v2/load_balancers"
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, lbListJSONResponse)
 	})
 
@@ -608,13 +608,13 @@ func TestLoadBlanacers_List(t *testing.T) {
 	assert.Equal(t, expected, loadBalancers)
 }
 
-func TestLoadBlanacers_List_Pagination(t *testing.T) {
+func TestLoadBalancers_List_Pagination(t *testing.T) {
 	setup()
 	defer teardown()
 
 	path := "/v2/load_balancers"
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		testFormValues(t, r, map[string]string{"page": "2"})
 		fmt.Fprint(w, lbListJSONResponse)
 	})
@@ -630,7 +630,7 @@ func TestLoadBlanacers_List_Pagination(t *testing.T) {
 	assert.Equal(t, "http://localhost:3001/v2/load_balancers?page=3&per_page=1", resp.Links.Pages.Last)
 }
 
-func TestLoadBlanacers_Delete(t *testing.T) {
+func TestLoadBalancers_Delete(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -638,7 +638,7 @@ func TestLoadBlanacers_Delete(t *testing.T) {
 	path := "/v2/load_balancers"
 	path = fmt.Sprintf("%s/%s", path, lbID)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.LoadBalancers.Delete(ctx, lbID)
@@ -648,7 +648,7 @@ func TestLoadBlanacers_Delete(t *testing.T) {
 	}
 }
 
-func TestLoadBlanacers_AddDroplets(t *testing.T) {
+func TestLoadBalancers_AddDroplets(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -665,7 +665,7 @@ func TestLoadBlanacers_AddDroplets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		assert.Equal(t, dropletIdsRequest, v)
 
 		fmt.Fprint(w, nil)
@@ -678,7 +678,7 @@ func TestLoadBlanacers_AddDroplets(t *testing.T) {
 	}
 }
 
-func TestLoadBlanacers_RemoveDroplets(t *testing.T) {
+func TestLoadBalancers_RemoveDroplets(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -695,7 +695,7 @@ func TestLoadBlanacers_RemoveDroplets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 		assert.Equal(t, dropletIdsRequest, v)
 
 		fmt.Fprint(w, nil)
@@ -708,7 +708,7 @@ func TestLoadBlanacers_RemoveDroplets(t *testing.T) {
 	}
 }
 
-func TestLoadBlanacers_AddForwardingRules(t *testing.T) {
+func TestLoadBalancers_AddForwardingRules(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -739,7 +739,7 @@ func TestLoadBlanacers_AddForwardingRules(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		assert.Equal(t, frr, v)
 
 		fmt.Fprint(w, nil)
@@ -752,7 +752,7 @@ func TestLoadBlanacers_AddForwardingRules(t *testing.T) {
 	}
 }
 
-func TestLoadBlanacers_RemoveForwardingRules(t *testing.T) {
+func TestLoadBalancers_RemoveForwardingRules(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -782,7 +782,7 @@ func TestLoadBlanacers_RemoveForwardingRules(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 		assert.Equal(t, frr, v)
 
 		fmt.Fprint(w, nil)
@@ -793,4 +793,109 @@ func TestLoadBlanacers_RemoveForwardingRules(t *testing.T) {
 	if err != nil {
 		t.Errorf("LoadBalancers.RemoveForwardingRules returned error: %v", err)
 	}
+}
+
+func TestLoadBalancers_AsRequest(t *testing.T) {
+	lb := &LoadBalancer{
+		ID:        "37e6be88-01ec-4ec7-9bc6-a514d4719057",
+		Name:      "test-loadbalancer",
+		IP:        "10.0.0.1",
+		Algorithm: "least_connections",
+		Status:    "active",
+		Created:   "2011-06-24T12:00:00Z",
+		HealthCheck: &HealthCheck{
+			Protocol:               "http",
+			Port:                   80,
+			Path:                   "/ping",
+			CheckIntervalSeconds:   30,
+			ResponseTimeoutSeconds: 10,
+			HealthyThreshold:       3,
+			UnhealthyThreshold:     3,
+		},
+		StickySessions: &StickySessions{
+			Type:             "cookies",
+			CookieName:       "nomnom",
+			CookieTtlSeconds: 32,
+		},
+		Region: &Region{
+			Slug: "lon1",
+		},
+		RedirectHttpToHttps: true,
+	}
+	lb.DropletIDs = make([]int, 1, 2)
+	lb.DropletIDs[0] = 12345
+	lb.ForwardingRules = make([]ForwardingRule, 1, 2)
+	lb.ForwardingRules[0] = ForwardingRule{
+		EntryProtocol:  "http",
+		EntryPort:      80,
+		TargetProtocol: "http",
+		TargetPort:     80,
+	}
+
+	want := &LoadBalancerRequest{
+		Name:      "test-loadbalancer",
+		Algorithm: "least_connections",
+		Region:    "lon1",
+		ForwardingRules: []ForwardingRule{ForwardingRule{
+			EntryProtocol:  "http",
+			EntryPort:      80,
+			TargetProtocol: "http",
+			TargetPort:     80,
+		}},
+		HealthCheck: &HealthCheck{
+			Protocol:               "http",
+			Port:                   80,
+			Path:                   "/ping",
+			CheckIntervalSeconds:   30,
+			ResponseTimeoutSeconds: 10,
+			HealthyThreshold:       3,
+			UnhealthyThreshold:     3,
+		},
+		StickySessions: &StickySessions{
+			Type:             "cookies",
+			CookieName:       "nomnom",
+			CookieTtlSeconds: 32,
+		},
+		DropletIDs:          []int{12345},
+		RedirectHttpToHttps: true,
+	}
+
+	r := lb.AsRequest()
+	assert.Equal(t, want, r)
+	assert.False(t, r.HealthCheck == lb.HealthCheck, "HealthCheck points to same struct")
+	assert.False(t, r.StickySessions == lb.StickySessions, "StickySessions points to same struct")
+
+	r.DropletIDs = append(r.DropletIDs, 54321)
+	r.ForwardingRules = append(r.ForwardingRules, ForwardingRule{
+		EntryProtocol:  "https",
+		EntryPort:      443,
+		TargetProtocol: "https",
+		TargetPort:     443,
+		TlsPassthrough: true,
+	})
+
+	// Check that original LoadBalancer hasn't changed
+	lb.DropletIDs = append(lb.DropletIDs, 13579)
+	lb.ForwardingRules = append(lb.ForwardingRules, ForwardingRule{
+		EntryProtocol:  "tcp",
+		EntryPort:      587,
+		TargetProtocol: "tcp",
+		TargetPort:     587,
+	})
+	assert.Equal(t, []int{12345, 54321}, r.DropletIDs)
+	assert.Equal(t, []ForwardingRule{
+		ForwardingRule{
+			EntryProtocol:  "http",
+			EntryPort:      80,
+			TargetProtocol: "http",
+			TargetPort:     80,
+		},
+		ForwardingRule{
+			EntryProtocol:  "https",
+			EntryPort:      443,
+			TargetProtocol: "https",
+			TargetPort:     443,
+			TlsPassthrough: true,
+		},
+	}, r.ForwardingRules)
 }

--- a/vendor/github.com/digitalocean/godo/regions.go
+++ b/vendor/github.com/digitalocean/godo/regions.go
@@ -1,6 +1,10 @@
 package godo
 
-import "github.com/digitalocean/godo/context"
+import (
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
 
 // RegionsService is an interface for interfacing with the regions
 // endpoints of the DigitalOcean API
@@ -43,7 +47,7 @@ func (s *RegionsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Region
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/regions_test.go
+++ b/vendor/github.com/digitalocean/godo/regions_test.go
@@ -12,7 +12,7 @@ func TestRegions_List(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/regions", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"regions":[{"slug":"1"},{"slug":"2"}]}`)
 	})
 
@@ -32,7 +32,7 @@ func TestRegions_ListRegionsMultiplePages(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/regions", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"regions": [{"id":1},{"id":2}], "links":{"pages":{"next":"http://example.com/v2/regions/?page=2"}}}`)
 	})
 
@@ -62,7 +62,7 @@ func TestRegions_RetrievePageByNumber(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/regions", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 

--- a/vendor/github.com/digitalocean/godo/sizes.go
+++ b/vendor/github.com/digitalocean/godo/sizes.go
@@ -1,6 +1,10 @@
 package godo
 
-import "github.com/digitalocean/godo/context"
+import (
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
 
 // SizesService is an interface for interfacing with the size
 // endpoints of the DigitalOcean API
@@ -47,7 +51,7 @@ func (s *SizesServiceOp) List(ctx context.Context, opt *ListOptions) ([]Size, *R
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/sizes_test.go
+++ b/vendor/github.com/digitalocean/godo/sizes_test.go
@@ -12,7 +12,7 @@ func TestSizes_List(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/sizes", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"sizes":[{"slug":"1"},{"slug":"2"}]}`)
 	})
 
@@ -32,7 +32,7 @@ func TestSizes_ListSizesMultiplePages(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/sizes", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"sizes": [{"id":1},{"id":2}], "links":{"pages":{"next":"http://example.com/v2/sizes/?page=2"}}}`)
 	})
 
@@ -62,7 +62,7 @@ func TestSizes_RetrievePageByNumber(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/sizes", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 

--- a/vendor/github.com/digitalocean/godo/snapshots.go
+++ b/vendor/github.com/digitalocean/godo/snapshots.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo/context"
 )
@@ -82,7 +83,7 @@ func (s *SnapshotsServiceOp) Get(ctx context.Context, snapshotID string) (*Snaps
 func (s *SnapshotsServiceOp) Delete(ctx context.Context, snapshotID string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", snapshotBasePath, snapshotID)
 
-	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +97,7 @@ func (s *SnapshotsServiceOp) Delete(ctx context.Context, snapshotID string) (*Re
 func (s *SnapshotsServiceOp) get(ctx context.Context, ID string) (*Snapshot, *Response, error) {
 	path := fmt.Sprintf("%s/%s", snapshotBasePath, ID)
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -122,7 +123,7 @@ func (s *SnapshotsServiceOp) list(ctx context.Context, opt *ListOptions, listOpt
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/snapshots_test.go
+++ b/vendor/github.com/digitalocean/godo/snapshots_test.go
@@ -14,7 +14,7 @@ func TestSnapshots_List(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/snapshots", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"snapshots":[{"id":"1"},{"id":"2", "size_gigabytes": 4.84}]}`)
 	})
 	ctx := context.Background()
@@ -34,7 +34,7 @@ func TestSnapshots_ListVolume(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/snapshots", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		expected := "volume"
 		actual := r.URL.Query().Get("resource_type")
 		if actual != expected {
@@ -60,7 +60,7 @@ func TestSnapshots_ListDroplet(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/snapshots", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		expected := "droplet"
 		actual := r.URL.Query().Get("resource_type")
 		if actual != expected {
@@ -87,7 +87,7 @@ func TestSnapshots_ListSnapshotsMultiplePages(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/snapshots", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"snapshots": [{"id":"1"},{"id":"2"}], "links":{"pages":{"next":"http://example.com/v2/snapshots/?page=2"}}}`)
 	})
 
@@ -117,7 +117,7 @@ func TestSnapshots_RetrievePageByNumber(t *testing.T) {
     }`
 
 	mux.HandleFunc("/v2/snapshots", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -136,7 +136,7 @@ func TestSnapshots_GetSnapshotByID(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/snapshots/12345", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"snapshot":{"id":"12345"}}`)
 	})
 
@@ -157,7 +157,7 @@ func TestSnapshots_Destroy(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/snapshots/12345", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	ctx := context.Background()

--- a/vendor/github.com/digitalocean/godo/storage.go
+++ b/vendor/github.com/digitalocean/godo/storage.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"net/http"
+
 	"github.com/digitalocean/godo/context"
 )
 
@@ -94,7 +96,7 @@ func (svc *StorageServiceOp) ListVolumes(ctx context.Context, params *ListVolume
 		}
 	}
 
-	req, err := svc.client.NewRequest(ctx, "GET", path, nil)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -116,7 +118,7 @@ func (svc *StorageServiceOp) ListVolumes(ctx context.Context, params *ListVolume
 func (svc *StorageServiceOp) CreateVolume(ctx context.Context, createRequest *VolumeCreateRequest) (*Volume, *Response, error) {
 	path := storageAllocPath
 
-	req, err := svc.client.NewRequest(ctx, "POST", path, createRequest)
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -133,7 +135,7 @@ func (svc *StorageServiceOp) CreateVolume(ctx context.Context, createRequest *Vo
 func (svc *StorageServiceOp) GetVolume(ctx context.Context, id string) (*Volume, *Response, error) {
 	path := fmt.Sprintf("%s/%s", storageAllocPath, id)
 
-	req, err := svc.client.NewRequest(ctx, "GET", path, nil)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -151,7 +153,7 @@ func (svc *StorageServiceOp) GetVolume(ctx context.Context, id string) (*Volume,
 func (svc *StorageServiceOp) DeleteVolume(ctx context.Context, id string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", storageAllocPath, id)
 
-	req, err := svc.client.NewRequest(ctx, "DELETE", path, nil)
+	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +176,7 @@ func (svc *StorageServiceOp) ListSnapshots(ctx context.Context, volumeID string,
 		return nil, nil, err
 	}
 
-	req, err := svc.client.NewRequest(ctx, "GET", path, nil)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -196,7 +198,7 @@ func (svc *StorageServiceOp) ListSnapshots(ctx context.Context, volumeID string,
 func (svc *StorageServiceOp) CreateSnapshot(ctx context.Context, createRequest *SnapshotCreateRequest) (*Snapshot, *Response, error) {
 	path := fmt.Sprintf("%s/%s/snapshots", storageAllocPath, createRequest.VolumeID)
 
-	req, err := svc.client.NewRequest(ctx, "POST", path, createRequest)
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -213,7 +215,7 @@ func (svc *StorageServiceOp) CreateSnapshot(ctx context.Context, createRequest *
 func (svc *StorageServiceOp) GetSnapshot(ctx context.Context, id string) (*Snapshot, *Response, error) {
 	path := fmt.Sprintf("%s/%s", storageSnapPath, id)
 
-	req, err := svc.client.NewRequest(ctx, "GET", path, nil)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -231,7 +233,7 @@ func (svc *StorageServiceOp) GetSnapshot(ctx context.Context, id string) (*Snaps
 func (svc *StorageServiceOp) DeleteSnapshot(ctx context.Context, id string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", storageSnapPath, id)
 
-	req, err := svc.client.NewRequest(ctx, "DELETE", path, nil)
+	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/storage_actions.go
+++ b/vendor/github.com/digitalocean/godo/storage_actions.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo/context"
 )
@@ -77,7 +78,7 @@ func (s *StorageActionsServiceOp) Resize(ctx context.Context, volumeID string, s
 func (s *StorageActionsServiceOp) doAction(ctx context.Context, volumeID string, request *ActionRequest) (*Action, *Response, error) {
 	path := storageAllocationActionPath(volumeID)
 
-	req, err := s.client.NewRequest(ctx, "POST", path, request)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,7 +93,7 @@ func (s *StorageActionsServiceOp) doAction(ctx context.Context, volumeID string,
 }
 
 func (s *StorageActionsServiceOp) get(ctx context.Context, path string) (*Action, *Response, error) {
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -107,7 +108,7 @@ func (s *StorageActionsServiceOp) get(ctx context.Context, path string) (*Action
 }
 
 func (s *StorageActionsServiceOp) list(ctx context.Context, path string) ([]Action, *Response, error) {
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/storage_actions_test.go
+++ b/vendor/github.com/digitalocean/godo/storage_actions_test.go
@@ -28,7 +28,7 @@ func TestStoragesActions_Attach(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, attachRequest) {
 			t.Errorf("want=%#v", attachRequest)
 			t.Errorf("got=%#v", v)
@@ -60,7 +60,7 @@ func TestStoragesActions_DetachByDropletID(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, detachByDropletIDRequest) {
 			t.Errorf("want=%#v", detachByDropletIDRequest)
 			t.Errorf("got=%#v", v)
@@ -80,7 +80,7 @@ func TestStorageActions_Get(t *testing.T) {
 	volumeID := "98d414c6-295e-4e3a-ac58-eb9456c1e1d1"
 
 	mux.HandleFunc("/v2/volumes/"+volumeID+"/actions/456", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
@@ -101,7 +101,7 @@ func TestStorageActions_List(t *testing.T) {
 	volumeID := "98d414c6-295e-4e3a-ac58-eb9456c1e1d1"
 
 	mux.HandleFunc("/v2/volumes/"+volumeID+"/actions", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprintf(w, `{"actions":[{"status":"in-progress"}]}`)
 	})
 
@@ -134,7 +134,7 @@ func TestStoragesActions_Resize(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, resizeRequest) {
 			t.Errorf("want=%#v", resizeRequest)
 			t.Errorf("got=%#v", v)

--- a/vendor/github.com/digitalocean/godo/storage_test.go
+++ b/vendor/github.com/digitalocean/godo/storage_test.go
@@ -48,7 +48,7 @@ func TestStorageVolumes_ListStorageVolumes(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/volumes/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -114,7 +114,7 @@ func TestStorageVolumes_Get(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/volumes/80d414c6-295e-4e3a-ac58-eb9456c1e1d1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -166,7 +166,7 @@ func TestStorageVolumes_ListVolumesByName(t *testing.T) {
 		if r.URL.Query().Get("name") != "myvolume" || r.URL.Query().Get("region") != "nyc3" {
 			t.Errorf("Storage.GetVolumeByName did not request the correct name or region")
 		}
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -222,7 +222,7 @@ func TestStorageVolumes_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, createRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 		}
@@ -277,7 +277,7 @@ func TestStorageVolumes_CreateFromSnapshot(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, createRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 		}
@@ -299,7 +299,7 @@ func TestStorageVolumes_Destroy(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/volumes/80d414c6-295e-4e3a-ac58-eb9456c1e1d1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Storage.DeleteVolume(ctx, "80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
@@ -342,7 +342,7 @@ func TestStorageSnapshots_ListStorageSnapshots(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/volumes/98d414c6-295e-4e3a-ac58-eb9456c1e1d1/snapshots", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -402,7 +402,7 @@ func TestStorageSnapshots_Get(t *testing.T) {
 	}`
 
 	mux.HandleFunc("/v2/snapshots/80d414c6-295e-4e3a-ac58-eb9456c1e1d1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, jBlob)
 	})
 
@@ -459,7 +459,7 @@ func TestStorageSnapshots_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, createRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 		}
@@ -481,7 +481,7 @@ func TestStorageSnapshots_Destroy(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/snapshots/80d414c6-295e-4e3a-ac58-eb9456c1e1d1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Storage.DeleteSnapshot(ctx, "80d414c6-295e-4e3a-ac58-eb9456c1e1d1")

--- a/vendor/github.com/digitalocean/godo/tags.go
+++ b/vendor/github.com/digitalocean/godo/tags.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo/context"
 )
@@ -93,7 +94,7 @@ func (s *TagsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Tag, *Res
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -114,7 +115,7 @@ func (s *TagsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Tag, *Res
 func (s *TagsServiceOp) Get(ctx context.Context, name string) (*Tag, *Response, error) {
 	path := fmt.Sprintf("%s/%s", tagsBasePath, name)
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -134,7 +135,7 @@ func (s *TagsServiceOp) Create(ctx context.Context, createRequest *TagCreateRequ
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
 
-	req, err := s.client.NewRequest(ctx, "POST", tagsBasePath, createRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, tagsBasePath, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -155,7 +156,7 @@ func (s *TagsServiceOp) Delete(ctx context.Context, name string) (*Response, err
 	}
 
 	path := fmt.Sprintf("%s/%s", tagsBasePath, name)
-	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +177,7 @@ func (s *TagsServiceOp) TagResources(ctx context.Context, name string, tagReques
 	}
 
 	path := fmt.Sprintf("%s/%s/resources", tagsBasePath, name)
-	req, err := s.client.NewRequest(ctx, "POST", path, tagRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, tagRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +198,7 @@ func (s *TagsServiceOp) UntagResources(ctx context.Context, name string, untagRe
 	}
 
 	path := fmt.Sprintf("%s/%s/resources", tagsBasePath, name)
-	req, err := s.client.NewRequest(ctx, "DELETE", path, untagRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, untagRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/tags_test.go
+++ b/vendor/github.com/digitalocean/godo/tags_test.go
@@ -169,7 +169,7 @@ func TestTags_List(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/tags", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, listJSON)
 	})
 
@@ -190,7 +190,7 @@ func TestTags_ListEmpty(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/tags", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, listEmptyJSON)
 	})
 
@@ -210,7 +210,7 @@ func TestTags_ListPaging(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/tags", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, listJSON)
 	})
 
@@ -226,7 +226,7 @@ func TestTags_Get(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/tags/testing-1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, getJSON)
 	})
 
@@ -263,7 +263,7 @@ func TestTags_Create(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, createRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 		}
@@ -287,7 +287,7 @@ func TestTags_Delete(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/tags/testing-1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 	})
 
 	_, err := client.Tags.Delete(ctx, "testing-1")
@@ -312,7 +312,7 @@ func TestTags_TagResource(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		if !reflect.DeepEqual(v, tagResourcesRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, tagResourcesRequest)
 		}
@@ -341,7 +341,7 @@ func TestTags_UntagResource(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 		if !reflect.DeepEqual(v, untagResourcesRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, untagResourcesRequest)
 		}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -80,7 +80,7 @@
 			"importpath": "github.com/digitalocean/godo",
 			"repository": "https://github.com/digitalocean/godo",
 			"vcs": "git",
-			"revision": "4fa9e9d999007b447089056a1c581b5594f0f851",
+			"revision": "801cee9569723107654606a8e00d79b56470072e",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
This PR implements support for creating CAA records, explained in [the following API document](https://developers.digitalocean.com/documentation/changelog/api-v2/caa-support-for-domain-record-resources/). 

Also, this vendors the latest version of godo.

/cc @mauricio @viola 

