### PR TITLE
Disable terminal ECHO flag when prompting for auth token

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -14,7 +14,6 @@ limitations under the License.
 package commands
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"os"
@@ -37,9 +36,13 @@ func retrieveUserTokenFromCommandLine() (string, error) {
 		return "", ErrUnknownTerminal
 	}
 
-	reader := bufio.NewReader(os.Stdin)
 	fmt.Print("DigitalOcean access token: ")
-	return reader.ReadString('\n')
+	passwdBytes, err := terminal.ReadPassword(0)
+	if err != nil {
+		return "", err
+	}
+
+	return string(passwdBytes), nil
 }
 
 // UnknownSchemeError signifies an unknown HTTP scheme.


### PR DESCRIPTION
This makes use of the [`ReadPassword` function in `golang.org/x/crypto/ssh/terminal`](https://godoc.org/golang.org/x/crypto/ssh/terminal#ReadPassword) to avoid forcing the user to expose their auth token when entering it on the command line in response to the `doctl auth init` prompt.

This does not yet address the issue of printing the auth token when running `doctl auth init` when one is already configured. I think I will file an issue to initiate discussion as to whether or not displaying the auth token is even a concern (I am accustomed to services like Github which more tightly control visibility of auth tokens).