### PR TITLE
kubernetes: Support cluster upgrades

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,15 +26,15 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:d846ae22056f62e81b30f90c58adadd97877e9c4880073234d7bcc3f05f47b3c"
+  digest = "1:1e939e850618a6703cae7f428bb322de9171567aacfc3fe7fc31faea020b5662"
   name = "github.com/digitalocean/godo"
   packages = [
     ".",
-    "util",
+    "util"
   ]
   pruneopts = ""
-  revision = "780261ee6a33765a8356afbdb8c3841f140e13fd"
-  version = "v1.13.0"
+  revision = "d01d7b058ec6814dfae599e25ff585aeca45c801"
+  version = "v1.14.0"
 
 [[projects]]
   digest = "1:f1a75a8e00244e5ea77ff274baa9559eb877437b240ee7b278f3fc560d9f08bf"
@@ -71,7 +71,7 @@
     "syntax/ast",
     "syntax/lexer",
     "util/runes",
-    "util/strings",
+    "util/strings"
   ]
   pruneopts = ""
   revision = "5ccd90ef52e1e632236f7326478d4faa74f99438"
@@ -82,7 +82,7 @@
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys",
+    "sortkeys"
   ]
   pruneopts = ""
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
@@ -141,7 +141,7 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token",
+    "json/token"
   ]
   pruneopts = ""
   revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
@@ -280,7 +280,7 @@
   name = "github.com/spf13/afero"
   packages = [
     ".",
-    "mem",
+    "mem"
   ]
   pruneopts = ""
   revision = "d40851caa0d747393da1ffb28f7f9d8b4eeffebd"
@@ -299,7 +299,7 @@
   name = "github.com/spf13/cobra"
   packages = [
     ".",
-    "doc",
+    "doc"
   ]
   pruneopts = ""
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
@@ -343,7 +343,7 @@
   packages = [
     "assert",
     "mock",
-    "require",
+    "require"
   ]
   pruneopts = ""
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
@@ -362,7 +362,7 @@
     "poly1305",
     "ssh",
     "ssh/agent",
-    "ssh/terminal",
+    "ssh/terminal"
   ]
   pruneopts = ""
   revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
@@ -377,7 +377,7 @@
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna",
+    "idna"
   ]
   pruneopts = ""
   revision = "351d144fa1fc0bd934e2408202be0c29f25e35a0"
@@ -388,7 +388,7 @@
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "internal",
+    "internal"
   ]
   pruneopts = ""
   revision = "d668ce993890a79bda886613ee587a69dd5da7a6"
@@ -399,7 +399,7 @@
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
   pruneopts = ""
   revision = "4ed8d59d0b35e1e29334a206d1b3f38b1e5dfb31"
@@ -421,7 +421,7 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
   pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
@@ -445,7 +445,7 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch",
+    "urlfetch"
   ]
   pruneopts = ""
   revision = "4a4468ece617fc8205e99368fa2200e9d1fad421"
@@ -504,7 +504,7 @@
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
-    "third_party/forked/golang/reflect",
+    "third_party/forked/golang/reflect"
   ]
   pruneopts = ""
   revision = "eb8c8024849baa3681995b2b0bd4da7ea1734ace"
@@ -531,7 +531,7 @@
     "util/connrotation",
     "util/flowcontrol",
     "util/homedir",
-    "util/integer",
+    "util/integer"
   ]
   pruneopts = ""
   revision = "1638f8970cefaa404ff3a62950f88b08292b2696"
@@ -583,7 +583,7 @@
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1",
     "k8s.io/client-go/tools/clientcmd",
-    "k8s.io/client-go/tools/clientcmd/api",
+    "k8s.io/client-go/tools/clientcmd/api"
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,7 +5,7 @@
 
 [[constraint]]
   name = "github.com/digitalocean/godo"
-  version = ">= 1.7.2"
+  version = ">= 1.14.0"
 
 [[constraint]]
   name = "github.com/dustin/go-humanize"

