### PR TITLE
Fix distfile basename in staging script

### DIFF
--- a/scripts/stage.sh
+++ b/scripts/stage.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 major=$1
 minor=$2
 patch=$3
-label=$4
+label=${4-}
 
 if [[ -z "$major" || -z "$minor" || -z "$patch" ]]; then
   echo "usage: $0 <major> <minor> <patch> [label]"
@@ -29,7 +29,7 @@ STAGE_DIR=$OUTPUT_DIR/stage
 RELEASE_DIR=$OUTPUT_DIR/release
 mkdir -p "$STAGE_DIR" "$RELEASE_DIR"
 
-if [[ -z $SKIPBUILD ]]; then
+if [[ -z ${SKIPBUILD-} ]]; then
   echo "building doctl"
 
   baseFlag="-X github.com/digitalocean/doctl"
@@ -52,7 +52,7 @@ fi
 cd "$RELEASE_DIR"
 
 for f in "$STAGE_DIR"/*; do
-  distfile_basename=$(basename "${f}%.exe")
+  distfile_basename=$(basename "${f%".exe"}")
 
   if [[ $f == *"windows"* ]]; then
     distfile=${distfile_basename}.zip


### PR DESCRIPTION
Before this change, the basename would always be generated to contain the string `.exe`. This fixes the script in a shellcheck-compliant way so that we're back to the old behaviour.

It also fixes the error introduced by the `u` flag in `set -euo pipefail` when the script is invoked without a `label` or set `SKIPBUILD` so that those fall back to an empty default value.