### PR TITLE
Validate type and confirm

### DIFF
--- a/commands/certificates.go
+++ b/commands/certificates.go
@@ -92,46 +92,48 @@ func RunCertificateCreate(c *CmdConfig) error {
 		Type:     cType,
 	}
 
-	pkPath, err := c.Doit.GetString(c.NS, doctl.ArgPrivateKeyPath)
-	if err != nil {
-		return err
-	}
-
-	if len(pkPath) > 0 {
-		pc, err := readInputFromFile(pkPath)
+	if cType == "custom" || cType == "" {
+		pkPath, err := c.Doit.GetString(c.NS, doctl.ArgPrivateKeyPath)
 		if err != nil {
 			return err
 		}
 
-		r.PrivateKey = pc
-	}
+		if len(pkPath) > 0 {
+			pc, err := readInputFromFile(pkPath)
+			if err != nil {
+				return err
+			}
 
-	lcPath, err := c.Doit.GetString(c.NS, doctl.ArgLeafCertificatePath)
-	if err != nil {
-		return err
-	}
+			r.PrivateKey = pc
+		}
 
-	if len(lcPath) > 0 {
-		lc, err := readInputFromFile(lcPath)
+		lcPath, err := c.Doit.GetString(c.NS, doctl.ArgLeafCertificatePath)
 		if err != nil {
 			return err
 		}
 
-		r.LeafCertificate = lc
-	}
+		if len(lcPath) > 0 {
+			lc, err := readInputFromFile(lcPath)
+			if err != nil {
+				return err
+			}
 
-	ccPath, err := c.Doit.GetString(c.NS, doctl.ArgCertificateChainPath)
-	if err != nil {
-		return err
-	}
+			r.LeafCertificate = lc
+		}
 
-	if len(ccPath) > 0 {
-		cc, err := readInputFromFile(ccPath)
+		ccPath, err := c.Doit.GetString(c.NS, doctl.ArgCertificateChainPath)
 		if err != nil {
 			return err
 		}
 
-		r.CertificateChain = cc
+		if len(ccPath) > 0 {
+			cc, err := readInputFromFile(ccPath)
+			if err != nil {
+				return err
+			}
+
+			r.CertificateChain = cc
+		}
 	}
 
 	cs := c.Certificates()


### PR DESCRIPTION
When creating a certificate, if you specify certificate of type `lets_encrypt` you get the following error:

```
doctl compute certificate create --type lets_encrypt --name test --dns-names "testing.example.net"
```
```
Error: (certificate.create.private-key-path) command is missing required arguments
```

You shouldn't have to specify the private key, leaf certificate or any other string.

I've wrapped these calls in an if statement, if anyone can tell me a better way I'm happy to oblige.