### PR TITLE
register your test at the top of the file

### DIFF
--- a/integration/account_test.go
+++ b/integration/account_test.go
@@ -11,8 +11,14 @@ import (
 	"time"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAccounts(t *testing.T) {
+	spec.Run(t, "account/get", testAccountGet, spec.Report(report.Terminal{}))
+	spec.Run(t, "account/ratelimit", testAccountRateLimit, spec.Report(report.Terminal{}))
+}
 
 func testAccountGet(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -17,8 +17,13 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAuth(t *testing.T) {
+	spec.Run(t, "auth/init", testAuthInit, spec.Report(report.Terminal{}))
+}
 
 func testAuthInit(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/auth_windows_test.go
+++ b/integration/auth_windows_test.go
@@ -6,7 +6,12 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 )
+
+func TestAuth(t *testing.T) {
+	spec.Run(t, "auth/init", testAuthInit, spec.Report(report.Terminal{}))
+}
 
 func testAuthInit(t *testing.T, when spec.G, it spec.S) {
 	it.Pend("this is not implemented on windows", func() {})

--- a/integration/droplet_actions_test.go
+++ b/integration/droplet_actions_test.go
@@ -10,8 +10,13 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDropletActions(t *testing.T) {
+	spec.Run(t, "compute/droplet/actions", testDropletActions, spec.Report(report.Terminal{}))
+}
 
 func testDropletActions(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/droplet_backups_test.go
+++ b/integration/droplet_backups_test.go
@@ -10,8 +10,13 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDropletBackups(t *testing.T) {
+	spec.Run(t, "compute/droplet/backups", testDropletBackups, spec.Report(report.Terminal{}))
+}
 
 func testDropletBackups(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/droplet_create_test.go
+++ b/integration/droplet_create_test.go
@@ -12,11 +12,16 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
 type dropletRequest struct {
 	Name string `json:"name"`
+}
+
+func TestDropletCreate(t *testing.T) {
+	spec.Run(t, "compute/droplet/create", testDropletCreate, spec.Report(report.Terminal{}))
 }
 
 func testDropletCreate(t *testing.T, when spec.G, it spec.S) {

--- a/integration/droplet_delete_test.go
+++ b/integration/droplet_delete_test.go
@@ -9,8 +9,13 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDropletDelete(t *testing.T) {
+	spec.Run(t, "compute/droplet/delete", testDropletDelete, spec.Report(report.Terminal{}))
+}
 
 func testDropletDelete(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/droplet_get_test.go
+++ b/integration/droplet_get_test.go
@@ -13,8 +13,13 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDropletGet(t *testing.T) {
+	spec.Run(t, "compute/droplet/get", testDropletGet, spec.Report(report.Terminal{}))
+}
 
 func testDropletGet(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/droplet_kernels_test.go
+++ b/integration/droplet_kernels_test.go
@@ -10,8 +10,13 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDropletKernels(t *testing.T) {
+	spec.Run(t, "compute/droplet/kernels", testDropletKernels, spec.Report(report.Terminal{}))
+}
 
 func testDropletKernels(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/droplet_list_test.go
+++ b/integration/droplet_list_test.go
@@ -10,8 +10,13 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDropletList(t *testing.T) {
+	spec.Run(t, "compute/droplet/list", testDropletList, spec.Report(report.Terminal{}))
+}
 
 func testDropletList(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/droplet_neighbors_test.go
+++ b/integration/droplet_neighbors_test.go
@@ -13,8 +13,13 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDropletNeighbors(t *testing.T) {
+	spec.Run(t, "compute/droplet/neighbors", testDropletNeighbors, spec.Report(report.Terminal{}))
+}
 
 func testDropletNeighbors(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/droplet_snapshots_test.go
+++ b/integration/droplet_snapshots_test.go
@@ -10,8 +10,13 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDropletSnapshots(t *testing.T) {
+	spec.Run(t, "compute/droplet/snapshots", testDropletSnapshots, spec.Report(report.Terminal{}))
+}
 
 func testDropletSnapshots(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/droplet_tag_test.go
+++ b/integration/droplet_tag_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,6 +22,10 @@ type tagRequest struct {
 		ResourceID   string `json:"resource_id"`
 		ResourceType string `json:"resource_type"`
 	} `json:"resources"`
+}
+
+func TestDropletTag(t *testing.T) {
+	spec.Run(t, "compute/droplet/tag", testDropletTag, spec.Report(report.Terminal{}))
 }
 
 func testDropletTag(t *testing.T, when spec.G, it spec.S) {

--- a/integration/image_create_test.go
+++ b/integration/image_create_test.go
@@ -10,8 +10,13 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestImageCreate(t *testing.T) {
+	spec.Run(t, "compute/image/create", testImageCreate, spec.Report(report.Terminal{}))
+}
 
 func testImageCreate(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 )
 
 const packagePath string = "github.com/digitalocean/doctl/cmd/doctl"
@@ -21,35 +20,7 @@ var (
 	builtBinaryPath string
 )
 
-func TestAll(t *testing.T) {
-	suite.Run(t)
-}
-
 func TestMain(m *testing.M) {
-	specOptions := []spec.Option{
-		spec.Report(report.Terminal{}),
-		spec.Random(),
-		spec.Parallel(),
-	}
-
-	suite = spec.New("integration", specOptions...)
-	suite("account/get", testAccountGet)
-	suite("account/ratelimit", testAccountRateLimit)
-	suite("auth/init", testAuthInit)
-	suite("compute/droplet/create", testDropletCreate)
-	suite("compute/droplet/delete", testDropletDelete)
-	suite("compute/droplet/tag", testDropletTag)
-	suite("compute/droplet/list", testDropletList)
-	suite("compute/droplet/kernels", testDropletKernels)
-	suite("compute/droplet/backups", testDropletBackups)
-	suite("compute/droplet/neighbors", testDropletNeighbors)
-	suite("compute/droplet/snapshots", testDropletSnapshots)
-	suite("compute/droplet/actions", testDropletActions)
-	suite("compute/droplet/get", testDropletGet)
-	suite("compute/image/create", testImageCreate)
-	suite("compute/region/list", testRegionList)
-	suite("compute/size/list", testSizeList)
-
 	tmpDir, err := ioutil.TempDir("", "integration-doctl")
 	if err != nil {
 		panic("failed to create temp dir")

--- a/integration/region_list_test.go
+++ b/integration/region_list_test.go
@@ -10,8 +10,13 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRegionList(t *testing.T) {
+	spec.Run(t, "compute/region/list", testRegionList, spec.Report(report.Terminal{}))
+}
 
 func testRegionList(t *testing.T, when spec.G, it spec.S) {
 	var (

--- a/integration/size_list_test.go
+++ b/integration/size_list_test.go
@@ -10,8 +10,13 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSizeList(t *testing.T) {
+	spec.Run(t, "compute/size/list", testSizeList, spec.Report(report.Terminal{}))
+}
 
 func testSizeList(t *testing.T, when spec.G, it spec.S) {
 	var (


### PR DESCRIPTION
- this is normally how go test works and removing
suite registration makes this appear more go
test like while still keeping the functionality
we like about spec