### PR TITLE
Die hardcoded version, die

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ _vendor-*
 
 /out
 
+# Build artifacts
+Dockerfile-e
+
 # Snapcraft
 parts/
 prime/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,12 +113,9 @@ You will also need a valid `GITHUB_TOKEN` environment variable with access to th
 1. Run `make changelog` and add the results to the [CHANGELOG](https://github.com/digitalocean/doctl/blob/master/CHANGELOG.md)
    under the version you're going to release if they aren't already there.
 
-   Update the version in:
-
-   * `doit.go`
-   * `Dockerfile`
-
 1. Generate a PR, get it reviewed, and merge
+
+1. Run `make bump-version`.
 
 1. To build `doctl` for all its platforms, run `scripts/stage.sh major minor patch` 
 (e.g. `scripts/stage.sh 1 5 0`). This will place all files and their checksums 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
+# docker build -t doctl_local --build-arg DOCTL_VERSION=1.23.1 .
+#
+# This Dockerfile exists so casual uses of `docker build` and `docker run` do something sane.
+# We don't recommend using it: If you want to develop in docker, please use `make docker_build`
+# instead.
+
 FROM alpine:3.8
 
-ENV DOCTL_VERSION=1.23.1
+ARG DOCTL_VERSION
+ENV DOCTL_VERSION=$DOCTL_VERSION
 
 RUN apk add --no-cache curl
 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,11 @@ shellcheck:
 	@echo "analyze shell scripts"
 	scripts/shell_check.sh
 
+.PHONY: version
+version:
+	@echo "doctl version"
+	scripts/version.sh
+
 my_d = $(shell pwd)
 OUT_D = $(shell echo $${OUT_D:-$(my_d)/builds})
 

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,27 @@ version:
 	@echo "doctl version"
 	scripts/version.sh
 
+# Bump defaults to patch. We provide friendly aliases
+# for patch, minor and major
+BUMP ?= patch
+ifeq ($(BUMP),bugfix)
+  BUMP = patch
+else ifeq ($(BUMP),feature)
+  BUMP = minor
+else ifeq ($(BUMP),breaking)
+  BUMP = major
+endif
+
+.PHONY: bump-version
+bump-version:
+	@echo "BUMP=<patch|feature|breaking> bump version"
+	@GO111MODULE=off go get -u github.com/jessfraz/junk/sembump # update sembump tool
+	$(eval VERSION = $(shell ./scripts/version.sh -s))
+	$(eval NEW_VERSION = $(shell sembump --kind $(BUMP) $(VERSION)))
+	@echo "Bumping VERSION from v$(VERSION) to v$(NEW_VERSION)"
+	@echo "v$(NEW_VERSION)" > VERSION
+	@sed -i'' -e 's/${VERSION}/${NEW_VERSION}/g' Dockerfile
+
 my_d = $(shell pwd)
 OUT_D = $(shell echo $${OUT_D:-$(my_d)/builds})
 

--- a/doit.go
+++ b/doit.go
@@ -43,32 +43,21 @@ const (
 	LatestReleaseURL = "https://api.github.com/repos/digitalocean/doctl/releases/latest"
 )
 
+// Version is the version info for doit.
+type Version struct {
+	Major, Minor, Patch int
+	Name, Build, Label  string
+}
+
 var (
 	// DoitConfig holds the app's current configuration.
 	DoitConfig Config = &LiveConfig{}
 
-	// DoitVersion is doit's version.
-	DoitVersion = Version{
-		Major: 1,
-		Minor: 23,
-		Patch: 1,
-		Label: "dev",
-	}
+	// Build, Major, Minor, Patch and Label are set at build time
+	Build, Major, Minor, Patch, Label string
 
-	// Build is doit's build tag.
-	Build string
-
-	// Major is doctl's major version.
-	Major string
-
-	// Minor is doctl's minor version.
-	Minor string
-
-	// Patch is doctl's patch version.
-	Patch string
-
-	// Label is doctl's label.
-	Label string
+	// DoitVersion is doctl's version.
+	DoitVersion Version
 
 	// TraceHTTP traces http connections.
 	TraceHTTP bool
@@ -76,12 +65,27 @@ var (
 
 func init() {
 	jww.SetStdoutThreshold(jww.LevelError)
-}
 
-// Version is the version info for doit.
-type Version struct {
-	Major, Minor, Patch int
-	Name, Build, Label  string
+	if Build != "" {
+		DoitVersion.Build = Build
+	}
+	if Major != "" {
+		i, _ := strconv.Atoi(Major)
+		DoitVersion.Major = i
+	}
+	if Minor != "" {
+		i, _ := strconv.Atoi(Minor)
+		DoitVersion.Minor = i
+	}
+	if Patch != "" {
+		i, _ := strconv.Atoi(Patch)
+		DoitVersion.Patch = i
+	}
+	if Label == "" {
+		DoitVersion.Label = "dev"
+	} else {
+		DoitVersion.Label = Label
+	}
 }
 
 func (v Version) String() string {

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,11 +1,52 @@
 #!/usr/bin/env bash
 
-set -eou pipefail
+# do NOT use pipefail in this script, as it will cause problems with the version
+# line
+
+set -e
+
+me=$(basename "$0")
+
+help_message="\
+Usage: $me [<options>]
+Display doctl version
+
+Options:
+
+  -h, --help  Show this help information.
+  -s, --short major.minor.patch only
+"
+
+parse_args() {
+  while : ; do
+    if [[ $1 = "-h" || $1 = "--help" ]]; then
+      echo "$help_message"
+      return 0
+    elif [[ $1 = "-s" || $1 = "--short" ]]; then
+      short=true
+      shift
+    else
+      break
+    fi
+  done
+}
+
+parse_args "$@"
+
+if ! git diff --exit-code --quiet --cached; then
+  echo "Aborting due to uncommitted changes in the index" >&2
+  exit 1
+fi
 
 version=$(git fetch --tags &>/dev/null | git tag -l | sort --version-sort | tail -n1 | cut -c 2-)
 
+if [[ $short = true ]]; then
+  echo "$version"
+  exit 0
+fi
+
 branch=$(git rev-parse --abbrev-ref HEAD)
-if [[ $branch != 'master' ]]; then
+if [[ $branch != 'master' && $branch != HEAD ]]; then
   version=${version}-${branch}
 fi
 


### PR DESCRIPTION
The `VERSION` file serves as a bridge between when we bump the version and when we tag it... I keep oscillating as to whether to run `bump-version` before or after submitting the PR for review.

Of course, once we're at CD, that will go away (yay).