--- a/args.go
+++ b/args.go
@@ -48,6 +48,8 @@ const (
 	ArgNodePoolNodeIDs = "node-ids"
 	// ArgMaintenanceWindow is a cluster's maintenance window argument
 	ArgMaintenanceWindow = "maintenance-window"
+	// ArgAutoUpdate is a cluster's auto-upgrade argument.
+	ArgAutoUpgrade = "auto-upgrade"
 	// ArgCommandWait is a wait for a resource to be created argument.
 	ArgCommandWait = "wait"
 	// ArgDropletID is a droplet id argument.

--- a/commands/displayers/kubernetes.go
+++ b/commands/displayers/kubernetes.go
@@ -26,6 +26,7 @@ func (clusters *KubernetesClusters) Cols() []string {
 			"Name",
 			"Region",
 			"Version",
+			"AutoUpgrade",
 			"Status",
 			"NodePools",
 		}
@@ -35,6 +36,7 @@ func (clusters *KubernetesClusters) Cols() []string {
 		"Name",
 		"Region",
 		"Version",
+		"AutoUpgrade",
 		"Status",
 		"Endpoint",
 		"IPv4",
@@ -50,12 +52,13 @@ func (clusters *KubernetesClusters) Cols() []string {
 func (clusters *KubernetesClusters) ColMap() map[string]string {
 	if clusters.Short {
 		return map[string]string{
-			"ID":        "ID",
-			"Name":      "Name",
-			"Region":    "Region",
-			"Version":   "Version",
-			"Status":    "Status",
-			"NodePools": "Node Pools",
+			"ID":          "ID",
+			"Name":        "Name",
+			"Region":      "Region",
+			"Version":     "Version",
+			"AutoUpgrade": "Auto Upgrade",
+			"Status":      "Status",
+			"NodePools":   "Node Pools",
 		}
 	}
 	return map[string]string{
@@ -63,6 +66,7 @@ func (clusters *KubernetesClusters) ColMap() map[string]string {
 		"Name":          "Name",
 		"Region":        "Region",
 		"Version":       "Version",
+		"AutoUpgrade":   "Auto Upgrade",
 		"ClusterSubnet": "Cluster Subnet",
 		"ServiceSubnet": "Service Subnet",
 		"IPv4":          "IPv4",
@@ -93,6 +97,7 @@ func (clusters *KubernetesClusters) KV() []map[string]interface{} {
 			"Name":          cluster.Name,
 			"Region":        cluster.RegionSlug,
 			"Version":       cluster.VersionSlug,
+			"AutoUpgrade":   cluster.AutoUpgrade,
 			"ClusterSubnet": cluster.ClusterSubnet,
 			"ServiceSubnet": cluster.ServiceSubnet,
 			"IPv4":          cluster.IPv4,

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -113,6 +113,7 @@ func kubernetesCluster() *Command {
 	cmdKubeClusterCreate := CmdBuilder(cmd, RunKubernetesClusterCreate(defaultKubernetesNodeSize, defaultKubernetesNodeCount), "create <name>", "create a cluster", Writer, aliasOpt("c"))
 	AddStringFlag(cmdKubeClusterCreate, doctl.ArgRegionSlug, "", defaultKubernetesRegion, `cluster region, possible values: see "doctl k8s options regions"`, requiredOpt())
 	AddStringFlag(cmdKubeClusterCreate, doctl.ArgClusterVersionSlug, "", "latest", `cluster version, possible values: see "doctl k8s options versions"`)
+	AddBoolFlag(cmdKubeClusterCreate, doctl.ArgAutoUpgrade, "", false, "whether to enable auto-upgrade for the cluster")
 	AddStringSliceFlag(cmdKubeClusterCreate, doctl.ArgTag, "", nil, "tags to apply to the cluster, repeat to add multiple tags at once")
 	AddStringFlag(cmdKubeClusterCreate, doctl.ArgSizeSlug, "", defaultKubernetesNodeSize, `size of nodes in the default node pool (incompatible with --`+doctl.ArgClusterNodePool+`), possible values: see "doctl k8s options sizes".`)
 	AddIntFlag(cmdKubeClusterCreate, doctl.ArgNodePoolCount, "", defaultKubernetesNodeCount, "number of nodes in the default node pool (incompatible with --"+doctl.ArgClusterNodePool+")")
@@ -129,6 +130,7 @@ format is in the form "name=your-name;size=size_slug;count=5;tag=tag1;tag=tag2" 
 	cmdKubeClusterUpdate := CmdBuilder(cmd, RunKubernetesClusterUpdate, "update <id|name>", "update a cluster's properties", Writer, aliasOpt("u"))
 	AddStringFlag(cmdKubeClusterUpdate, doctl.ArgClusterName, "", "", "new cluster name")
 	AddStringSliceFlag(cmdKubeClusterUpdate, doctl.ArgTag, "", nil, "tags to apply to the cluster, repeat to add multiple tags at once")
+	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgAutoUpgrade, "", false, "whether to enable auto-upgrade for the cluster")
 	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgClusterUpdateKubeconfig, "", true, "whether to update the cluster in your kubeconfig")
 	AddStringFlag(cmdKubeClusterUpdate, doctl.ArgMaintenanceWindow, "", "any=00:00", "maintenance window to be set to the cluster. Syntax is in the format: 'day=HH:MM', where time is in UTC time zone. Day can be one of: ['any', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']")
 
@@ -866,6 +868,12 @@ func buildClusterCreateRequestFromArgs(c *CmdConfig, r *godo.KubernetesClusterCr
 	}
 	r.VersionSlug = version
 
+	autoUpgrade, err := c.Doit.GetBool(c.NS, doctl.ArgAutoUpgrade)
+	if err != nil {
+		return err
+	}
+	r.AutoUpgrade = autoUpgrade
+
 	tags, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTag)
 	if err != nil {
 		return err
@@ -937,6 +945,12 @@ func buildClusterUpdateRequestFromArgs(c *CmdConfig, r *godo.KubernetesClusterUp
 		return err
 	}
 	r.MaintenancePolicy = maintenancePolicy
+
+	autoUpgrade, err := c.Doit.GetBool(c.NS, doctl.ArgAutoUpgrade)
+	if err != nil {
+		return err
+	}
+	r.AutoUpgrade = autoUpgrade
 
 	return nil
 }

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1508,7 +1508,10 @@ func versionMaxBy(versions []do.KubernetesVersion, selector func(do.KubernetesVe
 	if err != nil {
 		return max, err
 	}
-	for i, v := range versions[1:] {
+	// NOTE: We have to iterate over all of versions here even though we know
+	// versions[0] won't be greater than maxSV so that the index i will be a
+	// valid index into versions rather than into versions[1:].
+	for i, v := range versions {
 		sv, err := semver.Parse(selector(v))
 		if err != nil {
 			return max, err

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -25,6 +25,7 @@ var (
 				StartTime: "00:00",
 				Day:       godo.KubernetesMaintenanceDayAny,
 			},
+			AutoUpgrade: true,
 		},
 	}
 
@@ -254,6 +255,7 @@ func TestKubernetesCreate(t *testing.T) {
 				StartTime: "00:00",
 				Day:       godo.KubernetesMaintenanceDayAny,
 			},
+			AutoUpgrade: true,
 		}
 		tm.kubernetes.On("Create", &r).Return(&testCluster, nil)
 
@@ -270,6 +272,7 @@ func TestKubernetesCreate(t *testing.T) {
 				testNodePool.Name+"2", testNodePool.Size, testNodePool.Count, testNodePool.Tags[0], testNodePool.Tags[1],
 			),
 		})
+		config.Doit.Set(config.NS, doctl.ArgAutoUpgrade, testCluster.AutoUpgrade)
 
 		err := RunKubernetesClusterCreate("c-8", 3)(config)
 		assert.NoError(t, err)
@@ -286,6 +289,7 @@ func TestKubernetesUpdate(t *testing.T) {
 				StartTime: "00:00",
 				Day:       godo.KubernetesMaintenanceDayAny,
 			},
+			AutoUpgrade: false,
 		}
 		tm.kubernetes.On("Update", testCluster.ID, &r).Return(&testCluster, nil)
 
@@ -293,6 +297,7 @@ func TestKubernetesUpdate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgClusterName, testCluster.Name)
 		config.Doit.Set(config.NS, doctl.ArgTag, testCluster.Tags)
 		config.Doit.Set(config.NS, doctl.ArgMaintenanceWindow, "any=00:00")
+		config.Doit.Set(config.NS, doctl.ArgAutoUpgrade, false)
 
 		err := RunKubernetesClusterUpdate(config)
 		assert.NoError(t, err)
@@ -307,6 +312,7 @@ func TestKubernetesUpdate(t *testing.T) {
 				StartTime: "00:00",
 				Day:       godo.KubernetesMaintenanceDayAny,
 			},
+			AutoUpgrade: false,
 		}
 		tm.kubernetes.On("List").Return(testClusterList, nil)
 		tm.kubernetes.On("Update", testCluster.ID, &r).Return(&testCluster, nil)
@@ -315,6 +321,7 @@ func TestKubernetesUpdate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgClusterName, testCluster.Name)
 		config.Doit.Set(config.NS, doctl.ArgTag, testCluster.Tags)
 		config.Doit.Set(config.NS, doctl.ArgMaintenanceWindow, "any=00:00")
+		config.Doit.Set(config.NS, doctl.ArgAutoUpgrade, false)
 
 		err := RunKubernetesClusterUpdate(config)
 		assert.NoError(t, err)

--- a/do/mocks/KubernetesService.go
+++ b/do/mocks/KubernetesService.go
@@ -202,6 +202,29 @@ func (_m *KubernetesService) GetRegions() (do.KubernetesRegions, error) {
 	return r0, r1
 }
 
+// GetUpgrades provides a mock function with given fields: clusterID
+func (_m *KubernetesService) GetUpgrades(clusterID string) (do.KubernetesVersions, error) {
+	ret := _m.Called(clusterID)
+
+	var r0 do.KubernetesVersions
+	if rf, ok := ret.Get(0).(func(string) do.KubernetesVersions); ok {
+		r0 = rf(clusterID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(do.KubernetesVersions)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(clusterID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetVersions provides a mock function with given fields:
 func (_m *KubernetesService) GetVersions() (do.KubernetesVersions, error) {
 	ret := _m.Called()
@@ -329,4 +352,18 @@ func (_m *KubernetesService) UpdateNodePool(clusterID string, poolID string, req
 	}
 
 	return r0, r1
+}
+
+// Upgrade provides a mock function with given fields: clusterID, versionSlug
+func (_m *KubernetesService) Upgrade(clusterID string, versionSlug string) error {
+	ret := _m.Called(clusterID, versionSlug)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(clusterID, versionSlug)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.14.0] - 2019-05-13
+
+- #229 Add support for upgrading Kubernetes clusters - @adamwg
+
 ## [v1.13.0] - 2019-04-19
 
 - #213 Add tagging support for volume snapshots - @jcodybaker

--- a/vendor/github.com/digitalocean/godo/firewalls.go
+++ b/vendor/github.com/digitalocean/godo/firewalls.go
@@ -10,7 +10,7 @@ import (
 const firewallsBasePath = "/v2/firewalls"
 
 // FirewallsService is an interface for managing Firewalls with the DigitalOcean API.
-// See: https://developers.digitalocean.com/documentation/documentation/v2/#firewalls
+// See: https://developers.digitalocean.com/documentation/v2/#firewalls
 type FirewallsService interface {
 	Get(context.Context, string) (*Firewall, *Response, error)
 	Create(context.Context, *FirewallRequest) (*Firewall, *Response, error)

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.13.0"
+	libraryVersion = "1.14.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -23,9 +23,11 @@ const (
 type KubernetesService interface {
 	Create(context.Context, *KubernetesClusterCreateRequest) (*KubernetesCluster, *Response, error)
 	Get(context.Context, string) (*KubernetesCluster, *Response, error)
+	GetUpgrades(context.Context, string) ([]*KubernetesVersion, *Response, error)
 	GetKubeConfig(context.Context, string) (*KubernetesClusterConfig, *Response, error)
 	List(context.Context, *ListOptions) ([]*KubernetesCluster, *Response, error)
 	Update(context.Context, string, *KubernetesClusterUpdateRequest) (*KubernetesCluster, *Response, error)
+	Upgrade(context.Context, string, *KubernetesClusterUpgradeRequest) (*Response, error)
 	Delete(context.Context, string) (*Response, error)
 
 	CreateNodePool(ctx context.Context, clusterID string, req *KubernetesNodePoolCreateRequest) (*KubernetesNodePool, *Response, error)
@@ -56,6 +58,7 @@ type KubernetesClusterCreateRequest struct {
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
 
 	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy"`
+	AutoUpgrade       bool                         `json:"auto_upgrade"`
 }
 
 // KubernetesClusterUpdateRequest represents a request to update a Kubernetes cluster.
@@ -63,6 +66,12 @@ type KubernetesClusterUpdateRequest struct {
 	Name              string                       `json:"name,omitempty"`
 	Tags              []string                     `json:"tags,omitempty"`
 	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy"`
+	AutoUpgrade       bool                         `json:"auto_upgrade"`
+}
+
+// KubernetesClusterUpgradeRequest represents a request to upgrade a Kubernetes cluster.
+type KubernetesClusterUpgradeRequest struct {
+	VersionSlug string `json:"version,omitempty"`
 }
 
 // KubernetesNodePoolCreateRequest represents a request to create a node pool for a
@@ -104,6 +113,7 @@ type KubernetesCluster struct {
 	NodePools []*KubernetesNodePool `json:"node_pools,omitempty"`
 
 	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy,omitempty"`
+	AutoUpgrade       bool                         `json:"auto_upgrade,omitempty"`
 
 	Status    *KubernetesClusterStatus `json:"status,omitempty"`
 	CreatedAt time.Time                `json:"created_at,omitempty"`
@@ -204,6 +214,7 @@ const (
 	KubernetesClusterStatusDegraded     = KubernetesClusterStatusState("degraded")
 	KubernetesClusterStatusError        = KubernetesClusterStatusState("error")
 	KubernetesClusterStatusDeleted      = KubernetesClusterStatusState("deleted")
+	KubernetesClusterStatusUpgrading    = KubernetesClusterStatusState("upgrading")
 	KubernetesClusterStatusInvalid      = KubernetesClusterStatusState("invalid")
 )
 
@@ -225,6 +236,8 @@ func (s *KubernetesClusterStatusState) UnmarshalText(text []byte) error {
 		*s = KubernetesClusterStatusError
 	case KubernetesClusterStatusDeleted:
 		*s = KubernetesClusterStatusDeleted
+	case KubernetesClusterStatusUpgrading:
+		*s = KubernetesClusterStatusUpgrading
 	case "", KubernetesClusterStatusInvalid:
 		*s = KubernetesClusterStatusInvalid
 	default:
@@ -309,6 +322,10 @@ type kubernetesNodePoolsRoot struct {
 	Links     *Links                `json:"links,omitempty"`
 }
 
+type kubernetesUpgradesRoot struct {
+	AvailableUpgradeVersions []*KubernetesVersion `json:"available_upgrade_versions,omitempty"`
+}
+
 // Get retrieves the details of a Kubernetes cluster.
 func (svc *KubernetesServiceOp) Get(ctx context.Context, clusterID string) (*KubernetesCluster, *Response, error) {
 	path := fmt.Sprintf("%s/%s", kubernetesClustersPath, clusterID)
@@ -322,6 +339,22 @@ func (svc *KubernetesServiceOp) Get(ctx context.Context, clusterID string) (*Kub
 		return nil, resp, err
 	}
 	return root.Cluster, resp, nil
+}
+
+// GetUpgrades retrieves versions a Kubernetes cluster can be upgraded to. An
+// upgrade can be requested using `Upgrade`.
+func (svc *KubernetesServiceOp) GetUpgrades(ctx context.Context, clusterID string) ([]*KubernetesVersion, *Response, error) {
+	path := fmt.Sprintf("%s/%s/upgrades", kubernetesClustersPath, clusterID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(kubernetesUpgradesRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return root.AvailableUpgradeVersions, resp, nil
 }
 
 // Create creates a Kubernetes cluster.
@@ -411,6 +444,17 @@ func (svc *KubernetesServiceOp) Update(ctx context.Context, clusterID string, up
 		return nil, resp, err
 	}
 	return root.Cluster, resp, nil
+}
+
+// Upgrade upgrades a Kubernetes cluster to a new version. Valid upgrade
+// versions for a given cluster can be retrieved with `GetUpgrades`.
+func (svc *KubernetesServiceOp) Upgrade(ctx context.Context, clusterID string, upgrade *KubernetesClusterUpgradeRequest) (*Response, error) {
+	path := fmt.Sprintf("%s/%s/upgrade", kubernetesClustersPath, clusterID)
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, upgrade)
+	if err != nil {
+		return nil, err
+	}
+	return svc.client.Do(ctx, req, nil)
 }
 
 // CreateNodePool creates a new node pool in an existing Kubernetes cluster.

--- a/vendor/github.com/digitalocean/godo/projects.go
+++ b/vendor/github.com/digitalocean/godo/projects.go
@@ -17,7 +17,7 @@ const (
 )
 
 // ProjectsService is an interface for creating and managing Projects with the DigitalOcean API.
-// See: https://developers.digitalocean.com/documentation/documentation/v2/#projects
+// See: https://developers.digitalocean.com/documentation/v2/#projects
 type ProjectsService interface {
 	List(context.Context, *ListOptions) ([]Project, *Response, error)
 	GetDefault(context.Context) (*Project, *Response, error)


### PR DESCRIPTION
Add three pieces of functionality to support upgrading Kubernetes clusters:

1. Allow clusters to be created with auto-upgrade enabled, or have auto-upgrade enabled via `doctl k8s cluster update`. Show the auto-upgrade setting when getting or listing clusters.
2. Allow fetching available upgrade versions with `doctl k8s cluster get-upgrades`.
3. Allow for immediate upgrade of a cluster with `doctl k8s cluster upgrade`, which optionally takes a version. By default the latest available upgrade version will be used.