### PR TITLE
Makefile: fix Mac native build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOOS = linux
 UNAME_S := $(shell uname -s)
 UNAME_P := $(shell uname -p)
 ifeq ($(UNAME_S),Darwin)
-  NATIVE = darwin
+  GOOS = darwin
   GOARCH = 386
 endif
 


### PR DESCRIPTION
The Makefile would set the `darwin` target on an unused variable (`NATIVE`) instead of `GOOS`.