### PR TITLE
Godo v1.13.0 + Tag Support for Volumes + Vol Snapshots

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,15 +26,15 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:9d32b65d4aa95d67351ba8a6cf51b78fbe2b32c10ba2d69d480938393e1bd538"
+  digest = "1:d846ae22056f62e81b30f90c58adadd97877e9c4880073234d7bcc3f05f47b3c"
   name = "github.com/digitalocean/godo"
   packages = [
     ".",
     "util",
   ]
   pruneopts = ""
-  revision = "2e7ec7260974f189ff28c4c278c366b86a4b1050"
-  version = "v1.11.1"
+  revision = "780261ee6a33765a8356afbdb8c3841f140e13fd"
+  version = "v1.13.0"
 
 [[projects]]
   digest = "1:f1a75a8e00244e5ea77ff274baa9559eb877437b240ee7b278f3fc560d9f08bf"

--- a/args.go
+++ b/args.go
@@ -146,6 +146,8 @@ const (
 	ArgTagName = "tag-name"
 	// ArgTagNames is a slice of possible tag names
 	ArgTagNames = "tag-names"
+	// ArgTag specifies tag.  --tag can be repeated or multiple tags can be , separated.
+	ArgTag = "tag"
 	//ArgTemplate is template format
 	ArgTemplate = "template"
 	// ArgVersion is the version of the command to use

--- a/args.go
+++ b/args.go
@@ -143,8 +143,12 @@ const (
 	// ArgPollTime is how long before the next poll argument.
 	ArgPollTime = "poll-timeout"
 	// ArgTagName is a tag name
+	// NOTE: ArgTagName will be deprecated once existing uses have been migrated
+	// to use `--tag` (ArgTag). ArgTagName should not be used on new calls.
 	ArgTagName = "tag-name"
 	// ArgTagNames is a slice of possible tag names
+	// NOTE: ArgTagNames will be deprecated once existing uses have been migrated
+	// to use `--tag` (ArgTag). ArgTagNames should not be used on new calls.
 	ArgTagNames = "tag-names"
 	// ArgTag specifies tag.  --tag can be repeated or multiple tags can be , separated.
 	ArgTag = "tag"

--- a/commands/displayers/snapshot.go
+++ b/commands/displayers/snapshot.go
@@ -16,6 +16,7 @@ package displayers
 import (
 	"io"
 	"strconv"
+	"strings"
 
 	"github.com/digitalocean/doctl/do"
 )
@@ -32,13 +33,13 @@ func (s *Snapshot) JSON(out io.Writer) error {
 
 func (s *Snapshot) Cols() []string {
 	return []string{"ID", "Name", "CreatedAt", "Regions", "ResourceId",
-		"ResourceType", "MinDiskSize", "Size"}
+		"ResourceType", "MinDiskSize", "Size", "Tags"}
 }
 
 func (s *Snapshot) ColMap() map[string]string {
 	return map[string]string{
 		"ID": "ID", "Name": "Name", "CreatedAt": "Created at", "Regions": "Regions",
-		"ResourceId": "Resource ID", "ResourceType": "Resource Type", "MinDiskSize": "Min Disk Size", "Size": "Size"}
+		"ResourceId": "Resource ID", "ResourceType": "Resource Type", "MinDiskSize": "Min Disk Size", "Size": "Size", "Tags": "Tags"}
 }
 
 func (s *Snapshot) KV() []map[string]interface{} {
@@ -49,6 +50,7 @@ func (s *Snapshot) KV() []map[string]interface{} {
 			"ID": ss.ID, "Name": ss.Name, "ResourceId": ss.ResourceID,
 			"ResourceType": ss.ResourceType, "Regions": ss.Regions, "MinDiskSize": ss.MinDiskSize,
 			"Size": strconv.FormatFloat(ss.SizeGigaBytes, 'f', 2, 64) + " GiB", "CreatedAt": ss.Created,
+			"Tags": strings.Join(ss.Tags, ","),
 		}
 		out = append(out, o)
 	}

--- a/commands/displayers/volume.go
+++ b/commands/displayers/volume.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	"github.com/digitalocean/doctl/do"
 )
