### PR TITLE
Fix multiple linting issues in doctl

### DIFF
--- a/commands/displayers/certificate.go
+++ b/commands/displayers/certificate.go
@@ -14,7 +14,6 @@ limitations under the License.
 package displayers
 
 import (
-	"fmt"
 	"io"
 	"strings"
 
@@ -64,7 +63,7 @@ func (c *Certificate) KV() []map[string]interface{} {
 		o := map[string]interface{}{
 			"ID":              c.ID,
 			"Name":            c.Name,
-			"DNSNames":        fmt.Sprintf(strings.Join(c.DNSNames, ",")),
+			"DNSNames":        strings.Join(c.DNSNames, ","),
 			"SHA1Fingerprint": c.SHA1Fingerprint,
 			"NotAfter":        c.NotAfter,
 			"Created":         c.Created,

--- a/commands/displayers/kubernetes.go
+++ b/commands/displayers/kubernetes.go
@@ -1,7 +1,6 @@
 package displayers
 
 import (
-	"fmt"
 	"io"
 	"strings"
 
@@ -102,7 +101,7 @@ func (clusters *KubernetesClusters) KV() []map[string]interface{} {
 			"Status":        cluster.Status.State,
 			"Created":       cluster.CreatedAt,
 			"Updated":       cluster.UpdatedAt,
-			"NodePools":     fmt.Sprintf(strings.Join(nodePools, " ")),
+			"NodePools":     strings.Join(nodePools, " "),
 		}
 		out = append(out, o)
 	}

--- a/commands/displayers/load_balancer.go
+++ b/commands/displayers/load_balancer.go
@@ -85,11 +85,11 @@ func (lb *LoadBalancer) KV() []map[string]interface{} {
 			"Algorithm":           l.Algorithm,
 			"Region":              l.Region.Slug,
 			"Tag":                 l.Tag,
-			"DropletIDs":          fmt.Sprintf(strings.Trim(strings.Replace(fmt.Sprint(l.DropletIDs), " ", ",", -1), "[]")),
+			"DropletIDs":          strings.Trim(strings.Replace(fmt.Sprint(l.DropletIDs), " ", ",", -1), "[]"),
 			"RedirectHttpToHttps": l.RedirectHttpToHttps,
 			"StickySessions":      prettyPrintStruct(l.StickySessions),
 			"HealthCheck":         prettyPrintStruct(l.HealthCheck),
-			"ForwardingRules":     fmt.Sprintf(strings.Join(forwardingRules, " ")),
+			"ForwardingRules":     strings.Join(forwardingRules, " "),
 		}
 		out = append(out, o)
 	}

--- a/commands/displayers/output.go
+++ b/commands/displayers/output.go
@@ -60,7 +60,7 @@ func prettyPrintStruct(obj interface{}) string {
 		output = append(output, fmt.Sprintf("%v:%v", k, v))
 	}
 
-	return fmt.Sprintf(strings.Join(output, ","))
+	return strings.Join(output, ",")
 }
 
 // Displayable is a displable entity. These are used for printing results.

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -476,7 +476,7 @@ func RunDropletDelete(c *CmdConfig) error {
 			return err
 		}
 		if len(list) == 0 {
-			fmt.Fprintf(c.Out, fmt.Sprintf("nothing to delete: no droplets found by \"%s\" tag\n", tagName))
+			fmt.Fprintf(c.Out, "nothing to delete: no droplets found by \"%s\" tag\n", tagName)
 			return nil
 		}
 		ids := make([]string, 0, len(list))

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -571,10 +571,7 @@ func RunKubernetesKubeconfigSave(c *CmdConfig) error {
 		return err
 	}
 
-	if err := writeOrAddToKubeconfig(clusterID, kubeconfig); err != nil {
-		return err
-	}
-	return nil
+	return writeOrAddToKubeconfig(clusterID, kubeconfig)
 }
 
 // RunKubernetesKubeconfigRemove retrieves an existing kubernetes config and removes it from your local kubeconfig.
@@ -591,10 +588,8 @@ func RunKubernetesKubeconfigRemove(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	if err := removeFromKubeconfig(kubeconfig); err != nil {
-		return err
-	}
-	return nil
+
+	return removeFromKubeconfig(kubeconfig)
 }
 
 // Node Pools

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -577,42 +577,42 @@ func TestKubernetesLatestVersions(t *testing.T) {
 		{
 			name: "base case",
 			input: []do.KubernetesVersion{
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.13.0-do.not.use", KubernetesVersion: "1.13.0"},
 				},
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.12.1-do.3", KubernetesVersion: "1.12.1"},
 				},
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.12.1-do.2", KubernetesVersion: "1.12.1"},
 				},
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.11.1-do.2", KubernetesVersion: "1.11.1"},
 				},
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.11.1-do.1", KubernetesVersion: "1.11.1"},
 				},
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.10.7-gen2", KubernetesVersion: "1.10.7"},
 				},
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.10.7-gen1", KubernetesVersion: "1.10.7"},
 				},
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.10.7-gen0", KubernetesVersion: "1.10.7"},
 				},
 			},
 			want: []do.KubernetesVersion{
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.10.7-gen2", KubernetesVersion: "1.10.7"},
 				},
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.11.1-do.2", KubernetesVersion: "1.11.1"},
 				},
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.12.1-do.3", KubernetesVersion: "1.12.1"},
 				},
-				do.KubernetesVersion{
+				{
 					KubernetesVersion: &godo.KubernetesVersion{Slug: "1.13.0-do.not.use", KubernetesVersion: "1.13.0"},
 				},
 			},

--- a/doit.go
+++ b/doit.go
@@ -15,6 +15,7 @@ package doctl
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -180,7 +181,7 @@ func (c *LiveConfig) GetGodoClient(trace bool, accessToken string) (*godo.Client
 	}
 
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
-	oauthClient := oauth2.NewClient(oauth2.NoContext, tokenSource)
+	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
 
 	if trace {
 		r := newRecorder(oauthClient.Transport)

--- a/pkg/ssh/ssh_internal.go
+++ b/pkg/ssh/ssh_internal.go
@@ -39,7 +39,7 @@ func askForPassword(prompt string) (string, error) {
 	}()
 
 	t := terminal.NewTerminal(os.Stdin, ">")
-	fmt.Printf(prompt)
+	fmt.Print(prompt)
 	password, err := t.ReadPassword("")
 	if err != nil {
 		return "", err

--- a/pkg/system/chtimes.go
+++ b/pkg/system/chtimes.go
@@ -39,9 +39,5 @@ func Chtimes(name string, atime time.Time, mtime time.Time) error {
 		mtime = unixMinTime
 	}
 
-	if err := os.Chtimes(name, atime, mtime); err != nil {
-		return err
-	}
-
-	return nil
+	return os.Chtimes(name, atime, mtime)
 }

--- a/pkg/system/utimes_unix_test.go
+++ b/pkg/system/utimes_unix_test.go
@@ -41,7 +41,10 @@ func TestLUtimesNano(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ts := []syscall.Timespec{{0, 0}, {0, 0}}
+	ts := []syscall.Timespec{
+		{Sec: 0, Nsec: 0},
+		{Sec: 0, Nsec: 0},
+	}
 	if err := LUtimesNano(symlink, ts); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
i) govet - unkeyed fields
ii) golint - redundant err !-nil checks
iii) staticcheck - improper use of printf-style statements when there are no arguments used.
iv) removed use of oauth.NoContext which is deprecated.
v) run gofmt -s -w