### PR TITLE
commands: fix configuration file location for windows xp users

### DIFF
--- a/commands/xdg_windows.go
+++ b/commands/xdg_windows.go
@@ -26,11 +26,11 @@ func configHome() string {
 		if configHome == "" {
 			// If still empty, use the default path
 			userName := os.Getenv("USERNAME")
-			configHome = filepath.Join("C:/", "Users", userName, "AppData", "Local", "doctl", "config")
+			configHome = filepath.Join("C:/", "Users", userName, "AppData", "Local")
 		}
 	}
 
-	return filepath.Join(configHome, "doctl")
+	return filepath.Join(configHome, "doctl", "config")
 }
 
 // legacyConfigCheck is a no-op on windows since go doesn't have a chmod

--- a/commands/xdg_windows.go
+++ b/commands/xdg_windows.go
@@ -19,14 +19,18 @@ import (
 )
 
 func configHome() string {
-	// is this even a thing on windows?
-	configHome := os.Getenv("XDG_CONFIG_HOME")
+	configHome := os.Getenv("LOCALAPPDATA")
 	if configHome == "" {
-		userName := os.Getenv("USERNAME")
-		configHome = filepath.Join("C:/", "Users", userName, "AppData", "Local", "doctl", "config")
+		// Resort to APPDATA for Windows XP users.
+		configHome = os.Getenv("APPDATA")
+		if configHome == "" {
+			// If still empty, use the default path
+			userName := os.Getenv("USERNAME")
+			configHome = filepath.Join("C:/", "Users", userName, "AppData", "Local", "doctl", "config")
+		}
 	}
 
-	return configHome
+	return filepath.Join(configHome, "doctl")
 }
 
 // legacyConfigCheck is a no-op on windows since go doesn't have a chmod


### PR DESCRIPTION
Closes #240.

This is not an elegant solution, so any suggestion is appreciated.

Currently, on Windows, we're using the `XDG_CONFIG_HOME` to get the directory where we should store configuration file. However, that environment is Linux-specific, it doesn't exist on Windows.
We have a code to use the `C:\Users\Username\AppData\Local` directory, but it's not user-friendly, especially for XP users.

The `LOCALAPPDATA` variable contains the path to the `C:\Users\Username\AppData\Local` directory, which we're using to store `doctl` configuration file. But the problem is that it's only available on Vista or newer.

For XP users, we're using the `APPDATA` environment variable.
**This can introduce compatibility problems, as it will use the `Document and Settings` directory now instead of `Users`. Users have to move the configuration file manually, or to re-run the `doctl auth init` command.**

If somehow neither of those variables are available, we're resorting to the default, old, value.

/cc @mauricio