### PR TITLE
Add note about ORIGIN env var for releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,10 @@ and let TravisCI run shellcheck for you.
 
 1. Cut a release using `BUMP=(bugfix|feature|breaking) make bump_and_release`. 
    (Bugfix, feature and breaking are aliases for semver's patch, minor and major.
-   BUMP will also accept `patch`, `minor` and `major`, if you prefer.)
+   BUMP will also accept `patch`, `minor` and `major`, if you prefer). The command
+   assumes you have a remote repository named `origin` pointing to this
+   repository. If you'd prefer to specify a different remote repository, you can
+   do so by setting `ORIGIN=(preferred remote name)`.
 
 #### Oops! What now?
 


### PR DESCRIPTION
Adds a note to mention the `ORIGIN` environment variable that can be used to control which remote repo we release to. Given that the recommended setup for our team is to work on one of our own forks, it makes sense that some of us have `origin` set to that fork, so this note should clarify that we can release to something like `upstream` via `ORIGIN=upstream make bump_and_release`, for example.

---

@hilary Feel free to decline this if you think it adds too much verbosity to the doc. Just figured I'd raise this since I was pretty surprised when I realized halfway through a release that I was releasing to my own fork 😄