### PR TITLE
Change snap to classic confinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ brew install doctl
 You can use [Snap](https://snapcraft.io/) on [Snap-supported](https://snapcraft.io/docs/core/install) systems to install `doctl` with this command:
 
 ```
-sudo snap install doctl
+sudo snap install doctl --classic
 ```
   #### Arch Linux
   Arch users not using snaps can install from the [AUR](https://aur.archlinux.org/packages/doctl-bin/).

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,7 +2,7 @@ name: doctl
 version: "1.11.0"
 summary: A command line tool for DigitalOcean services
 description: doctl is a command line tool for DigitalOcean servics using the API.
-confinement: strict
+confinement: classic
 
 apps:
   doctl:


### PR DESCRIPTION
This fixes the `permission denied` errors mentioned in #263 and #347 