### PR TITLE
Expose 'tag-name' argument to the RunDropletDelete command.

### DIFF
--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -478,7 +478,7 @@ func RunDropletDelete(c *CmdConfig) error {
 			fmt.Fprintf(c.Out, fmt.Sprintf("nothing to delete: no droplets found by \"%s\" tag\n", tagName))
 			return nil
 		}
-		var ids []string
+		ids := make([]string, 0, len(list))
 		for _, droplet := range list {
 			ids = append(ids, strconv.Itoa(droplet.ID))
 		}

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -73,6 +73,7 @@ func Droplet() *Command {
 	cmdRunDropletDelete := CmdBuilder(cmd, RunDropletDelete, "delete <droplet-id|droplet-name> [droplet-id|droplet-name ...]", "Delete droplet by id or name", Writer,
 		aliasOpt("d", "del", "rm"), docCategories("droplet"))
 	AddBoolFlag(cmdRunDropletDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force droplet delete")
+	AddStringFlag(cmdRunDropletDelete, doctl.ArgTagName, "", "", "Tag name")
 
 	cmdRunDropletGet := CmdBuilder(cmd, RunDropletGet, "get <droplet-id>", "get droplet", Writer,
 		aliasOpt("g"), displayerType(&droplet{}), docCategories("droplet"))


### PR DESCRIPTION
The functionality was already implemented in `RunDropletDelete` but never exposed. With this change, we allow deletion of droplets by tag name through the CLI.

Ideally, I'd also like to add a test case. However, from a quick glance at `droplet_test.go` I cannot easily see how to do that -- the existing tests (like `TestDropletDeleteByTag`) seems to attach the tag name argument separately from the `Droplet()` function. It looks like we should be testing things differently to actually run through the system-under-test, though chances are I might be missing something. Pointers welcome. :)