### PR TITLE
nuke NSRoot from space!

### DIFF
--- a/commands/doit.go
+++ b/commands/doit.go
@@ -268,21 +268,17 @@ func AddStringSliceFlag(cmd *Command, name, shorthand string, def []string, desc
 }
 
 func flagName(cmd *Command, name string) string {
-	parentName := doctl.NSRoot
 	if cmd.Parent() != nil {
-		parentName = cmd.Parent().Name()
+		return fmt.Sprintf("%s.%s.%s", cmd.Parent().Name(), cmd.Name(), name)
 	}
-
-	return fmt.Sprintf("%s.%s.%s", parentName, cmd.Name(), name)
+	return fmt.Sprintf("%s.%s", cmd.Name(), name)
 }
 
 func cmdNS(cmd *cobra.Command) string {
-	parentName := doctl.NSRoot
 	if cmd.Parent() != nil {
-		parentName = cmd.Parent().Name()
+		return fmt.Sprintf("%s.%s", cmd.Parent().Name(), cmd.Name())
 	}
-
-	return fmt.Sprintf("%s.%s", parentName, cmd.Name())
+	return fmt.Sprintf("%s", cmd.Name())
 }
 
 // CmdRunner runs a command and passes in a cmdConfig.

--- a/doit.go
+++ b/doit.go
@@ -35,9 +35,6 @@ import (
 )
 
 const (
-	// NSRoot is a configuration key that signifies this value is at the root.
-	NSRoot = "doctl"
-
 	// LatestReleaseURL is the latest release URL endpoint.
 	LatestReleaseURL = "https://api.github.com/repos/digitalocean/doctl/releases/latest"
 )
@@ -251,10 +248,6 @@ func (c *LiveConfig) IsSet(key string) bool {
 
 // GetString returns a config value as a string.
 func (c *LiveConfig) GetString(ns, key string) (string, error) {
-	if ns == NSRoot {
-		return viper.GetString(key), nil
-	}
-
 	nskey := fmt.Sprintf("%s.%s", ns, key)
 
 	isRequired := viper.GetBool(fmt.Sprintf("required.%s", nskey))
@@ -269,10 +262,6 @@ func (c *LiveConfig) GetString(ns, key string) (string, error) {
 
 // GetBool returns a config value as a bool.
 func (c *LiveConfig) GetBool(ns, key string) (bool, error) {
-	if ns == NSRoot {
-		return viper.GetBool(key), nil
-	}
-
 	nskey := fmt.Sprintf("%s.%s", ns, key)
 
 	return viper.GetBool(nskey), nil
@@ -284,11 +273,6 @@ func (c *LiveConfig) GetBoolPtr(ns, key string) (*bool, error) {
 		return nil, nil
 	}
 
-	if ns == NSRoot {
-		val := viper.GetBool(key)
-		return &val, nil
-	}
-
 	nskey := fmt.Sprintf("%s.%s", ns, key)
 	val := viper.GetBool(nskey)
 
@@ -297,10 +281,6 @@ func (c *LiveConfig) GetBoolPtr(ns, key string) (*bool, error) {
 
 // GetInt returns a config value as an int.
 func (c *LiveConfig) GetInt(ns, key string) (int, error) {
-	if ns == NSRoot {
-		return viper.GetInt(key), nil
-	}
-
 	nskey := fmt.Sprintf("%s.%s", ns, key)
 
 	isRequired := viper.GetBool(fmt.Sprintf("required.%s", nskey))
@@ -315,14 +295,6 @@ func (c *LiveConfig) GetInt(ns, key string) (int, error) {
 
 // GetIntPtr returns a config value as an int pointer.
 func (c *LiveConfig) GetIntPtr(ns, key string) (*int, error) {
-	if ns == NSRoot {
-		if !c.IsSet(key) {
-			return nil, nil
-		}
-		val := viper.GetInt(key)
-		return &val, nil
-	}
-
 	nskey := fmt.Sprintf("%s.%s", ns, key)
 	isRequired := viper.GetBool(fmt.Sprintf("required.%s", nskey))
 	isSet := c.IsSet(key)
@@ -340,10 +312,6 @@ func (c *LiveConfig) GetIntPtr(ns, key string) (*int, error) {
 
 // GetStringSlice returns a config value as a string slice.
 func (c *LiveConfig) GetStringSlice(ns, key string) ([]string, error) {
-	if ns == NSRoot {
-		return viper.GetStringSlice(key), nil
-	}
-
 	nskey := fmt.Sprintf("%s.%s", ns, key)
 
 	isRequired := viper.GetBool(fmt.Sprintf("required.%s", nskey))


### PR DESCRIPTION
Co-Authored-By: Zachary Gershman <zachgersh@gmail.com>

In addition to running clean on the tests, we tried out the code
with:
- doctl auth init
- doctl compute droplet list
- doctl k8s cluster list
- doctl k8s cluster kubeconfig save
and a few others. (The k8s commands are particularly of interest as
there are interactions between the doctl config and kubeconfig.)

We tried the above command with command line options and using the
values from the doctl config file.