### PR TITLE
bump version and update changelog for databases support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to `doctl` will be documented in this file.
 
+
+## [1.15.0] - 2019-03-27
+
+- #421 Add support for managed databases - @sunny-b
+
 ## [1.14.0] - 2019-03-11
 
 - #415 Add support for custom domains in Spaces CDN - @xornivore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All changes to `doctl` will be documented in this file.
 
+## [1.15.0] - 2019-04-9
 
-## [1.15.0] - 2019-03-27
-
+- #422 update CONTRIBUTING.md with info on how to update vendored code - @mregmi
 - #421 Add support for managed databases - @sunny-b
 
 ## [1.14.0] - 2019-03-11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-ENV DOCTL_VERSION=1.14.0
+ENV DOCTL_VERSION=1.15.0
 
 RUN apk add --no-cache curl
 

--- a/README.md
+++ b/README.md
@@ -58,25 +58,25 @@ For example, with `wget`:
 
 ```
 cd ~
-wget https://github.com/digitalocean/doctl/releases/download/v1.14.0/doctl-1.14.0-linux-amd64.tar.gz
+wget https://github.com/digitalocean/doctl/releases/download/v1.15.0/doctl-1.15.0-linux-amd64.tar.gz
 ```
 
 Or with `curl`:
 
 ```
 cd ~
-curl -OL https://github.com/digitalocean/doctl/releases/download/v1.14.0/doctl-1.14.0-linux-amd64.tar.gz
+curl -OL https://github.com/digitalocean/doctl/releases/download/v1.15.0/doctl-1.15.0-linux-amd64.tar.gz
 ```
 
 Extract the binary. On GNU/Linux or OS X systems, you can use `tar`.
 
 ```
-tar xf ~/doctl-1.14.0-linux-amd64.tar.gz
+tar xf ~/doctl-1.15.0-linux-amd64.tar.gz
 ```
 
 Or download and extract with this oneliner:
 ```
-curl -sL https://github.com/digitalocean/doctl/releases/download/v1.14.0/doctl-1.14.0-linux-amd64.tar.gz | tar -xzv
+curl -sL https://github.com/digitalocean/doctl/releases/download/v1.15.0/doctl-1.15.0-linux-amd64.tar.gz | tar -xzv
 ```
 
 On Windows systems, you should be able to double-click the zip archive to extract the `doctl` executable.

--- a/doit.go
+++ b/doit.go
@@ -50,7 +50,7 @@ var (
 	// DoitVersion is doit's version.
 	DoitVersion = Version{
 		Major: 1,
-		Minor: 14,
+		Minor: 15,
 		Patch: 0,
 		Label: "dev",
 	}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: doctl
-version: "1.14.0"
+version: "1.15.0"
 summary: A command line tool for DigitalOcean services
 description: doctl is a command line tool for DigitalOcean servics using the API.
 confinement: classic


### PR DESCRIPTION
This updates the doctl `version` to `1.15.0` and updates the CHANGELOG to include the addition of Managed Databases.

cc: @hilary 