### PR TITLE
move completion into a new 'generate' namespace

### DIFF
--- a/commands/doit.go
+++ b/commands/doit.go
@@ -166,7 +166,7 @@ func Execute() {
 func addCommands() {
 	DoitCmd.AddCommand(Account())
 	DoitCmd.AddCommand(Auth())
-	DoitCmd.AddCommand(Completion())
+	DoitCmd.AddCommand(Generate())
 	DoitCmd.AddCommand(computeCmd())
 	DoitCmd.AddCommand(Version())
 }
@@ -307,7 +307,7 @@ type CmdConfig struct {
 	Out  io.Writer
 	Args []string
 
-	initServices func(*CmdConfig) error
+	initServices          func(*CmdConfig) error
 	getContextAccessToken func() string
 	setContextAccessToken func(string)
 
@@ -389,24 +389,24 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			}
 
 			return token
-	},
+		},
 
-	setContextAccessToken: func(token string) {
-		context := Context
-		if context == "" {
-			context = viper.GetString("context")
-		}
+		setContextAccessToken: func(token string) {
+			context := Context
+			if context == "" {
+				context = viper.GetString("context")
+			}
 
-		switch context {
-		case "default":
-			viper.Set(doctl.ArgAccessToken, token)
-		default:
-			contexts := viper.GetStringMapString("auth-contexts")
-			contexts[context] = token
+			switch context {
+			case "default":
+				viper.Set(doctl.ArgAccessToken, token)
+			default:
+				contexts := viper.GetStringMapString("auth-contexts")
+				contexts[context] = token
 
-			viper.Set("auth-contexts", contexts)
-		}
-	},
+				viper.Set("auth-contexts", contexts)
+			}
+		},
 	}
 
 	if initGodo {

--- a/commands/generate.go
+++ b/commands/generate.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2017 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Completion creates the completion command
+func Generate() *Command {
+	cmd := &Command{
+		Command: &cobra.Command{
+			Use:   "generate",
+			Short: "generation commands",
+			Long:  "generate is used to generate external scripts and documentation",
+		},
+		IsIndex: true,
+	}
+
+	cmd.AddCommand(Completion())
+
+	return cmd
+}


### PR DESCRIPTION
This creates a new "namespace" called `generate` and moves the `completion` command (and its subcommands) under it. This potentially takes care of #297 and makes room for #238