### PR TITLE
fix use of github-changelog-generator on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,10 @@ jobs:
     before_deploy:
     - echo "$DOCKER_PASSWORD" | docker login --username sammytheshark --password-stdin
     - sudo snap install goreleaser --classic
+    - go get -u github.com/digitalocean/github-changelog-generator
     deploy:
     - provider: script
-      script: make release
+      script: ./scripts/release_travis.sh
       skip_cleanup: true
       on:
         tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,23 +35,7 @@ jobs:
     env: CACHE_NAME=WINDOWS_1.13
 
   - stage: deploy
-    if: branch=master and type=push
-    script:
-    - echo "building snap"
-    - make _build_snap
-    dist: bionic
-    go: 1.13.x
-    services: docker
-    env: CACHE_NAME=DEPLOY_CANDIDATE_SNAP
-    deploy:
-    - provider: snap
-      channel: candidate
-      snap: doctl_v*.snap
-      skip_cleanup: true
-      on:
-        repo: digitalocean/doctl
-
-  - if: type=push
+    if: type=push
     script: echo "running goreleaser"
     dist: bionic
     go: 1.13.x
@@ -84,3 +68,20 @@ jobs:
       on:
         tags: true
         repo: digitalocean/doctl
+
+  - if: branch=master and type=push
+    script:
+    - echo "building snap"
+    - make _build_snap
+    dist: bionic
+    go: 1.13.x
+    services: docker
+    env: CACHE_NAME=DEPLOY_CANDIDATE_SNAP
+    deploy:
+    - provider: snap
+      channel: candidate
+      snap: doctl_v*.snap
+      skip_cleanup: true
+      on:
+        repo: digitalocean/doctl
+

--- a/scripts/release_travis.sh
+++ b/scripts/release_travis.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "generating changelog"
+tfile=$(mktemp /tmp/doctl-CHANGELOG-XXXXXX)
+github-changelog-generator -org digitalocean -repo doctl >"$tfile"
+
+goreleaser --rm-dist --release-notes="$tfile"
+
+echo "released!"


### PR DESCRIPTION
github-changelog-generator behaves a bit differently on travis than it does locally. It appears to need a GITHUB_TOKEN to authenticate. Also, the bump to go 1.13 changed the way GO111MODULE worked.