### PR TITLE
Fix linter violations.

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -109,6 +109,8 @@ func RunAuthInit(retrieveUserTokenFunc func() (string, error)) func(c *CmdConfig
 	}
 }
 
+// RunAuthSwitch changes the default context and writes it to the
+// configuration.
 func RunAuthSwitch(c *CmdConfig) error {
 	context := Context
 	if context == "" {

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -47,8 +47,8 @@ var DoitCmd = &Command{
 // Context holds the current auth context
 var Context string
 
-// ApiURL holds the API URL to use.
-var ApiURL string
+// APIURL holds the API URL to use.
+var APIURL string
 
 // Token holds the global authorization token.
 var Token string
@@ -82,7 +82,7 @@ func init() {
 	DoitCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.config/doctl/config.yaml)")
 	DoitCmd.PersistentFlags().StringVarP(&Token, doctl.ArgAccessToken, "t", "", "API V2 Access Token")
 	DoitCmd.PersistentFlags().StringVarP(&Output, "output", "o", "text", "output format [text|json]")
-	DoitCmd.PersistentFlags().StringVarP(&ApiURL, "api-url", "u", "", "Override default API V2 endpoint")
+	DoitCmd.PersistentFlags().StringVarP(&APIURL, "api-url", "u", "", "Override default API V2 endpoint")
 	DoitCmd.PersistentFlags().BoolVarP(&Verbose, doctl.ArgVerbose, "v", false, "verbose output")
 	DoitCmd.PersistentFlags().BoolVarP(&Trace, "trace", "", false, "trace api access")
 

--- a/commands/domains.go
+++ b/commands/domains.go
@@ -178,9 +178,9 @@ func RunDomainDelete(c *CmdConfig) error {
 
 		err := ds.Delete(name)
 		return err
-	} else {
-		return fmt.Errorf("operation aborted")
 	}
+
+	return fmt.Errorf("operation aborted")
 }
 
 // RunRecordList list records for a domain.

--- a/commands/floating_ips.go
+++ b/commands/floating_ips.go
@@ -129,9 +129,9 @@ func RunFloatingIPDelete(c *CmdConfig) error {
 	if force || AskForConfirm("delete floating IP") == nil {
 		ip := c.Args[0]
 		return fis.Delete(ip)
-	} else {
-		return fmt.Errorf("operation aborted")
 	}
+
+	return fmt.Errorf("operation aborted")
 }
 
 // RunFloatingIPList runs floating IP create.

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -536,7 +536,7 @@ func execCredentialFromConfig(config *clientcmdapi.Config) (*clientauthenticatio
 	block, _ := pem.Decode(authInfo.ClientCertificateData)
 	if cert, err := x509.ParseCertificate(block.Bytes); err == nil && !cert.NotAfter.IsZero() {
 		// Expire the credentials 10 minutes before NotAfter to account for clock skew
-		t = &metav1.Time{cert.NotAfter.Add(-10 * time.Minute)}
+		t = &metav1.Time{Time: cert.NotAfter.Add(-10 * time.Minute)}
 	}
 
 	execCredential := &clientauthentication.ExecCredential{
@@ -1017,14 +1017,14 @@ func mergeKubeconfig(clusterID string, remote, local *clientcmdapi.Config) error
 	remoteCtx, ok := remote.Contexts[remote.CurrentContext]
 	if !ok {
 		// this is a bug in the backend, we received incomplete/non-sensical data
-		return fmt.Errorf("the remote config has no context entry named %q. This is a bug, please open a ticket with DigitalOcean!",
+		return fmt.Errorf("the remote config has no context entry named %q -- this is a bug, please open a ticket with DigitalOcean",
 			remote.CurrentContext,
 		)
 	}
 	remoteCluster, ok := remote.Clusters[remoteCtx.Cluster]
 	if !ok {
 		// this is a bug in the backend, we received incomplete/non-sensical data
-		return fmt.Errorf("the remote config has no cluster entry named %q. This is a bug, please open a ticket with DigitalOcean!",
+		return fmt.Errorf("the remote config has no cluster entry named %q -- this is a bug, please open a ticket with DigitalOcean",
 			remoteCtx.Cluster,
 		)
 	}
@@ -1058,7 +1058,7 @@ func removeKubeconfig(remote, local *clientcmdapi.Config) error {
 	remoteCtx, ok := remote.Contexts[remote.CurrentContext]
 	if !ok {
 		// this is a bug in the backend, we received incomplete/non-sensical data
-		return fmt.Errorf("the remote config has no context entry named %q. This is a bug, please open a ticket with DigitalOcean!",
+		return fmt.Errorf("the remote config has no context entry named %q -- this is a bug, please open a ticket with DigitalOcean",
 			remote.CurrentContext,
 		)
 	}

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -577,21 +577,44 @@ func TestKubernetesLatestVersions(t *testing.T) {
 		{
 			name: "base case",
 			input: []do.KubernetesVersion{
-				{&godo.KubernetesVersion{Slug: "1.13.0-do.not.use", KubernetesVersion: "1.13.0"}},
-				{&godo.KubernetesVersion{Slug: "1.12.1-do.3", KubernetesVersion: "1.12.1"}},
-				{&godo.KubernetesVersion{Slug: "1.12.1-do.2", KubernetesVersion: "1.12.1"}},
-				{&godo.KubernetesVersion{Slug: "1.12.1-do.1", KubernetesVersion: "1.12.1"}},
-				{&godo.KubernetesVersion{Slug: "1.11.1-do.2", KubernetesVersion: "1.11.1"}},
-				{&godo.KubernetesVersion{Slug: "1.11.1-do.1", KubernetesVersion: "1.11.1"}},
-				{&godo.KubernetesVersion{Slug: "1.10.7-gen2", KubernetesVersion: "1.10.7"}},
-				{&godo.KubernetesVersion{Slug: "1.10.7-gen1", KubernetesVersion: "1.10.7"}},
-				{&godo.KubernetesVersion{Slug: "1.10.7-gen0", KubernetesVersion: "1.10.7"}},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.13.0-do.not.use", KubernetesVersion: "1.13.0"},
+				},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.12.1-do.3", KubernetesVersion: "1.12.1"},
+				},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.12.1-do.2", KubernetesVersion: "1.12.1"},
+				},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.11.1-do.2", KubernetesVersion: "1.11.1"},
+				},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.11.1-do.1", KubernetesVersion: "1.11.1"},
+				},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.10.7-gen2", KubernetesVersion: "1.10.7"},
+				},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.10.7-gen1", KubernetesVersion: "1.10.7"},
+				},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.10.7-gen0", KubernetesVersion: "1.10.7"},
+				},
 			},
 			want: []do.KubernetesVersion{
-				{&godo.KubernetesVersion{Slug: "1.10.7-gen2", KubernetesVersion: "1.10.7"}},
-				{&godo.KubernetesVersion{Slug: "1.11.1-do.2", KubernetesVersion: "1.11.1"}},
-				{&godo.KubernetesVersion{Slug: "1.12.1-do.3", KubernetesVersion: "1.12.1"}},
-				{&godo.KubernetesVersion{Slug: "1.13.0-do.not.use", KubernetesVersion: "1.13.0"}},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.10.7-gen2", KubernetesVersion: "1.10.7"},
+				},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.11.1-do.2", KubernetesVersion: "1.11.1"},
+				},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.12.1-do.3", KubernetesVersion: "1.12.1"},
+				},
+				do.KubernetesVersion{
+					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.13.0-do.not.use", KubernetesVersion: "1.13.0"},
+				},
 			},
 		},
 	}

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -284,7 +284,7 @@ func fillStructFromStringSliceArgs(obj interface{}, s string) error {
 		if len(p) == 2 {
 			m[p[0]] = p[1]
 		} else {
-			return fmt.Errorf("Unexpected input value %v. Must be a key:value pair.", p)
+			return fmt.Errorf("Unexpected input value %v: must be a key:value pair", p)
 		}
 	}
 
