### PR TITLE
move test helpers to test

### DIFF
--- a/commands/confirmation.go
+++ b/commands/confirmation.go
@@ -1,34 +1,8 @@
 package commands
 
 import (
-	"bufio"
 	"fmt"
-	"io"
-	"os"
-	"strings"
 )
-
-// retriveUserInput is a function that can retrive user input in form of string. By default,
-// it will prompt the user. In test, you can replace this with code that returns the appropriate response.
-var retrieveUserInput = func(message string) (string, error) {
-	return readUserInput(os.Stdin, message)
-}
-
-// readUserInput is similar to retrieveUserInput but takes an explicit
-// io.Reader to read user input from. It is meant to allow simplified testing
-// as to-be-read inputs can be injected conveniently.
-func readUserInput(in io.Reader, message string) (string, error) {
-	reader := bufio.NewReader(in)
-	warnConfirm("Are you sure you want to " + message + " (y/N) ? ")
-	answer, err := reader.ReadString('\n')
-	if err != nil {
-		return "", err
-	}
-
-	answer = strings.TrimRight(answer, "\r\n")
-
-	return strings.ToLower(answer), nil
-}
 
 // AskForConfirm parses and verifies user input for confirmation.
 func AskForConfirm(message string) error {

--- a/commands/confirmation_test.go
+++ b/commands/confirmation_test.go
@@ -1,13 +1,36 @@
 package commands
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var retrieveUserInput = func(message string) (string, error) {
+	return readUserInput(os.Stdin, message)
+}
+
+// readUserInput is similar to retrieveUserInput but takes an explicit
+// io.Reader to read user input from. It is meant to allow simplified testing
+// as to-be-read inputs can be injected conveniently.
+func readUserInput(in io.Reader, message string) (string, error) {
+	reader := bufio.NewReader(in)
+	warnConfirm("Are you sure you want to " + message + " (y/N) ? ")
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	answer = strings.TrimRight(answer, "\r\n")
+
+	return strings.ToLower(answer), nil
+}
 
 func TestAskForConfirmYes(t *testing.T) {
 	rui := retrieveUserInput


### PR DESCRIPTION
a small bit bit of cleanup in passing

both of these helpers are only used in the test file, so I moved them to the test file. Notice, however, that, by moving them to the test, I removed four imports from the production module!

Don't prematurely generalize... 