### PR TITLE
cleanup betacmd and more

### DIFF
--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -43,9 +43,3 @@ func hiddenCmd() cmdOption {
 	}
 }
 
-// betaCmd tags commands as beta.
-func betaCmd() cmdOption {
-	return func(c *Command) {
-		c.Hidden = !isBeta()
-	}
-}

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -200,16 +200,12 @@ func requiredOpt() flagOpt {
 	return func(c *Command, name, key string) {
 		c.MarkFlagRequired(key)
 
-		key = requiredKey(key)
+		key = fmt.Sprintf("required.%s", key)
 		viper.Set(key, true)
 
 		u := c.Flag(name).Usage
 		c.Flag(name).Usage = fmt.Sprintf("%s %s", u, requiredColor("(required)"))
 	}
-}
-
-func requiredKey(key string) string {
-	return fmt.Sprintf("required.%s", key)
 }
 
 func betaOpt() flagOpt {

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -89,8 +89,6 @@ func init() {
 	rootPFlagSet.BoolVarP(&Trace, "trace", "", false, "trace api access")
 	rootPFlagSet.BoolVarP(&Verbose, doctl.ArgVerbose, "v", false, "verbose output")
 
-	viper.BindEnv("enable-beta", "DIGITALOCEAN_ENABLE_BETA")
-
 	addCommands()
 
 	cobra.OnInitialize(initConfig)
@@ -206,16 +204,6 @@ func requiredOpt() flagOpt {
 		u := c.Flag(name).Usage
 		c.Flag(name).Usage = fmt.Sprintf("%s %s", u, requiredColor("(required)"))
 	}
-}
-
-func betaOpt() flagOpt {
-	return func(c *Command, name, key string) {
-		c.Flag(name).Hidden = !isBeta()
-	}
-}
-
-func isBeta() bool {
-	return viper.GetBool("enable-beta")
 }
 
 // AddStringFlag adds a string flag to a command.


### PR DESCRIPTION
this PR includes several small commits, each with a small, focused refactor:

* streamlining the global viper getters/setters (which will eventually go away, but at least we can have them readable in the meantime)
* inlining requiredKey, more of that viper
* removing the global effect beta system (later we'll add the ability to make a command beta, which will hide it in help unless that specific beta command is enabled)