### PR TITLE
Ensure all 'get' and 'list' commands support the 'format' flag.

### DIFF
--- a/commands/certificates.go
+++ b/commands/certificates.go
@@ -35,20 +35,31 @@ func Certificate() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunCertificateGet, "get <id>", "get certificate", Writer, aliasOpt("g"), displayerType(&displayers.Certificate{}))
+	CmdBuilder(cmd, RunCertificateGet, "get <id>", "get certificate", Writer,
+		aliasOpt("g"), displayerType(&displayers.Certificate{}))
 
-	cmdCertificateCreate := CmdBuilder(cmd, RunCertificateCreate, "create", "create new certificate", Writer, aliasOpt("c"))
-	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateName, "", "", "certificate name", requiredOpt())
-	AddStringSliceFlag(cmdCertificateCreate, doctl.ArgCertificateDNSNames, "", []string{}, "comma-separated list of domain names, required for lets_encrypt certificate")
-	AddStringFlag(cmdCertificateCreate, doctl.ArgPrivateKeyPath, "", "", "path to a private key for the certificate, required for custom certificate")
-	AddStringFlag(cmdCertificateCreate, doctl.ArgLeafCertificatePath, "", "", "path to a certificate leaf, required for custom certificate")
-	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateChainPath, "", "", "path to a certificate chain")
-	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateType, "", "", "certificate type, possible values: custom or lets_encrypt")
+	cmdCertificateCreate := CmdBuilder(cmd, RunCertificateCreate, "create",
+		"create new certificate", Writer, aliasOpt("c"))
+	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateName, "", "",
+		"certificate name", requiredOpt())
+	AddStringSliceFlag(cmdCertificateCreate, doctl.ArgCertificateDNSNames, "",
+		[]string{}, "comma-separated list of domain names, required for lets_encrypt certificate")
+	AddStringFlag(cmdCertificateCreate, doctl.ArgPrivateKeyPath, "", "",
+		"path to a private key for the certificate, required for custom certificate")
+	AddStringFlag(cmdCertificateCreate, doctl.ArgLeafCertificatePath, "", "",
+		"path to a certificate leaf, required for custom certificate")
+	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateChainPath, "", "",
+		"path to a certificate chain")
+	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateType, "", "",
+		"certificate type, possible values: custom or lets_encrypt")
 
-	CmdBuilder(cmd, RunCertificateList, "list", "list certificates", Writer, aliasOpt("ls"), displayerType(&displayers.Certificate{}))
+	CmdBuilder(cmd, RunCertificateList, "list", "list certificates", Writer,
+		aliasOpt("ls"), displayerType(&displayers.Certificate{}))
 
-	cmdCertificateDelete := CmdBuilder(cmd, RunCertificateDelete, "delete <id>", "delete certificate", Writer, aliasOpt("d", "rm"))
-	AddBoolFlag(cmdCertificateDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force certificate delete")
+	cmdCertificateDelete := CmdBuilder(cmd, RunCertificateDelete, "delete <id>",
+		"delete certificate", Writer, aliasOpt("d", "rm"))
+	AddBoolFlag(cmdCertificateDelete, doctl.ArgForce, doctl.ArgShortForce, false,
+		"Force certificate delete")
 
 	return cmd
 }

--- a/commands/certificates.go
+++ b/commands/certificates.go
@@ -35,7 +35,7 @@ func Certificate() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunCertificateGet, "get <id>", "get certificate", Writer, aliasOpt("g"))
+	CmdBuilder(cmd, RunCertificateGet, "get <id>", "get certificate", Writer, aliasOpt("g"), displayerType(&displayers.Certificate{}))
 
 	cmdCertificateCreate := CmdBuilder(cmd, RunCertificateCreate, "create", "create new certificate", Writer, aliasOpt("c"))
 	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateName, "", "", "certificate name", requiredOpt())
@@ -45,7 +45,7 @@ func Certificate() *Command {
 	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateChainPath, "", "", "path to a certificate chain")
 	AddStringFlag(cmdCertificateCreate, doctl.ArgCertificateType, "", "", "certificate type, possible values: custom or lets_encrypt")
 
-	CmdBuilder(cmd, RunCertificateList, "list", "list certificates", Writer, aliasOpt("ls"))
+	CmdBuilder(cmd, RunCertificateList, "list", "list certificates", Writer, aliasOpt("ls"), displayerType(&displayers.Certificate{}))
 
 	cmdCertificateDelete := CmdBuilder(cmd, RunCertificateDelete, "delete <id>", "delete certificate", Writer, aliasOpt("d", "rm"))
 	AddBoolFlag(cmdCertificateDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force certificate delete")

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -133,6 +133,10 @@ func assertCommandNames(t *testing.T, cmd *Command, expected ...string) {
 		names = append(names, c.Name())
 		if c.Name() == "list" {
 			assert.Contains(t, c.Aliases, "ls", "Missing 'ls' alias for 'list' command.")
+			assert.NotNil(t, c.Flags().Lookup("format"), "Missing 'format' flag for 'list' command.")
+		}
+		if c.Name() == "get" {
+			assert.NotNil(t, c.Flags().Lookup("format"), "Missing 'format' flag for 'get' command.")
 		}
 	}
 

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -43,8 +43,8 @@ func Databases() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunDatabaseList, "list", "list database clusters", Writer, aliasOpt("ls"))
-	CmdBuilder(cmd, RunDatabaseGet, "get <database-id>", "get a database cluster", Writer, aliasOpt("g"))
+	CmdBuilder(cmd, RunDatabaseList, "list", "list database clusters", Writer, aliasOpt("ls"), displayerType(&displayers.Databases{}))
+	CmdBuilder(cmd, RunDatabaseGet, "get <database-id>", "get a database cluster", Writer, aliasOpt("g"), displayerType(&displayers.Databases{}))
 
 	cmdDatabaseCreate := CmdBuilder(cmd, RunDatabaseCreate, "create <name>", "create a database cluster", Writer,
 		aliasOpt("c"))
@@ -59,10 +59,10 @@ func Databases() *Command {
 	AddBoolFlag(cmdDatabaseDelete, doctl.ArgForce, doctl.ArgShortForce, false, "force database delete")
 
 	CmdBuilder(cmd, RunDatabaseConnectionGet, "connection <database-id>", "get database cluster connection info", Writer,
-		aliasOpt("conn"))
+		aliasOpt("conn"), displayerType(&displayers.DatabaseConnection{}))
 
 	CmdBuilder(cmd, RunDatabaseBackupsList, "backups <database-id>", "list database cluster backups", Writer,
-		aliasOpt("bu"))
+		aliasOpt("bu"), displayerType(&displayers.DatabaseBackups{}))
 
 	cmdDatabaseResize := CmdBuilder(cmd, RunDatabaseResize, "resize <database-id>", "resize a database cluster", Writer,
 		aliasOpt("rs"))
@@ -303,7 +303,8 @@ func databaseMaintenanceWindow() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunDatabaseMaintenanceGet, "get <database-id>", "get maintenance window info", Writer, aliasOpt("g"))
+	CmdBuilder(cmd, RunDatabaseMaintenanceGet, "get <database-id>", "get maintenance window info", Writer, aliasOpt("g"),
+		displayerType(&displayers.DatabaseMaintenanceWindow{}))
 
 	cmdDatabaseCreate := CmdBuilder(cmd, RunDatabaseMaintenanceUpdate, "update <database-id>", "update maintenance window", Writer,
 		aliasOpt("u"))