@@ -34,7 +35,7 @@ func (a *Volume) JSON(out io.Writer) error {
 
 func (a *Volume) Cols() []string {
 	return []string{
-		"ID", "Name", "Size", "Region", "Filesystem Type", "Filesystem Label", "DropletIDs",
+		"ID", "Name", "Size", "Region", "Filesystem Type", "Filesystem Label", "DropletIDs", "Tags",
 	}
 }
 
@@ -47,6 +48,7 @@ func (a *Volume) ColMap() map[string]string {
 		"Filesystem Type":  "Filesystem Type",
 		"Filesystem Label": "Filesystem Label",
 		"DropletIDs":       "Droplet IDs",
+		"Tags":             "Tags",
 	}
 
 }
@@ -61,6 +63,7 @@ func (a *Volume) KV() []map[string]interface{} {
 			"Region":           volume.Region.Slug,
 			"Filesystem Type":  volume.FilesystemType,
 			"Filesystem Label": volume.FilesystemLabel,
+			"Tags":             strings.Join(volume.Tags, ","),
 		}
 		m["DropletIDs"] = ""
 		if len(volume.DropletIDs) != 0 {

--- a/commands/volumes_test.go
+++ b/commands/volumes_test.go
@@ -93,6 +93,7 @@ func TestVolumeCreate(t *testing.T) {
 			SizeGigaBytes: 100,
 			Region:        "atlantis",
 			Description:   "test description",
+			Tags:          []string{"one", "two"},
 		}
 		tm.volumes.On("CreateVolume", &tcr).Return(&testVolume, nil)
 
@@ -101,6 +102,7 @@ func TestVolumeCreate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgVolumeRegion, "atlantis")
 		config.Doit.Set(config.NS, doctl.ArgVolumeSize, "100GiB")
 		config.Doit.Set(config.NS, doctl.ArgVolumeDesc, "test description")
+		config.Doit.Set(config.NS, doctl.ArgTag, []string{"one", "two"})
 
 		err := RunVolumeCreate(config)
 		assert.NoError(t, err)
@@ -126,12 +128,14 @@ func TestVolumesSnapshot(t *testing.T) {
 			VolumeID:    testVolume.ID,
 			Name:        "test-volume-snapshot",
 			Description: "test description",
+			Tags:        []string{"one", "two"},
 		}
 		tm.volumes.On("CreateSnapshot", &tcr).Return(nil, nil)
 
 		config.Args = append(config.Args, testVolume.ID)
 		config.Doit.Set(config.NS, doctl.ArgSnapshotName, "test-volume-snapshot")
 		config.Doit.Set(config.NS, doctl.ArgSnapshotDesc, "test description")
+		config.Doit.Set(config.NS, doctl.ArgTag, []string{"one", "two"})
 
 		err := RunVolumeSnapshot(config)
 		assert.NoError(t, err)

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v1.13.0] - 2019-04-19
+
+- #213 Add tagging support for volume snapshots - @jcodybaker
+
+## [v1.12.0] - 2019-04-18
+
+- #224 Add maintenance window support for Kubernetes- @fatih
+
 ## [v1.11.1] - 2019-04-04
 
 - #222 Fix Create Database Pools json fields - @sunny-b

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.11.1"
+	libraryVersion = "1.13.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -53,12 +54,15 @@ type KubernetesClusterCreateRequest struct {
 	VPCUUID     string   `json:"vpc_uuid,omitempty"`
 
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
+
+	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy"`
 }
 
 // KubernetesClusterUpdateRequest represents a request to update a Kubernetes cluster.
 type KubernetesClusterUpdateRequest struct {
-	Name string   `json:"name,omitempty"`
-	Tags []string `json:"tags,omitempty"`
+	Name              string                       `json:"name,omitempty"`
+	Tags              []string                     `json:"tags,omitempty"`
+	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy"`
 }
 
 // KubernetesNodePoolCreateRequest represents a request to create a node pool for a