@@ -341,11 +341,11 @@ func buildRequestFromArgs(c *CmdConfig, r *godo.LoadBalancerRequest) error {
 	}
 	r.Tag = tag
 
-	redirectHttpToHttps, err := c.Doit.GetBool(c.NS, doctl.ArgRedirectHttpToHttps)
+	redirectHTTPToHTTPS, err := c.Doit.GetBool(c.NS, doctl.ArgRedirectHttpToHttps)
 	if err != nil {
 		return err
 	}
-	r.RedirectHttpToHttps = redirectHttpToHttps
+	r.RedirectHttpToHttps = redirectHTTPToHTTPS
 
 	dropletIDsList, err := c.Doit.GetStringSlice(c.NS, doctl.ArgDropletIDs)
 	if err != nil {

--- a/commands/projects.go
+++ b/commands/projects.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Projects creates the projects commands hierarchy.
 func Projects() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
@@ -57,6 +58,7 @@ func Projects() *Command {
 	return cmd
 }
 
+// ProjectResourcesCmd creates the project resources commands hierarchy.
 func ProjectResourcesCmd() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
@@ -118,6 +120,7 @@ func RunProjectsCreate(c *CmdConfig) error {
 	return c.Display(&displayers.Project{Projects: do.Projects{*p}})
 }
 
+// RunProjectsUpdate updates an existing Project with a given configuration.
 func RunProjectsUpdate(c *CmdConfig) error {
 	if len(c.Args) != 1 {
 		return doctl.NewMissingArgsErr(c.NS)
@@ -138,6 +141,7 @@ func RunProjectsUpdate(c *CmdConfig) error {
 	return c.Display(&displayers.Project{Projects: do.Projects{*p}})
 }
 
+// RunProjectsDelete deletes a Project with a given configuration.
 func RunProjectsDelete(c *CmdConfig) error {
 	if len(c.Args) < 1 {
 		return doctl.NewMissingArgsErr(c.NS)
@@ -166,6 +170,7 @@ func RunProjectsDelete(c *CmdConfig) error {
 	return fmt.Errorf("operation aborted")
 }
 
+// RunProjectResourcesList lists the Projects.
 func RunProjectResourcesList(c *CmdConfig) error {
 	if len(c.Args) != 1 {
 		return doctl.NewMissingArgsErr(c.NS)
@@ -181,6 +186,7 @@ func RunProjectResourcesList(c *CmdConfig) error {
 	return c.Display(&displayers.ProjectResource{ProjectResources: list})
 }
 
+// RunProjectResourcesGet retrieves a Project Resource.
 func RunProjectResourcesGet(c *CmdConfig) error {
 	if len(c.Args) != 1 {
 		return doctl.NewMissingArgsErr(c.NS)
@@ -209,6 +215,7 @@ func RunProjectResourcesGet(c *CmdConfig) error {
 	}
 }
 
+// RunProjectResourcesAssign assigns a Project Resource.
 func RunProjectResourcesAssign(c *CmdConfig) error {
 	if len(c.Args) != 1 {
 		return doctl.NewMissingArgsErr(c.NS)

--- a/commands/sshkeys.go
+++ b/commands/sshkeys.go
@@ -183,9 +183,9 @@ func RunKeyDelete(c *CmdConfig) error {
 	if force || AskForConfirm("delete ssh key") == nil {
 		rawKey := c.Args[0]
 		return ks.Delete(rawKey)
-	} else {
-		return fmt.Errorf("operation aborted")
 	}
+
+	return fmt.Errorf("operation aborted")
 }
 
 // RunKeyUpdate updates a key.

--- a/commands/volume_actions.go
+++ b/commands/volume_actions.go
@@ -97,7 +97,7 @@ func RunVolumeAttach(c *CmdConfig) error {
 	return performVolumeAction(c, fn)
 }
 
-// RunVolumeDetachByDropletID detaches a volume by droplet ID
+// RunVolumeDetach detaches a volume by droplet ID
 func RunVolumeDetach(c *CmdConfig) error {
 	fn := func(das do.VolumeActionsService) (*do.Action, error) {
 		if len(c.Args) != 2 {

--- a/commands/xdg.go
+++ b/commands/xdg.go
@@ -22,9 +22,8 @@ import (
 func configHome() string {
 	if xdgPath := os.Getenv("XDG_CONFIG_HOME"); xdgPath != "" {
 		return filepath.Join(xdgPath, "doctl")
-	} else {
-		return filepath.Join(homeDir(), ".config", "doctl")
 	}
+	return filepath.Join(homeDir(), ".config", "doctl")
 }
 
 func legacyConfigCheck() {


### PR DESCRIPTION
Consists of naming style alignments, code simplifications, and trailing punctuation-free error messages.