### PR TITLE
Display context being used instead of token

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -78,6 +78,11 @@ func RunAuthInit(retrieveUserTokenFunc func() (string, error)) func(c *CmdConfig
 	return func(c *CmdConfig) error {
 		token := c.getContextAccessToken()
 
+		context := Context
+		if context == "" {
+			context = viper.GetString("context")
+		}
+
 		if token == "" {
 			in, err := retrieveUserTokenFunc()
 			if err != nil {
@@ -85,7 +90,7 @@ func RunAuthInit(retrieveUserTokenFunc func() (string, error)) func(c *CmdConfig
 			}
 			token = strings.TrimSpace(in)
 		} else {
-			fmt.Fprintf(c.Out, "Using token [%v]", token)
+			fmt.Fprintf(c.Out, "Using token for context [%v]", context)
 			fmt.Fprintln(c.Out)
 		}
 


### PR DESCRIPTION
In https://github.com/digitalocean/doctl/pull/428 we disabled the terminal ECHO flag to prevent `doctl` from echoing a user's auth token when calling `doctl auth init` for the first time (ie no auth token currently set in the `doctl` config file).

The behavior not covered in the PR was to prevent `doctl auth init` from displaying the auth token when it is already set. Instead, this PR is proposing that we display the auth context name similar to what is shown when running `doctl auth switch`. The effect is that `doctl auth init` when an auth token is already set shows:

```
Using token for context [default]

Validating token... OK
```

An alternative approach might be to instead show something like:

```
Using token [XXXXXX**********************************************************]
Validating token... OK
```

Where `XXXXXX` shown above would be the first 6 characters of the auth token. I obviously prefer using the context name but thought I would mention this possibility for maintainers to consider.