@@ -379,8 +380,8 @@ func databaseUser() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunDatabaseUserList, "list <database-id>", "list database users", Writer, aliasOpt("ls"))
-	CmdBuilder(cmd, RunDatabaseUserGet, "get <database-id> <user-id>", "get a database user", Writer, aliasOpt("g"))
+	CmdBuilder(cmd, RunDatabaseUserList, "list <database-id>", "list database users", Writer, aliasOpt("ls"), displayerType(&displayers.DatabaseUsers{}))
+	CmdBuilder(cmd, RunDatabaseUserGet, "get <database-id> <user-id>", "get a database user", Writer, aliasOpt("g"), displayerType(&displayers.DatabaseUsers{}))
 	CmdBuilder(cmd, RunDatabaseUserCreate, "create <database-id> <user-name>", "create a database user", Writer, aliasOpt("c"))
 
 	cmdDatabaseUserDelete := CmdBuilder(cmd, RunDatabaseUserDelete, "delete <database-id> <user-id>", "delete database cluster", Writer,
@@ -477,8 +478,8 @@ func databasePool() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunDatabasePoolList, "list <database-id>", "list database pools", Writer, aliasOpt("ls"))
-	CmdBuilder(cmd, RunDatabasePoolGet, "get <database-id> <pool-name>", "get a database pool", Writer, aliasOpt("g"))
+	CmdBuilder(cmd, RunDatabasePoolList, "list <database-id>", "list database pools", Writer, aliasOpt("ls"), displayerType(&displayers.DatabasePools{}))
+	CmdBuilder(cmd, RunDatabasePoolGet, "get <database-id> <pool-name>", "get a database pool", Writer, aliasOpt("g"), displayerType(&displayers.DatabasePools{}))
 	cmdDatabasePoolCreate := CmdBuilder(cmd, RunDatabasePoolCreate, "create <database-id> <pool-name>", "create a database pool", Writer,
 		aliasOpt("c"))
 	AddStringFlag(cmdDatabasePoolCreate, doctl.ArgDatabasePoolMode, "", "transaction", "pool mode")
@@ -612,8 +613,8 @@ func databaseDB() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunDatabaseDBList, "list <database-id>", "list dbs", Writer, aliasOpt("ls"))
-	CmdBuilder(cmd, RunDatabaseDBGet, "get <database-id> <db-name>", "get a db", Writer, aliasOpt("g"))
+	CmdBuilder(cmd, RunDatabaseDBList, "list <database-id>", "list dbs", Writer, aliasOpt("ls"), displayerType(&displayers.DatabaseDBs{}))
+	CmdBuilder(cmd, RunDatabaseDBGet, "get <database-id> <db-name>", "get a db", Writer, aliasOpt("g"), displayerType(&displayers.DatabaseDBs{}))
 	CmdBuilder(cmd, RunDatabaseDBCreate, "create <database-id> <db-name>", "create a db", Writer, aliasOpt("c"))
 
 	cmdDatabaseDBDelete := CmdBuilder(cmd, RunDatabaseDBDelete, "delete <database-id> <db-name>", "delete db", Writer,
@@ -710,8 +711,8 @@ func databaseReplica() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunDatabaseReplicaList, "list <database-id>", "list database replicas", Writer, aliasOpt("ls"))
-	CmdBuilder(cmd, RunDatabaseReplicaGet, "get <database-id> <replica-name>", "get a database replica", Writer, aliasOpt("g"))
+	CmdBuilder(cmd, RunDatabaseReplicaList, "list <database-id>", "list database replicas", Writer, aliasOpt("ls"), displayerType(&displayers.DatabaseReplicas{}))
+	CmdBuilder(cmd, RunDatabaseReplicaGet, "get <database-id> <replica-name>", "get a database replica", Writer, aliasOpt("g"), displayerType(&displayers.DatabaseReplicas{}))
 
 	cmdDatabaseReplicaCreate := CmdBuilder(cmd, RunDatabaseReplicaCreate, "create <database-id> <replica-name>", "create a database replica", Writer,
 		aliasOpt("c"))

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -303,13 +303,16 @@ func databaseMaintenanceWindow() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunDatabaseMaintenanceGet, "get <database-id>", "get maintenance window info", Writer, aliasOpt("g"),
+	CmdBuilder(cmd, RunDatabaseMaintenanceGet, "get <database-id>",
+		"get maintenance window info", Writer, aliasOpt("g"),
 		displayerType(&displayers.DatabaseMaintenanceWindow{}))
 
-	cmdDatabaseCreate := CmdBuilder(cmd, RunDatabaseMaintenanceUpdate, "update <database-id>", "update maintenance window", Writer,
-		aliasOpt("u"))
-	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseMaintenanceDay, "", "", "new maintenance window day", requiredOpt())
-	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseMaintenanceHour, "", "", "new maintenance window hour", requiredOpt())
+	cmdDatabaseCreate := CmdBuilder(cmd, RunDatabaseMaintenanceUpdate,
+		"update <database-id>", "update maintenance window", Writer, aliasOpt("u"))
+	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseMaintenanceDay, "", "",
+		"new maintenance window day", requiredOpt())
+	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseMaintenanceHour, "", "",
+		"new maintenance window hour", requiredOpt())
 
 	return cmd
 }
@@ -380,12 +383,17 @@ func databaseUser() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunDatabaseUserList, "list <database-id>", "list database users", Writer, aliasOpt("ls"), displayerType(&displayers.DatabaseUsers{}))
-	CmdBuilder(cmd, RunDatabaseUserGet, "get <database-id> <user-id>", "get a database user", Writer, aliasOpt("g"), displayerType(&displayers.DatabaseUsers{}))
-	CmdBuilder(cmd, RunDatabaseUserCreate, "create <database-id> <user-name>", "create a database user", Writer, aliasOpt("c"))
+	CmdBuilder(cmd, RunDatabaseUserList, "list <database-id>", "list database users",
+		Writer, aliasOpt("ls"), displayerType(&displayers.DatabaseUsers{}))
+	CmdBuilder(cmd, RunDatabaseUserGet, "get <database-id> <user-id>",
+		"get a database user", Writer, aliasOpt("g"),
+		displayerType(&displayers.DatabaseUsers{}))
+	CmdBuilder(cmd, RunDatabaseUserCreate, "create <database-id> <user-name>",
+		"create a database user", Writer, aliasOpt("c"))
 
-	cmdDatabaseUserDelete := CmdBuilder(cmd, RunDatabaseUserDelete, "delete <database-id> <user-id>", "delete database cluster", Writer,
-		aliasOpt("rm"))
+	cmdDatabaseUserDelete := CmdBuilder(cmd, RunDatabaseUserDelete,
+		"delete <database-id> <user-id>", "delete database cluster",
+		Writer, aliasOpt("rm"))
 	AddBoolFlag(cmdDatabaseUserDelete, doctl.ArgForce, doctl.ArgShortForce, false, "force database delete")
 
 	return cmd
