### PR TITLE
Restore old config file location

### DIFF
--- a/commands/doit.go
+++ b/commands/doit.go
@@ -48,22 +48,30 @@ var (
 	Writer           = os.Stdout
 
 	// PFlag vars
-	APIURL           string // customize API base URL
-	Context          string // current auth context
-	Output           string // global output format
-	Token            string // global authorization token
-	Trace            bool   // toggles http tracing output
-	Verbose          bool
+	APIURL  string // customize API base URL
+	Context string // current auth context
+	Output  string // global output format
+	Token   string // global authorization token
+	Trace   bool   // toggles http tracing output
+	Verbose bool
 	// end PFlag vars
 
+	cfgDir        string                    // full path to the config directory
 	cfgFile       string                    // full path to config file
 	cfgFileWriter = defaultConfigFileWriter // create default cfgFileWriter
 	requiredColor = color.New(color.Bold).SprintfFunc()
 )
 
 func init() {
+	cfgDir = findConfigDir()
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+	cfgFile = filepath.Join(cfgDir, defaultConfigName)
+
 	DoitCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c",
-		filepath.Join(configHome(), defaultConfigName), "config file")
+		cfgFile, "config file")
 	cobra.OnInitialize(initConfig)
 
 	DoitCmd.PersistentFlags().StringVarP(&APIURL, "api-url", "u", "", "Override default API V2 endpoint")
@@ -82,14 +90,6 @@ func init() {
 	viper.BindEnv("enable-beta", "DIGITALOCEAN_ENABLE_BETA")
 
 	addCommands()
-}
-
-// in case we ever want to change this, or let folks configure it...
-func configHome() string {
-	cfgDir, err := os.UserConfigDir()
-	checkErr(err)
-
-	return filepath.Join(cfgDir, "doctl")
 }
 
 func initConfig() {

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -248,7 +248,7 @@ func kubernetesKubeconfig() *Command {
 }
 
 func kubeconfigCachePath() string {
-	return filepath.Join(configHome(), "cache", "exec-credential")
+	return filepath.Join(cfgDir, "cache", "exec-credential")
 }
 
 func kubernetesNodePools() *Command {

--- a/commands/xdg.go
+++ b/commands/xdg.go
@@ -1,0 +1,26 @@
+// Copyright 2019 The Doctl Authors All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func findConfigDir() string {
+	if xdgPath := os.Getenv("XDG_CONFIG_HOME"); xdgPath != "" {
+		return filepath.Join(xdgPath, "doctl")
+	}
+	return filepath.Join(os.Getenv("HOME"), ".config", "doctl")
+}

--- a/commands/xdg_test.go
+++ b/commands/xdg_test.go
@@ -12,15 +12,13 @@ const (
 )
 
 func Test_findConfigDir(t *testing.T) {
-	var expectedConfigDir string
-	actualConfigDir := findConfigDir()
-
 	switch runtime.GOOS {
 	case goosDarwin, goosLinux:
-		expectedConfigDir = "/.config/doctl"
-	}
+		expectedConfigDir := "/.config/doctl"
+		actualConfigDir := findConfigDir()
 
-	if !strings.Contains(actualConfigDir, expectedConfigDir) {
-		t.Fatalf("expected %s to contain %s", actualConfigDir, expectedConfigDir)
+		if !strings.Contains(actualConfigDir, expectedConfigDir) {
+			t.Fatalf("expected %s to contain %s", actualConfigDir, expectedConfigDir)
+		}
 	}
 }

--- a/commands/xdg_test.go
+++ b/commands/xdg_test.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	goosDarwin = "darwin"
+	goosLinux  = "linux"
+)
+
+func Test_findConfigDir(t *testing.T) {
+	var expectedConfigDir string
+	actualConfigDir := findConfigDir()
+
+	switch runtime.GOOS {
+	case goosDarwin, goosLinux:
+		expectedConfigDir = "/.config/doctl"
+	}
+
+	if !strings.Contains(actualConfigDir, expectedConfigDir) {
+		t.Fatalf("expected %s to contain %s", actualConfigDir, expectedConfigDir)
+	}
+}

--- a/commands/xdg_windows.go
+++ b/commands/xdg_windows.go
@@ -18,7 +18,7 @@ import (
 	"path/filepath"
 )
 
-func findConfigDir() (string, error) {
+func findConfigDir() string {
 	cfgHome := os.Getenv("LOCALAPPDATA")
 	if cfgHome == "" {
 		// Resort to APPDATA for Windows XP users.

--- a/commands/xdg_windows.go
+++ b/commands/xdg_windows.go
@@ -1,0 +1,34 @@
+// Copyright 2019 The Doctl Authors All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func findConfigDir() (string, error) {
+	cfgHome := os.Getenv("LOCALAPPDATA")
+	if cfgHome == "" {
+		// Resort to APPDATA for Windows XP users.
+		cfgHome = os.Getenv("APPDATA")
+		if cfgHome == "" {
+			// If still empty, use the default path
+			userName := os.Getenv("USERNAME")
+			cfgHome = filepath.Join("C:/", "Users", userName, "AppData", "Local")
+		}
+	}
+
+	return filepath.Join(cfgHome, "doctl", "config")
+}


### PR DESCRIPTION
Relates to #595.

In our most recent release, we created two issues,

• We stopped creating the directory where the config lives for users who had just installed doctl, causing file creates to fail,
• The default Go 1.13 behaviour changed the expected location of the config file, so all users who updated ended up needing to create a new config file, which breaks due to the above point.

This restores the old behaviour, minus the check for the legacy config, as I don't think that's needed anymore.