@@ -99,9 +103,98 @@ type KubernetesCluster struct {
 
 	NodePools []*KubernetesNodePool `json:"node_pools,omitempty"`
 
+	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy,omitempty"`
+
 	Status    *KubernetesClusterStatus `json:"status,omitempty"`
 	CreatedAt time.Time                `json:"created_at,omitempty"`
 	UpdatedAt time.Time                `json:"updated_at,omitempty"`
+}
+
+// KubernetesMaintenancePolicy is a configuration to set the maintenance window
+// of a cluster
+type KubernetesMaintenancePolicy struct {
+	StartTime string                         `json:"start_time"`
+	Duration  string                         `json:"duration"`
+	Day       KubernetesMaintenancePolicyDay `json:"day"`
+}
+
+// KubernetesMaintenancePolicyDay represents the possible days of a maintenance
+// window
+type KubernetesMaintenancePolicyDay int
+
+const (
+	KubernetesMaintenanceDayAny KubernetesMaintenancePolicyDay = iota
+	KubernetesMaintenanceDayMonday
+	KubernetesMaintenanceDayTuesday
+	KubernetesMaintenanceDayWednesday
+	KubernetesMaintenanceDayThursday
+	KubernetesMaintenanceDayFriday
+	KubernetesMaintenanceDaySaturday
+	KubernetesMaintenanceDaySunday
+)
+
+var (
+	days = [...]string{
+		"any",
+		"monday",
+		"tuesday",
+		"wednesday",
+		"thursday",
+		"friday",
+		"saturday",
+		"sunday",
+	}
+
+	toDay = map[string]KubernetesMaintenancePolicyDay{
+		"any":       KubernetesMaintenanceDayAny,
+		"monday":    KubernetesMaintenanceDayMonday,
+		"tuesday":   KubernetesMaintenanceDayTuesday,
+		"wednesday": KubernetesMaintenanceDayWednesday,
+		"thursday":  KubernetesMaintenanceDayThursday,
+		"friday":    KubernetesMaintenanceDayFriday,
+		"saturday":  KubernetesMaintenanceDaySaturday,
+		"sunday":    KubernetesMaintenanceDaySunday,
+	}
+)
+
+// KubernetesMaintenanceToDay returns the appropriate KubernetesMaintenancePolicyDay for the given string.
+func KubernetesMaintenanceToDay(day string) (KubernetesMaintenancePolicyDay, error) {
+	d, ok := toDay[day]
+	if !ok {
+		return 0, fmt.Errorf("unknown day: %q", day)
+	}
+
+	return d, nil
+}
+
+func (k KubernetesMaintenancePolicyDay) String() string {
+	if KubernetesMaintenanceDayAny <= k && k <= KubernetesMaintenanceDaySunday {
+		return days[k]
+	}
+	return fmt.Sprintf("%d !Weekday", k)
+
+}
+
+func (k *KubernetesMaintenancePolicyDay) UnmarshalJSON(data []byte) error {
+	var val string
+	if err := json.Unmarshal(data, &val); err != nil {
+		return err
+	}
+
+	parsed, err := KubernetesMaintenanceToDay(val)
+	if err != nil {
+		return err
+	}
+	*k = parsed
+	return nil
+}
+
+func (k KubernetesMaintenancePolicyDay) MarshalJSON() ([]byte, error) {
+	if KubernetesMaintenanceDayAny <= k && k <= KubernetesMaintenanceDaySunday {
+		return json.Marshal(days[k])
+	}
+
+	return nil, fmt.Errorf("invalid day: %d", k)
 }
 
 // Possible states for a cluster.

--- a/vendor/github.com/digitalocean/godo/kubernetes_test.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes_test.go
@@ -246,6 +246,10 @@ func TestKubernetesClusters_Get(t *testing.T) {
 				},
 			},
 		},
+		MaintenancePolicy: &KubernetesMaintenancePolicy{
+			StartTime: "00:00",
+			Day:       KubernetesMaintenanceDayMonday,
+		},
 		CreatedAt: time.Date(2018, 6, 15, 7, 10, 23, 0, time.UTC),
 		UpdatedAt: time.Date(2018, 6, 15, 7, 11, 26, 0, time.UTC),
 	}
@@ -294,6 +298,10 @@ func TestKubernetesClusters_Get(t *testing.T) {
 				]
 			}
 		],
+		"maintenance_policy": {
+			"start_time": "00:00",
+			"day": "monday"
+		},
 		"created_at": "2018-06-15T07:10:23Z",
 		"updated_at": "2018-06-15T07:11:26Z"
 	}
@@ -348,6 +356,10 @@ func TestKubernetesClusters_Create(t *testing.T) {
 				Tags:  []string{"tag-1"},
 			},
 		},
+		MaintenancePolicy: &KubernetesMaintenancePolicy{
+			StartTime: "00:00",
+			Day:       KubernetesMaintenanceDayMonday,
+		},
 	}
 	createRequest := &KubernetesClusterCreateRequest{
 		Name:        want.Name,
@@ -363,6 +375,7 @@ func TestKubernetesClusters_Create(t *testing.T) {
 				Tags:  want.NodePools[0].Tags,
 			},
 		},
