### PR TITLE
Updated looksLikeUUID to only match hyphenated UUIDs (Fixes #461)

### DIFF
--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1679,7 +1679,7 @@ func nodeByName(name string, nodes []*godo.KubernetesNode) (*godo.KubernetesNode
 }
 
 func looksLikeUUID(str string) bool {
-	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[14][a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
+	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-4][a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
 	return r.MatchString(str)
 }
 

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -30,7 +31,6 @@ import (
 	"github.com/digitalocean/doctl/commands/displayers"
 	"github.com/digitalocean/doctl/do"
 	"github.com/digitalocean/godo"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -1679,8 +1679,8 @@ func nodeByName(name string, nodes []*godo.KubernetesNode) (*godo.KubernetesNode
 }
 
 func looksLikeUUID(str string) bool {
-	_, err := uuid.Parse(str)
-	return err == nil
+	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
+	return r.MatchString(str)
 }
 
 func getVersionOrLatest(c *CmdConfig) (string, error) {

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1679,7 +1679,7 @@ func nodeByName(name string, nodes []*godo.KubernetesNode) (*godo.KubernetesNode
 }
 
 func looksLikeUUID(str string) bool {
-	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
+	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[14][a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
 	return r.MatchString(str)
 }
 

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -1001,24 +1001,33 @@ func TestLatestVersionForUpgrade(t *testing.T) {
 func Test_looksLikeUUID(t *testing.T) {
 	tests := []struct {
 		name string
+		arg  string
 		want bool
 	}{
 		{
-			name: "21464f77-42fc-4a32-9aa4-a101843e94c0",
+			name: "UUIDv1",
+			arg:  "a235f190-01a4-11ea-af17-4989e8155574",
+			want: true,
+		},
+		{
+			name: "UUIDv4",
+			arg:  "21464f77-42fc-4a32-9aa4-a101843e94c0",
 			want: true,
 		},
 		{
 			name: "my-cluster",
+			arg:  "my-cluster",
 			want: false,
 		},
 		{
 			name: "f8291060b73f4fa7b60586fe51a1d862",
+			arg:  "f8291060b73f4fa7b60586fe51a1d862",
 			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := looksLikeUUID(tt.name); got != tt.want {
+			if got := looksLikeUUID(tt.arg); got != tt.want {
 				t.Errorf("looksLikeUUID() = %v, want %v", got, tt.want)
 			}
 		})

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -994,6 +993,33 @@ func TestLatestVersionForUpgrade(t *testing.T) {
 			} else {
 				require.True(t, found)
 				require.Equal(t, tt.want, slug)
+			}
+		})
+	}
+}
+
+func Test_looksLikeUUID(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{
+			name: "21464f77-42fc-4a32-9aa4-a101843e94c0",
+			want: true,
+		},
+		{
+			name: "my-cluster",
+			want: false,
+		},
+		{
+			name: "f8291060b73f4fa7b60586fe51a1d862",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := looksLikeUUID(tt.name); got != tt.want {
+				t.Errorf("looksLikeUUID() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Cluster names that happened to be 32 characters were [getting treated as UUIDs](https://github.com/google/uuid/blob/16ca3eab7d2086fd5a82993a291cbf3b87fe38b7/uuid.go#L60-L61) which causes issue #461. 

Based on [The tests](https://github.com/digitalocean/doctl/blob/d055080faf145deac6ce9df725c8b27e1a2432fc/commands/kubernetes_test.go#L19), I'm hypothesizing that the DO api is assuming UUID's to always be represented in the hyphenated form (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).

This PR updates the `looksLikeUUID()` function to use a strict regex match rather than `uuid.Parse()`'s more lenient checking, which should address the issue in #461 .