### PR TITLE
dbaas: add private-network-uuid to create, migrate, and replica create

### DIFF
--- a/args.go
+++ b/args.go
@@ -253,6 +253,9 @@ const (
 	// ArgDatabasePoolMode is the flag for connection pool mode
 	ArgDatabasePoolMode = "mode"
 
+	// ArgPrivateNetworkUUID is the flag for VPC UUID
+	ArgPrivateNetworkUUID = "private-network-uuid"
+
 	// ArgForce forces confirmation on actions
 	ArgForce = "force"
 )

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -53,6 +53,7 @@ func Databases() *Command {
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgSizeSlug, "", defaultDatabaseNodeSize, "database size")
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseEngine, "", defaultDatabaseEngine, "database engine")
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgVersion, "", defaultDatabaseEngineVersion, "database engine version")
+	AddStringFlag(cmdDatabaseCreate, doctl.ArgPrivateNetworkUUID, "", "", "private network uuid")
 
 	cmdDatabaseDelete := CmdBuilder(cmd, RunDatabaseDelete, "delete <database-id>", "delete database cluster", Writer,
 		aliasOpt("rm"))
@@ -72,6 +73,7 @@ func Databases() *Command {
 	cmdDatabaseMigrate := CmdBuilder(cmd, RunDatabaseMigrate, "migrate <database-id", "migrate a database cluster", Writer,
 		aliasOpt("m"))
 	AddStringFlag(cmdDatabaseMigrate, doctl.ArgRegionSlug, "", "", "new database region", requiredOpt())
+	AddStringFlag(cmdDatabaseMigrate, doctl.ArgPrivateNetworkUUID, "", "", "private network uuid")
 
 	cmd.AddCommand(databaseReplica())
 	cmd.AddCommand(databaseMaintenanceWindow())
@@ -160,6 +162,12 @@ func buildDatabaseCreateRequestFromArgs(c *CmdConfig) (*godo.DatabaseCreateReque
 		return nil, err
 	}
 	r.Version = version
+
+	privateNetworkUUID, err := c.Doit.GetString(c.NS, doctl.ArgPrivateNetworkUUID)
+	if err != nil {
+		return nil, err
+	}
+	r.PrivateNetworkUUID = privateNetworkUUID
 
 	return r, nil
 }
@@ -289,6 +297,12 @@ func buildDatabaseMigrateRequestFromArgs(c *CmdConfig) (*godo.DatabaseMigrateReq
 		return nil, err
 	}
 	r.Region = region
+
+	privateNetworkUUID, err := c.Doit.GetString(c.NS, doctl.ArgPrivateNetworkUUID)
+	if err != nil {
+		return nil, err
+	}
+	r.PrivateNetworkUUID = privateNetworkUUID
 
 	return r, nil
 }
@@ -747,6 +761,8 @@ func databaseReplica() *Command {
 		defaultDatabaseRegion, "database replica region")
 	AddStringFlag(cmdDatabaseReplicaCreate, doctl.ArgSizeSlug, "",
 		defaultDatabaseNodeSize, "database replica size")
+	AddStringFlag(cmdDatabaseReplicaCreate, doctl.ArgPrivateNetworkUUID, "",
+		"", "private network uuid")
 
 	cmdDatabaseReplicaDelete := CmdBuilder(cmd, RunDatabaseReplicaDelete,
 		"delete <database-id> <replica-name>", "delete database replica",
@@ -830,6 +846,12 @@ func buildDatabaseCreateReplicaRequestFromArgs(c *CmdConfig) (*godo.DatabaseCrea
 		return nil, err
 	}
 	r.Region = region
+
+	privateNetworkUUID, err := c.Doit.GetString(c.NS, doctl.ArgPrivateNetworkUUID)
+	if err != nil {
+		return nil, err
+	}
+	r.PrivateNetworkUUID = privateNetworkUUID
 
 	return r, nil
 }

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -56,6 +56,7 @@ var (
 			Users: []godo.DatabaseUser{
 				*testGODOUser,
 			},
+			PrivateNetworkUUID: "1fe49b6c-ac8e-11e9-98cb-3bec94f411bc",
 		},
 	}
 
