### PR TITLE
Remove beta opt-in from database commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to `doctl` will be documented in this file.
 
+## [1.17.0] - UNRELEASED
+
+ - #438 Remove need to opt-in to database commands. - @andrewsomething
+
 ## [1.16.0] - 2019-04-25
 
 - #431 Godo v1.13.0 + Tag Support for Volumes + Vol Snapshots - @jcodybaker

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -40,7 +40,6 @@ func Databases() *Command {
 			Aliases: []string{"db", "dbs", "d", "database"},
 			Short:   "database commands",
 			Long:    "database is used to access managed databases commands",
-			Hidden:  !isBeta(),
 		},
 	}
 


### PR DESCRIPTION
This PR removes the need to opt-in to database commands by setting the `DIGITALOCEAN_ENABLE_BETA` environment variable.