### PR TITLE
1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.21.0] - 2019-07-11
+
+- PR #482 - @eddiezane - Allow completion of aliases in zsh
+- PR #477 - @hilary - describe current status of snap in README
+- PR #474 - @DazWilkin - Support "Are you sure?" prompting
+- PR #473 - @KritR - Added NixPkgs as Package Manager Option
+- PR #472 - @hilary - migrate from go dep to go modules
+
 ## [1.20.1] - 2019-06-14
 
  - #471 add macport to README - @hilary

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-ENV DOCTL_VERSION=1.20.1
+ENV DOCTL_VERSION=1.21.0
 
 RUN apk add --no-cache curl
 

--- a/doit.go
+++ b/doit.go
@@ -50,8 +50,8 @@ var (
 	// DoitVersion is doit's version.
 	DoitVersion = Version{
 		Major: 1,
-		Minor: 20,
-		Patch: 1,
+		Minor: 21,
+		Patch: 0,
 		Label: "dev",
 	}
 


### PR DESCRIPTION
The change in format to the changelog is a result of using [github-release-notes](https://github.com/buchanae/github-release-notes), which will be baked into the scripts real soon now(tm).