### PR TITLE
Allow completion of aliases in zsh

### DIFF
--- a/commands/completion.go
+++ b/commands/completion.go
@@ -247,6 +247,7 @@ __doctl_convert_bash_to_zsh() {
 	-e "s/${LWORD}compgen${RWORD}/__doctl_compgen/g" \
 	-e "s/${LWORD}compopt${RWORD}/__doctl_compopt/g" \
 	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
+	-e 's/aliashash\["\(.\{1,\}\)"\]/aliashash[\1]/g' \
 	-e "s/\\\$(type${RWORD}/\$(__doctl_type/g" \
 	<<'BASH_COMPLETION_EOF'
 `


### PR DESCRIPTION
This PR allows the completion of aliases of commands in zsh.

For example:

`doctl k8s <tab>` will now properly complete as if the command was typed as `doctl kubernetes <tab>`

Ref:
https://github.com/helm/helm/pull/5680
https://github.com/helm/helm/commit/48f0e3101d49a3de1466ff75fc786ce012f369cc