### PR TITLE
Don't assume the fd for stdin is 0

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/digitalocean/doctl"
 
@@ -41,7 +42,7 @@ func retrieveUserTokenFromCommandLine() (string, error) {
 	}
 
 	fmt.Print("DigitalOcean access token: ")
-	passwdBytes, err := terminal.ReadPassword(0)
+	passwdBytes, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #573

On Unix, the file descriptor for stdin is 0. On Windows, this isn't the case, so we need to use `syscall.Stdin` to get the correct file descriptor in order to use `terminal.ReadPassword`, as noted in this Go issue: https://github.com/golang/go/issues/11914.