### PR TITLE
Makefile: enable build via make and create local container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-*
-!Dockerfile

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,10 @@
+FROM golang:1.9-alpine
+
+ENV MAKE_TARGET linux_amd64
+
+RUN  apk update && \
+     apk add bash && \
+     apk add curl && \
+     apk add git && \
+     apk add make && \
+     apk add libc6-compat

--- a/Dockerfile.cntr
+++ b/Dockerfile.cntr
@@ -1,0 +1,27 @@
+FROM doctl_builder
+
+ENV CGO=0
+ENV OUT_D /out
+
+RUN mkdir -p /out
+RUN mkdir -p /go/src/github.com/digitalocean/doctl
+ADD . /go/src/github.com/digitalocean/doctl/
+
+RUN cd /go/src/github.com/digitalocean/doctl && \
+    make build_linux_amd64 OUT=/out && \
+    make build_linux_386   OUT=/out && \
+    make build_mac         OUT=/out
+
+RUN find /out
+
+FROM alpine:latest
+
+VOLUME ["/copy"]
+
+RUN  apk update && \
+     apk add rsync && \
+     apk add libc6-compat
+
+COPY --from=0 /out/* /app/
+
+ENTRYPOINT ["/app/doctl_linux_amd64"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+.PHONE: build
+export CGO=0
+
+my_d=$(shell pwd)
+OUT_D = $(shell echo $${OUT_D:-$(my_d)/builds})
+
+GOOS = linux
+UNAME_S := $(shell uname -s)
+UNAME_P := $(shell uname -p)
+ifeq ($(UNAME_S),Darwin)
+  NATIVE = darwin
+  GOARCH = 386
+endif
+
+GOARCH = amd64
+ifneq ($(UNAME_P), x86_64)
+  GOARCH = 386
+endif
+
+native: _build
+native:
+	@mv $(OUT_D)/doctl_$(GOOS)_$(GOARCH) $(OUT_D)/doctl
+	@echo "built $(OUT_D)/doctl"
+
+_build:
+	@mkdir -p builds
+	@echo "building doctl"
+	@cd cmd/doctl && env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(OUT_D)/doctl_$(GOOS)_$(GOARCH)
+	@echo "built $(OUT_D)/doctl_$(GOOS)_$(GOARCH)"
+
+
+build_mac: GOOS = darwin
+build_mac: GOARCH = 386
+build_mac: _build
+
+build_linux_386: GOARCH = 386
+build_linux_386: _build
+
+build_linux_amd64: GOARCH = amd64
+build_linux_amd64: _build
+
+clean:
+	@rm -rf builds
+
+_base_docker_cntr:
+	docker build -f Dockerfile.build . -t doctl_builder
+
+docker_build: _base_docker_cntr
+docker_build:
+	@mkdir -p $(OUT_D)
+	@docker build -f Dockerfile.cntr . -t doctl_local
+	@docker run --rm \
+		-v $(OUT_D):/copy \
+		-it --entrypoint /usr/bin/rsync \
+		doctl_local -av /app/ /copy/
+	@docker run --rm \
+		-v $(OUT_D):/copy \
+		-it --entrypoint /bin/chown \
+		alpine -R $(shell whoami | id -u): /copy
+	@echo "Built binaries to $(OUT_D)"
+	@echo "Created a local Docker container. To use, run: docker run --rm -it doctl_local"


### PR DESCRIPTION
`make` will build local go binary
`make {linux_amd64,linux_386,macos}` will compile for Linux/Mac
`make docker_build` will create a container and copy out Linux and Mac Binaries to `builds`
