### PR TITLE
floating-ip-action: adjust action-id for consistency

### DIFF
--- a/commands/floating_ip_actions.go
+++ b/commands/floating_ip_actions.go
@@ -34,9 +34,10 @@ func FloatingIPAction() *Command {
 		},
 	}
 
-	CmdBuilder(cmd, RunFloatingIPActionsGet,
-		"get <floating-ip> <action-id>", "get floating-ip action", Writer,
+	cmdFloatingIPActionGet := CmdBuilder(cmd, RunFloatingIPActionsGet,
+		"get <floating-ip>", "get floating-ip action", Writer,
 		displayerType(&displayers.Action{}))
+	AddIntFlag(cmdFloatingIPActionGet, doctl.ArgActionID, "", 0, "action id", requiredOpt())
 
 	CmdBuilder(cmd, RunFloatingIPActionsAssign,
 		"assign <floating-ip> <droplet-id>", "assign a floating IP to a droplet", Writer,
@@ -51,7 +52,7 @@ func FloatingIPAction() *Command {
 
 // RunFloatingIPActionsGet retrieves an action for a floating IP.
 func RunFloatingIPActionsGet(c *CmdConfig) error {
-	if len(c.Args) != 2 {
+	if len(c.Args) != 1 {
 		return doctl.NewMissingArgsErr(c.NS)
 	}
 
@@ -59,7 +60,7 @@ func RunFloatingIPActionsGet(c *CmdConfig) error {
 
 	fia := c.FloatingIPActions()
 
-	actionID, err := strconv.Atoi(c.Args[1])
+	actionID, err := c.Doit.GetInt(c.NS, doctl.ArgActionID)
 	if err != nil {
 		return err
 	}

--- a/commands/floating_ip_actions_test.go
+++ b/commands/floating_ip_actions_test.go
@@ -16,6 +16,7 @@ package commands
 import (
 	"testing"
 
+	"github.com/digitalocean/doctl"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,7 +30,9 @@ func TestFloatingIPActionsGet(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.floatingIPActions.EXPECT().Get("127.0.0.1", 2).Return(&testAction, nil)
 
-		config.Args = append(config.Args, "127.0.0.1", "2")
+		config.Args = append(config.Args, "127.0.0.1")
+
+		config.Doit.Set(config.NS, doctl.ArgActionID, 2)
 
 		err := RunFloatingIPActionsGet(config)
 		assert.NoError(t, err)

--- a/integration/compute_floating_ip_action_test.go
+++ b/integration/compute_floating_ip_action_test.go
@@ -94,7 +94,7 @@ var _ = suite("compute/floating-ip-action", func(t *testing.T, when spec.G, it s
 				"floating-ip-action",
 				"get",
 				"77",
-				"66",
+				"--action-id", "66",
 			)
 
 			output, err := cmd.CombinedOutput()


### PR DESCRIPTION
most of our other commands have a flag for action-id, this move to this pattern.