### PR TITLE
commands: show public images for distros and apps by default

### DIFF
--- a/commands/images.go
+++ b/commands/images.go
@@ -42,12 +42,12 @@ func Images() *Command {
 	cmdImagesListDistribution := CmdBuilder(cmd, RunImagesListDistribution,
 		"list-distribution", "list distribution images", Writer,
 		displayerType(&image{}), docCategories("image"))
-	AddBoolFlag(cmdImagesListDistribution, doctl.ArgImagePublic, "", false, "List public images")
+	AddBoolFlag(cmdImagesListDistribution, doctl.ArgImagePublic, "", true, "List public images")
 
 	cmdImagesListApplication := CmdBuilder(cmd, RunImagesListApplication,
 		"list-application", "list application images", Writer,
 		displayerType(&image{}), docCategories("image"))
-	AddBoolFlag(cmdImagesListApplication, doctl.ArgImagePublic, "", false, "List public images")
+	AddBoolFlag(cmdImagesListApplication, doctl.ArgImagePublic, "", true, "List public images")
 
 	cmdImagesListUser := CmdBuilder(cmd, RunImagesListUser,
 		"list-user", "list user images", Writer,


### PR DESCRIPTION
This PR addresses the problem reported in #279, #261 and #251.

Currently, commands `doctl compute image list-distribution` and `doctl compute image list-application` don't return any output without `--public` flag.
I believe this should not be the case, as you can't have private distributions or applications.
This confuses user, so I decided to make a PR to fix the problem.

The `doctl compute image list` command still shows only private images. I can update flag's default value for this command as well, if that's needed.

However, there is a problem for existing `doctl` users.
The `doctl auth init` command creates configuration file with all keys set to flag's default values. This means that configuration file still has `false` set on the changed flags. Users have to manually update the appropriate keys in the configuration file:
```yaml
...
image.list-distribution.public: true
image.list-application.public: true
...
```
New users will have the above flags set to `true` by default.

/cc @mauricio @viola 