@@ -478,18 +486,28 @@ func databasePool() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunDatabasePoolList, "list <database-id>", "list database pools", Writer, aliasOpt("ls"), displayerType(&displayers.DatabasePools{}))
-	CmdBuilder(cmd, RunDatabasePoolGet, "get <database-id> <pool-name>", "get a database pool", Writer, aliasOpt("g"), displayerType(&displayers.DatabasePools{}))
-	cmdDatabasePoolCreate := CmdBuilder(cmd, RunDatabasePoolCreate, "create <database-id> <pool-name>", "create a database pool", Writer,
+	CmdBuilder(cmd, RunDatabasePoolList, "list <database-id>", "list database pools",
+		Writer, aliasOpt("ls"), displayerType(&displayers.DatabasePools{}))
+	CmdBuilder(cmd, RunDatabasePoolGet, "get <database-id> <pool-name>",
+		"get a database pool", Writer, aliasOpt("g"),
+		displayerType(&displayers.DatabasePools{}))
+	cmdDatabasePoolCreate := CmdBuilder(cmd, RunDatabasePoolCreate,
+		"create <database-id> <pool-name>", "create a database pool", Writer,
 		aliasOpt("c"))
-	AddStringFlag(cmdDatabasePoolCreate, doctl.ArgDatabasePoolMode, "", "transaction", "pool mode")
-	AddIntFlag(cmdDatabasePoolCreate, doctl.ArgSizeSlug, "", 0, "pool size", requiredOpt())
-	AddStringFlag(cmdDatabasePoolCreate, doctl.ArgDatabasePoolUserName, "", "", "database user name", requiredOpt())
-	AddStringFlag(cmdDatabasePoolCreate, doctl.ArgDatabasePoolDBName, "", "", "database db name", requiredOpt())
+	AddStringFlag(cmdDatabasePoolCreate, doctl.ArgDatabasePoolMode, "",
+		"transaction", "pool mode")
+	AddIntFlag(cmdDatabasePoolCreate, doctl.ArgSizeSlug, "", 0, "pool size",
+		requiredOpt())
+	AddStringFlag(cmdDatabasePoolCreate, doctl.ArgDatabasePoolUserName, "", "",
+		"database user name", requiredOpt())
+	AddStringFlag(cmdDatabasePoolCreate, doctl.ArgDatabasePoolDBName, "", "",
+		"database db name", requiredOpt())
 
-	cmdDatabasePoolDelete := CmdBuilder(cmd, RunDatabasePoolDelete, "delete <database-id> <pool-name>", "delete database cluster", Writer,
+	cmdDatabasePoolDelete := CmdBuilder(cmd, RunDatabasePoolDelete,
+		"delete <database-id> <pool-name>", "delete database cluster", Writer,
 		aliasOpt("rm"))
-	AddBoolFlag(cmdDatabasePoolDelete, doctl.ArgForce, doctl.ArgShortForce, false, "force database delete")
+	AddBoolFlag(cmdDatabasePoolDelete, doctl.ArgForce, doctl.ArgShortForce,
+		false, "force database delete")
 
 	return cmd
 }
@@ -613,13 +631,17 @@ func databaseDB() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunDatabaseDBList, "list <database-id>", "list dbs", Writer, aliasOpt("ls"), displayerType(&displayers.DatabaseDBs{}))
-	CmdBuilder(cmd, RunDatabaseDBGet, "get <database-id> <db-name>", "get a db", Writer, aliasOpt("g"), displayerType(&displayers.DatabaseDBs{}))
-	CmdBuilder(cmd, RunDatabaseDBCreate, "create <database-id> <db-name>", "create a db", Writer, aliasOpt("c"))
+	CmdBuilder(cmd, RunDatabaseDBList, "list <database-id>", "list dbs", Writer,
+		aliasOpt("ls"), displayerType(&displayers.DatabaseDBs{}))
+	CmdBuilder(cmd, RunDatabaseDBGet, "get <database-id> <db-name>", "get a db",
+		Writer, aliasOpt("g"), displayerType(&displayers.DatabaseDBs{}))
+	CmdBuilder(cmd, RunDatabaseDBCreate, "create <database-id> <db-name>",
+		"create a db", Writer, aliasOpt("c"))
 
-	cmdDatabaseDBDelete := CmdBuilder(cmd, RunDatabaseDBDelete, "delete <database-id> <db-name>", "delete db", Writer,
-		aliasOpt("rm"))
-	AddBoolFlag(cmdDatabaseDBDelete, doctl.ArgForce, doctl.ArgShortForce, false, "force database delete")
+	cmdDatabaseDBDelete := CmdBuilder(cmd, RunDatabaseDBDelete,
+		"delete <database-id> <db-name>", "delete db", Writer, aliasOpt("rm"))
+	AddBoolFlag(cmdDatabaseDBDelete, doctl.ArgForce, doctl.ArgShortForce,
+		false, "force database delete")
 
 	return cmd
 }
@@ -711,20 +733,30 @@ func databaseReplica() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunDatabaseReplicaList, "list <database-id>", "list database replicas", Writer, aliasOpt("ls"), displayerType(&displayers.DatabaseReplicas{}))
-	CmdBuilder(cmd, RunDatabaseReplicaGet, "get <database-id> <replica-name>", "get a database replica", Writer, aliasOpt("g"), displayerType(&displayers.DatabaseReplicas{}))
+	CmdBuilder(cmd, RunDatabaseReplicaList, "list <database-id>",
+		"list database replicas", Writer, aliasOpt("ls"),
+		displayerType(&displayers.DatabaseReplicas{}))
+	CmdBuilder(cmd, RunDatabaseReplicaGet, "get <database-id> <replica-name>",
+		"get a database replica", Writer, aliasOpt("g"),
+		displayerType(&displayers.DatabaseReplicas{}))
 
-	cmdDatabaseReplicaCreate := CmdBuilder(cmd, RunDatabaseReplicaCreate, "create <database-id> <replica-name>", "create a database replica", Writer,
-		aliasOpt("c"))
-	AddStringFlag(cmdDatabaseReplicaCreate, doctl.ArgRegionSlug, "", defaultDatabaseRegion, "database replica region")
-	AddStringFlag(cmdDatabaseReplicaCreate, doctl.ArgSizeSlug, "", defaultDatabaseNodeSize, "database replica size")
+	cmdDatabaseReplicaCreate := CmdBuilder(cmd, RunDatabaseReplicaCreate,
+		"create <database-id> <replica-name>", "create a database replica",
+		Writer, aliasOpt("c"))
+	AddStringFlag(cmdDatabaseReplicaCreate, doctl.ArgRegionSlug, "",
+		defaultDatabaseRegion, "database replica region")
+	AddStringFlag(cmdDatabaseReplicaCreate, doctl.ArgSizeSlug, "",
+		defaultDatabaseNodeSize, "database replica size")
 
-	cmdDatabaseReplicaDelete := CmdBuilder(cmd, RunDatabaseReplicaDelete, "delete <database-id> <replica-name>", "delete database replica", Writer,
-		aliasOpt("rm"))
-	AddBoolFlag(cmdDatabaseReplicaDelete, doctl.ArgForce, doctl.ArgShortForce, false, "force database delete")
+	cmdDatabaseReplicaDelete := CmdBuilder(cmd, RunDatabaseReplicaDelete,
+		"delete <database-id> <replica-name>", "delete database replica",
+		Writer, aliasOpt("rm"))
+	AddBoolFlag(cmdDatabaseReplicaDelete, doctl.ArgForce, doctl.ArgShortForce,
+		false, "force database delete")
 
