### PR TITLE
Work with kubectl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ parts/
 prime/
 stage/
 *.snap
+snap/.snapcraft/

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Use "doctl [command] --help" for more information about a command.
         - [Using a Package Manager (Preferred)](#using-a-package-manager-preferred)
             - [MacOS](#macos)
             - [Snap supported OS](#snap-supported-os)
+                - [Use with `kubectl`](#use-with-kubectl)
+                - [Using `doctl compute ssh`](#using-doctl-compute-ssh)
             - [Arch Linux](#arch-linux)
-            - [Windows](#windows)
         - [Downloading a Release from GitHub](#downloading-a-release-from-github)
         - [Building with Docker](#building-with-docker)
         - [Building the Development Version from Source](#building-the-development-version-from-source)
@@ -76,28 +77,41 @@ the port is community maintained and may not be on the latest version.
 
 #### Snap supported OS
 
-_Note: If you need to use [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) with your DO
-resources, you [cannot currently install `doctl` via snap](https://forum.snapcraft.io/t/classic-confinement-request-doctl/11785)._
-
 You can use [Snap](https://snapcraft.io/) on [Snap-supported](https://snapcraft.io/docs/core/install) systems to install `doctl` with this command:
 
 ```
 sudo snap install doctl
 ```
 
-If you want to use `doctl compute ssh`, you'll need to connect the doctl snap to the core [ssh-keys interface](https://docs.snapcraft.io/ssh-keys-interface):
+##### Use with `kubectl`
+
+At present, you'll need to connect the snap to the `doctl` and
+`kubectl` config files in order to use `kubectl` with your DOKS. After 
+installing the snap, run
+
+```
+sudo snap connect doctl:doctl-config
+sudo snap connect doctl:kubectl-config
+```
+
+You should only need to create these connections once; upgrades should
+honor the existing connection.
+
+##### Using `doctl compute ssh`
+
+If you want to use `doctl compute ssh`, you'll need to connect the
+doctl snap to the core [ssh-keys interface](https://docs.snapcraft.io/ssh-keys-interface).
+After installing the snap, run
 
 ```
 sudo snap connect doctl:ssh-keys :ssh-keys
 ```
 
+You should only need to create the connection once; upgrades should honor the existing connection.
+
 #### Arch Linux
 
 Arch users not using a package manager can install from the [AUR](https://aur.archlinux.org/packages/doctl-bin/).
-
-#### Windows
-
-Support for Windows package managers is on the way.
 
 ### Downloading a Release from GitHub
 

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1311,7 +1311,7 @@ func mergeKubeconfig(clusterID string, remote, local *clientcmdapi.Config, setCu
 	local.AuthInfos[remoteCtx.AuthInfo] = &clientcmdapi.AuthInfo{
 		Exec: &clientcmdapi.ExecConfig{
 			APIVersion: clientauthentication.SchemeGroupVersion.String(),
-			Command:    os.Args[0],
+			Command:    doctl.CommandName(),
 			Args: []string{
 				"kubernetes",
 				"cluster",

--- a/doit.go
+++ b/doit.go
@@ -339,3 +339,12 @@ func (c *LiveConfig) GetStringSlice(ns, key string) ([]string, error) {
 func emptyStringSlice(s []string) bool {
 	return len(s) == 1 && s[0] == "[]"
 }
+
+// CommandName returns the name by which doctl was invoked
+func CommandName() string {
+	name, ok := os.LookupEnv("SNAP_NAME")
+	if !ok {
+		return os.Args[0]
+	}
+	return name
+}

--- a/snap/local/doctl-launch
+++ b/snap/local/doctl-launch
@@ -1,0 +1,3 @@
+#!/bin/sh
+real_home=$(getent passwd "$(id -u)" | cut -d ':' -f 6)
+HOME=$real_home doctl.real "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,9 +3,8 @@ version-script: git tag -l | sort --version-sort | tail -n1 | cut -c 2-
 version: git
 summary: A command line tool for DigitalOcean services
 description: doctl is a command line tool for DigitalOcean services using the API.
-base: core18
 
-grade: stable
+grade: devel
 confinement: strict
 
 build-packages:
@@ -13,7 +12,10 @@ build-packages:
   - git
 
 parts:
+  go:
+    source-tag: go1.11.4
   launcher:
+    after: [go]
     source: snap/local
     plugin: dump
     organize:
@@ -35,7 +37,7 @@ plugs:
   kube-config:
     interface: personal-files
     write:
-      - $HOME/.kube
+      -	$HOME/.kube
       - $HOME/.kube/config
   doctl-config:
     interface: personal-files

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,8 +3,9 @@ version-script: git tag -l | sort --version-sort | tail -n1 | cut -c 2-
 version: git
 summary: A command line tool for DigitalOcean services
 description: doctl is a command line tool for DigitalOcean services using the API.
+base: core18
 
-grade: devel
+grade: stable
 confinement: strict
 
 build-packages:
@@ -12,10 +13,7 @@ build-packages:
   - git
 
 parts:
-  go:
-    source-tag: go1.11.4
   launcher:
-    after: [go]
     source: snap/local
     plugin: dump
     organize:
@@ -37,7 +35,7 @@ plugs:
   kube-config:
     interface: personal-files
     write:
-      -	$HOME/.kube
+      - $HOME/.kube
       - $HOME/.kube/config
   doctl-config:
     interface: personal-files

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ version: git
 summary: A command line tool for DigitalOcean services
 description: doctl is a command line tool for DigitalOcean services using the API.
 
-grade: stable
+grade: devel
 confinement: strict
 
 build-packages:
@@ -14,17 +14,44 @@ build-packages:
 parts:
   go:
     source-tag: go1.11.4
-  doctl:
+  launcher:
     after: [go]
+    source: snap/local
+    plugin: dump
+    organize:
+      '*': bin/
+    override-stage: |
+      cd $SNAPCRAFT_PART_INSTALL
+      chmod +x bin/doctl-launch
+      snapcraftctl stage
+  doctl:
+    after: [launcher]
     source: .
     plugin: go
     go-importpath: github.com/digitalocean/doctl
     go-packages: [github.com/digitalocean/doctl/cmd/doctl]
+    organize:
+      bin/doctl: bin/doctl.real
+
+plugs:
+  kube-config:
+    interface: personal-files
+    write:
+      -	$HOME/.kube
+      - $HOME/.kube/config
+  doctl-config:
+    interface: personal-files
+    write:
+      - $HOME/.config
+      - $HOME/.config/doctl
+      - $HOME/.config/doctl/.config
 
 apps:
   doctl:
-    command: bin/doctl
+    command: bin/doctl-launch
     plugs:
       - home
       - network
       - ssh-keys
+      - kube-config
+      - doctl-config

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,6 @@ version-script: git tag -l | sort --version-sort | tail -n1 | cut -c 2-
 version: git
 summary: A command line tool for DigitalOcean services
 description: doctl is a command line tool for DigitalOcean services using the API.
-base: core18
 
 grade: stable
 confinement: strict
@@ -13,7 +12,10 @@ build-packages:
   - git
 
 parts:
+  go:
+    source-tag: go1.11.4
   launcher:
+    after: [go]
     source: snap/local
     plugin: dump
     organize:
@@ -37,12 +39,6 @@ plugs:
     write:
       - $HOME/.kube
       - $HOME/.kube/config
-  doctl-config:
-    interface: personal-files
-    write:
-      - $HOME/.config
-      - $HOME/.config/doctl
-      - $HOME/.config/doctl/.config
 
 apps:
   doctl:
@@ -52,4 +48,3 @@ apps:
       - network
       - ssh-keys
       - kube-config
-      - doctl-config

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ version: git
 summary: A command line tool for DigitalOcean services
 description: doctl is a command line tool for DigitalOcean services using the API.
 
-grade: devel
+grade: stable
 confinement: strict
 
 build-packages:
@@ -37,7 +37,7 @@ plugs:
   kube-config:
     interface: personal-files
     write:
-      -	$HOME/.kube
+      - $HOME/.kube
       - $HOME/.kube/config
   doctl-config:
     interface: personal-files

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,6 +3,7 @@ version-script: git tag -l | sort --version-sort | tail -n1 | cut -c 2-
 version: git
 summary: A command line tool for DigitalOcean services
 description: doctl is a command line tool for DigitalOcean services using the API.
+base: core18
 
 grade: stable
 confinement: strict
@@ -12,10 +13,7 @@ build-packages:
   - git
 
 parts:
-  go:
-    source-tag: go1.11.4
   launcher:
-    after: [go]
     source: snap/local
     plugin: dump
     organize:
@@ -39,6 +37,12 @@ plugs:
     write:
       - $HOME/.kube
       - $HOME/.kube/config
+  doctl-config:
+    interface: personal-files
+    write:
+      - $HOME/.config
+      - $HOME/.config/doctl
+      - $HOME/.config/doctl/.config
 
 apps:
   doctl:
@@ -48,3 +52,4 @@ apps:
       - network
       - ssh-keys
       - kube-config
+      - doctl-config


### PR DESCRIPTION
Fixes #457 (and #451, which is closely related) using snap's `personal-files` interface and a, well, hack. (Injecting knowledge about a packager into our CLI qualifies as a hack to me, but that's me. And the benefit of having strict confinement for our devs is substantial.) 

At present, using the snap version requires a bit of setup.  After installing the snap, connect the config plugs:

```bash
sudo snap connect doctl:doctl-config
sudo snap connect doctl:kubectl-config
```

The setup only has to be done once; upgrading and/or removing and reinstalling the snap does not remove the connections.

We can submit a request for each of the `personal-files` plugs to [auto-connect](https://forum.snapcraft.io/t/process-for-aliases-auto-connections-and-tracks/455). See, for example, https://forum.snapcraft.io/t/requesting-auto-connection-of-personal-files-to-sam-cli/10641.

