### PR TITLE
Fix typo in project resources command

### DIFF
--- a/commands/projects.go
+++ b/commands/projects.go
@@ -70,7 +70,7 @@ func ProjectResourcesCmd() *Command {
 	CmdBuilder(cmd, RunProjectResourcesList, "list <project-id>", "list project resources", Writer, aliasOpt("ls"), displayerType(&displayers.ProjectResource{}))
 	CmdBuilder(cmd, RunProjectResourcesGet, "get <urn>", "get a project resource by its URN", Writer, aliasOpt("g"))
 
-	cmdProjectResourcesAssign := CmdBuilder(cmd, RunProjectResourcesAssign, "assign <project-id> --resource=<urn> [--resource=<urn> ...]", "assign one or more resources to a project project", Writer, aliasOpt("a"))
+	cmdProjectResourcesAssign := CmdBuilder(cmd, RunProjectResourcesAssign, "assign <project-id> --resource=<urn> [--resource=<urn> ...]", "assign one or more resources to a project", Writer, aliasOpt("a"))
 	AddStringSliceFlag(cmdProjectResourcesAssign, doctl.ArgProjectResource, "", []string{}, "resource URNs denoting resources to assign to the project")
 
 	return cmd


### PR DESCRIPTION
Fairly simple typo fix - "project" was repeated twice in the usage for `doctl projects resources --help` so I removed the extra copy.