@@ -92,11 +93,12 @@ var (
 
 	testDBReplica = do.DatabaseReplica{
 		DatabaseReplica: &godo.DatabaseReplica{
-			Name:       "sunny-db-replica",
-			Connection: testGODOConnection,
-			Region:     "nyc1",
-			Status:     "online",
-			CreatedAt:  time.Now(),
+			Name:               "sunny-db-replica",
+			Connection:         testGODOConnection,
+			Region:             "nyc1",
+			Status:             "online",
+			CreatedAt:          time.Now(),
+			PrivateNetworkUUID: "1fe49b6c-ac8e-11e9-98cb-3bec94f411bc",
 		},
 	}
 
@@ -249,12 +251,13 @@ func TestDatabasesList(t *testing.T) {
 
 func TestDatabasesCreate(t *testing.T) {
 	r := &godo.DatabaseCreateRequest{
-		Name:       testDBCluster.Name,
-		Region:     testDBCluster.RegionSlug,
-		Version:    testDBCluster.VersionSlug,
-		EngineSlug: testDBCluster.EngineSlug,
-		NumNodes:   testDBCluster.NumNodes,
-		SizeSlug:   testDBCluster.SizeSlug,
+		Name:               testDBCluster.Name,
+		Region:             testDBCluster.RegionSlug,
+		Version:            testDBCluster.VersionSlug,
+		EngineSlug:         testDBCluster.EngineSlug,
+		NumNodes:           testDBCluster.NumNodes,
+		SizeSlug:           testDBCluster.SizeSlug,
+		PrivateNetworkUUID: testDBCluster.PrivateNetworkUUID,
 	}
 
 	// Successful call
@@ -267,6 +270,7 @@ func TestDatabasesCreate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgVersion, testDBCluster.VersionSlug)
 		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, testDBCluster.EngineSlug)
 		config.Doit.Set(config.NS, doctl.ArgDatabaseNumNodes, testDBCluster.NumNodes)
+		config.Doit.Set(config.NS, doctl.ArgPrivateNetworkUUID, testDBCluster.PrivateNetworkUUID)
 
 		err := RunDatabaseCreate(config)
 		assert.NoError(t, err)
@@ -311,7 +315,8 @@ func TestDatabasesDelete(t *testing.T) {
 
 func TestDatabaseMigrate(t *testing.T) {
 	r := &godo.DatabaseMigrateRequest{
-		Region: testDBCluster.RegionSlug,
+		Region:             testDBCluster.RegionSlug,
+		PrivateNetworkUUID: testDBCluster.PrivateNetworkUUID,
 	}
 
 	// Success
@@ -319,6 +324,7 @@ func TestDatabaseMigrate(t *testing.T) {
 		tm.databases.On("Migrate", testDBCluster.ID, r).Return(nil)
 		config.Args = append(config.Args, testDBCluster.ID)
 		config.Doit.Set(config.NS, doctl.ArgRegionSlug, testDBCluster.RegionSlug)
+		config.Doit.Set(config.NS, doctl.ArgPrivateNetworkUUID, testDBCluster.PrivateNetworkUUID)
 
 		err := RunDatabaseMigrate(config)
 		assert.NoError(t, err)
@@ -329,6 +335,7 @@ func TestDatabaseMigrate(t *testing.T) {
 		tm.databases.On("Migrate", testDBCluster.ID, r).Return(errTest)
 		config.Args = append(config.Args, testDBCluster.ID)
 		config.Doit.Set(config.NS, doctl.ArgRegionSlug, testDBCluster.RegionSlug)
+		config.Doit.Set(config.NS, doctl.ArgPrivateNetworkUUID, testDBCluster.PrivateNetworkUUID)
 
 		err := RunDatabaseMigrate(config)
 		assert.EqualError(t, err, errTest.Error())
@@ -801,9 +808,10 @@ func TestDatabasesListReplicas(t *testing.T) {
 
 func TestDatabaseReplicaCreate(t *testing.T) {
 	r := &godo.DatabaseCreateReplicaRequest{
-		Name:   testDBReplica.Name,
-		Region: testDBReplica.Region,
-		Size:   testDBCluster.SizeSlug,
+		Name:               testDBReplica.Name,
+		Region:             testDBReplica.Region,
+		Size:               testDBCluster.SizeSlug,
+		PrivateNetworkUUID: testDBCluster.PrivateNetworkUUID,
 	}
 
 	// Successful call
@@ -813,6 +821,7 @@ func TestDatabaseReplicaCreate(t *testing.T) {
 		config.Args = append(config.Args, testDBCluster.ID, testDBReplica.Name)
 		config.Doit.Set(config.NS, doctl.ArgRegionSlug, testDBReplica.Region)
 		config.Doit.Set(config.NS, doctl.ArgSizeSlug, testDBCluster.SizeSlug)
+		config.Doit.Set(config.NS, doctl.ArgPrivateNetworkUUID, testDBCluster.PrivateNetworkUUID)
 
 		err := RunDatabaseReplicaCreate(config)
 		assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cpuguy83/go-md2man v1.0.7 // indirect
-	github.com/digitalocean/godo v1.16.0
+	github.com/digitalocean/godo v1.19.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.7.0
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/cpuguy83/go-md2man v1.0.7/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dY
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.16.0 h1:IZm/fNQpnTlYXrnsb7ai/N70SUHn+qsSFRk27Xfnjbs=
-github.com/digitalocean/godo v1.16.0/go.mod h1:AAPQ+tiM4st79QHlEBTg8LM7JQNre4SAQCbn56wEyKY=
+github.com/digitalocean/godo v1.19.0 h1:9ApuchfzGD/XI8Zm0RRnZnytdfYHPjPTRKTnmzQNV7o=
+github.com/digitalocean/godo v1.19.0/go.mod h1:AAPQ+tiM4st79QHlEBTg8LM7JQNre4SAQCbn56wEyKY=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [v1.19.0] - 2019-07-19
+
+- #244 dbaas: add private-network-uuid field to create request
+
+## [v1.18.0] - 2019-07-17
+
+- #241 Databases: support for custom VPC UUID on migrate @mikejholly
+- #240 Add the ability to get URN for a Database @stack72
+- #236 Fix omitempty typos in JSON struct tags @amccarthy1
+
+## [v1.17.0] - 2019-06-21
+
+- #238 Add support for Redis eviction policy in Databases @mikejholly
+
 ## [v1.16.0] - 2019-06-04
 
 - #233 Add Kubernetes DeleteNode method, deprecate RecycleNodePoolNodes @bouk

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -22,6 +22,7 @@ const (
 	databasePoolsPath       = databaseBasePath + "/%s/pools"
 	databaseReplicaPath     = databaseBasePath + "/%s/replicas/%s"
 	databaseReplicasPath    = databaseBasePath + "/%s/replicas"
+	evictionPolicyPath      = databaseBasePath + "/%s/eviction_policy"
 )
 
 // DatabasesService is an interface for interfacing with the databases endpoints
@@ -52,6 +53,8 @@ type DatabasesService interface {
 	ListReplicas(context.Context, string, *ListOptions) ([]DatabaseReplica, *Response, error)
 	CreateReplica(context.Context, string, *DatabaseCreateReplicaRequest) (*DatabaseReplica, *Response, error)
 	DeleteReplica(context.Context, string, string) (*Response, error)
+	GetEvictionPolicy(context.Context, string) (string, *Response, error)
+	SetEvictionPolicy(context.Context, string, string) (*Response, error)
 }
 
 // DatabasesServiceOp handles communication with the Databases related methods
@@ -120,12 +123,13 @@ type DatabaseBackup struct {
 
 // DatabaseCreateRequest represents a request to create a database cluster
 type DatabaseCreateRequest struct {
-	Name       string `json:"name,omitempty"`
-	EngineSlug string `json:"engine,omitempty"`
-	Version    string `json:"version,omitempty"`
-	SizeSlug   string `json:"size,omitempty"`
-	Region     string `json:"region,omitempty"`
-	NumNodes   int    `json:"num_nodes,omitempty"`
+	Name               string `json:"name,omitempty"`
+	EngineSlug         string `json:"engine,omitempty"`
+	Version            string `json:"version,omitempty"`
+	SizeSlug           string `json:"size,omitempty"`
+	Region             string `json:"region,omitempty"`
+	NumNodes           int    `json:"num_nodes,omitempty"`
+	PrivateNetworkUUID string `json:"private_network_uuid"`
 }
 
 // DatabaseResizeRequest can be used to initiate a database resize operation.
@@ -136,7 +140,8 @@ type DatabaseResizeRequest struct {
 
 // DatabaseMigrateRequest can be used to initiate a database migrate operation.
 type DatabaseMigrateRequest struct {
-	Region string `json:"region,omitempty"`
+	Region             string `json:"region,omitempty"`
+	PrivateNetworkUUID string `json:"private_network_uuid"`
 }
 
 // DatabaseUpdateMaintenanceRequest can be used to update the database's maintenance window.
@@ -196,9 +201,10 @@ type DatabaseCreateDBRequest struct {
 
 // DatabaseCreateReplicaRequest is used to create a new read-only replica
 type DatabaseCreateReplicaRequest struct {
-	Name   string `json:"name"`
-	Region string `json:"region"`
-	Size   string `json:"size"`
+	Name               string `json:"name"`
+	Region             string `json:"region"`
+	Size               string `json:"size"`
+	PrivateNetworkUUID string `json:"private_network_uuid"`
 }
 
 type databaseUserRoot struct {
@@ -243,6 +249,14 @@ type databaseReplicaRoot struct {
 
 type databaseReplicasRoot struct {
 	Replicas []DatabaseReplica `json:"replicas"`
+}
+
+type evictionPolicyRoot struct {
+	EvictionPolicy string `json:"eviction_policy"`
+}
+
+func (d Database) URN() string {
+	return ToURN("dbaas", d.ID)
 }
 
 // List returns a list of the Databases visible with the caller's API token
@@ -612,6 +626,36 @@ func (svc *DatabasesServiceOp) CreateReplica(ctx context.Context, databaseID str
 func (svc *DatabasesServiceOp) DeleteReplica(ctx context.Context, databaseID, name string) (*Response, error) {
 	path := fmt.Sprintf(databaseReplicaPath, databaseID, name)
 	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// GetEvictionPolicy loads the eviction policy for a given Redis cluster.
+func (svc *DatabasesServiceOp) GetEvictionPolicy(ctx context.Context, databaseID string) (string, *Response, error) {
+	path := fmt.Sprintf(evictionPolicyPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	root := new(evictionPolicyRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return "", resp, err
+	}
+	return root.EvictionPolicy, resp, nil
+}
+
+// SetEvictionPolicy updates the eviction policy for a given Redis cluster.
+func (svc *DatabasesServiceOp) SetEvictionPolicy(ctx context.Context, databaseID, policy string) (*Response, error) {
+	path := fmt.Sprintf(evictionPolicyPath, databaseID)
+	root := &evictionPolicyRoot{EvictionPolicy: policy}
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, root)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.16.0"
+	libraryVersion = "1.19.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/tags.go
+++ b/vendor/github.com/digitalocean/godo/tags.go
@@ -47,8 +47,8 @@ const (
 
 // Resource represent a single resource for associating/disassociating with tags
 type Resource struct {
-	ID   string       `json:"resource_id,omit_empty"`
-	Type ResourceType `json:"resource_type,omit_empty"`
+	ID   string       `json:"resource_id,omitempty"`
+	Type ResourceType `json:"resource_type,omitempty"`
 }
 
 // TaggedResources represent the set of resources a tag is attached to

--- a/vendor/github.com/spf13/afero/go.sum
+++ b/vendor/github.com/spf13/afero/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/blang/semver
 github.com/cpuguy83/go-md2man/md2man
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.16.0
+# github.com/digitalocean/godo v1.19.0
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util
 # github.com/dustin/go-humanize v1.0.0


### PR DESCRIPTION
This adds the `private-network-uuid` field to Database creates, migrates and replica creates so that users can use `doctl` to move/create their Databases inside of their private networks/VPCs.

cc: @hilary @mikejholly 