### PR TITLE
k8s: use ExecCredential for authentication

### DIFF
--- a/args.go
+++ b/args.go
@@ -148,6 +148,10 @@ const (
 	ArgTagNames = "tag-names"
 	//ArgTemplate is template format
 	ArgTemplate = "template"
+	// ArgVersion is the version of the command to use
+	ArgVersion = "version"
+	// ArgVerbose enables verbose output
+	ArgVerbose = "verbose"
 
 	// ArgOutput is an output type argument.
 	ArgOutput = "output"

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -83,7 +83,7 @@ func init() {
 	DoitCmd.PersistentFlags().StringVarP(&Token, doctl.ArgAccessToken, "t", "", "API V2 Access Token")
 	DoitCmd.PersistentFlags().StringVarP(&Output, "output", "o", "text", "output format [text|json]")
 	DoitCmd.PersistentFlags().StringVarP(&ApiURL, "api-url", "u", "", "Override default API V2 endpoint")
-	DoitCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+	DoitCmd.PersistentFlags().BoolVarP(&Verbose, doctl.ArgVerbose, "v", false, "verbose output")
 	DoitCmd.PersistentFlags().BoolVarP(&Trace, "trace", "", false, "trace api access")
 
 	DoitCmd.PersistentFlags().StringVarP(&Context, doctl.ArgContext, "", "", "authentication context name")


### PR DESCRIPTION
This changes the behavior of saving kubeconfig locally to set up an [exec plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins) in the kubeconfig, which gets called to talk to our API and retrieve credentials to authenticate against the Kubernetes server.

It caches the credentials under `~/.config/doctl/cache/kubeconfig/<uuid>.json`