### PR TITLE
adds default config integration test

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -77,7 +77,7 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	if len(contents) != 0 {
-		err = ioutil.WriteFile(location, contents, 0700)
+		err = ioutil.WriteFile(location, contents, 0644)
 		if err != nil {
 			panic("failed to restore contents of config")
 		}


### PR DESCRIPTION
Now that we have this config this test is potentially destructive to a users config, if they run the test locally. We've tried to mitigate this in the test setup / teardown by having it copy / re save the config that was originally there (if it exists).

- missing integration test was added to make sure we don't accidentally reconfigure the spot our config file is stored in.
- formatting changed here because it was not `go fmt` correctly (still wouldn't pass golint but that's another PR)

