### PR TITLE
disable usage statement on error

### DIFF
--- a/commands/doit.go
+++ b/commands/doit.go
@@ -480,10 +480,10 @@ func cmdBuilderWithInit(parent *Command, cr CmdRunner, cliText, desc string, out
 				args,
 				initCmd,
 			)
-			checkErr(err, cmd)
+			checkErr(err)
 
 			err = cr(c)
-			checkErr(err, cmd)
+			checkErr(err)
 		},
 	}
 

--- a/commands/errors.go
+++ b/commands/errors.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/shiena/ansicolor"
-	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
@@ -47,7 +46,7 @@ type outputError struct {
 	Detail string `json:"detail"`
 }
 
-func checkErr(err error, cmd ...*cobra.Command) {
+func checkErr(err error) {
 	if err == nil {
 		return
 	}
@@ -56,9 +55,6 @@ func checkErr(err error, cmd ...*cobra.Command) {
 
 	switch output {
 	default:
-		if len(cmd) > 0 {
-			cmd[0].Help()
-		}
 		fmt.Fprintf(color.Output, "%s: %v\n", colorErr, err)
 	case "json":
 		es := outputErrors{

--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Doctl Authors All rights reserved.
+Copyright 2018-2019 The Doctl Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,7 +15,7 @@ package doctl
 
 import "fmt"
 
-// MissingArgsErr is an error returned when their are too few arguments for a command.
+// MissingArgsErr is returned when there are too few arguments for a command.
 type MissingArgsErr struct {
 	Command string
 }
@@ -31,7 +31,7 @@ func (e *MissingArgsErr) Error() string {
 	return fmt.Sprintf("(%s) command is missing required arguments", e.Command)
 }
 
-// InvalidURNErr is an error returned when their are too few arguments for a command.
+// InvalidURNErr is returned when the URN format is not valid.
 type InvalidURNErr struct {
 	URN string
 }


### PR DESCRIPTION
in time we'll leverage cobra's innate usage statement management, but for now let's just stop obscuring the actual error message