### PR TITLE
set ldflags in snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,17 @@ parts:
     override-build: |
       version=$(scripts/version.sh)
       snapcraftctl set-version ${version}
-      GO111MODULE=on go build -mod=vendor -o doctl cmd/doctl/main.go
+
+      short=${version%+*}
+      short=${short%-*}
+      baseFlag="-X github.com/digitalocean/doctl"
+      ldFlags="${baseFlag}.Label=release ${baseFlag}.Build=$(git rev-parse --short HEAD)"
+      ldFlags="${ldFlags} ${baseFlag}.Major=$(echo ${short} | cut -d'.' -f1)"
+      ldFlags="${ldFlags} ${baseFlag}.Minor=$(echo ${short} | cut -d'.' -f2)"
+      ldFlags="${ldFlags} ${baseFlag}.Patch=$(echo ${short} | cut -d'.' -f3 | cut -d'+' -f1)"
+
+      GO111MODULE=on go build -ldflags "${ldFlags}" -mod=vendor -o doctl cmd/doctl/main.go
+
       chmod +x doctl
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
       mv doctl $SNAPCRAFT_PART_INSTALL/bin/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,4 @@
 name: doctl
-version-script: scripts/version.sh
 version: git
 summary: A command line tool for DigitalOcean services
 description: doctl is a command line tool for DigitalOcean services using the API.
@@ -33,6 +32,8 @@ parts:
     override-pull: |
       git clone https://github.com/digitalocean/doctl.git .
     override-build: |
+      version=$(scripts/version.sh)
+      snapcraftctl set-version ${version}
       GO111MODULE=on go build -mod=vendor -o doctl cmd/doctl/main.go
       chmod +x doctl
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin


### PR DESCRIPTION
also updated how the version is set because `version-script` has been deprecated