### PR TITLE
firewall: omit the port field for the icmp

### DIFF
--- a/commands/firewalls_test.go
+++ b/commands/firewalls_test.go
@@ -48,7 +48,7 @@ func TestFirewallCreate(t *testing.T) {
 			InboundRules: []godo.InboundRule{
 				{
 					Protocol:  "icmp",
-					PortRange: "0",
+					PortRange: "",
 					Sources:   &godo.Sources{},
 				},
 				{
@@ -67,7 +67,7 @@ func TestFirewallCreate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgFirewallName, "firewall")
 		config.Doit.Set(config.NS, doctl.ArgTagNames, []string{"backend"})
 		config.Doit.Set(config.NS, doctl.ArgDropletIDs, []string{"1", "2"})
-		config.Doit.Set(config.NS, doctl.ArgInboundRules, "protocol:icmp,ports:0 protocol:tcp,ports:8000-9000,address:127.0.0.0,address:0::/0,address:::/1")
+		config.Doit.Set(config.NS, doctl.ArgInboundRules, "protocol:icmp protocol:tcp,ports:8000-9000,address:127.0.0.0,address:0::/0,address:::/1")
 
 		err := RunFirewallCreate(config)
 		assert.NoError(t, err)

--- a/commands/output.go
+++ b/commands/output.go
@@ -848,12 +848,20 @@ func firewallRulesPrintHelper(fw do.Firewall) (string, string) {
 
 	for _, ir := range fw.InboundRules {
 		ss := firewallInAndOutboundRulesPrintHelper(ir.Sources.Addresses, ir.Sources.Tags, ir.Sources.DropletIDs, ir.Sources.LoadBalancerUIDs)
-		irs = append(irs, fmt.Sprintf("%v:%v,%v:%v,%v", "protocol", ir.Protocol, "ports", ir.PortRange, ss))
+		if ir.Protocol == "icmp" {
+			irs = append(irs, fmt.Sprintf("%v:%v,%v", "protocol", ir.Protocol, ss))
+		} else {
+			irs = append(irs, fmt.Sprintf("%v:%v,%v:%v,%v", "protocol", ir.Protocol, "ports", ir.PortRange, ss))
+		}
 	}
 
 	for _, or := range fw.OutboundRules {
 		ds := firewallInAndOutboundRulesPrintHelper(or.Destinations.Addresses, or.Destinations.Tags, or.Destinations.DropletIDs, or.Destinations.LoadBalancerUIDs)
-		ors = append(ors, fmt.Sprintf("%v:%v,%v:%v,%v", "protocol", or.Protocol, "ports", or.PortRange, ds))
+		if or.Protocol == "icmp" {
+			ors = append(ors, fmt.Sprintf("%v:%v,%v", "protocol", or.Protocol, ds))
+		} else {
+			ors = append(ors, fmt.Sprintf("%v:%v,%v:%v,%v", "protocol", or.Protocol, "ports", or.PortRange, ds))
+		}
 	}
 
 	return strings.Join(irs, " "), strings.Join(ors, " ")


### PR DESCRIPTION
Currently "compute firewall list" shows following for a rule using icmp

... protocol:icmp,ports:0,address:0.0.0.0/0,address:::/0 ...

Problem is using this syntax ends up with an error.

```
$ doctl compute firewall create --name test --outbound-rules "protocol:icmp,ports:all,address:0.0.0.0/0,address:::/0"
...
Error: POST https://api.digitalocean.com/v2/firewalls: 422 (request UUID) You must specify a positive value for ports.
```

whereas omitting the port field works as expected.

```
$ doctl compute firewall create --name test --outbound-rules "protocol:icmp,address:0.0.0.0/0,address:::/0"
ID                                      Name    Status     Created At              Inbound Rules    Outbound Rules                                          Droplet IDs    Tags          Pending Changes
...
```

so this change omits the ports field from the "compute firewall list" output.