### PR TITLE
tests organized the same but now all appear as one suite

### DIFF
--- a/integration/account_test.go
+++ b/integration/account_test.go
@@ -11,16 +11,10 @@ import (
 	"time"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAccounts(t *testing.T) {
-	spec.Run(t, "account/get", testAccountGet, spec.Report(report.Terminal{}))
-	spec.Run(t, "account/ratelimit", testAccountRateLimit, spec.Report(report.Terminal{}))
-}
-
-func testAccountGet(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("account/get", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -69,9 +63,9 @@ func testAccountGet(t *testing.T, when spec.G, it spec.S) {
 
 		expect.Equal(strings.TrimSpace(accountOutput), strings.TrimSpace(string(output)))
 	})
-}
+})
 
-func testAccountRateLimit(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("account/ratelimit", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -115,7 +109,7 @@ func testAccountRateLimit(t *testing.T, when spec.G, it spec.S) {
 
 		expect.Equal(expectedOutput, strings.TrimSpace(string(output)))
 	})
-}
+})
 
 const accountOutput string = `
 Email                     Droplet Limit    Email Verified    UUID                                        Status

--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -17,15 +17,10 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAuth(t *testing.T) {
-	spec.Run(t, "auth/init", testAuthInit, spec.Report(report.Terminal{}))
-}
-
-func testAuthInit(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("auth/init", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -160,4 +155,4 @@ func testAuthInit(t *testing.T, when spec.G, it spec.S) {
 			expect.Contains(buf.String(), fmt.Sprintf("unable to use supplied token to access API: GET %s/v2/account: 418", server.URL))
 		})
 	})
-}
+})

--- a/integration/auth_windows_test.go
+++ b/integration/auth_windows_test.go
@@ -6,13 +6,8 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 )
 
-func TestAuth(t *testing.T) {
-	spec.Run(t, "auth/init", testAuthInit, spec.Report(report.Terminal{}))
-}
-
-func testAuthInit(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("auth/init", func(t *testing.T, when spec.G, it spec.S) {
 	it.Pend("this is not implemented on windows", func() {})
-}
+})

--- a/integration/databases_create_test.go
+++ b/integration/databases_create_test.go
@@ -14,15 +14,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDatabasesCreate(t *testing.T) {
-	spec.Run(t, "databases/create", testDatabasesCreate, spec.Report(report.Terminal{}))
-}
-
-func testDatabasesCreate(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("database/create", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -97,7 +92,7 @@ func testDatabasesCreate(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
-}
+})
 
 const databasesCreateOutput = `
 ID         Name                Engine    Version         Number of Nodes    Region    Status      Size       URI    Created At

--- a/integration/droplet_actions_test.go
+++ b/integration/droplet_actions_test.go
@@ -10,15 +10,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDropletActions(t *testing.T) {
-	spec.Run(t, "compute/droplet/actions", testDropletActions, spec.Report(report.Terminal{}))
-}
-
-func testDropletActions(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/droplet/actions", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -64,7 +59,7 @@ func testDropletActions(t *testing.T, when spec.G, it spec.S) {
 			expect.Equal(strings.TrimSpace(dropletActionsOutput), strings.TrimSpace(string(output)))
 		})
 	})
-}
+})
 
 const dropletActionsOutput = `
 ID    Status       Type    Started At                       Completed At                     Resource ID    Resource Type    Region

--- a/integration/droplet_backups_test.go
+++ b/integration/droplet_backups_test.go
@@ -10,15 +10,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDropletBackups(t *testing.T) {
-	spec.Run(t, "compute/droplet/backups", testDropletBackups, spec.Report(report.Terminal{}))
-}
-
-func testDropletBackups(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/droplet/backups", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -72,7 +67,7 @@ func testDropletBackups(t *testing.T, when spec.G, it spec.S) {
 			expect.Equal(strings.TrimSpace(dropletBackupsOutput), strings.TrimSpace(string(output)))
 		})
 	})
-}
+})
 
 const dropletBackupsOutput = `
 ID      Name     Type        Distribution    Slug      Public    Min Disk

