### PR TITLE
Write JSON for nil slices as [] instead of null

### DIFF
--- a/commands/displayers/output_test.go
+++ b/commands/displayers/output_test.go
@@ -1,0 +1,52 @@
+package displayers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/do"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDisplayerDisplay(t *testing.T) {
+	emptyVolumes := make([]do.Volume, 0)
+	var nilVolumes []do.Volume
+
+	tests := []struct {
+		name         string
+		item         Displayable
+		expectedJSON string
+	}{
+		{
+			name:         "displaying a non-nil slice of Volumes should return an empty JSON array",
+			item:         &Volume{Volumes: emptyVolumes},
+			expectedJSON: `[]`,
+		},
+		{
+			name:         "displaying a nil slice of Volumes should return an empty JSON array",
+			item:         &Volume{Volumes: nilVolumes},
+			expectedJSON: `[]`,
+		},
+	}
+
+	cfg := doctl.NewTestConfig()
+	cfg.Set(doctl.NSRoot, "output", "json")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+
+			displayer := Displayer{
+				Config: cfg,
+				Item:   tt.item,
+				Out:    out,
+			}
+
+			err := displayer.Display()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedJSON, out.String())
+		})
+	}
+}

--- a/commands/ssh_test.go
+++ b/commands/ssh_test.go
@@ -83,7 +83,7 @@ func TestSSH_CustomPort(t *testing.T) {
 		rm := &mocks.Runner{}
 		rm.On("Run").Return(nil)
 
-		tc := config.Doit.(*TestConfig)
+		tc := config.Doit.(*doctl.TestConfig)
 		tc.SSHFn = func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner {
 			assert.Equal(t, 2222, port)
 			return rm
@@ -104,7 +104,7 @@ func TestSSH_CustomUser(t *testing.T) {
 		rm := &mocks.Runner{}
 		rm.On("Run").Return(nil)
 
-		tc := config.Doit.(*TestConfig)
+		tc := config.Doit.(*doctl.TestConfig)
 		tc.SSHFn = func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner {
 			assert.Equal(t, "foobar", user)
 			return rm
@@ -125,7 +125,7 @@ func TestSSH_AgentForwarding(t *testing.T) {
 		rm := &mocks.Runner{}
 		rm.On("Run").Return(nil)
 
-		tc := config.Doit.(*TestConfig)
+		tc := config.Doit.(*doctl.TestConfig)
 		tc.SSHFn = func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner {
 			assert.Equal(t, true, opts[doctl.ArgsSSHAgentForwarding])
 			return rm
@@ -146,7 +146,7 @@ func TestSSH_CommandExecuting(t *testing.T) {
 		rm := &mocks.Runner{}
 		rm.On("Run").Return(nil)
 
-		tc := config.Doit.(*TestConfig)
+		tc := config.Doit.(*doctl.TestConfig)
 		tc.SSHFn = func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner {
 			assert.Equal(t, "uptime", opts[doctl.ArgSSHCommand])
 			return rm

--- a/doit.go
+++ b/doit.go
@@ -335,6 +335,78 @@ func (c *LiveConfig) GetStringSlice(ns, key string) ([]string, error) {
 	return out, nil
 }
 
+// TestConfig is an implementation of Config for testing.
+type TestConfig struct {
+	SSHFn    func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner
+	v        *viper.Viper
+	IsSetMap map[string]bool
+}
+
+var _ Config = &TestConfig{}
+
+// NewTestConfig creates a new, ready-to-use instance of a TestConfig.
+func NewTestConfig() *TestConfig {
+	return &TestConfig{
+		SSHFn: func(u, h, kp string, p int, opts ssh.Options) runner.Runner {
+			return &MockRunner{}
+		},
+		v:        viper.New(),
+		IsSetMap: make(map[string]bool),
+	}
+}
+
+// GetGodoClient mocks a GetGodoClient call. The returned godo client will
+// be nil.
+func (c *TestConfig) GetGodoClient(trace bool, accessToken string) (*godo.Client, error) {
+	return &godo.Client{}, nil
+}
+
+// SSH returns a mock SSH runner.
+func (c *TestConfig) SSH(user, host, keyPath string, port int, opts ssh.Options) runner.Runner {
+	return c.SSHFn(user, host, keyPath, port, opts)
+}
+
+// Set sets a config key.
+func (c *TestConfig) Set(ns, key string, val interface{}) {
+	nskey := fmt.Sprintf("%s-%s", ns, key)
+	c.v.Set(nskey, val)
+	c.IsSetMap[key] = true
+}
+
+// IsSet returns true if the given key is set on the config.
+func (c *TestConfig) IsSet(key string) bool {
+	return c.IsSetMap[key]
+}
+
+// GetString returns the string value for the key in the given namespace. Because
+// this is a mock implementation, and error will never be returned.
+func (c *TestConfig) GetString(ns, key string) (string, error) {
+	nskey := fmt.Sprintf("%s-%s", ns, key)
+	return c.v.GetString(nskey), nil
+}
+
+// GetInt returns the int value for the key in the given namespace. Because
+// this is a mock implementation, and error will never be returned.
+func (c *TestConfig) GetInt(ns, key string) (int, error) {
+	nskey := fmt.Sprintf("%s-%s", ns, key)
+	return c.v.GetInt(nskey), nil
+}
+
+// GetStringSlice returns the string slice value for the key in the given
+// namespace. Because this is a mock implementation, and error will never be
+// returned.
+func (c *TestConfig) GetStringSlice(ns, key string) ([]string, error) {
+	nskey := fmt.Sprintf("%s-%s", ns, key)
+	return c.v.GetStringSlice(nskey), nil
+}
+
+// GetBool returns the bool value for the key in the given namespace. Because
+// this is a mock implementation, and error will never be returned.
+func (c *TestConfig) GetBool(ns, key string) (bool, error) {
+	nskey := fmt.Sprintf("%s-%s", ns, key)
+	return c.v.GetBool(nskey), nil
+}
+
 // This is needed because an empty StringSlice flag returns `["[]"]`
 func emptyStringSlice(s []string) bool {
 	return len(s) == 1 && s[0] == "[]"


### PR DESCRIPTION
Fixes #479 (and a few other similar cases when I tested manually).

According to Go's JSON marshalling logic, a nil slice is rendered as `null` in JSON. Due to some of the filtering we do on the returned API results, there are cases where we send a pointer to a struct containing only a nil slice to the displaying logic. This ends up being rendered as `null`. To correct this, I've added a check to the JSON displaying logic for any `Displayable` type that writes `[]` instead of `null` for this particular case.

In order to write a test for this, I decided to move the TestConfig from the doctl_test package to the doctl package. This let me import it in the commands_test package to reuse it, and should encourage further reuse.