### PR TITLE
cmd: allow multiple firewalls to be deleted in same time

### DIFF
--- a/commands/firewalls.go
+++ b/commands/firewalls.go
@@ -56,7 +56,7 @@ func Firewall() *Command {
 
 	CmdBuilder(cmd, RunFirewallListByDroplet, "list-by-droplet <droplet_id>", "list firewalls by droplet ID", Writer)
 
-	cmdRunRecordDelete := CmdBuilder(cmd, RunFirewallDelete, "delete <id>", "delete firewall", Writer, aliasOpt("d", "rm"))
+	cmdRunRecordDelete := CmdBuilder(cmd, RunFirewallDelete, "delete <id> [id ...]", "delete firewall", Writer, aliasOpt("d", "rm"))
 	AddBoolFlag(cmdRunRecordDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force firewall delete")
 
 	cmdAddDroplets := CmdBuilder(cmd, RunFirewallAddDroplets, "add-droplets <id>", "add droplets to the firewall", Writer)
@@ -172,20 +172,21 @@ func RunFirewallListByDroplet(c *CmdConfig) error {
 
 // RunFirewallDelete deletes a Firewall by its identifier.
 func RunFirewallDelete(c *CmdConfig) error {
-	if len(c.Args) != 1 {
+	if len(c.Args) < 1 {
 		return doctl.NewMissingArgsErr(c.NS)
 	}
-	fID := c.Args[0]
 
 	force, err := c.Doit.GetBool(c.NS, doctl.ArgForce)
 	if err != nil {
 		return err
 	}
 
-	if force || AskForConfirm("delete this Firewall") == nil {
-		fs := c.Firewalls()
-		if err := fs.Delete(fID); err != nil {
-			return err
+	fs := c.Firewalls()
+	if force || AskForConfirm(fmt.Sprintf("delete %d firewall(s)", len(c.Args))) == nil {
+		for _, id := range c.Args {
+			if err := fs.Delete(id); err != nil {
+				return err
+			}
 		}
 	} else {
 		return fmt.Errorf("operation aborted")


### PR DESCRIPTION
Currently, to delete multiple firewalls, you need to execute several commands to delete them, as one command can delete only one firewall. This PR allows users to delete multiple firewalls using single `firewall delete` command, like they can do for Droplets.

With #303 merged, users can also delete all firewalls in the same time by chaining `delete` and `list` commands, e.g. `doctl compute firewall delete -f $(doctl compute firewall list --no-header --format ID)`.