### PR TITLE
Remove upgrade command from droplet-action

### DIFF
--- a/commands/droplet_actions.go
+++ b/commands/droplet_actions.go
@@ -108,11 +108,6 @@ func DropletAction() *Command {
 		displayerType(&action{}), docCategories("droplet"))
 	AddBoolFlag(cmdDropletActionEnablePrivateNetworking, doctl.ArgCommandWait, "", false, "Wait for action to complete")
 
-	cmdDropletActionUpgrade := CmdBuilder(cmd, RunDropletActionUpgrade,
-		"upgrade <droplet-id>", "upgrade droplet", Writer,
-		displayerType(&action{}), docCategories("droplet"))
-	AddBoolFlag(cmdDropletActionUpgrade, doctl.ArgCommandWait, "", false, "Wait for action to complete")
-
 	cmdDropletActionRestore := CmdBuilder(cmd, RunDropletActionRestore,
 		"restore <droplet-id>", "restore backup", Writer,
 		displayerType(&action{}), docCategories("droplet"))
@@ -335,25 +330,6 @@ func RunDropletActionEnablePrivateNetworking(c *CmdConfig) error {
 		}
 
 		a, err := das.EnablePrivateNetworking(id)
-		return a, err
-	}
-
-	return performAction(c, fn)
-}
-
-// RunDropletActionUpgrade upgrades a droplet.
-func RunDropletActionUpgrade(c *CmdConfig) error {
-	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
-		}
-		id, err := strconv.Atoi(c.Args[0])
-
-		if err != nil {
-			return nil, err
-		}
-
-		a, err := das.Upgrade(id)
 		return a, err
 	}
 

--- a/commands/droplet_actions_test.go
+++ b/commands/droplet_actions_test.go
@@ -23,7 +23,7 @@ import (
 func TestDropletActionCommand(t *testing.T) {
 	cmd := DropletAction()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "change-kernel", "disable-backups", "enable-ipv6", "enable-private-networking", "get", "power-cycle", "power-off", "power-on", "password-reset", "reboot", "rebuild", "rename", "resize", "restore", "shutdown", "snapshot", "upgrade")
+	assertCommandNames(t, cmd, "change-kernel", "disable-backups", "enable-ipv6", "enable-private-networking", "get", "power-cycle", "power-off", "power-on", "password-reset", "reboot", "rebuild", "rename", "resize", "restore", "shutdown", "snapshot")
 }
 
 func TestDropletActionsChangeKernel(t *testing.T) {
@@ -226,17 +226,6 @@ func TestDropletActionsSnapshot(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgSnapshotName, "name")
 
 		err := RunDropletActionSnapshot(config)
-		assert.NoError(t, err)
-	})
-}
-
-func TestDropletActionsUpgrade(t *testing.T) {
-	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.dropletActions.On("Upgrade", 1).Return(&testAction, nil)
-
-		config.Args = append(config.Args, "1")
-
-		err := RunDropletActionUpgrade(config)
 		assert.NoError(t, err)
 	})
 }

--- a/do/droplet_actions.go
+++ b/do/droplet_actions.go
@@ -47,7 +47,6 @@ type DropletActionsService interface {
 	EnableIPv6ByTag(string) (Actions, error)
 	EnablePrivateNetworking(int) (*Action, error)
 	EnablePrivateNetworkingByTag(string) (Actions, error)
-	Upgrade(int) (*Action, error)
 	Get(int, int) (*Action, error)
 	GetByURI(string) (*Action, error)
 }
@@ -215,11 +214,6 @@ func (das *dropletActionsService) EnablePrivateNetworking(id int) (*Action, erro
 func (das *dropletActionsService) EnablePrivateNetworkingByTag(tag string) (Actions, error) {
 	a, _, err := das.client.DropletActions.EnablePrivateNetworkingByTag(context.TODO(), tag)
 	return das.handleTagActionResponse(a, err)
-}
-
-func (das *dropletActionsService) Upgrade(id int) (*Action, error) {
-	a, _, err := das.client.DropletActions.Upgrade(context.TODO(), id)
-	return das.handleActionResponse(a, err)
 }
 
 func (das *dropletActionsService) Get(id int, actionID int) (*Action, error) {

--- a/do/mocks/DropletActionsService.go
+++ b/do/mocks/DropletActionsService.go
@@ -653,26 +653,3 @@ func (_m *DropletActionsService) SnapshotByTag(_a0 string, _a1 string) (do.Actio
 
 	return r0, r1
 }
-
-// Upgrade provides a mock function with given fields: _a0
-func (_m *DropletActionsService) Upgrade(_a0 int) (*do.Action, error) {
-	ret := _m.Called(_a0)
-
-	var r0 *do.Action
-	if rf, ok := ret.Get(0).(func(int) *do.Action); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*do.Action)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(int) error); ok {
-		r1 = rf(_a0)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}


### PR DESCRIPTION
Hi, the upgrade droplet action is no longer supported by the v2 API. (See the [droplet-actions endpoint in the docs](https://developers.digitalocean.com/documentation/v2/#droplet-actions))

Running `doctl compute droplet-action upgrade <droplet-id>` results in:

```
Error: POST https://api.digitalocean.com/v2/droplets/<droplet-id>/actions: 410 The specified action type is no longer available.
```

This PR removes the `upgrade` subcommand from `droplet-action` as well as associated tests and mocks.

Let me know if it looks good or if there's anything else I need to do.