### PR TITLE
Update version string to 1.8.3-dev

### DIFF
--- a/doit.go
+++ b/doit.go
@@ -47,9 +47,9 @@ var (
 	// DoitVersion is doit's version.
 	DoitVersion = Version{
 		Major: 1,
-		Minor: 7,
-		Patch: 2,
-		Label: "stable",
+		Minor: 8,
+		Patch: 3,
+		Label: "dev",
 	}
 
 	// Build is doit's build tag.


### PR DESCRIPTION
Update the version string to show `1.8.3-dev` instead of `1.7.2`, as `1.8.3` is the latest version.

Closes #329 