### PR TITLE
kubernetes: Fetch credentials after cluster is provisioned

### DIFF
--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -261,17 +261,17 @@ func RunKubernetesClusterCreate(defaultNodeSize string, defaultNodeCount int) fu
 			return err
 		}
 
-		if update {
-			notice("cluster created, fetching credentials")
-			tryUpdateKubeconfig(kube, cluster.ID, clusterName)
-		}
-
 		if wait {
 			notice("cluster is provisioning, waiting for cluster to be running")
 			cluster, err = waitForClusterRunning(kube, cluster.ID)
 			if err != nil {
 				warn("cluster didn't become running: %v", err)
 			}
+		}
+
+		if update {
+			notice("cluster created, fetching credentials")
+			tryUpdateKubeconfig(kube, cluster.ID, clusterName)
 		}
 
 		return displayClusters(c, true, *cluster)


### PR DESCRIPTION
We currently try to fetch the credentials before the cluster is provisioned, which can lead to a 404 if the credentials aren't ready yet. This changes the order of operations so that the credentials are fetched after the cluster is done provisioning.


Fixes #399