### PR TITLE
Implement context switching, allowing for multiple configured API access keys

### DIFF
--- a/args.go
+++ b/args.go
@@ -16,6 +16,8 @@ package doctl
 const (
 	// ArgAccessToken is the access token to be used for the operations
 	ArgAccessToken = "access-token"
+	// ArgContext is the name of the auth context to use
+	ArgContext = "context"
 	// ArgActionID is an action id argument.
 	ArgActionID = "action-id"
 	// ArgActionAfter is an action after argument.

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -23,11 +23,9 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/digitalocean/doctl"
 )
 
-// ErrUnknownTerminal signies an unknown terminal. It is returned when doit
+// ErrUnknownTerminal signifies an unknown terminal. It is returned when doit
 // can't ascertain the current terminal type with requesting an auth token.
 var ErrUnknownTerminal = errors.New("unknown terminal")
 
@@ -73,7 +71,7 @@ func Auth() *Command {
 // XDG_CONFIG_HOME is not set, use $HOME/.config. On Windows use %APPDATA%/doctl/config.
 func RunAuthInit( retrieveUserTokenFunc func() (string, error) ) func (c *CmdConfig) error {
 	return func(c * CmdConfig) error {
-		token := viper.GetString(doctl.ArgAccessToken)
+		token := c.getContextAccessToken()
 
 		if token == "" {
 			in, err := retrieveUserTokenFunc()
@@ -86,7 +84,7 @@ func RunAuthInit( retrieveUserTokenFunc func() (string, error) ) func (c *CmdCon
 			fmt.Fprintln(c.Out)
 		}
 
-		viper.Set(doctl.ArgAccessToken, string(token))
+		c.setContextAccessToken(string(token))
 
 		fmt.Fprintln(c.Out)
 		fmt.Fprint(c.Out, "Validating token... ")

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -18,22 +18,23 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/digitalocean/doctl/do"
-	"github.com/stretchr/testify/assert"
 	"errors"
-	"github.com/spf13/viper"
+
 	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/do"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthCommand(t *testing.T) {
 	cmd := Auth()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "init")
+	assertCommandNames(t, cmd, "init", "switch")
 }
 
 func TestAuthInit(t *testing.T) {
 	cfw := cfgFileWriter
-	viper.Set(doctl.ArgAccessToken, nil);
+	viper.Set(doctl.ArgAccessToken, nil)
 	defer func() {
 		cfgFileWriter = cfw
 	}()
@@ -54,10 +55,10 @@ func TestAuthInit(t *testing.T) {
 
 func TestAuthInitWithProvidedToken(t *testing.T) {
 	cfw := cfgFileWriter
-	viper.Set(doctl.ArgAccessToken, "valid-token");
+	viper.Set(doctl.ArgAccessToken, "valid-token")
 	defer func() {
 		cfgFileWriter = cfw
-		viper.Set(doctl.ArgAccessToken, nil);
+		viper.Set(doctl.ArgAccessToken, nil)
 	}()
 
 	retrieveUserTokenFunc := func() (string, error) {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -184,6 +184,12 @@ func withTestClient(t *testing.T, tFn testFn) {
 		// can stub this out, since the return is dictated by the mocks.
 		initServices: func(c *CmdConfig) error { return nil },
 
+		getContextAccessToken: func() string {
+			return viper.GetString(doctl.ArgAccessToken)
+		},
+
+		setContextAccessToken: func(token string) {	},
+
 		Keys:              func() do.KeysService { return &tm.keys },
 		Sizes:             func() do.SizesService { return &tm.sizes },
 		Regions:           func() do.RegionsService { return &tm.regions },

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -246,7 +246,7 @@ func NewTestConfig() *TestConfig {
 
 var _ doctl.Config = &TestConfig{}
 
-func (c *TestConfig) GetGodoClient(trace bool) (*godo.Client, error) {
+func (c *TestConfig) GetGodoClient(trace bool, accessToken string) (*godo.Client, error) {
 	return &godo.Client{}, nil
 }
 

--- a/doit.go
+++ b/doit.go
@@ -153,7 +153,7 @@ func (glv *GithubLatestVersioner) LatestVersion() (string, error) {
 
 // Config is an interface that represent doit's config.
 type Config interface {
-	GetGodoClient(trace bool) (*godo.Client, error)
+	GetGodoClient(trace bool, accessToken string) (*godo.Client, error)
 	SSH(user, host, keyPath string, port int, opts ssh.Options) runner.Runner
 	Set(ns, key string, val interface{})
 	GetString(ns, key string) (string, error)
@@ -170,13 +170,12 @@ type LiveConfig struct {
 var _ Config = &LiveConfig{}
 
 // GetGodoClient returns a GodoClient.
-func (c *LiveConfig) GetGodoClient(trace bool) (*godo.Client, error) {
-	token := viper.GetString(ArgAccessToken)
-	if token == "" {
+func (c *LiveConfig) GetGodoClient(trace bool, accessToken string) (*godo.Client, error) {
+	if accessToken == "" {
 		return nil, fmt.Errorf("access token is required. (hint: run 'doctl auth init')")
 	}
 
-	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
 	oauthClient := oauth2.NewClient(oauth2.NoContext, tokenSource)
 
 	if trace {


### PR DESCRIPTION
Related issue: #266 

This is a proposed implementation of support for multiple accounts. The idea behind this is each account is associated with a context, which contains the API access key.

A new global option is added: `context`. It defaults to `default`, and should contain the name of the DO account that will be used.

If it is set to `default`, all existing auth functionality is preserved (using `--access-token` or the corresponding environment variable). This makes this feature backwards-compatible.

To configure a "named" account called, say, `foo`, run `doctl auth init --context foo`. This will prompt the user for the API key and save it in the config file. Whenever `--context foo` is passed to any other command, that API key will be used.

[This suggestion](https://github.com/digitalocean/doctl/issues/266#issuecomment-372329792) could also be added with the current implementation. It would simply update the `context` config value.

@mauricio please let me know what you think and if this is what you had in mind for how this would work.