### PR TITLE
Confirm dialog for deleting by ID now specifies number of droplets to…

### DIFF
--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -473,7 +473,7 @@ func RunDropletDelete(c *CmdConfig) error {
 		return nil
 	}
 
-	if force || AskForConfirm("delete droplet(s)") == nil {
+	if force || AskForConfirm(fmt.Sprintf("delete %d droplet(s)", len(c.Args))) == nil {
 
 		fn := func(ids []int) error {
 			for _, id := range ids {


### PR DESCRIPTION
… be deleted.

Problem: I commonly nest `doctl compute droplet list` commands within `doctl compute droplet delete` to delete droplets by name. It would be a nice last-minute sanity check to see the length of the ID's generated by the list command in the confirm dialog. 