### PR TITLE
remove extracted error and make more informative

### DIFF
--- a/commands/projects.go
+++ b/commands/projects.go
@@ -216,7 +216,7 @@ func RunProjectResourcesGet(c *CmdConfig) error {
 
 	parts, isValid := validateURN(urn)
 	if !isValid {
-		return doctl.NewInvalidURNErr(urn)
+		return fmt.Errorf(`URN must be in the format "do:<resource_type>:<resource_id>" but was %q`, urn)
 	}
 
 	c.Args = []string{parts[2]}

--- a/commands/projects_test.go
+++ b/commands/projects_test.go
@@ -194,7 +194,7 @@ func TestProjectResourcesGetWithInvalidURN(t *testing.T) {
 		config.Args = append(config.Args, "fakeurn")
 		err := RunProjectResourcesGet(config)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "URN must be in the format")
+		assert.Contains(t, err.Error(), `URN must be in the format "do:<resource_type>:<resource_id>" but was "fakeurn"`)
 	})
 }
 

--- a/errors.go
+++ b/errors.go
@@ -30,19 +30,3 @@ func NewMissingArgsErr(cmd string) *MissingArgsErr {
 func (e *MissingArgsErr) Error() string {
 	return fmt.Sprintf("(%s) command is missing required arguments", e.Command)
 }
-
-// InvalidURNErr is returned when the URN format is not valid.
-type InvalidURNErr struct {
-	URN string
-}
-
-var _ error = &InvalidURNErr{}
-
-// NewInvalidURNErr creates a InvalidURNErr instance.
-func NewInvalidURNErr(urn string) *InvalidURNErr {
-	return &InvalidURNErr{URN: urn}
-}
-
-func (e *InvalidURNErr) Error() string {
-	return fmt.Sprintf("URN must be in the format \"do:<resource_type>:<resource_id>\"")
-}

--- a/errors_test.go
+++ b/errors_test.go
@@ -23,8 +23,3 @@ func TestMissingArgsErr(t *testing.T) {
 	err := NewMissingArgsErr("test-cmd")
 	assert.Equal(t, "(test-cmd) command is missing required arguments", err.Error())
 }
-
-func TestInvalidURNErr(t *testing.T) {
-	err := NewInvalidURNErr("Darth Vader")
-	assert.Equal(t, "URN must be in the format \"do:<resource_type>:<resource_id>\"", err.Error())
-}


### PR DESCRIPTION
- This error type was exracted but only being used
in one place. Condensing means we have one less
extracted piece of code to go find / maintain
later (especially when its not shared).
- I've also gone and ahead and implemented what
seems to be the errors original intent, show the
malformed URN with your error (this was not implemented)