### PR TITLE
fix --tag for kubernetes create/update

### DIFF
--- a/args.go
+++ b/args.go
@@ -38,8 +38,6 @@ const (
 	ArgClusterVersionSlug = "version"
 	// ArgClusterNodePool are a cluster's node pools arguments.
 	ArgClusterNodePool = "node-pool"
-	// ArgClusterTag is a cluster's tags arguments.
-	ArgClusterTag = "tag"
 	// ArgClusterUpdateKubeconfig updates the local kubeconfig.
 	ArgClusterUpdateKubeconfig = "update-kubeconfig"
 	// ArgNodePoolName is a cluster's node pool name argument.
@@ -146,6 +144,8 @@ const (
 	ArgTagName = "tag-name"
 	// ArgTagNames is a slice of possible tag names
 	ArgTagNames = "tag-names"
+	// ArgTag specifies tag.  --tag can be repeated or multiple tags can be , separated.
+	ArgTag = "tag"
 	//ArgTemplate is template format
 	ArgTemplate = "template"
 	// ArgVersion is the version of the command to use

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -113,7 +113,7 @@ func kubernetesCluster() *Command {
 	cmdKubeClusterCreate := CmdBuilder(cmd, RunKubernetesClusterCreate(defaultKubernetesNodeSize, defaultKubernetesNodeCount), "create <name>", "create a cluster", Writer, aliasOpt("c"))
 	AddStringFlag(cmdKubeClusterCreate, doctl.ArgRegionSlug, "", defaultKubernetesRegion, `cluster region, possible values: see "doctl k8s options regions"`, requiredOpt())
 	AddStringFlag(cmdKubeClusterCreate, doctl.ArgClusterVersionSlug, "", "latest", `cluster version, possible values: see "doctl k8s options versions"`)
-	AddStringSliceFlag(cmdKubeClusterCreate, doctl.ArgClusterTag, "", nil, "tags to apply to the cluster, repeat to add multiple tags at once")
+	AddStringSliceFlag(cmdKubeClusterCreate, doctl.ArgTag, "", nil, "tags to apply to the cluster, repeat to add multiple tags at once")
 	AddStringFlag(cmdKubeClusterCreate, doctl.ArgSizeSlug, "", defaultKubernetesNodeSize, `size of nodes in the default node pool (incompatible with --`+doctl.ArgClusterNodePool+`), possible values: see "doctl k8s options sizes".`)
 	AddIntFlag(cmdKubeClusterCreate, doctl.ArgNodePoolCount, "", defaultKubernetesNodeCount, "number of nodes in the default node pool (incompatible with --"+doctl.ArgClusterNodePool+")")
 	AddStringSliceFlag(cmdKubeClusterCreate, doctl.ArgClusterNodePool, "", nil, `cluster node pools, can be repeated to create multiple node pools at once (incompatible with --`+doctl.ArgSizeSlug+` and --`+doctl.ArgNodePoolCount+`)
@@ -127,7 +127,7 @@ format is in the form "name=your-name;size=size_slug;count=5;tag=tag1;tag=tag2" 
 
 	cmdKubeClusterUpdate := CmdBuilder(cmd, RunKubernetesClusterUpdate, "update <id|name>", "update a cluster's properties", Writer, aliasOpt("u"))
 	AddStringFlag(cmdKubeClusterUpdate, doctl.ArgClusterName, "", "", "new cluster name")
-	AddStringSliceFlag(cmdKubeClusterUpdate, doctl.ArgClusterTag, "", nil, "tags to apply to the cluster, repeat to add multiple tags at once")
+	AddStringSliceFlag(cmdKubeClusterUpdate, doctl.ArgTag, "", nil, "tags to apply to the cluster, repeat to add multiple tags at once")
 	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgClusterUpdateKubeconfig, "", true, "whether to update the cluster in your kubeconfig")
 
 	cmdKubeClusterDelete := CmdBuilder(cmd, RunKubernetesClusterDelete, "delete <id|name>", "delete a cluster", Writer, aliasOpt("d", "rm"))
@@ -176,12 +176,12 @@ func kubernetesNodePools() *Command {
 	AddStringFlag(cmdKubeNodePoolCreate, doctl.ArgNodePoolName, "", "", "node pool name", requiredOpt())
 	AddStringFlag(cmdKubeNodePoolCreate, doctl.ArgSizeSlug, "", "", "size of nodes in the node pool (see `doctl k8s options sizes`)", requiredOpt())
 	AddIntFlag(cmdKubeNodePoolCreate, doctl.ArgNodePoolCount, "", 0, "count of nodes in the node pool", requiredOpt())
-	AddStringFlag(cmdKubeNodePoolCreate, doctl.ArgClusterTag, "", "", "tags to apply to the node pool, repeat to add multiple tags at once")
+	AddStringFlag(cmdKubeNodePoolCreate, doctl.ArgTag, "", "", "tags to apply to the node pool, repeat to add multiple tags at once")
 
 	cmdKubeNodePoolUpdate := CmdBuilder(cmd, RunKubernetesNodePoolUpdate, "update <cluster-id|cluster-name> <pool-id|pool-name>", "update an existing node pool in a cluster", Writer, aliasOpt("u"))
 	AddStringFlag(cmdKubeNodePoolUpdate, doctl.ArgNodePoolName, "", "", "node pool name")
 	AddIntFlag(cmdKubeNodePoolUpdate, doctl.ArgNodePoolCount, "", 0, "count of nodes in the node pool")
-	AddStringFlag(cmdKubeNodePoolUpdate, doctl.ArgClusterTag, "", "", "tags to apply to the node pool, repeat to add multiple tags at once")
+	AddStringFlag(cmdKubeNodePoolUpdate, doctl.ArgTag, "", "", "tags to apply to the node pool, repeat to add multiple tags at once")
 
 	cmdKubeNodePoolRecycle := CmdBuilder(cmd, RunKubernetesNodePoolRecycle, "recycle <cluster-id|cluster-name> <pool-id|pool-name>", "recycle nodes in a node pool", Writer, aliasOpt("r"))
 	AddStringFlag(cmdKubeNodePoolRecycle, doctl.ArgNodePoolNodeIDs, "", "", "ID or name of the nodes in the node pool to recycle")
@@ -778,7 +778,7 @@ func buildClusterCreateRequestFromArgs(c *CmdConfig, r *godo.KubernetesClusterCr
 	}
 	r.VersionSlug = version
 
-	tags, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTagNames)
+	tags, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTag)
 	if err != nil {
 		return err
 	}
@@ -832,7 +832,7 @@ func buildClusterUpdateRequestFromArgs(c *CmdConfig, r *godo.KubernetesClusterUp
 	}
 	r.Name = name
 
-	tags, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTagNames)
+	tags, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTag)
 	if err != nil {
 		return err
 	}
@@ -936,7 +936,7 @@ func buildNodePoolCreateRequestFromArgs(c *CmdConfig, r *godo.KubernetesNodePool
 	}
 	r.Count = count
 
-	tags, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTagNames)
+	tags, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTag)
 	if err != nil {
 		return err
 	}
@@ -958,7 +958,7 @@ func buildNodePoolUpdateRequestFromArgs(c *CmdConfig, r *godo.KubernetesNodePool
 	}
 	r.Count = count
 
-	tags, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTagNames)
+	tags, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTag)
 	if err != nil {
 		return err
 	}

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -204,7 +204,7 @@ func TestKubernetesCreate(t *testing.T) {
 		config.Args = append(config.Args, testCluster.Name)
 		config.Doit.Set(config.NS, doctl.ArgRegionSlug, testCluster.RegionSlug)
 		config.Doit.Set(config.NS, doctl.ArgClusterVersionSlug, testCluster.VersionSlug)
-		config.Doit.Set(config.NS, doctl.ArgTagNames, testCluster.Tags)
+		config.Doit.Set(config.NS, doctl.ArgTag, testCluster.Tags)
 		config.Doit.Set(config.NS, doctl.ArgClusterNodePool, []string{
 			fmt.Sprintf("name=%s;size=%s;count=%d;tag=%s;tag=%s",
 				testNodePool.Name+"1", testNodePool.Size, testNodePool.Count, testNodePool.Tags[0], testNodePool.Tags[1],
@@ -230,7 +230,7 @@ func TestKubernetesUpdate(t *testing.T) {
 
 		config.Args = append(config.Args, testCluster.ID)
 		config.Doit.Set(config.NS, doctl.ArgClusterName, testCluster.Name)
-		config.Doit.Set(config.NS, doctl.ArgTagNames, testCluster.Tags)
+		config.Doit.Set(config.NS, doctl.ArgTag, testCluster.Tags)
 
 		err := RunKubernetesClusterUpdate(config)
 		assert.NoError(t, err)
@@ -246,7 +246,7 @@ func TestKubernetesUpdate(t *testing.T) {
 
 		config.Args = append(config.Args, testCluster.Name)
 		config.Doit.Set(config.NS, doctl.ArgClusterName, testCluster.Name)
-		config.Doit.Set(config.NS, doctl.ArgTagNames, testCluster.Tags)
+		config.Doit.Set(config.NS, doctl.ArgTag, testCluster.Tags)
 
 		err := RunKubernetesClusterUpdate(config)
 		assert.NoError(t, err)
@@ -381,7 +381,7 @@ func TestKubernetesNodePool_Create(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
 		config.Doit.Set(config.NS, doctl.ArgSizeSlug, testNodePool.Size)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
-		config.Doit.Set(config.NS, doctl.ArgTagNames, testNodePool.Tags)
+		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
 
 		err := RunKubernetesNodePoolCreate(config)
 		assert.NoError(t, err)
@@ -402,7 +402,7 @@ func TestKubernetesNodePool_Create(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
 		config.Doit.Set(config.NS, doctl.ArgSizeSlug, testNodePool.Size)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
-		config.Doit.Set(config.NS, doctl.ArgTagNames, testNodePool.Tags)
+		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
 
 		err := RunKubernetesNodePoolCreate(config)
 		assert.NoError(t, err)
@@ -423,7 +423,7 @@ func TestKubernetesNodePool_Update(t *testing.T) {
 
 		config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
-		config.Doit.Set(config.NS, doctl.ArgTagNames, testNodePool.Tags)
+		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
 
 		err := RunKubernetesNodePoolUpdate(config)
 		assert.NoError(t, err)
@@ -442,7 +442,7 @@ func TestKubernetesNodePool_Update(t *testing.T) {
 
 		config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
-		config.Doit.Set(config.NS, doctl.ArgTagNames, testNodePool.Tags)
+		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
 
 		err := RunKubernetesNodePoolUpdate(config)
 		assert.NoError(t, err)
@@ -461,7 +461,7 @@ func TestKubernetesNodePool_Update(t *testing.T) {
 
 		config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
-		config.Doit.Set(config.NS, doctl.ArgTagNames, testNodePool.Tags)
+		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
 
 		err := RunKubernetesNodePoolUpdate(config)
 		assert.NoError(t, err)
@@ -481,7 +481,7 @@ func TestKubernetesNodePool_Update(t *testing.T) {
 
 		config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
-		config.Doit.Set(config.NS, doctl.ArgTagNames, testNodePool.Tags)
+		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
 
 		err := RunKubernetesNodePoolUpdate(config)
 		assert.NoError(t, err)


### PR DESCRIPTION
`buildClusterCreateRequestFromArgs` and `buildClusterUpdateRequestFromArgs` incorrectly references the `--tag` field (`doctl.ArgClusterTag`) by (`doctl.ArgTagName` `--tag-name`). The test unfortunately also referenced `doctl.ArgTagName` so this went unnoticed.  Correct this handling, and move to `doctl.ArgTag` which will be shared by volume and snapshot creation.