-	CmdBuilder(cmd, RunDatabaseReplicaConnectionGet, "connection <database-id> <replica-name>", "get database replica connection info", Writer,
-		aliasOpt("conn"))
+	CmdBuilder(cmd, RunDatabaseReplicaConnectionGet,
+		"connection <database-id> <replica-name>",
+		"get database replica connection info", Writer, aliasOpt("conn"))
 
 	return cmd
 }

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -105,8 +105,8 @@ func kubernetesCluster() *Command {
 
 	cmd.AddCommand(kubernetesNodePools())
 
-	CmdBuilder(cmd, RunKubernetesClusterGet, "get <id|name>", "get a cluster", Writer, aliasOpt("g"))
-	CmdBuilder(cmd, RunKubernetesClusterList, "list", "get a list of your clusters", Writer, aliasOpt("ls"))
+	CmdBuilder(cmd, RunKubernetesClusterGet, "get <id|name>", "get a cluster", Writer, aliasOpt("g"), displayerType(&displayers.KubernetesClusters{}))
+	CmdBuilder(cmd, RunKubernetesClusterList, "list", "get a list of your clusters", Writer, aliasOpt("ls"), displayerType(&displayers.KubernetesClusters{}))
 	CmdBuilder(cmd, RunKubernetesClusterGetUpgrades, "get-upgrades <id|name>", "get available upgrades for a cluster", Writer, aliasOpt("gu"))
 
 	cmdKubeClusterCreate := CmdBuilder(cmd, RunKubernetesClusterCreate(defaultKubernetesNodeSize, defaultKubernetesNodeCount), "create <name>", "create a cluster", Writer, aliasOpt("c"))
@@ -180,8 +180,8 @@ func kubernetesNodePools() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunKubernetesNodePoolGet, "get <cluster-id|cluster-name> <pool-id|pool-name>", "get a cluster's node pool", Writer, aliasOpt("g"))
-	CmdBuilder(cmd, RunKubernetesNodePoolList, "list <cluster-id|cluster-name>", "list a cluster's node pools", Writer, aliasOpt("ls"))
+	CmdBuilder(cmd, RunKubernetesNodePoolGet, "get <cluster-id|cluster-name> <pool-id|pool-name>", "get a cluster's node pool", Writer, aliasOpt("g"), displayerType(&displayers.KubernetesNodePools{}))
+	CmdBuilder(cmd, RunKubernetesNodePoolList, "list <cluster-id|cluster-name>", "list a cluster's node pools", Writer, aliasOpt("ls"), displayerType(&displayers.KubernetesNodePools{}))
 
 	cmdKubeNodePoolCreate := CmdBuilder(cmd, RunKubernetesNodePoolCreate, "create <cluster-id|cluster-name>", "create a new node pool for a cluster", Writer, aliasOpt("c"))
 	AddStringFlag(cmdKubeNodePoolCreate, doctl.ArgNodePoolName, "", "", "node pool name", requiredOpt())

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -105,44 +105,74 @@ func kubernetesCluster() *Command {
 
 	cmd.AddCommand(kubernetesNodePools())
 
-	CmdBuilder(cmd, RunKubernetesClusterGet, "get <id|name>", "get a cluster", Writer, aliasOpt("g"), displayerType(&displayers.KubernetesClusters{}))
-	CmdBuilder(cmd, RunKubernetesClusterList, "list", "get a list of your clusters", Writer, aliasOpt("ls"), displayerType(&displayers.KubernetesClusters{}))
-	CmdBuilder(cmd, RunKubernetesClusterGetUpgrades, "get-upgrades <id|name>", "get available upgrades for a cluster", Writer, aliasOpt("gu"))
+	CmdBuilder(cmd, RunKubernetesClusterGet, "get <id|name>", "get a cluster",
+		Writer, aliasOpt("g"), displayerType(&displayers.KubernetesClusters{}))
+	CmdBuilder(cmd, RunKubernetesClusterList, "list", "get a list of your clusters",
+		Writer, aliasOpt("ls"), displayerType(&displayers.KubernetesClusters{}))
+	CmdBuilder(cmd, RunKubernetesClusterGetUpgrades, "get-upgrades <id|name>",
+		"get available upgrades for a cluster", Writer, aliasOpt("gu"))
 
-	cmdKubeClusterCreate := CmdBuilder(cmd, RunKubernetesClusterCreate(defaultKubernetesNodeSize, defaultKubernetesNodeCount), "create <name>", "create a cluster", Writer, aliasOpt("c"))
-	AddStringFlag(cmdKubeClusterCreate, doctl.ArgRegionSlug, "", defaultKubernetesRegion, `cluster region, possible values: see "doctl k8s options regions"`, requiredOpt())
-	AddStringFlag(cmdKubeClusterCreate, doctl.ArgClusterVersionSlug, "", "latest", `cluster version, possible values: see "doctl k8s options versions"`)
-	AddBoolFlag(cmdKubeClusterCreate, doctl.ArgAutoUpgrade, "", false, "whether to enable auto-upgrade for the cluster")
-	AddStringSliceFlag(cmdKubeClusterCreate, doctl.ArgTag, "", nil, "tags to apply to the cluster, repeat to add multiple tags at once")
-	AddStringFlag(cmdKubeClusterCreate, doctl.ArgSizeSlug, "", defaultKubernetesNodeSize, `size of nodes in the default node pool (incompatible with --`+doctl.ArgClusterNodePool+`), possible values: see "doctl k8s options sizes".`)
-	AddIntFlag(cmdKubeClusterCreate, doctl.ArgNodePoolCount, "", defaultKubernetesNodeCount, "number of nodes in the default node pool (incompatible with --"+doctl.ArgClusterNodePool+")")
-	AddStringSliceFlag(cmdKubeClusterCreate, doctl.ArgClusterNodePool, "", nil, `cluster node pools, can be repeated to create multiple node pools at once (incompatible with --`+doctl.ArgSizeSlug+` and --`+doctl.ArgNodePoolCount+`)
+	cmdKubeClusterCreate := CmdBuilder(cmd, RunKubernetesClusterCreate(defaultKubernetesNodeSize,
+		defaultKubernetesNodeCount), "create <name>", "create a cluster",
+		Writer, aliasOpt("c"))
+	AddStringFlag(cmdKubeClusterCreate, doctl.ArgRegionSlug, "", defaultKubernetesRegion,
+		`cluster region, possible values: see "doctl k8s options regions"`, requiredOpt())
+	AddStringFlag(cmdKubeClusterCreate, doctl.ArgClusterVersionSlug, "", "latest",
+		`cluster version, possible values: see "doctl k8s options versions"`)
+	AddBoolFlag(cmdKubeClusterCreate, doctl.ArgAutoUpgrade, "", false,
+		"whether to enable auto-upgrade for the cluster")
+	AddStringSliceFlag(cmdKubeClusterCreate, doctl.ArgTag, "", nil,
+		"tags to apply to the cluster, repeat to add multiple tags at once")
+	AddStringFlag(cmdKubeClusterCreate, doctl.ArgSizeSlug, "",
+		defaultKubernetesNodeSize,
+		`size of nodes in the default node pool (incompatible with --`+doctl.ArgClusterNodePool+`), possible values: see "doctl k8s options sizes".`)
+	AddIntFlag(cmdKubeClusterCreate, doctl.ArgNodePoolCount, "",
+		defaultKubernetesNodeCount,
+		"number of nodes in the default node pool (incompatible with --"+doctl.ArgClusterNodePool+")")
+	AddStringSliceFlag(cmdKubeClusterCreate, doctl.ArgClusterNodePool, "", nil,
+		`cluster node pools, can be repeated to create multiple node pools at once (incompatible with --`+doctl.ArgSizeSlug+` and --`+doctl.ArgNodePoolCount+`)
 format is in the form "name=your-name;size=size_slug;count=5;tag=tag1;tag=tag2" where:
 	- name:   name of the node pool, must be unique in the cluster
 	- size:   size for the nodes in the node pool, possible values: see "doctl k8s options sizes".
 	- count:  number of nodes in the node pool.
 	- tag:    tags to apply to the node pool, repeat to add multiple tags at once.`)
-	AddBoolFlag(cmdKubeClusterCreate, doctl.ArgClusterUpdateKubeconfig, "", true, "whether to add the created cluster to your kubeconfig")
-	AddBoolFlag(cmdKubeClusterCreate, doctl.ArgCommandWait, "", true, "whether to wait for the created cluster to become running")
-	AddBoolFlag(cmdKubeClusterCreate, doctl.ArgSetCurrentContext, "", true, "whether to set the current kubectl context to that of the new cluster")
-	AddStringFlag(cmdKubeClusterCreate, doctl.ArgMaintenanceWindow, "", "any=00:00", "maintenance window to be set to the cluster. Syntax is in the format: 'day=HH:MM', where time is in UTC time zone. Day can be one of: ['any', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']")
+	AddBoolFlag(cmdKubeClusterCreate, doctl.ArgClusterUpdateKubeconfig, "", true,
+		"whether to add the created cluster to your kubeconfig")
+	AddBoolFlag(cmdKubeClusterCreate, doctl.ArgCommandWait, "", true,
+		"whether to wait for the created cluster to become running")
+	AddBoolFlag(cmdKubeClusterCreate, doctl.ArgSetCurrentContext, "", true,
+		"whether to set the current kubectl context to that of the new cluster")
+	AddStringFlag(cmdKubeClusterCreate, doctl.ArgMaintenanceWindow, "", "any=00:00",
+		"maintenance window to be set to the cluster. Syntax is in the format: 'day=HH:MM', where time is in UTC time zone. Day can be one of: ['any', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']")
 
-	cmdKubeClusterUpdate := CmdBuilder(cmd, RunKubernetesClusterUpdate, "update <id|name>", "update a cluster's properties", Writer, aliasOpt("u"))
-	AddStringFlag(cmdKubeClusterUpdate, doctl.ArgClusterName, "", "", "new cluster name")
-	AddStringSliceFlag(cmdKubeClusterUpdate, doctl.ArgTag, "", nil, "tags to apply to the cluster, repeat to add multiple tags at once")
-	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgAutoUpgrade, "", false, "whether to enable auto-upgrade for the cluster")
-	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgClusterUpdateKubeconfig, "", true, "whether to update the cluster in your kubeconfig")
-	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgSetCurrentContext, "", true, "whether to set the current kubectl context to that of the new cluster")
-	AddStringFlag(cmdKubeClusterUpdate, doctl.ArgMaintenanceWindow, "", "any=00:00", "maintenance window to be set to the cluster. Syntax is in the format: 'day=HH:MM', where time is in UTC time zone. Day can be one of: ['any', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']")
+	cmdKubeClusterUpdate := CmdBuilder(cmd, RunKubernetesClusterUpdate, "update <id|name>",
+		"update a cluster's properties", Writer, aliasOpt("u"))
+	AddStringFlag(cmdKubeClusterUpdate, doctl.ArgClusterName, "", "",
+		"new cluster name")
+	AddStringSliceFlag(cmdKubeClusterUpdate, doctl.ArgTag, "", nil,
+		"tags to apply to the cluster, repeat to add multiple tags at once")
+	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgAutoUpgrade, "", false,
+		"whether to enable auto-upgrade for the cluster")
+	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgClusterUpdateKubeconfig, "",
+		true, "whether to update the cluster in your kubeconfig")
+	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgSetCurrentContext, "", true,
+		"whether to set the current kubectl context to that of the new cluster")
+	AddStringFlag(cmdKubeClusterUpdate, doctl.ArgMaintenanceWindow, "", "any=00:00",
+		"maintenance window to be set to the cluster. Syntax is in the format: 'day=HH:MM', where time is in UTC time zone. Day can be one of: ['any', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']")
 
-	cmdKubeClusterUpgrade := CmdBuilder(cmd, RunKubernetesClusterUpgrade, "upgrade <id|name>", "upgrade a cluster to a new version", Writer)
-	AddStringFlag(cmdKubeClusterUpgrade, doctl.ArgClusterVersionSlug, "", "latest", `new cluster version, possible values: see "doctl k8s get-upgrades <cluster>".
+	cmdKubeClusterUpgrade := CmdBuilder(cmd, RunKubernetesClusterUpgrade,
+		"upgrade <id|name>", "upgrade a cluster to a new version", Writer)
+	AddStringFlag(cmdKubeClusterUpgrade, doctl.ArgClusterVersionSlug, "", "latest",
+		`new cluster version, possible values: see "doctl k8s get-upgrades <cluster>".
 The special value "latest" will select the most recent patch version for your cluster's minor version.
 For example, if a cluster is on 1.12.1 and upgrades are available to 1.12.3 and 1.13.1, 1.12.3 will be "latest".`)
 
-	cmdKubeClusterDelete := CmdBuilder(cmd, RunKubernetesClusterDelete, "delete <id|name>", "delete a cluster", Writer, aliasOpt("d", "rm"))
-	AddBoolFlag(cmdKubeClusterDelete, doctl.ArgForce, doctl.ArgShortForce, false, "force cluster delete")
-	AddBoolFlag(cmdKubeClusterDelete, doctl.ArgClusterUpdateKubeconfig, "", true, "whether to remove the deleted cluster to your kubeconfig")
+	cmdKubeClusterDelete := CmdBuilder(cmd, RunKubernetesClusterDelete,
+		"delete <id|name>", "delete a cluster", Writer, aliasOpt("d", "rm"))
+	AddBoolFlag(cmdKubeClusterDelete, doctl.ArgForce, doctl.ArgShortForce, false,
+		"force cluster delete")
+	AddBoolFlag(cmdKubeClusterDelete, doctl.ArgClusterUpdateKubeconfig, "", true,
+		"whether to remove the deleted cluster to your kubeconfig")
 
 	return cmd
 }
@@ -180,25 +210,45 @@ func kubernetesNodePools() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunKubernetesNodePoolGet, "get <cluster-id|cluster-name> <pool-id|pool-name>", "get a cluster's node pool", Writer, aliasOpt("g"), displayerType(&displayers.KubernetesNodePools{}))
-	CmdBuilder(cmd, RunKubernetesNodePoolList, "list <cluster-id|cluster-name>", "list a cluster's node pools", Writer, aliasOpt("ls"), displayerType(&displayers.KubernetesNodePools{}))
+	CmdBuilder(cmd, RunKubernetesNodePoolGet, "get <cluster-id|cluster-name> <pool-id|pool-name>",
+		"get a cluster's node pool", Writer, aliasOpt("g"),
+		displayerType(&displayers.KubernetesNodePools{}))
+	CmdBuilder(cmd, RunKubernetesNodePoolList, "list <cluster-id|cluster-name>",
+		"list a cluster's node pools", Writer, aliasOpt("ls"),
+		displayerType(&displayers.KubernetesNodePools{}))
 
