### PR TITLE
Default to showing public images for image list command

### DIFF
--- a/commands/images.go
+++ b/commands/images.go
@@ -38,7 +38,7 @@ func Images() *Command {
 
 	cmdImagesList := CmdBuilder(cmd, RunImagesList, "list", "list images", Writer,
 		aliasOpt("ls"), displayerType(&displayers.Image{}), docCategories("image"))
-	AddBoolFlag(cmdImagesList, doctl.ArgImagePublic, "", false, "List public images")
+	AddBoolFlag(cmdImagesList, doctl.ArgImagePublic, "", true, "List public images")
 
 	cmdImagesListDistribution := CmdBuilder(cmd, RunImagesListDistribution,
 		"list-distribution", "list distribution images", Writer,


### PR DESCRIPTION
Because the other `image list-application` and `image list-distribution` commands display public images by default, it's confusing that `image list` (which logically should have everything present in the others) doesn't show the public images.