--- a/integration/droplet_create_test.go
+++ b/integration/droplet_create_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,11 +19,7 @@ type dropletRequest struct {
 	Name string `json:"name"`
 }
 
-func TestDropletCreate(t *testing.T) {
-	spec.Run(t, "compute/droplet/create", testDropletCreate, spec.Report(report.Terminal{}))
-}
-
-func testDropletCreate(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/droplet/create", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect  *require.Assertions
 		server  *httptest.Server
@@ -168,7 +163,7 @@ func testDropletCreate(t *testing.T, when spec.G, it spec.S) {
 			})
 		}
 	})
-}
+})
 
 const dropletCreateResponse = `{
   "droplet": {

--- a/integration/droplet_delete_test.go
+++ b/integration/droplet_delete_test.go
@@ -9,15 +9,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDropletDelete(t *testing.T) {
-	spec.Run(t, "compute/droplet/delete", testDropletDelete, spec.Report(report.Terminal{}))
-}
-
-func testDropletDelete(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/droplet/delete", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -85,4 +80,4 @@ func testDropletDelete(t *testing.T, when spec.G, it spec.S) {
 			})
 		}
 	})
-}
+})

--- a/integration/droplet_get_test.go
+++ b/integration/droplet_get_test.go
@@ -13,15 +13,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDropletGet(t *testing.T) {
-	spec.Run(t, "compute/droplet/get", testDropletGet, spec.Report(report.Terminal{}))
-}
-
-func testDropletGet(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/droplet/get", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect     *require.Assertions
 		server     *httptest.Server
@@ -117,7 +112,7 @@ func testDropletGet(t *testing.T, when spec.G, it spec.S) {
 			expect.Equal(strings.TrimSpace(dropletGetTemplateOutput), strings.TrimSpace(string(output)))
 		})
 	})
-}
+})
 
 const dropletGetConfig = `
 ---

--- a/integration/droplet_kernels_test.go
+++ b/integration/droplet_kernels_test.go
@@ -10,15 +10,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDropletKernels(t *testing.T) {
-	spec.Run(t, "compute/droplet/kernels", testDropletKernels, spec.Report(report.Terminal{}))
-}
-
-func testDropletKernels(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/droplet/kernels", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -64,7 +59,7 @@ func testDropletKernels(t *testing.T, when spec.G, it spec.S) {
 			expect.Equal(strings.TrimSpace(dropletKernelsOutput), strings.TrimSpace(string(output)))
 		})
 	})
-}
+})
 
 const dropletKernelsOutput = `
 ID     Name    Version

--- a/integration/droplet_list_test.go
+++ b/integration/droplet_list_test.go
@@ -10,15 +10,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDropletList(t *testing.T) {
-	spec.Run(t, "compute/droplet/list", testDropletList, spec.Report(report.Terminal{}))
-}
-
-func testDropletList(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/droplet/list", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -110,7 +105,7 @@ func testDropletList(t *testing.T, when spec.G, it spec.S) {
 			expect.Equal(strings.TrimSpace(dropletListEmptyOutput), strings.TrimSpace(string(output)))
 		})
 	})
-}
+})
 
 const dropletListResponse = `{
   "droplets": [{

--- a/integration/droplet_neighbors_test.go
+++ b/integration/droplet_neighbors_test.go
@@ -13,15 +13,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDropletNeighbors(t *testing.T) {
-	spec.Run(t, "compute/droplet/neighbors", testDropletNeighbors, spec.Report(report.Terminal{}))
-}
-
-func testDropletNeighbors(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/droplet/neighbors", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect     *require.Assertions
 		server     *httptest.Server
@@ -105,7 +100,7 @@ func testDropletNeighbors(t *testing.T, when spec.G, it spec.S) {
 			expect.Equal(strings.TrimSpace(dropletNeighborsHeadersOutput), strings.TrimSpace(string(output)))
 		})
 	})
-}
+})
 
 const dropletNeighborsConfig = `
 ---

--- a/integration/droplet_snapshots_test.go
+++ b/integration/droplet_snapshots_test.go
@@ -10,15 +10,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDropletSnapshots(t *testing.T) {
-	spec.Run(t, "compute/droplet/snapshots", testDropletSnapshots, spec.Report(report.Terminal{}))
-}
-
-func testDropletSnapshots(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/droplet/snapshots", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -64,7 +59,7 @@ func testDropletSnapshots(t *testing.T, when spec.G, it spec.S) {
 			expect.Equal(strings.TrimSpace(dropletSnapshotsOutput), strings.TrimSpace(string(output)))
 		})
 	})
-}
+})
 
 const dropletSnapshotsOutput = `
 ID      Name           Type        Distribution    Slug      Public    Min Disk

