### PR TITLE
Add the enable-backups droplet action

### DIFF
--- a/commands/droplet_actions.go
+++ b/commands/droplet_actions.go
@@ -63,6 +63,11 @@ func DropletAction() *Command {
 		aliasOpt("g"), displayerType(&action{}), docCategories("droplet"))
 	AddIntFlag(cmdDropletActionGet, doctl.ArgActionID, "", 0, "Action ID", requiredOpt())
 
+	cmdDropletActionEnableBackups := CmdBuilder(cmd, RunDropletActionEnableBackups,
+		"enable-backups <droplet-id>", "enable backups", Writer,
+		displayerType(&action{}), docCategories("droplet"))
+	AddBoolFlag(cmdDropletActionEnableBackups, doctl.ArgCommandWait, "", false, "Wait for action to complete")
+
 	cmdDropletActionDisableBackups := CmdBuilder(cmd, RunDropletActionDisableBackups,
 		"disable-backups <droplet-id>", "disable backups", Writer,
 		displayerType(&action{}), docCategories("droplet"))
@@ -165,6 +170,24 @@ func RunDropletActionGet(c *CmdConfig) error {
 		}
 
 		a, err := das.Get(dropletID, actionID)
+		return a, err
+	}
+
+	return performAction(c, fn)
+}
+
+// RunDropletActionEnableBackups disables backups for a droplet.
+func RunDropletActionEnableBackups(c *CmdConfig) error {
+	fn := func(das do.DropletActionsService) (*do.Action, error) {
+		if len(c.Args) != 1 {
+			return nil, doctl.NewMissingArgsErr(c.NS)
+		}
+		id, err := strconv.Atoi(c.Args[0])
+		if err != nil {
+			return nil, err
+		}
+
+		a, err := das.EnableBackups(id)
 		return a, err
 	}
 

--- a/commands/droplet_actions_test.go
+++ b/commands/droplet_actions_test.go
@@ -23,7 +23,7 @@ import (
 func TestDropletActionCommand(t *testing.T) {
 	cmd := DropletAction()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "change-kernel", "disable-backups", "enable-ipv6", "enable-private-networking", "get", "power-cycle", "power-off", "power-on", "password-reset", "reboot", "rebuild", "rename", "resize", "restore", "shutdown", "snapshot")
+	assertCommandNames(t, cmd, "change-kernel", "enable-backups", "disable-backups", "enable-ipv6", "enable-private-networking", "get", "power-cycle", "power-off", "power-on", "password-reset", "reboot", "rebuild", "rename", "resize", "restore", "shutdown", "snapshot")
 }
 
 func TestDropletActionsChangeKernel(t *testing.T) {
@@ -36,6 +36,17 @@ func TestDropletActionsChangeKernel(t *testing.T) {
 		err := RunDropletActionChangeKernel(config)
 		assert.NoError(t, err)
 	})
+}
+func TestDropletActionsEnableBackups(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.dropletActions.On("EnableBackups", 1).Return(&testAction, nil)
+
+		config.Args = append(config.Args, "1")
+
+		err := RunDropletActionEnableBackups(config)
+		assert.NoError(t, err)
+	})
+
 }
 func TestDropletActionsDisableBackups(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {


### PR DESCRIPTION
Adds the [`enable-backups`](https://developers.digitalocean.com/documentation/v2/#enable-backups) droplet action which wasn't implemented in the CLI.