### PR TITLE
removes mistakenly added focus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test_unit:
 test_integration:
 	@echo "==> run integration tests"
 	@echo ""
-	go test -mod=vendor ./integration
+	go test -v -mod=vendor ./integration
 
 .PHONY: test
 test: test_unit test_integration

--- a/integration/projects_list_test.go
+++ b/integration/projects_list_test.go
@@ -66,7 +66,7 @@ var _ = suite("projects/list", func(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("all required flags are passed", func() {
-		it.Focus("lists the projects", func() {
+		it("lists the projects", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,


### PR DESCRIPTION
- set integration tests to run in verbose mode since
we'd like to see test pass/fail/skip counts anyway.