### PR TITLE
kubernetes: Fix case where kube.Get returns a nil cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to `doctl` will be documented in this file.
 
 ## [1.13.1] - UNRELEASED
 
+- #408 k8s: Fix case where kube.Get returns a nil cluster
 - #398 Link to docs to create a Github token - @bouk
 - #392 Simplify newline trimming in retrieveUserInput - @timoreimann
 - #401 k8s: Fetch credentials after cluster is provisioned - @bouk

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1083,16 +1083,17 @@ func waitForClusterRunning(kube do.KubernetesService, clusterID string) (*do.Kub
 			}
 		}
 		cluster, err := kube.Get(clusterID)
-		if err != nil {
+		if err == nil {
+			failCount = 0
+		} else {
+			// Allow for transient API failures
+			failCount++
 			if failCount >= maxAPIFailures {
 				return nil, err
 			}
-			// tolerate transient API failures
-			time.Sleep(time.Second)
-		} else {
-			failCount = 0 // API responded, reset it's error counter
 		}
-		if cluster.Status == nil {
+
+		if cluster == nil || cluster.Status == nil {
 			time.Sleep(1 * time.Second)
 			continue
 		}

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -626,3 +626,17 @@ func TestKubernetesLatestVersions(t *testing.T) {
 		})
 	}
 }
+
+type nilCluster struct {
+	do.KubernetesService
+}
+
+func (n *nilCluster) Get(clusterID string) (*do.KubernetesCluster, error) {
+	return nil, fmt.Errorf("can't find %s", clusterID)
+}
+
+func Test_waitForClusterRunningDoesntPanicWithNilGet(t *testing.T) {
+	cluster, err := waitForClusterRunning(&nilCluster{}, "123")
+	require.Nil(t, cluster)
+	require.EqualError(t, err, "can't find 123")
+}


### PR DESCRIPTION
We've seen this issue:

```
$ doctl kubernetes cluster create node-readiness-debug --node-pool name=node-pool-node-readiness-debug1;size=s-2vcpu-4gb;count=1 --region lon1
Notice: cluster created, fetching credentials
Notice: adding cluster credentials to kubeconfig file found in "/Users/treimann/.kube/config"
Notice: cluster is provisioning, waiting for cluster to be running
....................
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1674bc7]

goroutine 1 [running]:
github.com/digitalocean/doctl/commands.waitForClusterRunning(0x18f7640, 0xc000532340, 0xc0005c4330, 0x24, 0x0, 0x0, 0x0)
    /private/tmp/doctl-20190125-78561-1oqpqh5/doctl-1.13.0/src/github.com/digitalocean/doctl/commands/kubernetes.go:1095 +0xf7
github.com/digitalocean/doctl/commands.RunKubernetesClusterCreate.func1(0xc000334120, 0x0, 0xc000137cb0)
    /private/tmp/doctl-20190125-78561-1oqpqh5/doctl-1.13.0/src/github.com/digitalocean/doctl/commands/kubernetes.go:271 +0x3a0
github.com/digitalocean/doctl/commands.cmdBuilderWithInit.func1(0xc00031af00, 0xc0003245a0, 0x1, 0x3)
    /private/tmp/doctl-20190125-78561-1oqpqh5/doctl-1.13.0/src/github.com/digitalocean/doctl/commands/doit.go:468 +0x153
github.com/digitalocean/doctl/vendor/github.com/spf13/cobra.(*Command).execute(0xc00031af00, 0xc0003244e0, 0x3, 0x3, 0xc00031af00, 0xc0003244e0)
    /private/tmp/doctl-20190125-78561-1oqpqh5/doctl-1.13.0/src/github.com/digitalocean/doctl/vendor/github.com/spf13/cobra/command.go:766 +0x2cc
github.com/digitalocean/doctl/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x1e7d0c0, 0x1851958, 0xc000137f30, 0xc000137f28)
    /private/tmp/doctl-20190125-78561-1oqpqh5/doctl-1.13.0/src/github.com/digitalocean/doctl/vendor/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/digitalocean/doctl/vendor/github.com/spf13/cobra.(*Command).Execute(0x1e7d0c0, 0x1851958, 0xc0000be000)
    /private/tmp/doctl-20190125-78561-1oqpqh5/doctl-1.13.0/src/github.com/digitalocean/doctl/vendor/github.com/spf13/cobra/command.go:800 +0x2b
github.com/digitalocean/doctl/commands.Execute()
    /private/tmp/doctl-20190125-78561-1oqpqh5/doctl-1.13.0/src/github.com/digitalocean/doctl/commands/doit.go:164 +0x30
main.main()
    /private/tmp/doctl-20190125-78561-1oqpqh5/doctl-1.13.0/src/github.com/digitalocean/doctl/cmd/doctl/main.go:24 +0x3b
```

Which is caused by a nil cluster being returned from kube.Get not being handled properly.