### PR TITLE
xdg: fix config path when XDG_CONFIG_HOME is set

### DIFF
--- a/commands/doit.go
+++ b/commands/doit.go
@@ -130,6 +130,12 @@ func findConfig() (string, error) {
 		warn(msg)
 	}
 
+	legacyXDGPath := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "config.yaml")
+	if _, err := os.Stat(legacyXDGPath); err == nil {
+		msg := fmt.Sprintf("Configuration detected at %q. Please move config.yaml to %s",
+			legacyXDGPath, configPath())
+		warn(msg)
+	}
 	ch := configHome()
 	if err := os.MkdirAll(ch, 0755); err != nil {
 		return "", err

--- a/commands/xdg.go
+++ b/commands/xdg.go
@@ -20,12 +20,11 @@ import (
 )
 
 func configHome() string {
-	configHome := os.Getenv("XDG_CONFIG_HOME")
-	if configHome == "" {
-		configHome = filepath.Join(homeDir(), ".config", "doctl")
+	if xdgPath := os.Getenv("XDG_CONFIG_HOME"); xdgPath != "" {
+		return filepath.Join(xdgPath, "doctl")
+	} else {
+		return filepath.Join(homeDir(), ".config", "doctl")
 	}
-
-	return configHome
 }
 
 func legacyConfigCheck() {


### PR DESCRIPTION
Closes #246 

When `XDG_CONFIG_HOME` path is set, `doctl` creates configuration file directly in that directory instead of creating it in the `doctl` subdirectory.

This PR also adds warning if configuration file is present in the root of the `XDG_CONFIG_HOME` directory.

/cc @mauricio