### PR TITLE
adds droplet delete test

### DIFF
--- a/integration/droplet_delete_test.go
+++ b/integration/droplet_delete_test.go
@@ -1,0 +1,83 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func testDropletDelete(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/droplets":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				w.Write([]byte(`{"droplets":[{"name":"some-droplet-name", "id": 1337}]}`))
+			case "/v2/droplets/1337":
+				if req.Method != "DELETE" {
+					w.WriteHeader(http.StatusTeapot)
+					return
+				}
+
+				w.Write([]byte(`{}`))
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	when("all required flags are passed", func() {
+		base := []string{
+			"-t", "some-magic-token",
+			"compute",
+			"droplet",
+		}
+
+		cases := []struct {
+			desc string
+			args []string
+		}{
+			{desc: "command is delete", args: append(base, []string{"delete", "some-droplet-name", "--force"}...)},
+			{desc: "command is rm", args: append(base, []string{"rm", "some-droplet-name", "--force"}...)},
+			{desc: "command is d", args: append(base, []string{"d", "some-droplet-name", "--force"}...)},
+			{desc: "command is del", args: append(base, []string{"del", "some-droplet-name", "--force"}...)},
+		}
+
+		for _, c := range cases {
+			commandArgs := c.args
+
+			when(c.desc, func() {
+				it("deletes a droplet", func() {
+					finalArgs := append([]string{"-u", server.URL}, commandArgs...)
+					cmd := exec.Command(builtBinaryPath, finalArgs...)
+
+					output, err := cmd.CombinedOutput()
+					expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+				})
+			})
+		}
+	})
+}

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -37,6 +37,7 @@ func TestMain(m *testing.M) {
 	suite("account/ratelimit", testAccountRateLimit)
 	suite("auth/init", testAuthInit)
 	suite("compute/droplet/create", testDropletCreate)
+	suite("compute/droplet/delete", testDropletDelete)
 
 	tmpDir, err := ioutil.TempDir("", "integration-doctl")
 	if err != nil {


### PR DESCRIPTION
where `server.URL` is may look weird in the test. Why is it there? It's due to the fact that the `Before` is not evaluated until right before the `it`. If we had it back up in `base` it results in a `nil` dereference due to the fact that the Before has not yet run.