-	cmdKubeNodePoolCreate := CmdBuilder(cmd, RunKubernetesNodePoolCreate, "create <cluster-id|cluster-name>", "create a new node pool for a cluster", Writer, aliasOpt("c"))
-	AddStringFlag(cmdKubeNodePoolCreate, doctl.ArgNodePoolName, "", "", "node pool name", requiredOpt())
-	AddStringFlag(cmdKubeNodePoolCreate, doctl.ArgSizeSlug, "", "", "size of nodes in the node pool (see `doctl k8s options sizes`)", requiredOpt())
-	AddIntFlag(cmdKubeNodePoolCreate, doctl.ArgNodePoolCount, "", 0, "count of nodes in the node pool", requiredOpt())
-	AddStringFlag(cmdKubeNodePoolCreate, doctl.ArgTag, "", "", "tags to apply to the node pool, repeat to add multiple tags at once")
+	cmdKubeNodePoolCreate := CmdBuilder(cmd, RunKubernetesNodePoolCreate,
+		"create <cluster-id|cluster-name>", "create a new node pool for a cluster",
+		Writer, aliasOpt("c"))
+	AddStringFlag(cmdKubeNodePoolCreate, doctl.ArgNodePoolName, "", "",
+		"node pool name", requiredOpt())
+	AddStringFlag(cmdKubeNodePoolCreate, doctl.ArgSizeSlug, "", "",
+		"size of nodes in the node pool (see `doctl k8s options sizes`)", requiredOpt())
+	AddIntFlag(cmdKubeNodePoolCreate, doctl.ArgNodePoolCount, "", 0,
+		"count of nodes in the node pool", requiredOpt())
+	AddStringFlag(cmdKubeNodePoolCreate, doctl.ArgTag, "", "",
+		"tags to apply to the node pool, repeat to add multiple tags at once")
 
-	cmdKubeNodePoolUpdate := CmdBuilder(cmd, RunKubernetesNodePoolUpdate, "update <cluster-id|cluster-name> <pool-id|pool-name>", "update an existing node pool in a cluster", Writer, aliasOpt("u"))
+	cmdKubeNodePoolUpdate := CmdBuilder(cmd, RunKubernetesNodePoolUpdate,
+		"update <cluster-id|cluster-name> <pool-id|pool-name>",
+		"update an existing node pool in a cluster", Writer, aliasOpt("u"))
 	AddStringFlag(cmdKubeNodePoolUpdate, doctl.ArgNodePoolName, "", "", "node pool name")
-	AddIntFlag(cmdKubeNodePoolUpdate, doctl.ArgNodePoolCount, "", 0, "count of nodes in the node pool")
-	AddStringFlag(cmdKubeNodePoolUpdate, doctl.ArgTag, "", "", "tags to apply to the node pool, repeat to add multiple tags at once")
+	AddIntFlag(cmdKubeNodePoolUpdate, doctl.ArgNodePoolCount, "", 0,
+		"count of nodes in the node pool")
+	AddStringFlag(cmdKubeNodePoolUpdate, doctl.ArgTag, "", "",
+		"tags to apply to the node pool, repeat to add multiple tags at once")
 