+		MaintenancePolicy: want.MaintenancePolicy,
 	}
 
 	jBlob := `
@@ -389,7 +402,11 @@ func TestKubernetesClusters_Create(t *testing.T) {
 					"tag-1"
 				]
 			}
-		]
+		],
+		"maintenance_policy": {
+			"start_time": "00:00",
+			"day": "monday"
+		}
 	}
 }`
 
@@ -434,10 +451,15 @@ func TestKubernetesClusters_Update(t *testing.T) {
 				Tags:  []string{"tag-1"},
 			},
 		},
+		MaintenancePolicy: &KubernetesMaintenancePolicy{
+			StartTime: "00:00",
+			Day:       KubernetesMaintenanceDayMonday,
+		},
 	}
 	updateRequest := &KubernetesClusterUpdateRequest{
-		Name: want.Name,
-		Tags: want.Tags,
+		Name:              want.Name,
+		Tags:              want.Tags,
+		MaintenancePolicy: want.MaintenancePolicy,
 	}
 
 	jBlob := `
@@ -464,7 +486,11 @@ func TestKubernetesClusters_Update(t *testing.T) {
 					"tag-1"
 				]
 			}
-		]
+		],
+		"maintenance_policy": {
+			"start_time": "00:00",
+			"day": "monday"
+		}
 	}
 }`
 
@@ -797,4 +823,67 @@ func TestKubernetesVersions_List(t *testing.T) {
 	got, _, err := kubeSvc.GetOptions(ctx)
 	require.NoError(t, err)
 	require.Equal(t, want, got)
+}
+
+var maintenancePolicyDayTests = []struct {
+	name  string
+	json  string
+	day   KubernetesMaintenancePolicyDay
+	valid bool
+}{
+	{
+		name:  "sunday",
+		day:   KubernetesMaintenanceDaySunday,
+		json:  `"sunday"`,
+		valid: true,
+	},
+
+	{
+		name:  "any",
+		day:   KubernetesMaintenanceDayAny,
+		json:  `"any"`,
+		valid: true,
+	},
+
+	{
+		name:  "invalid",
+		day:   100, // invalid input
+		json:  `"invalid weekday (100)"`,
+		valid: false,
+	},
+}
+
+func TestWeekday_UnmarshalJSON(t *testing.T) {
+	for _, ts := range maintenancePolicyDayTests {
+		t.Run(ts.name, func(t *testing.T) {
+			var got KubernetesMaintenancePolicyDay
+			err := json.Unmarshal([]byte(ts.json), &got)
+			valid := err == nil
+			if valid != ts.valid {
+				t.Errorf("valid unmarshal case\n\tgot: %+v\n\twant : %+v", valid, ts.valid)
+			}
+
+			if valid && got != ts.day {
+				t.Errorf("\ninput: %s\ngot : %+v\nwant  : %+v\n",
+					ts.day, got, ts.day)
+			}
+		})
+	}
+}
+
+func TestWeekday_MarshalJSON(t *testing.T) {
+	for _, ts := range maintenancePolicyDayTests {
+		t.Run(ts.name, func(t *testing.T) {
+			out, err := json.Marshal(ts.day)
+			valid := err == nil
+			if valid != ts.valid {
+				t.Errorf("valid marshal case\n\tgot: %+v\n\twant : %+v", valid, ts.valid)
+			}
+
+			if valid && ts.json != string(out) {
+				t.Errorf("\ninput: %s\ngot : %+v\nwant  : %+v\n",
+					ts.day, string(out), ts.json)
+			}
+		})
+	}
 }

