### PR TITLE
Add support for Let's Encrypt certificates.

### DIFF
--- a/args.go
+++ b/args.go
@@ -147,12 +147,16 @@ const (
 
 	// ArgCertificateName is a name of the certificate.
 	ArgCertificateName = "name"
+	// ArgCertificateDNSNames is a list of DNS names.
+	ArgCertificateDNSNames = "dns-names"
 	// ArgPrivateKeyPath is a path to a private key for the certificate.
 	ArgPrivateKeyPath = "private-key-path"
 	// ArgLeafCertificatePath is a path to a certificate leaf.
 	ArgLeafCertificatePath = "leaf-certificate-path"
 	// ArgCertificateChainPath is a path to a certificate chain.
 	ArgCertificateChainPath = "certificate-chain-path"
+	// ArgCertificateType is a certificate type.
+	ArgCertificateType = "type"
 
 	// ArgLoadBalancerName is a name of the load balancer.
 	ArgLoadBalancerName = "name"

--- a/commands/output.go
+++ b/commands/output.go
@@ -675,9 +675,12 @@ func (c *certificate) Cols() []string {
 	return []string{
 		"ID",
 		"Name",
+		"DNSNames",
 		"SHA1Fingerprint",
 		"NotAfter",
 		"Created",
+		"Type",
+		"State",
 	}
 }
 
@@ -685,9 +688,12 @@ func (c *certificate) ColMap() map[string]string {
 	return map[string]string{
 		"ID":              "ID",
 		"Name":            "Name",
+		"DNSNames":        "DNS Names",
 		"SHA1Fingerprint": "SHA-1 Fingerprint",
 		"NotAfter":        "Expiration Date",
 		"Created":         "Created At",
+		"Type":            "Type",
+		"State":           "State",
 	}
 }
 
@@ -698,9 +704,12 @@ func (c *certificate) KV() []map[string]interface{} {
 		o := map[string]interface{}{
 			"ID":              c.ID,
 			"Name":            c.Name,
+			"DNSNames":        fmt.Sprintf(strings.Join(c.DNSNames, ",")),
 			"SHA1Fingerprint": c.SHA1Fingerprint,
 			"NotAfter":        c.NotAfter,
 			"Created":         c.Created,
+			"Type":            c.Type,
+			"State":           c.State,
 		}
 		out = append(out, o)
 	}


### PR DESCRIPTION
This change set add support for Lets Encrypt Certificates.

## Certificate commands
## Get certificate `certificate get <id>`
```
get certificate

Usage:
  doctl compute certificate get <id> [flags]

Aliases:
  get, g
```

`$ doctl compute certificate get 83f6ccba-52c4-4b37-9faf-59787e082da9`
```
ID                                      Name        DNS Names    SHA-1 Fingerprint                           Expiration Date         Created At              Type      State
83f6ccba-52c4-4b37-9faf-59787e082da9    test-123                 2e3c2ba8016faf80f431700ff2865ef6dba30a81    2022-01-26T15:50:00Z    2017-08-22T17:00:26Z    custom    verified
```

## Create new certificate `certificate create`
```
create new certificate

Usage:
  doctl compute certificate create [flags]

Aliases:
  create, c


Flags:
      --certificate-chain-path string   path to a certificate chain
      --dns-names value                 comma-separated list of domain names, required for lets_encrypt certificate (default [])
      --leaf-certificate-path string    path to a certificate leaf, required for custom certificate
      --name string                     certificate name (required)
      --private-key-path string         path to a private key for the certificate, required for custom certificate
      --type string                     certificate type, possible values: custom or lets_encrypt
```
### Create custom certificate
`$ doctl compute certificate create --name web-cert-01 --private-key-path ~/my-secrets/priv-key.pem --certificate-chain-path ~/my-secrets/cer-chain.crt  --leaf-certificate-path ~/my-secrets/leaf-cer.crt`

```
ID                                      Name           DNS Names    SHA-1 Fingerprint                           Expiration Date         Created At              Type      State
67c4ff29-6fd2-4bd8-aa44-b3914d904c8b    web-cert-01                 6a70e706ec245cfb66956b150c56befcf12a5d5a    2022-01-26T15:50:00Z    2017-09-12T22:01:54Z    custom    verified
```

### Create lets_encrypt certificate
`$ doctl compute certificate create --name "lets-encrypt-cert" --dns-names testdomain.com,api.testdomain.com --type lets_encrypt`

```
ID                                      Name                 DNS Names                             SHA-1 Fingerprint    Expiration Date         Created At              Type            State
e2fd0eec-9813-4dfd-9562-5d11e3948041    lets-encrypt-cert    testdomain.com,api.testdomain.com                         0001-01-01T00:00:00Z    2017-09-12T21:52:59Z    lets_encrypt    pending

```

## Get all certificates `certificate list`
`$ doctl compute certificate list`

```
ID                                      Name                     DNS Names                                                   SHA-1 Fingerprint                           Expiration Date         Created At              Type            State
381fa989-bedf-48d4-8b3e-8ff7488d01d2    doctl-test-new           api.violababola.com,backend.violababola.com                 d6f7d89bac284b0bc75f555cde7d3b0942967655    2017-12-06T18:39:00Z    2017-09-07T19:38:46Z    lets_encrypt    verified
67c4ff29-6fd2-4bd8-aa44-b3914d904c8b    web-cert-01                                                                          6a70e706ec245cfb66956b150c56befcf12a5d5a    2022-01-26T15:50:00Z    2017-09-12T22:01:54Z    custom          verified
```