-	cmdKubeNodePoolRecycle := CmdBuilder(cmd, RunKubernetesNodePoolRecycle, "recycle <cluster-id|cluster-name> <pool-id|pool-name>", "recycle nodes in a node pool", Writer, aliasOpt("r"))
-	AddStringFlag(cmdKubeNodePoolRecycle, doctl.ArgNodePoolNodeIDs, "", "", "ID or name of the nodes in the node pool to recycle")
+	cmdKubeNodePoolRecycle := CmdBuilder(cmd, RunKubernetesNodePoolRecycle,
+		"recycle <cluster-id|cluster-name> <pool-id|pool-name>", "recycle nodes in a node pool", Writer, aliasOpt("r"))
+	AddStringFlag(cmdKubeNodePoolRecycle, doctl.ArgNodePoolNodeIDs, "", "",
+		"ID or name of the nodes in the node pool to recycle")
 
-	cmdKubeNodePoolDelete := CmdBuilder(cmd, RunKubernetesNodePoolDelete, "delete <cluster-id|cluster-name> <pool-id|pool-name>", "delete node pool from a cluster", Writer, aliasOpt("d", "rm"))
-	AddBoolFlag(cmdKubeNodePoolDelete, doctl.ArgForce, doctl.ArgShortForce, false, "force node pool delete")
+	cmdKubeNodePoolDelete := CmdBuilder(cmd, RunKubernetesNodePoolDelete,
+		"delete <cluster-id|cluster-name> <pool-id|pool-name>",
+		"delete node pool from a cluster", Writer, aliasOpt("d", "rm"))
+	AddBoolFlag(cmdKubeNodePoolDelete, doctl.ArgForce, doctl.ArgShortForce,
+		false, "force node pool delete")
+
 	return cmd
 }
 
@@ -212,9 +262,12 @@ func kubernetesOptions() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunKubeOptionsListVersion, "versions", "versions that can be used to create a Kubernetes cluster", Writer, aliasOpt("v"))
-	CmdBuilder(cmd, RunKubeOptionsListRegion, "regions", "regions that can be used to create a Kubernetes cluster", Writer, aliasOpt("r"))
-	CmdBuilder(cmd, RunKubeOptionsListNodeSizes, "sizes", "sizes that nodes in a Kubernetes cluster can have", Writer, aliasOpt("s"))
+	CmdBuilder(cmd, RunKubeOptionsListVersion, "versions",
+		"versions that can be used to create a Kubernetes cluster", Writer, aliasOpt("v"))
+	CmdBuilder(cmd, RunKubeOptionsListRegion, "regions",
+		"regions that can be used to create a Kubernetes cluster", Writer, aliasOpt("r"))
+	CmdBuilder(cmd, RunKubeOptionsListNodeSizes, "sizes",
+		"sizes that nodes in a Kubernetes cluster can have", Writer, aliasOpt("s"))
 	return cmd
 }
 

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -36,7 +36,7 @@ func LoadBalancer() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunLoadBalancerGet, "get <id>", "get load balancer", Writer, aliasOpt("g"))
+	CmdBuilder(cmd, RunLoadBalancerGet, "get <id>", "get load balancer", Writer, aliasOpt("g"), displayerType(&displayers.LoadBalancer{}))
 
 	cmdRecordCreate := CmdBuilder(cmd, RunLoadBalancerCreate, "create", "create load balancer", Writer, aliasOpt("c"))
 	AddStringFlag(cmdRecordCreate, doctl.ArgLoadBalancerName, "", "", "load balancer name", requiredOpt())
