### PR TITLE
Add integration tests for firewall CRUD operations

### DIFF
--- a/integration/firewall_create_test.go
+++ b/integration/firewall_create_test.go
@@ -26,14 +26,14 @@ var _ = suite("compute/firewall/create", func(t *testing.T, when spec.G, it spec
 		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			switch req.URL.Path {
 			case "/v2/firewalls":
-				if req.Method != http.MethodPost {
-					w.WriteHeader(http.StatusMethodNotAllowed)
-					return
-				}
-
 				auth := req.Header.Get("Authorization")
 				if auth != "Bearer some-magic-token" {
 					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
 				}
 
@@ -69,7 +69,7 @@ var _ = suite("compute/firewall/create", func(t *testing.T, when spec.G, it spec
 				)
 
 				output, err := cmd.CombinedOutput()
-				expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+				expect.NoError(err, fmt.Sprintf("received error output from command %s: %s", alias, output))
 				expect.Equal(strings.TrimSpace(firewallCreateOutput), strings.TrimSpace(string(output)))
 			}
 		})

--- a/integration/firewall_get_test.go
+++ b/integration/firewall_get_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ = suite("compute/firewall/list", func(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/firewall/get", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server
@@ -24,13 +24,13 @@ var _ = suite("compute/firewall/list", func(t *testing.T, when spec.G, it spec.S
 
 		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			switch req.URL.Path {
-			case "/v2/firewalls":
+			case "/v2/firewalls/e4b9c960-d385-4950-84f3-d102162e6be5":
 				auth := req.Header.Get("Authorization")
 				if auth != "Bearer some-magic-token" {
 					w.WriteHeader(http.StatusUnauthorized)
 					return
 				}
-				w.Write([]byte(firewallListResponse))
+				w.Write([]byte(firewallGetResponse))
 			default:
 				dump, err := httputil.DumpRequest(req, true)
 				if err != nil {
@@ -43,8 +43,9 @@ var _ = suite("compute/firewall/list", func(t *testing.T, when spec.G, it spec.S
 	})
 
 	when("all required flags are passed", func() {
-		it("lists firewalls", func() {
-			aliases := []string{"list", "ls"}
+		it("gets a firewall", func() {
+			const id = "e4b9c960-d385-4950-84f3-d102162e6be5"
+			aliases := []string{"get", "g"}
 
 			for _, alias := range aliases {
 				cmd := exec.Command(builtBinaryPath,
@@ -53,35 +54,36 @@ var _ = suite("compute/firewall/list", func(t *testing.T, when spec.G, it spec.S
 					"compute",
 					"firewall",
 					alias,
+					id,
 				)
 
 				output, err := cmd.CombinedOutput()
 				expect.NoError(err, fmt.Sprintf("received error output from command %s: %s", alias, output))
-				expect.Equal(strings.TrimSpace(firewallListOutput), strings.TrimSpace(string(output)))
+				expect.Equal(strings.TrimSpace(firewallGetOutput), strings.TrimSpace(string(output)))
 			}
 		})
 	})
 })
 
-const firewallListResponse = `{
-  "firewalls":[{
-	"id":"e4b9c960-d385-4950-84f3-d102162e6be5",
-	"name":"test-firewall",
-	"status":"succeeded",
-	"inbound_rules":[{
+const firewallGetResponse = `{
+  "firewall": {
+    "id":"e4b9c960-d385-4950-84f3-d102162e6be5",
+    "name":"test-firewall",
+    "status":"succeeded",
+    "inbound_rules":[{
 	  "protocol":"tcp",
 	  "ports":"443",
 	  "sources":{}
-	}],
-	"outbound_rules":[],
-	"created_at":"2019-10-24T20:30:26Z",
-	"droplet_ids":[],
-	"tags":[],
+    }],
+    "outbound_rules":[],
+    "created_at":"2019-10-24T20:30:26Z",
+    "droplet_ids":[],
+    "tags":[],
 	"pending_changes":[]
-  }]
+  }
 }`
 
-const firewallListOutput = `
+const firewallGetOutput = `
 ID                                      Name             Status       Created At              Inbound Rules              Outbound Rules    Droplet IDs    Tags    Pending Changes
 e4b9c960-d385-4950-84f3-d102162e6be5    test-firewall    succeeded    2019-10-24T20:30:26Z    protocol:tcp,ports:443,
 `

--- a/integration/firewall_get_test.go
+++ b/integration/firewall_get_test.go
@@ -30,6 +30,12 @@ var _ = suite("compute/firewall/get", func(t *testing.T, when spec.G, it spec.S)
 					w.WriteHeader(http.StatusUnauthorized)
 					return
 				}
+
+				if req.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
 				w.Write([]byte(firewallGetResponse))
 			default:
 				dump, err := httputil.DumpRequest(req, true)

--- a/integration/firewall_list_test.go
+++ b/integration/firewall_list_test.go
@@ -1,0 +1,83 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite("compute/firewall/list", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/firewalls":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				w.Write([]byte(firewallListResponse))
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	when("all required flags are passed", func() {
+		it("lists droplets", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"firewall",
+				"list",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Equal(strings.TrimSpace(firewallListOutput), strings.TrimSpace(string(output)))
+		})
+	})
+})
+
+const firewallListResponse = `{
+  "firewalls":[{
+	"id":"e4b9c960-d385-4950-84f3-d102162e6be5",
+	"name":"test-firewall",
+	"status":"succeeded",
+	"inbound_rules":[{
+	  "protocol":"tcp",
+	  "ports":"443",
+	  "sources":{}
+	}],
+	"outbound_rules":[],
+	"created_at":"2019-10-24T20:30:26Z",
+	"droplet_ids":[],
+	"tags":[],
+	"pending_changes":[]
+  }]
+}`
+
+const firewallListOutput = `
+ID                                      Name             Status       Created At              Inbound Rules              Outbound Rules    Droplet IDs    Tags    Pending Changes
+e4b9c960-d385-4950-84f3-d102162e6be5    test-firewall    succeeded    2019-10-24T20:30:26Z    protocol:tcp,ports:443,
+`

--- a/integration/firewall_list_test.go
+++ b/integration/firewall_list_test.go
@@ -30,6 +30,12 @@ var _ = suite("compute/firewall/list", func(t *testing.T, when spec.G, it spec.S
 					w.WriteHeader(http.StatusUnauthorized)
 					return
 				}
+
+				if req.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
 				w.Write([]byte(firewallListResponse))
 			default:
 				dump, err := httputil.DumpRequest(req, true)

--- a/integration/firewall_update_test.go
+++ b/integration/firewall_update_test.go
@@ -1,0 +1,115 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite("compute/firewall/update", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/firewalls/e4b9c960-d385-4950-84f3-d102162e6be5":
+				if req.Method != http.MethodPut {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				body, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+				expect.JSONEq(firewallUpdateRequestBody, string(body))
+
+				w.Write([]byte(firewallUpdateResponse))
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	when("an updated name and the old inbound rules are provided", func() {
+		it("updates a firewall", func() {
+			const id = "e4b9c960-d385-4950-84f3-d102162e6be5"
+			aliases := []string{"update", "u"}
+
+			for _, alias := range aliases {
+				cmd := exec.Command(builtBinaryPath,
+					"-t", "some-magic-token",
+					"-u", server.URL,
+					"compute",
+					"firewall",
+					alias,
+					id,
+					"--name", "updated-test-firewall",
+					"--inbound-rules", `protocol:tcp,ports:443`,
+				)
+
+				output, err := cmd.CombinedOutput()
+				expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+				expect.Equal(strings.TrimSpace(firewallUpdateOutput), strings.TrimSpace(string(output)))
+			}
+		})
+	})
+})
+
+const (
+	firewallUpdateOutput = `
+ID                                      Name                     Status       Created At              Inbound Rules              Outbound Rules    Droplet IDs    Tags    Pending Changes
+e4b9c960-d385-4950-84f3-d102162e6be5    updated-test-firewall    succeeded    2019-10-24T20:30:26Z    protocol:tcp,ports:443,`
+
+	firewallUpdateRequestBody = `{
+  "name":"updated-test-firewall",
+  "inbound_rules":[{
+	"protocol":"tcp",
+	"ports":"443",
+	"sources":{}
+  }],
+  "outbound_rules":null,
+  "droplet_ids":[],
+  "tags":[]
+}`
+
+	firewallUpdateResponse = `{
+  "firewall": {
+	"id":"e4b9c960-d385-4950-84f3-d102162e6be5",
+	"name":"updated-test-firewall",
+	"status":"succeeded",
+	"inbound_rules":[{
+	  "protocol":"tcp",
+	  "ports":"443",
+	  "sources":{}
+	}],
+	"outbound_rules":[],
+	"created_at":"2019-10-24T20:30:26Z",
+	"droplet_ids":[],
+	"tags":[],
+	"pending_changes":[]
+  }
+}`
+)

--- a/integration/firewall_update_test.go
+++ b/integration/firewall_update_test.go
@@ -26,14 +26,14 @@ var _ = suite("compute/firewall/update", func(t *testing.T, when spec.G, it spec
 		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			switch req.URL.Path {
 			case "/v2/firewalls/e4b9c960-d385-4950-84f3-d102162e6be5":
-				if req.Method != http.MethodPut {
-					w.WriteHeader(http.StatusMethodNotAllowed)
-					return
-				}
-
 				auth := req.Header.Get("Authorization")
 				if auth != "Bearer some-magic-token" {
 					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodPut {
+					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
 				}
 
@@ -71,7 +71,7 @@ var _ = suite("compute/firewall/update", func(t *testing.T, when spec.G, it spec
 				)
 
 				output, err := cmd.CombinedOutput()
-				expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+				expect.NoError(err, fmt.Sprintf("received error output from command %s: %s", alias, output))
 				expect.Equal(strings.TrimSpace(firewallUpdateOutput), strings.TrimSpace(string(output)))
 			}
 		})


### PR DESCRIPTION
Adds the integration tests for firewall CRUD operations. Next up are all the commands affecting a firewall's Droplets, tags, and inbound/outbound rules.