--- a/integration/droplet_tag_test.go
+++ b/integration/droplet_tag_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,11 +23,7 @@ type tagRequest struct {
 	} `json:"resources"`
 }
 
-func TestDropletTag(t *testing.T) {
-	spec.Run(t, "compute/droplet/tag", testDropletTag, spec.Report(report.Terminal{}))
-}
-
-func testDropletTag(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/droplet/tag", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -156,4 +151,4 @@ func testDropletTag(t *testing.T, when spec.G, it spec.S) {
 			})
 		}
 	})
-}
+})

--- a/integration/image_create_test.go
+++ b/integration/image_create_test.go
@@ -10,15 +10,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestImageCreate(t *testing.T) {
-	spec.Run(t, "compute/image/create", testImageCreate, spec.Report(report.Terminal{}))
-}
-
-func testImageCreate(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/image/create", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -120,7 +115,7 @@ func testImageCreate(t *testing.T, when spec.G, it spec.S) {
 			})
 		}
 	})
-}
+})
 
 const imageCreateResponse = `{
 	"image": {

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -11,14 +11,19 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 )
 
 const packagePath string = "github.com/digitalocean/doctl/cmd/doctl"
 
 var (
-	suite           spec.Suite
+	suite           = spec.New("", spec.Report(report.Terminal{}), spec.Random(), spec.Parallel())
 	builtBinaryPath string
 )
+
+func TestRun(t *testing.T) {
+	suite.Run(t)
+}
 
 func TestMain(m *testing.M) {
 	tmpDir, err := ioutil.TempDir("", "integration-doctl")

--- a/integration/region_list_test.go
+++ b/integration/region_list_test.go
@@ -10,15 +10,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegionList(t *testing.T) {
-	spec.Run(t, "compute/region/list", testRegionList, spec.Report(report.Terminal{}))
-}
-
-func testRegionList(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/region/list", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -96,7 +91,7 @@ func testRegionList(t *testing.T, when spec.G, it spec.S) {
 			expect.Equal(strings.TrimSpace(regionListNoHeaderOutput), strings.TrimSpace(string(output)))
 		})
 	})
-}
+})
 
 const regionListResponse = `{
   "regions": [

--- a/integration/size_list_test.go
+++ b/integration/size_list_test.go
@@ -10,15 +10,10 @@ import (
 	"testing"
 
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/require"
 )
 
-func TestSizeList(t *testing.T) {
-	spec.Run(t, "compute/size/list", testSizeList, spec.Report(report.Terminal{}))
-}
-
-func testSizeList(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/size/list", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -96,7 +91,7 @@ func testSizeList(t *testing.T, when spec.G, it spec.S) {
 			expect.Equal(strings.TrimSpace(sizeListNoHeaderOutput), strings.TrimSpace(string(output)))
 		})
 	})
-}
+})
 
 const sizeListResponse = `{
   "sizes": [


### PR DESCRIPTION
with the last merge we were in a spot where the tests were organized better (people couldn't forget to declare their suite) but each new test was a new suite (which made the reporter look weird when running in verbose mode).

This keeps the original ease of declaring a test as part of the suite but also fixes the reporter so all tests appear as part of the same suite (accurate test counts and such).