### PR TITLE
DOKS: support creating empty node pool

### DIFF
--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1293,11 +1293,14 @@ func buildNodePoolCreateRequestFromArgs(c *CmdConfig, r *godo.KubernetesNodePool
 	}
 	r.Size = size
 
-	count, err := c.Doit.GetInt(c.NS, doctl.ArgNodePoolCount)
+	count, err := c.Doit.GetIntPtr(c.NS, doctl.ArgNodePoolCount)
 	if err != nil {
 		return err
 	}
-	r.Count = count
+	if count == nil {
+		count = intPtr(0)
+	}
+	r.Count = *count
 
 	tags, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTag)
 	if err != nil {
@@ -1815,4 +1818,12 @@ func versionMaxBy(versions []do.KubernetesVersion, selector func(do.KubernetesVe
 func versionSortBy(versions []do.KubernetesVersion, less func(i, j do.KubernetesVersion) bool) []do.KubernetesVersion {
 	sort.Slice(versions, func(i, j int) bool { return less(versions[i], versions[j]) })
 	return versions
+}
+
+func boolPtr(val bool) *bool {
+	return &val
+}
+
+func intPtr(val int) *int {
+	return &val
 }

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -994,11 +994,3 @@ func TestLatestVersionForUpgrade(t *testing.T) {
 		})
 	}
 }
-
-func boolPtr(val bool) *bool {
-	return &val
-}
-
-func intPtr(val int) *int {
-	return &val
-}


### PR DESCRIPTION
Currently when trying to create a Kubernetes cluster node pool with `--count=0`, we hit this error:
```shell
$ doctl k c np create blue --count=0 --auto-scale=true --min-nodes=1 --max-nodes=2 --size=s-1vcpu-2gb --name=blue-2
Error: (node-pool.create.count) command is missing required arguments
```

This PR fixes that.