### PR TITLE
Add flag to set current-context in local KubeConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to `doctl` will be documented in this file.
 
+## [1.18.0] - UNRELEASED
+
+ - #440 Add flag to set local KubeConfig's current-context. - @eddiezane
+
 ## [1.17.0] - UNRELEASED
 
  - #438 Remove need to opt-in to database commands. - @andrewsomething

--- a/args.go
+++ b/args.go
@@ -48,6 +48,8 @@ const (
 	ArgNodePoolNodeIDs = "node-ids"
 	// ArgCommandWait is a wait for a resource to be created argument.
 	ArgCommandWait = "wait"
+	// ArgSetCurrentContext is a flag to set the new kubeconfig context as current.
+	ArgSetCurrentContext = "set-current-context"
 	// ArgDropletID is a droplet id argument.
 	ArgDropletID = "droplet-id"
 	// ArgDropletIDs is a list of droplet IDs.


### PR DESCRIPTION
This PR adds a new flag of `--set-current-context` when creating or updating a cluster, or saving a KubeConfig, that will set the `current-context` of your local KubeConfig to the new cluster. It defaults to true as this should be the expected behavior.

edit: Closes #394 