### PR TITLE
add mock assertions for databases service

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -243,6 +243,7 @@ func withTestClient(t *testing.T, tFn testFn) {
 	assert.True(t, tm.cdns.AssertExpectations(t))
 	assert.True(t, tm.projects.AssertExpectations(t))
 	assert.True(t, tm.kubernetes.AssertExpectations(t))
+	assert.True(t, tm.databases.AssertExpectations(t))
 }
 
 type TestConfig struct {


### PR DESCRIPTION
I forgot to add the database mock assertions in `commands_test` for my databases update. This adds those assertions in.