### PR TITLE
Make image name positional and add default image

### DIFF
--- a/commands/images.go
+++ b/commands/images.go
@@ -67,7 +67,7 @@ func Images() *Command {
 	AddStringFlag(cmdRunImagesCreate, doctl.ArgImageName, "", "", "The custom image name", requiredOpt())
 	AddStringFlag(cmdRunImagesCreate, doctl.ArgImageExternalURL, "", "", "Custom image retrieval URL", requiredOpt())
 	AddStringFlag(cmdRunImagesCreate, doctl.ArgRegionSlug, "", "", "Region slug identifier", requiredOpt())
-	AddStringFlag(cmdRunImagesCreate, doctl.ArgImageDistro, "", "", "Custom image distribution")
+	AddStringFlag(cmdRunImagesCreate, doctl.ArgImageDistro, "", "Unknown", "Custom image distribution")
 	AddStringFlag(cmdRunImagesCreate, doctl.ArgImageDescription, "", "", "Text to describe an image")
 	AddStringSliceFlag(cmdRunImagesCreate, doctl.ArgTagNames, "", []string{}, "List of new or existing tags")
 
@@ -260,10 +260,11 @@ func RunImagesCreate(c *CmdConfig) error {
 }
 
 func buildCustomImageRequestFromArgs(c *CmdConfig, r *godo.CustomImageCreateRequest) error {
-	name, err := c.Doit.GetString(c.NS, doctl.ArgImageName)
-	if err != nil {
-		return err
+	if len(c.Args) != 1 {
+		return doctl.NewMissingArgsErr(c.NS)
 	}
+	name := c.Args[0]
+
 	addr, err := c.Doit.GetString(c.NS, doctl.ArgImageExternalURL)
 	if err != nil {
 		return err

--- a/commands/images_test.go
+++ b/commands/images_test.go
@@ -141,6 +141,7 @@ func TestImagesCreate(t *testing.T) {
 
 		tm.images.EXPECT().Create(&r).Return(&testImage, nil)
 
+		config.Args = append(config.Args, "test-image")
 		config.Doit.Set(config.NS, doctl.ArgImageName, "test-image")
 		config.Doit.Set(config.NS, doctl.ArgImageExternalURL, addr)
 		config.Doit.Set(config.NS, doctl.ArgRegionSlug, "nyc1")

--- a/integration/image_create_test.go
+++ b/integration/image_create_test.go
@@ -48,8 +48,7 @@ func testImageCreate(t *testing.T, when spec.G, it spec.S) {
 				"-u", server.URL,
 				"compute",
 				"image",
-				"create",
-				"--image-name", "ubuntu-18.04-minimal",
+				"create", "ubuntu-18.04-minimal",
 				"--image-url", "http://cloud-images.ubuntu.com/minimal/releases/bionic/release/ubuntu-18.04-minimal-cloudimg-amd64.img",
 				"--region", "nyc3",
 			)
@@ -66,7 +65,7 @@ func testImageCreate(t *testing.T, when spec.G, it spec.S) {
 			"-u", "https://www.example.com",
 			"compute",
 			"image",
-			"create",
+			"create", "test-image",
 		}
 
 		baseErr := `Error: (image.create%s) command is missing required arguments`
@@ -78,17 +77,8 @@ func testImageCreate(t *testing.T, when spec.G, it spec.S) {
 		}{
 			{
 				"missing all",
-				fmt.Sprintf(baseErr, ".image-name"),
+				fmt.Sprintf(baseErr, ".image-url"),
 				base,
-			},
-			{
-				"missing name",
-				fmt.Sprintf(baseErr, ".image-name"),
-				append(base, []string{
-					"--image-description", "an ubuntu custom minimal image",
-					"--image-url", "http://cloud-images.ubuntu.com/minimal/releases/bionic/release/ubuntu-18.04-minimal-cloudimg-amd64.img",
-					"--region", "nyc3",
-				}...),
 			},
 			{
 				"missing region",
@@ -135,9 +125,7 @@ const imageCreateResponse = `{
 	  "error_message": "",
 	  "id": 38413969,
 	  "name": "ubuntu-18.04-minimal",
-	  "regions": [
-  
-	  ],
+	  "regions": [],
 	  "type": "custom",
 	  "tags": [
 		"base-image",


### PR DESCRIPTION
Updates the new command to create custom images to turn the `--image-name` flag into a positional argument, and adds a default to the image distribution flag.

This is small follow-up to the excellent work done by @VictorAvelar 🎉 