### PR TITLE
Make sure setting variable `DIR` before called on scripts/_build.sh

### DIFF
--- a/scripts/_build.sh
+++ b/scripts/_build.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../"
+OUT_D=${OUT_D:-${DIR}/builds}
+mkdir -p "$OUT_D"
+
 base="-X github.com/digitalocean/doctl."
 build="$("$DIR"/scripts/version.sh -c)"
 ldflags="${base}Build=${build}"
@@ -15,10 +19,6 @@ ldflags="${ldflags} ${base}Minor=${minor}"
 
 patch="$(echo "$version" | cut -d . -f3)"
 ldflags="${ldflags} ${base}Patch=${patch}"
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../"
-OUT_D=${OUT_D:-${DIR}/builds}
-mkdir -p "$OUT_D"
 
 (
   export GOOS=${GOOS:-linux}


### PR DESCRIPTION
Fix error like below when invoking `make native` to build doctl executable:
```
$ make native
=> building doctl via go build

scripts/_build.sh: line 6: DIR: unbound variable
make: *** [Makefile:43: _build] Error 1
```