--- a/vendor/github.com/digitalocean/godo/snapshots.go
+++ b/vendor/github.com/digitalocean/godo/snapshots.go
@@ -37,6 +37,7 @@ type Snapshot struct {
 	MinDiskSize   int      `json:"min_disk_size,omitempty"`
 	SizeGigaBytes float64  `json:"size_gigabytes,omitempty"`
 	Created       string   `json:"created_at,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
 }
 
 type snapshotRoot struct {

--- a/vendor/github.com/digitalocean/godo/snapshots_test.go
+++ b/vendor/github.com/digitalocean/godo/snapshots_test.go
@@ -176,10 +176,11 @@ func TestSnapshot_String(t *testing.T) {
 		MinDiskSize:   20,
 		SizeGigaBytes: 4.84,
 		Created:       "2013-11-27T09:24:55Z",
+		Tags:          []string{"one", "two"},
 	}
 
 	stringified := snapshot.String()
-	expected := `godo.Snapshot{ID:"1", Name:"Snapsh176ot", ResourceID:"0", ResourceType:"droplet", Regions:["one"], MinDiskSize:20, SizeGigaBytes:4.84, Created:"2013-11-27T09:24:55Z"}`
+	expected := `godo.Snapshot{ID:"1", Name:"Snapsh176ot", ResourceID:"0", ResourceType:"droplet", Regions:["one"], MinDiskSize:20, SizeGigaBytes:4.84, Created:"2013-11-27T09:24:55Z", Tags:["one" "two"]}`
 	if expected != stringified {
 		t.Errorf("Snapshot.String returned %+v, expected %+v", stringified, expected)
 	}

--- a/vendor/github.com/digitalocean/godo/storage.go
+++ b/vendor/github.com/digitalocean/godo/storage.go
@@ -175,9 +175,10 @@ func (svc *StorageServiceOp) DeleteVolume(ctx context.Context, id string) (*Resp
 // SnapshotCreateRequest represents a request to create a block store
 // volume.
 type SnapshotCreateRequest struct {
-	VolumeID    string `json:"volume_id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	VolumeID    string   `json:"volume_id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags"`
 }
 
 // ListSnapshots lists all snapshots related to a storage volume.

--- a/vendor/github.com/digitalocean/godo/storage_test.go
+++ b/vendor/github.com/digitalocean/godo/storage_test.go
@@ -631,6 +631,7 @@ func TestStorageSnapshots_Create(t *testing.T) {
 		VolumeID:    "98d414c6-295e-4e3a-ac58-eb9456c1e1d1",
 		Name:        "my snapshot",
 		Description: "my description",
+		Tags:        []string{"one", "two"},
 	}
 
 	want := &Snapshot{
@@ -639,6 +640,7 @@ func TestStorageSnapshots_Create(t *testing.T) {
 		Name:          "my snapshot",
 		SizeGigaBytes: 100,
 		Created:       "2002-10-02T15:00:00.05Z",
+		Tags:          []string{"one", "two"},
 	}
 	jBlob := `{
 		"snapshot":{
@@ -647,7 +649,8 @@ func TestStorageSnapshots_Create(t *testing.T) {
 			"name": "my snapshot",
 			"description": "my description",
 			"size_gigabytes": 100,
-			"created_at": "2002-10-02T15:00:00.05Z"
+			"created_at": "2002-10-02T15:00:00.05Z",
+			"tags": ["one", "two"]
 		},
 		"links": {
 	    "pages": {

--- a/vendor/github.com/digitalocean/godo/tags.go
+++ b/vendor/github.com/digitalocean/godo/tags.go
@@ -33,14 +33,16 @@ var _ TagsService = &TagsServiceOp{}
 type ResourceType string
 
 const (
-	//DropletResourceType holds the string representing our ResourceType of Droplet.
+	// DropletResourceType holds the string representing our ResourceType of Droplet.
 	DropletResourceType ResourceType = "droplet"
-	//ImageResourceType holds the string representing our ResourceType of Image.
+	// ImageResourceType holds the string representing our ResourceType of Image.
 	ImageResourceType ResourceType = "image"
-	//VolumeResourceType holds the string representing our ResourceType of Volume.
+	// VolumeResourceType holds the string representing our ResourceType of Volume.
 	VolumeResourceType ResourceType = "volume"
-	//LoadBalancerResourceType holds the string representing our ResourceType of LoadBalancer.
+	// LoadBalancerResourceType holds the string representing our ResourceType of LoadBalancer.
 	LoadBalancerResourceType ResourceType = "load_balancer"
+	// VolumeSnapshotResourceType holds the string representing our ResourceType for storage Snapshots.
+	VolumeSnapshotResourceType ResourceType = "volumesnapshot"
 )
 
 // Resource represent a single resource for associating/disassociating with tags


### PR DESCRIPTION
Contains two commits.
- Update godo vendor to v1.13.0.
- Add tag support for volumes and volume snapshots.
