### PR TITLE
refactor old scripts/build.sh to use make native

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,12 +3,8 @@
 set -eou pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-OUT_DIR="$DIR/../out"
-mkdir -p "$OUT_DIR"
+OUT_D="$DIR/../out"
 
-go build \
-  -o "$OUT_DIR/doctl" \
-  -ldflags "-X github.com/digitalocean/doctl/Build=$(git rev-parse --short HEAD)" \
-  github.com/digitalocean/doctl/cmd/doctl
+cd "$DIR/../." && OUT_D="$OUT_D" make native
 
-chmod +x "$OUT_DIR/doctl"
+chmod +x "$OUT_D/doctl"


### PR DESCRIPTION
we should deprecate this at some point and remove it, but it's not doing any harm at this point.