### PR TITLE
try proposed work-around for snap in production

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,6 +48,7 @@ plugs:
   kube-config:
     interface: personal-files
     write:
+      - $HOME/.kube/config.lock
       - $HOME/.kube/config
 
 apps:


### PR DESCRIPTION
https://forum.snapcraft.io/t/personal-files-request-for-doctl-was-classic-confinement-request-doctl/11785/26

I posted my deep dive into the issue with `.kube/config` to the snap
forums five days ago. In that post I described a work-around for the
configuration file. We've been engaging with Canonical about
kube-config for six weeks now. Let's go ahead and see whether the
work-around works in production, or whether we can only include the
lines we were given in the thread in our interface definition.