@@ -60,7 +60,7 @@ func LoadBalancer() *Command {
 	AddStringFlag(cmdRecordUpdate, doctl.ArgHealthCheck, "", "", "comma-separated key:value list, example value: protocol:http,port:80,path:/index.html,check_interval_seconds:10,response_timeout_seconds:5,healthy_threshold:5,unhealthy_threshold:3")
 	AddStringFlag(cmdRecordUpdate, doctl.ArgForwardingRules, "", "", "comma-separated key:value list, example value: entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306, use quoted string of space-separated values for multiple rules")
 
-	CmdBuilder(cmd, RunLoadBalancerList, "list", "list load balancers", Writer, aliasOpt("ls"))
+	CmdBuilder(cmd, RunLoadBalancerList, "list", "list load balancers", Writer, aliasOpt("ls"), displayerType(&displayers.LoadBalancer{}))
 
 	cmdRunRecordDelete := CmdBuilder(cmd, RunLoadBalancerDelete, "delete <id>", "delete load balancer", Writer, aliasOpt("d", "rm"))
 	AddBoolFlag(cmdRunRecordDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force load balancer delete")

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -36,46 +36,76 @@ func LoadBalancer() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunLoadBalancerGet, "get <id>", "get load balancer", Writer, aliasOpt("g"), displayerType(&displayers.LoadBalancer{}))
+	CmdBuilder(cmd, RunLoadBalancerGet, "get <id>", "get load balancer", Writer,
+		aliasOpt("g"), displayerType(&displayers.LoadBalancer{}))
 
-	cmdRecordCreate := CmdBuilder(cmd, RunLoadBalancerCreate, "create", "create load balancer", Writer, aliasOpt("c"))
-	AddStringFlag(cmdRecordCreate, doctl.ArgLoadBalancerName, "", "", "load balancer name", requiredOpt())
-	AddStringFlag(cmdRecordCreate, doctl.ArgRegionSlug, "", "", "load balancer region location, example value: nyc1", requiredOpt())
-	AddStringFlag(cmdRecordCreate, doctl.ArgLoadBalancerAlgorithm, "", "round_robin", "load balancing algorithm, possible values: round_robin or least_connections")
-	AddBoolFlag(cmdRecordCreate, doctl.ArgRedirectHttpToHttps, "", false, "flag to redirect HTTP requests to the load balancer on port 80 to HTTPS on port 443")
+	cmdRecordCreate := CmdBuilder(cmd, RunLoadBalancerCreate, "create",
+		"create load balancer", Writer, aliasOpt("c"))
+	AddStringFlag(cmdRecordCreate, doctl.ArgLoadBalancerName, "", "",
+		"load balancer name", requiredOpt())
+	AddStringFlag(cmdRecordCreate, doctl.ArgRegionSlug, "", "",
+		"load balancer region location, example value: nyc1", requiredOpt())
+	AddStringFlag(cmdRecordCreate, doctl.ArgLoadBalancerAlgorithm, "",
+		"round_robin", "load balancing algorithm, possible values: round_robin or least_connections")
+	AddBoolFlag(cmdRecordCreate, doctl.ArgRedirectHttpToHttps, "", false,
+		"flag to redirect HTTP requests to the load balancer on port 80 to HTTPS on port 443")
 	AddStringFlag(cmdRecordCreate, doctl.ArgTagName, "", "", "droplet tag name")
-	AddStringSliceFlag(cmdRecordCreate, doctl.ArgDropletIDs, "", []string{}, "comma-separated list of droplet IDs, example value: 12,33")
-	AddStringFlag(cmdRecordCreate, doctl.ArgStickySessions, "", "", "comma-separated key:value list, example value: type:cookies,cookie_name:DO-LB,cookie_ttl_seconds:5")
-	AddStringFlag(cmdRecordCreate, doctl.ArgHealthCheck, "", "", "comma-separated key:value list, example value: protocol:http,port:80,path:/index.html,check_interval_seconds:10,response_timeout_seconds:5,healthy_threshold:5,unhealthy_threshold:3")
-	AddStringFlag(cmdRecordCreate, doctl.ArgForwardingRules, "", "", "comma-separated key:value list, example value: entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306, use quoted string of space-separated values for multiple rules")
+	AddStringSliceFlag(cmdRecordCreate, doctl.ArgDropletIDs, "", []string{},
+		"comma-separated list of droplet IDs, example value: 12,33")
+	AddStringFlag(cmdRecordCreate, doctl.ArgStickySessions, "", "",
+		"comma-separated key:value list, example value: type:cookies,cookie_name:DO-LB,cookie_ttl_seconds:5")
+	AddStringFlag(cmdRecordCreate, doctl.ArgHealthCheck, "", "",
+		"comma-separated key:value list, example value: protocol:http,port:80,path:/index.html,check_interval_seconds:10,response_timeout_seconds:5,healthy_threshold:5,unhealthy_threshold:3")
+	AddStringFlag(cmdRecordCreate, doctl.ArgForwardingRules, "", "",
+		"comma-separated key:value list, example value: entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306, use quoted string of space-separated values for multiple rules")
 
-	cmdRecordUpdate := CmdBuilder(cmd, RunLoadBalancerUpdate, "update <id>", "update load balancer", Writer, aliasOpt("u"))
-	AddStringFlag(cmdRecordUpdate, doctl.ArgLoadBalancerName, "", "", "load balancer name", requiredOpt())
-	AddStringFlag(cmdRecordUpdate, doctl.ArgRegionSlug, "", "", "load balancer region location, example value: nyc1", requiredOpt())
-	AddStringFlag(cmdRecordUpdate, doctl.ArgLoadBalancerAlgorithm, "", "round_robin", "load balancing algorithm, possible values: round_robin or least_connections")
-	AddBoolFlag(cmdRecordUpdate, doctl.ArgRedirectHttpToHttps, "", false, "flag to redirect HTTP requests to the load balancer on port 80 to HTTPS on port 443")
+	cmdRecordUpdate := CmdBuilder(cmd, RunLoadBalancerUpdate, "update <id>",
+		"update load balancer", Writer, aliasOpt("u"))
+	AddStringFlag(cmdRecordUpdate, doctl.ArgLoadBalancerName, "", "",
+		"load balancer name", requiredOpt())
+	AddStringFlag(cmdRecordUpdate, doctl.ArgRegionSlug, "", "",
+		"load balancer region location, example value: nyc1", requiredOpt())
+	AddStringFlag(cmdRecordUpdate, doctl.ArgLoadBalancerAlgorithm, "",
+		"round_robin", "load balancing algorithm, possible values: round_robin or least_connections")
+	AddBoolFlag(cmdRecordUpdate, doctl.ArgRedirectHttpToHttps, "", false,
+		"flag to redirect HTTP requests to the load balancer on port 80 to HTTPS on port 443")
 	AddStringFlag(cmdRecordUpdate, doctl.ArgTagName, "", "", "droplet tag name")
-	AddStringSliceFlag(cmdRecordUpdate, doctl.ArgDropletIDs, "", []string{}, "comma-separated list of droplet IDs, example value: 12,33")
-	AddStringFlag(cmdRecordUpdate, doctl.ArgStickySessions, "", "", "comma-separated key:value list, example value, example value: type:cookies,cookie_name:DO-LB,cookie_ttl_seconds:5")
-	AddStringFlag(cmdRecordUpdate, doctl.ArgHealthCheck, "", "", "comma-separated key:value list, example value: protocol:http,port:80,path:/index.html,check_interval_seconds:10,response_timeout_seconds:5,healthy_threshold:5,unhealthy_threshold:3")
-	AddStringFlag(cmdRecordUpdate, doctl.ArgForwardingRules, "", "", "comma-separated key:value list, example value: entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306, use quoted string of space-separated values for multiple rules")
+	AddStringSliceFlag(cmdRecordUpdate, doctl.ArgDropletIDs, "", []string{},
+		"comma-separated list of droplet IDs, example value: 12,33")
+	AddStringFlag(cmdRecordUpdate, doctl.ArgStickySessions, "", "",
+		"comma-separated key:value list, example value, example value: type:cookies,cookie_name:DO-LB,cookie_ttl_seconds:5")
+	AddStringFlag(cmdRecordUpdate, doctl.ArgHealthCheck, "", "",
+		"comma-separated key:value list, example value: protocol:http,port:80,path:/index.html,check_interval_seconds:10,response_timeout_seconds:5,healthy_threshold:5,unhealthy_threshold:3")
+	AddStringFlag(cmdRecordUpdate, doctl.ArgForwardingRules, "", "",
+		"comma-separated key:value list, example value: entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306, use quoted string of space-separated values for multiple rules")
 
-	CmdBuilder(cmd, RunLoadBalancerList, "list", "list load balancers", Writer, aliasOpt("ls"), displayerType(&displayers.LoadBalancer{}))
+	CmdBuilder(cmd, RunLoadBalancerList, "list", "list load balancers", Writer,
+		aliasOpt("ls"), displayerType(&displayers.LoadBalancer{}))
 
-	cmdRunRecordDelete := CmdBuilder(cmd, RunLoadBalancerDelete, "delete <id>", "delete load balancer", Writer, aliasOpt("d", "rm"))
-	AddBoolFlag(cmdRunRecordDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force load balancer delete")
+	cmdRunRecordDelete := CmdBuilder(cmd, RunLoadBalancerDelete, "delete <id>",
+		"delete load balancer", Writer, aliasOpt("d", "rm"))
+	AddBoolFlag(cmdRunRecordDelete, doctl.ArgForce, doctl.ArgShortForce, false,
+		"Force load balancer delete")
 
-	cmdAddDroplets := CmdBuilder(cmd, RunLoadBalancerAddDroplets, "add-droplets <id>", "add droplets to the load balancer", Writer)
-	AddStringSliceFlag(cmdAddDroplets, doctl.ArgDropletIDs, "", []string{}, "comma-separated list of droplet IDs, example valus: 12,33")
+	cmdAddDroplets := CmdBuilder(cmd, RunLoadBalancerAddDroplets, "add-droplets <id>",
+		"add droplets to the load balancer", Writer)
+	AddStringSliceFlag(cmdAddDroplets, doctl.ArgDropletIDs, "", []string{},
+		"comma-separated list of droplet IDs, example valus: 12,33")
 
-	cmdRemoveDroplets := CmdBuilder(cmd, RunLoadBalancerRemoveDroplets, "remove-droplets <id>", "remove droplets from the load balancer", Writer)
-	AddStringSliceFlag(cmdRemoveDroplets, doctl.ArgDropletIDs, "", []string{}, "comma-separated list of droplet IDs, example value: 12,33")
+	cmdRemoveDroplets := CmdBuilder(cmd, RunLoadBalancerRemoveDroplets,
+		"remove-droplets <id>", "remove droplets from the load balancer", Writer)
+	AddStringSliceFlag(cmdRemoveDroplets, doctl.ArgDropletIDs, "", []string{},
+		"comma-separated list of droplet IDs, example value: 12,33")
 
-	cmdAddForwardingRules := CmdBuilder(cmd, RunLoadBalancerAddForwardingRules, "add-forwarding-rules <id>", "add forwarding rules to the load balancer", Writer)
-	AddStringFlag(cmdAddForwardingRules, doctl.ArgForwardingRules, "", "", "comma-separated key:value list, example value: entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306, use quoted string of space-separated values for multiple rules")
+	cmdAddForwardingRules := CmdBuilder(cmd, RunLoadBalancerAddForwardingRules,
+		"add-forwarding-rules <id>", "add forwarding rules to the load balancer", Writer)
+	AddStringFlag(cmdAddForwardingRules, doctl.ArgForwardingRules, "", "",
+		"comma-separated key:value list, example value: entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306, use quoted string of space-separated values for multiple rules")
 
-	cmdRemoveForwardingRules := CmdBuilder(cmd, RunLoadBalancerRemoveForwardingRules, "remove-forwarding-rules <id>", "remove forwarding rules from the load balancer", Writer)
-	AddStringFlag(cmdRemoveForwardingRules, doctl.ArgForwardingRules, "", "", "comma-separated key:value list, example value: entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306, use quoted string of space-separated values for multiple rules")
+	cmdRemoveForwardingRules := CmdBuilder(cmd, RunLoadBalancerRemoveForwardingRules,
+		"remove-forwarding-rules <id>", "remove forwarding rules from the load balancer", Writer)
+	AddStringFlag(cmdRemoveForwardingRules, doctl.ArgForwardingRules, "", "",
+		"comma-separated key:value list, example value: entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306, use quoted string of space-separated values for multiple rules")
 
 	return cmd
 }

--- a/commands/projects.go
+++ b/commands/projects.go
@@ -34,24 +34,40 @@ func Projects() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunProjectsList, "list", "list projects", Writer, aliasOpt("ls"), displayerType(&displayers.Project{}))
-	CmdBuilder(cmd, RunProjectsGet, "get <id>", "get a project; use \"default\" as ID to get default project", Writer, aliasOpt("g"), displayerType(&displayers.Project{}))
+	CmdBuilder(cmd, RunProjectsList, "list", "list projects", Writer, aliasOpt("ls"),
+		displayerType(&displayers.Project{}))
+	CmdBuilder(cmd, RunProjectsGet, "get <id>",
+		"get a project; use \"default\" as ID to get default project", Writer,
+		aliasOpt("g"), displayerType(&displayers.Project{}))
 
