### PR TITLE
k8s: default to usable settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to `doctl` will be documented in this file.
 
+## [1.12.2] - UNRELEASED
+
+- #383 Fix bad default for cluster node sizes, improve help and warn of kubeconfig expiry date.
+
 ## [1.12.1] - 2018-12-09
 
 - #354 volumes: Fix droplet ID display when listing volumes - @adamwg

--- a/args.go
+++ b/args.go
@@ -38,6 +38,8 @@ const (
 	ArgClusterVersionSlug = "version"
 	// ArgClusterNodePool are a cluster's node pools arguments.
 	ArgClusterNodePool = "node-pool"
+	// ArgClusterTag is a cluster's tags arguments.
+	ArgClusterTag = "tag"
 	// ArgClusterUpdateKubeconfig updates the local kubeconfig.
 	ArgClusterUpdateKubeconfig = "update-kubeconfig"
 	// ArgNodePoolName is a cluster's node pool name argument.

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -84,7 +84,7 @@ func Kubernetes() *Command {
 func kubernetesCluster() *Command {
 
 	const (
-		defaultNodeSize  = "s-1vcpu-1gb"
+		defaultNodeSize  = "s-1vcpu-2gb"
 		defaultNodeCount = 3
 		defaultRegion    = "nyc1"
 	)


### PR DESCRIPTION
The default node size slug baked in the binary isn't valid for Kubernetes clusters. Fix that, and improve the help strings a bit while at it.