### PR TITLE
Revert "move test helpers to test"

### DIFF
--- a/commands/confirmation.go
+++ b/commands/confirmation.go
@@ -1,8 +1,34 @@
 package commands
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"os"
+	"strings"
 )
+
+// retriveUserInput is a function that can retrive user input in form of string. By default,
+// it will prompt the user. In test, you can replace this with code that returns the appropriate response.
+var retrieveUserInput = func(message string) (string, error) {
+	return readUserInput(os.Stdin, message)
+}
+
+// readUserInput is similar to retrieveUserInput but takes an explicit
+// io.Reader to read user input from. It is meant to allow simplified testing
+// as to-be-read inputs can be injected conveniently.
+func readUserInput(in io.Reader, message string) (string, error) {
+	reader := bufio.NewReader(in)
+	warnConfirm("Are you sure you want to " + message + " (y/N) ? ")
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	answer = strings.TrimRight(answer, "\r\n")
+
+	return strings.ToLower(answer), nil
+}
 
 // AskForConfirm parses and verifies user input for confirmation.
 func AskForConfirm(message string) error {

--- a/commands/confirmation_test.go
+++ b/commands/confirmation_test.go
@@ -1,36 +1,13 @@
 package commands
 
 import (
-	"bufio"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var retrieveUserInput = func(message string) (string, error) {
-	return readUserInput(os.Stdin, message)
-}
-
-// readUserInput is similar to retrieveUserInput but takes an explicit
-// io.Reader to read user input from. It is meant to allow simplified testing
-// as to-be-read inputs can be injected conveniently.
-func readUserInput(in io.Reader, message string) (string, error) {
-	reader := bufio.NewReader(in)
-	warnConfirm("Are you sure you want to " + message + " (y/N) ? ")
-	answer, err := reader.ReadString('\n')
-	if err != nil {
-		return "", err
-	}
-
-	answer = strings.TrimRight(answer, "\r\n")
-
-	return strings.ToLower(answer), nil
-}
 
 func TestAskForConfirmYes(t *testing.T) {
 	rui := retrieveUserInput


### PR DESCRIPTION
Reverts digitalocean/doctl#542, as as master currently won’t build due to `retrieveUserInput` not being defined in `AskForConfirm` in commands/confirmation.go. The test suite doesn't report this as a failure, as that function _is_ defined in commands/confirmation_test.go. Might be worth adding a `go build` command to our CI to catch things like this in the future, although I can't imagine they'd be too common.