-	cmdProjectsCreate := CmdBuilder(cmd, RunProjectsCreate, "create", "create project", Writer, aliasOpt("c"), displayerType(&displayers.Project{}))
-	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectName, "", "", "project name", requiredOpt())
-	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectPurpose, "", "", "project purpose", requiredOpt())
-	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectDescription, "", "", "a description of your project")
-	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectEnvironment, "", "", "the environment in which your project resides. Should be one of 'Development', 'Staging', 'Production'.")
+	cmdProjectsCreate := CmdBuilder(cmd, RunProjectsCreate, "create",
+		"create project", Writer, aliasOpt("c"),
+		displayerType(&displayers.Project{}))
+	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectName, "", "",
+		"project name", requiredOpt())
+	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectPurpose, "", "",
+		"project purpose", requiredOpt())
+	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectDescription, "", "",
+		"a description of your project")
+	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectEnvironment, "", "",
+		"the environment in which your project resides. Should be one of 'Development', 'Staging', 'Production'.")
 
-	cmdProjectsUpdate := CmdBuilder(cmd, RunProjectsUpdate, "update <id>", "update project; use \"default\" as ID to update the default project", Writer, aliasOpt("u"), displayerType(&displayers.Project{}))
+	cmdProjectsUpdate := CmdBuilder(cmd, RunProjectsUpdate, "update <id>",
+		"update project; use \"default\" as ID to update the default project",
+		Writer, aliasOpt("u"), displayerType(&displayers.Project{}))
 	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectName, "", "", "project name")
 	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectPurpose, "", "", "project purpose")
-	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectDescription, "", "", "a description of your project")
-	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectEnvironment, "", "", "the environment in which your project resides. Should be one of 'Development', 'Staging', 'Production'.")
-	AddBoolFlag(cmdProjectsUpdate, doctl.ArgProjectIsDefault, "", false, "set the specified project as your default project")
+	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectDescription, "", "",
+		"a description of your project")
+	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectEnvironment, "", "",
+		"the environment in which your project resides. Should be one of 'Development', 'Staging', 'Production'.")
+	AddBoolFlag(cmdProjectsUpdate, doctl.ArgProjectIsDefault, "", false,
+		"set the specified project as your default project")
 
-	cmdProjectsDelete := CmdBuilder(cmd, RunProjectsDelete, "delete <id> [<id> ...]", "delete project", Writer, aliasOpt("d", "rm"))
-	AddBoolFlag(cmdProjectsDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force project delete")
+	cmdProjectsDelete := CmdBuilder(cmd, RunProjectsDelete, "delete <id> [<id> ...]",
+		"delete project", Writer, aliasOpt("d", "rm"))
+	AddBoolFlag(cmdProjectsDelete, doctl.ArgForce, doctl.ArgShortForce, false,
+		"Force project delete")
 
 	cmd.AddCommand(ProjectResourcesCmd())
 
@@ -67,11 +83,16 @@ func ProjectResourcesCmd() *Command {
 			Long:  "project resources commands are for assigning and listing resources in projects",
 		},
 	}
-	CmdBuilder(cmd, RunProjectResourcesList, "list <project-id>", "list project resources", Writer, aliasOpt("ls"), displayerType(&displayers.ProjectResource{}))
-	CmdBuilder(cmd, RunProjectResourcesGet, "get <urn>", "get a project resource by its URN", Writer, aliasOpt("g"), displayerType(&displayers.ProjectResource{}))
+	CmdBuilder(cmd, RunProjectResourcesList, "list <project-id>", "list project resources",
+		Writer, aliasOpt("ls"), displayerType(&displayers.ProjectResource{}))
+	CmdBuilder(cmd, RunProjectResourcesGet, "get <urn>", "get a project resource by its URN",
+		Writer, aliasOpt("g"), displayerType(&displayers.ProjectResource{}))
 
-	cmdProjectResourcesAssign := CmdBuilder(cmd, RunProjectResourcesAssign, "assign <project-id> --resource=<urn> [--resource=<urn> ...]", "assign one or more resources to a project", Writer, aliasOpt("a"))
-	AddStringSliceFlag(cmdProjectResourcesAssign, doctl.ArgProjectResource, "", []string{}, "resource URNs denoting resources to assign to the project")
+	cmdProjectResourcesAssign := CmdBuilder(cmd, RunProjectResourcesAssign,
+		"assign <project-id> --resource=<urn> [--resource=<urn> ...]",
+		"assign one or more resources to a project", Writer, aliasOpt("a"))
+	AddStringSliceFlag(cmdProjectResourcesAssign, doctl.ArgProjectResource, "",
+		[]string{}, "resource URNs denoting resources to assign to the project")
 
 	return cmd
 }

--- a/commands/projects.go
+++ b/commands/projects.go
@@ -68,7 +68,7 @@ func ProjectResourcesCmd() *Command {
 		},
 	}
 	CmdBuilder(cmd, RunProjectResourcesList, "list <project-id>", "list project resources", Writer, aliasOpt("ls"), displayerType(&displayers.ProjectResource{}))
-	CmdBuilder(cmd, RunProjectResourcesGet, "get <urn>", "get a project resource by its URN", Writer, aliasOpt("g"))
+	CmdBuilder(cmd, RunProjectResourcesGet, "get <urn>", "get a project resource by its URN", Writer, aliasOpt("g"), displayerType(&displayers.ProjectResource{}))
 
 	cmdProjectResourcesAssign := CmdBuilder(cmd, RunProjectResourcesAssign, "assign <project-id> --resource=<urn> [--resource=<urn> ...]", "assign one or more resources to a project", Writer, aliasOpt("a"))
 	AddStringSliceFlag(cmdProjectResourcesAssign, doctl.ArgProjectResource, "", []string{}, "resource URNs denoting resources to assign to the project")

--- a/commands/tags.go
+++ b/commands/tags.go
@@ -39,10 +39,10 @@ func Tags() *Command {
 		docCategories("tag"))
 
 	CmdBuilder(cmd, RunCmdTagGet, "get <tag-name>", "get tag", Writer,
-		docCategories("tag"))
+		displayerType(&displayers.Tag{}), docCategories("tag"))
 
 	CmdBuilder(cmd, RunCmdTagList, "list", "list tags", Writer,
-		aliasOpt("ls"), docCategories("tag"))
+		aliasOpt("ls"), displayerType(&displayers.Tag{}), docCategories("tag"))
 
 	cmdRunTagDelete := CmdBuilder(cmd, RunCmdTagDelete, "delete <tag-name>...", "delete tags", Writer,
 		docCategories("tag"))


### PR DESCRIPTION
This PR first adds a test ensuring that we consistently accept the `--format` flag for all `get` and `list` commands.  The following commits then fix the the failing tests by adding `--format` support to certificates, databases, kubernetes, load balancers (#340), projects, and tags respectively.