### PR TITLE
No longer require ip-address when creating domains (Fixes: #366).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to `doctl` will be documented in this file.
 
+## [1.12.1] - UNRELEASED
+
+- #369 No longer require ip-address when creating domains - @andrewsomething
+
 ## [1.12.0] - 2018-11-26
 
 - #370 Projects API is no longer in beta. See https://developers.digitalocean.com/documentation/v2/#projects for more details - @mchitten

--- a/commands/domains.go
+++ b/commands/domains.go
@@ -39,7 +39,7 @@ func Domain() *Command {
 
 	cmdDomainCreate := CmdBuilder(cmd, RunDomainCreate, "create <domain>", "create domain", Writer,
 		aliasOpt("c"), displayerType(&displayers.Domain{}), docCategories("domain"))
-	AddStringFlag(cmdDomainCreate, doctl.ArgIPAddress, "", "", "IP address", requiredOpt())
+	AddStringFlag(cmdDomainCreate, doctl.ArgIPAddress, "", "", "IP address, creates an initial A record when provided")
 
 	CmdBuilder(cmd, RunDomainList, "list", "list domains", Writer,
 		aliasOpt("ls"), displayerType(&displayers.Domain{}), docCategories("domain"))


### PR DESCRIPTION
Previously, the API required that you provide an IP address when
creating a new domain in order to create an initial A record. This
behavior was changed to be optional:

https://developers.digitalocean.com/documentation/changelog/api-v2/create-domains-without-providing-an-ip-address/