### PR TITLE
Support --wait flag on volume-action commands

### DIFF
--- a/commands/volume_actions.go
+++ b/commands/volume_actions.go
@@ -59,11 +59,13 @@ func VolumeAction() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunVolumeAttach, "attach <volume-id> <droplet-id>", "attach a volume", Writer,
+	cmdRunVolumeAttach := CmdBuilder(cmd, RunVolumeAttach, "attach <volume-id> <droplet-id>", "attach a volume", Writer,
 		aliasOpt("a"))
+	AddBoolFlag(cmdRunVolumeAttach, doctl.ArgCommandWait, "", false, "Wait for volume to attach")
 
-	CmdBuilder(cmd, RunVolumeDetach, "detach <volume-id> <droplet-id>", "detach a volume", Writer,
+	cmdRunVolumeDetach := CmdBuilder(cmd, RunVolumeDetach, "detach <volume-id> <droplet-id>", "detach a volume", Writer,
 		aliasOpt("d"))
+	AddBoolFlag(cmdRunVolumeDetach, doctl.ArgCommandWait, "", false, "Wait for volume to detach")
 
 	CmdBuilder(cmd, RunVolumeDetach, "detach-by-droplet-id <volume-id> <droplet-id>", "detach a volume (deprecated - use detach instead)",
 		Writer)
@@ -74,6 +76,7 @@ func VolumeAction() *Command {
 		requiredOpt())
 	AddStringFlag(cmdRunVolumeResize, doctl.ArgRegionSlug, "", "", "Volume region",
 		requiredOpt())
+	AddBoolFlag(cmdRunVolumeResize, doctl.ArgCommandWait, "", false, "Wait for volume to resize")
 
 	return cmd
 

--- a/commands/volume_actions_test.go
+++ b/commands/volume_actions_test.go
@@ -36,6 +36,18 @@ func TestVolumeActionsAttach(t *testing.T) {
 		err := RunVolumeAttach(config)
 		assert.NoError(t, err)
 	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.volumeActions.EXPECT().Attach(testVolume.ID, testDroplet.ID).Return(&testAction, nil)
+		tm.actions.EXPECT().Get(1).Return(&testAction, nil)
+
+		config.Args = append(config.Args, testVolume.ID)
+		config.Args = append(config.Args, fmt.Sprintf("%d", testDroplet.ID))
+		config.Doit.Set(config.NS, doctl.ArgCommandWait, true)
+
+		err := RunVolumeAttach(config)
+		assert.NoError(t, err)
+	})
 }
 
 func TestVolumeDetach(t *testing.T) {
@@ -43,6 +55,18 @@ func TestVolumeDetach(t *testing.T) {
 		tm.volumeActions.EXPECT().Detach(testVolume.ID, testDroplet.ID).Return(&testAction, nil)
 		config.Args = append(config.Args, testVolume.ID)
 		config.Args = append(config.Args, fmt.Sprintf("%d", testDroplet.ID))
+
+		err := RunVolumeDetach(config)
+		assert.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.volumeActions.EXPECT().Detach(testVolume.ID, testDroplet.ID).Return(&testAction, nil)
+		tm.actions.EXPECT().Get(1).Return(&testAction, nil)
+
+		config.Args = append(config.Args, testVolume.ID)
+		config.Args = append(config.Args, fmt.Sprintf("%d", testDroplet.ID))
+		config.Doit.Set(config.NS, doctl.ArgCommandWait, true)
 
 		err := RunVolumeDetach(config)
 		assert.NoError(t, err)
@@ -56,6 +80,20 @@ func TestVolumeResize(t *testing.T) {
 
 		config.Doit.Set(config.NS, doctl.ArgSizeSlug, 150)
 		config.Doit.Set(config.NS, doctl.ArgRegionSlug, "dev0")
+
+		err := RunVolumeResize(config)
+		assert.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.volumeActions.EXPECT().Resize(testVolume.ID, 150, "dev0").Return(&testAction, nil)
+		tm.actions.EXPECT().Get(1).Return(&testAction, nil)
+
+		config.Args = append(config.Args, testVolume.ID)
+
+		config.Doit.Set(config.NS, doctl.ArgSizeSlug, 150)
+		config.Doit.Set(config.NS, doctl.ArgRegionSlug, "dev0")
+		config.Doit.Set(config.NS, doctl.ArgCommandWait, true)
 
 		err := RunVolumeResize(config)
 		assert.NoError(t, err)


### PR DESCRIPTION
Fixes #543

Adds support for the wait flag on all volume-action commands. Since each command ends up calling `performVolumeAction` which supports the `--wait` flag, this fix was just a matter of defining that flag on each command.