### PR TITLE
volume-action: removes command that was deprecated

### DIFF
--- a/commands/volume_actions.go
+++ b/commands/volume_actions.go
@@ -67,9 +67,6 @@ func VolumeAction() *Command {
 		aliasOpt("d"))
 	AddBoolFlag(cmdRunVolumeDetach, doctl.ArgCommandWait, "", false, "Wait for volume to detach")
 
-	CmdBuilder(cmd, RunVolumeDetach, "detach-by-droplet-id <volume-id> <droplet-id>", "detach a volume (deprecated - use detach instead)",
-		Writer)
-
 	cmdRunVolumeResize := CmdBuilder(cmd, RunVolumeResize, "resize <volume-id>", "resize a volume", Writer,
 		aliasOpt("r"))
 	AddIntFlag(cmdRunVolumeResize, doctl.ArgSizeSlug, "", 0, "New size",

--- a/commands/volume_actions_test.go
+++ b/commands/volume_actions_test.go
@@ -24,7 +24,7 @@ import (
 func TestVolumeActionCommand(t *testing.T) {
 	cmd := VolumeAction()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "attach", "detach", "detach-by-droplet-id", "resize")
+	assertCommandNames(t, cmd, "attach", "detach", "resize")
 }
 
 func TestVolumeActionsAttach(t *testing.T) {


### PR DESCRIPTION
- this command has detach as its parallel already
- command that was removed has been deprecated for over 2 years
- users should have an easy fix (switch to detach) if they
are even using this action