### PR TITLE
projects API GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to `doctl` will be documented in this file.
 
+## [1.12.0] - 2018-11-26
+
+- #370 Projects API is no longer in beta. See https://developers.digitalocean.com/documentation/v2/#projects for more details - @mchitten
+- #365 Add support for kubernetes API [beta] - @aybabtme
+
 ## [1.11.0] - 2018-10-01
 
 - #348 Add support for projects API [beta] - @mchitten

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 
-ENV DOCTL_VERSION=1.11.0
+ENV DOCTL_VERSION=1.12.0
 
 RUN apk add --no-cache curl
 

--- a/README.md
+++ b/README.md
@@ -58,25 +58,25 @@ For example, with `wget`:
 
 ```
 cd ~
-wget https://github.com/digitalocean/doctl/releases/download/v1.11.0/doctl-1.11.0-linux-amd64.tar.gz
+wget https://github.com/digitalocean/doctl/releases/download/v1.12.0/doctl-1.12.0-linux-amd64.tar.gz
 ```
 
 Or with `curl`:
 
 ```
 cd ~
-curl -OL https://github.com/digitalocean/doctl/releases/download/v1.11.0/doctl-1.11.0-linux-amd64.tar.gz
+curl -OL https://github.com/digitalocean/doctl/releases/download/v1.12.0/doctl-1.12.0-linux-amd64.tar.gz
 ```
 
 Extract the binary. On GNU/Linux or OS X systems, you can use `tar`.
 
 ```
-tar xf ~/doctl-1.11.0-linux-amd64.tar.gz
+tar xf ~/doctl-1.12.0-linux-amd64.tar.gz
 ```
 
 Or download and extract with this oneliner:
 ```
-curl -sL https://github.com/digitalocean/doctl/releases/download/v1.11.0/doctl-1.11.0-linux-amd64.tar.gz | tar -xzv
+curl -sL https://github.com/digitalocean/doctl/releases/download/v1.12.0/doctl-1.12.0-linux-amd64.tar.gz | tar -xzv
 ```
 
 On Windows systems, you should be able to double-click the zip archive to extract the `doctl` executable.

--- a/commands/projects.go
+++ b/commands/projects.go
@@ -28,28 +28,28 @@ func Projects() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
 			Use:   "projects",
-			Short: "[beta] projects commands",
-			Long:  "[beta] projects commands are for creating and managing projects",
+			Short: "projects commands",
+			Long:  "projects commands are for creating and managing projects",
 		},
 	}
 
-	CmdBuilder(cmd, RunProjectsList, "list", "list projects", Writer, aliasOpt("ls"), displayerType(&displayers.Project{}), betaCmd())
-	CmdBuilder(cmd, RunProjectsGet, "get <id>", "get a project; use \"default\" as ID to get default project", Writer, aliasOpt("g"), displayerType(&displayers.Project{}), betaCmd())
+	CmdBuilder(cmd, RunProjectsList, "list", "list projects", Writer, aliasOpt("ls"), displayerType(&displayers.Project{}))
+	CmdBuilder(cmd, RunProjectsGet, "get <id>", "get a project; use \"default\" as ID to get default project", Writer, aliasOpt("g"), displayerType(&displayers.Project{}))
 
-	cmdProjectsCreate := CmdBuilder(cmd, RunProjectsCreate, "create", "create project", Writer, aliasOpt("c"), displayerType(&displayers.Project{}), betaCmd())
+	cmdProjectsCreate := CmdBuilder(cmd, RunProjectsCreate, "create", "create project", Writer, aliasOpt("c"), displayerType(&displayers.Project{}))
 	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectName, "", "", "project name", requiredOpt())
 	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectPurpose, "", "", "project purpose", requiredOpt())
 	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectDescription, "", "", "a description of your project")
 	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectEnvironment, "", "", "the environment in which your project resides. Should be one of 'Development', 'Staging', 'Production'.")
 
-	cmdProjectsUpdate := CmdBuilder(cmd, RunProjectsUpdate, "update <id>", "update project; use \"default\" as ID to update the default project", Writer, aliasOpt("u"), displayerType(&displayers.Project{}), betaCmd())
+	cmdProjectsUpdate := CmdBuilder(cmd, RunProjectsUpdate, "update <id>", "update project; use \"default\" as ID to update the default project", Writer, aliasOpt("u"), displayerType(&displayers.Project{}))
 	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectName, "", "", "project name")
 	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectPurpose, "", "", "project purpose")
 	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectDescription, "", "", "a description of your project")
 	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectEnvironment, "", "", "the environment in which your project resides. Should be one of 'Development', 'Staging', 'Production'.")
 	AddBoolFlag(cmdProjectsUpdate, doctl.ArgProjectIsDefault, "", false, "set the specified project as your default project")
 
-	cmdProjectsDelete := CmdBuilder(cmd, RunProjectsDelete, "delete <id> [<id> ...]", "delete project", Writer, aliasOpt("d", "rm"), betaCmd())
+	cmdProjectsDelete := CmdBuilder(cmd, RunProjectsDelete, "delete <id> [<id> ...]", "delete project", Writer, aliasOpt("d", "rm"))
 	AddBoolFlag(cmdProjectsDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force project delete")
 
 	cmd.AddCommand(ProjectResourcesCmd())
@@ -65,10 +65,10 @@ func ProjectResourcesCmd() *Command {
 			Long:  "project resources commands are for assigning and listing resources in projects",
 		},
 	}
-	CmdBuilder(cmd, RunProjectResourcesList, "list <project-id>", "list project resources", Writer, aliasOpt("ls"), displayerType(&displayers.ProjectResource{}), betaCmd())
-	CmdBuilder(cmd, RunProjectResourcesGet, "get <urn>", "get a project resource by its URN", Writer, aliasOpt("g"), betaCmd())
+	CmdBuilder(cmd, RunProjectResourcesList, "list <project-id>", "list project resources", Writer, aliasOpt("ls"), displayerType(&displayers.ProjectResource{}))
+	CmdBuilder(cmd, RunProjectResourcesGet, "get <urn>", "get a project resource by its URN", Writer, aliasOpt("g"))
 
-	cmdProjectResourcesAssign := CmdBuilder(cmd, RunProjectResourcesAssign, "assign <project-id> --resource=<urn> [--resource=<urn> ...]", "assign one or more resources to a project project", Writer, aliasOpt("a"), betaCmd())
+	cmdProjectResourcesAssign := CmdBuilder(cmd, RunProjectResourcesAssign, "assign <project-id> --resource=<urn> [--resource=<urn> ...]", "assign one or more resources to a project project", Writer, aliasOpt("a"))
 	AddStringSliceFlag(cmdProjectResourcesAssign, doctl.ArgProjectResource, "", []string{}, "resource URNs denoting resources to assign to the project")
 
 	return cmd

--- a/doit.go
+++ b/doit.go
@@ -49,7 +49,7 @@ var (
 	// DoitVersion is doit's version.
 	DoitVersion = Version{
 		Major: 1,
-		Minor: 11,
+		Minor: 12,
 		Patch: 0,
 		Label: "dev",
 	}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: doctl
-version: "1.11.0"
+version: "1.12.0"
 summary: A command line tool for DigitalOcean services
 description: doctl is a command line tool for DigitalOcean servics using the API.
 confinement: strict


### PR DESCRIPTION
Projects API is no longer in beta. See #353 for details on projects commands, and https://developers.digitalocean.com/documentation/v2/#projects for documentation.

