### PR TITLE
consolidate live and test flag semantics

### DIFF
--- a/commands/cdns.go
+++ b/commands/cdns.go
@@ -135,7 +135,7 @@ func RunCDNUpdate(c *CmdConfig) error {
 	cs := c.CDNs()
 
 	var item *do.CDN
-	if c.Doit.IsSet(doctl.ArgCDNTTL) {
+	if c.Doit.IsSet(c.NS, doctl.ArgCDNTTL) {
 		ttl, err := c.Doit.GetInt(c.NS, doctl.ArgCDNTTL)
 		if err != nil {
 			return err
@@ -152,7 +152,7 @@ func RunCDNUpdate(c *CmdConfig) error {
 		}
 	}
 
-	if c.Doit.IsSet(doctl.ArgCDNDomain) {
+	if c.Doit.IsSet(c.NS, doctl.ArgCDNDomain) {
 		domain, certID, err := getCDNDomainAndCertID(c)
 		if err != nil {
 			return err

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1114,7 +1114,7 @@ func buildClusterCreateRequestFromArgs(c *CmdConfig, r *godo.KubernetesClusterCr
 	}
 
 	// multiple node pools
-	if c.Doit.IsSet(doctl.ArgSizeSlug) || c.Doit.IsSet(doctl.ArgNodePoolCount) {
+	if c.Doit.IsSet(c.NS, doctl.ArgSizeSlug) || c.Doit.IsSet(c.NS, doctl.ArgNodePoolCount) {
 		return fmt.Errorf("flags %q and %q cannot be provided when %q is present", doctl.ArgSizeSlug, doctl.ArgNodePoolCount, doctl.ArgClusterNodePool)
 	}
 

--- a/commands/projects.go
+++ b/commands/projects.go
@@ -307,7 +307,7 @@ func buildProjectsCreateRequestFromArgs(c *CmdConfig, r *godo.CreateProjectReque
 }
 
 func buildProjectsUpdateRequestFromArgs(c *CmdConfig, r *godo.UpdateProjectRequest) error {
-	if c.Doit.IsSet(doctl.ArgProjectName) {
+	if c.Doit.IsSet(c.NS, doctl.ArgProjectName) {
 		name, err := c.Doit.GetString(c.NS, doctl.ArgProjectName)
 		if err != nil {
 			return err
@@ -315,7 +315,7 @@ func buildProjectsUpdateRequestFromArgs(c *CmdConfig, r *godo.UpdateProjectReque
 		r.Name = name
 	}
 
-	if c.Doit.IsSet(doctl.ArgProjectPurpose) {
+	if c.Doit.IsSet(c.NS, doctl.ArgProjectPurpose) {
 		purpose, err := c.Doit.GetString(c.NS, doctl.ArgProjectPurpose)
 		if err != nil {
 			return err
@@ -323,7 +323,7 @@ func buildProjectsUpdateRequestFromArgs(c *CmdConfig, r *godo.UpdateProjectReque
 		r.Purpose = purpose
 	}
 
-	if c.Doit.IsSet(doctl.ArgProjectDescription) {
+	if c.Doit.IsSet(c.NS, doctl.ArgProjectDescription) {
 		description, err := c.Doit.GetString(c.NS, doctl.ArgProjectDescription)
 		if err != nil {
 			return err
@@ -331,7 +331,7 @@ func buildProjectsUpdateRequestFromArgs(c *CmdConfig, r *godo.UpdateProjectReque
 		r.Description = description
 	}
 
-	if c.Doit.IsSet(doctl.ArgProjectEnvironment) {
+	if c.Doit.IsSet(c.NS, doctl.ArgProjectEnvironment) {
 		environment, err := c.Doit.GetString(c.NS, doctl.ArgProjectEnvironment)
 		if err != nil {
 			return err
@@ -339,7 +339,7 @@ func buildProjectsUpdateRequestFromArgs(c *CmdConfig, r *godo.UpdateProjectReque
 		r.Environment = environment
 	}
 
-	if c.Doit.IsSet(doctl.ArgProjectIsDefault) {
+	if c.Doit.IsSet(c.NS, doctl.ArgProjectIsDefault) {
 		isDefault, err := c.Doit.GetBool(c.NS, doctl.ArgProjectIsDefault)
 		if err != nil {
 			return err


### PR DESCRIPTION
- IsSet behaved differently between live and test
- namespacing was done differently between live and test
- alone of all the config methods, IsSet was not namespaced,
  and therefore had different semantics from the other
  methods in that it did not reference viper