### PR TITLE
Create a volume from a volume snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to `doctl` will be documented in this file.
 ## [1.17.0] - UNRELEASED
 
  - #438 Remove need to opt-in to database commands. - @andrewsomething
+ - #420 Allow creating Volumes from a Snapshots. - @bentranter
 
 ## [1.16.0] - 2019-04-25
 

--- a/args.go
+++ b/args.go
@@ -166,6 +166,8 @@ const (
 	ArgVolumeDesc = "desc"
 	// ArgVolumeRegion is the region of a volume.
 	ArgVolumeRegion = "region"
+	// ArgVolumeSnapshot is the snapshot from which to create a volume.
+	ArgVolumeSnapshot = "snapshot"
 	// ArgVolumeFilesystemType is the filesystem type for a volume.
 	ArgVolumeFilesystemType = "fs-type"
 	// ArgVolumeFilesystemLabel is the filesystem label for a volume.

--- a/commands/displayers/volume.go
+++ b/commands/displayers/volume.go
@@ -60,10 +60,13 @@ func (a *Volume) KV() []map[string]interface{} {
 			"ID":               volume.ID,
 			"Name":             volume.Name,
 			"Size":             strconv.FormatInt(volume.SizeGigaBytes, 10) + " GiB",
-			"Region":           volume.Region.Slug,
 			"Filesystem Type":  volume.FilesystemType,
 			"Filesystem Label": volume.FilesystemLabel,
 			"Tags":             strings.Join(volume.Tags, ","),
+		}
+		m["Region"] = ""
+		if volume.Region != nil {
+			m["Region"] = volume.Region.Slug
 		}
 		m["DropletIDs"] = ""
 		if len(volume.DropletIDs) != 0 {

--- a/commands/volumes_test.go
+++ b/commands/volumes_test.go
@@ -109,6 +109,29 @@ func TestVolumeCreate(t *testing.T) {
 	})
 }
 
+func TestVolumeCreateFromSnapshot(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tcr := godo.VolumeCreateRequest{
+			Name:          "test-volume",
+			SizeGigaBytes: 100,
+			SnapshotID:    "ed6414f7-7873-4dd2-90cf-f4f354c293e6",
+			Description:   "test description",
+			Tags:          []string{"one", "two"},
+		}
+		tm.volumes.On("CreateVolume", &tcr).Return(&testVolume, nil)
+
+		config.Args = append(config.Args, "test-volume")
+
+		config.Doit.Set(config.NS, doctl.ArgVolumeSnapshot, "ed6414f7-7873-4dd2-90cf-f4f354c293e6")
+		config.Doit.Set(config.NS, doctl.ArgVolumeSize, "100GiB")
+		config.Doit.Set(config.NS, doctl.ArgVolumeDesc, "test description")
+		config.Doit.Set(config.NS, doctl.ArgTag, []string{"one", "two"})
+
+		err := RunVolumeCreate(config)
+		assert.NoError(t, err)
+	})
+}
+
 func TestVolumesDelete(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.volumes.On("DeleteVolume", "test-volume").Return(nil)


### PR DESCRIPTION
Adds a `--snapshot` flag to the `doctl compute volume create` command, allowing users to create a new volume from an existing volume snapshot.

If merged, this should fix #420.

I wasn't exactly sure how to handle the `--region` flag. In `doctl` it's currently marked as required, but in the [API documentation](https://developers.digitalocean.com/documentation/v2/#create-a-new-block-storage-volume), it's stated that, 
> "The region [...] should not be specified with a snapshot_id".

My initial approach was to remove the `requiredOpt()` argument from the region flag, and update the usage string to indicate that either a region or snapshot must be included.

This is where trouble began.

I suspect there's some issue when using a non-required flag that is already registered as a required flag on a different command. Even with the `requiredOpt()` call removed from the `--region` flag, `doctl` still reported the flag as being required when I was manually testing this change. If I changed the name of the flag from `--region` to `--region-id`, `doctl` no longer reported that I was missing a required flag, presumably because that was the only usage of `--region-id` in any command.

With that said, despite the API documentation's recommendation, the command works when a region flag is set, although the API seems to ignore this flag. If I try to create a new volume from a volume snapshot and set the region to NYC1, but the volume snapshot is in TOR1, the new volume will be created in TOR1. I'm assuming that it uses the region of the snapshot, rather than the provided region value.

Anyway — I did spend some time digging, but not a ton of time, so I could be wrong about all of this. Just wanted to share my findings to hopefully save others some time if they run into this same potential issue. I figure that for expected backwards compatibility, and due to the issue I ran into, it makes sense for `doctl` to keep the `--region` flag required for now.
