### PR TITLE
Accept a port of zero for SRV records

### DIFF
--- a/commands/domains.go
+++ b/commands/domains.go
@@ -233,7 +233,7 @@ func RunRecordCreate(c *CmdConfig) error {
 		return err
 	}
 
-	rPort, err := c.Doit.GetInt(c.NS, doctl.ArgRecordPort)
+	rPort, err := c.Doit.GetIntPtr(c.NS, doctl.ArgRecordPort)
 	if err != nil {
 		return err
 	}
@@ -258,7 +258,7 @@ func RunRecordCreate(c *CmdConfig) error {
 		return err
 	}
 
-	drcr := &godo.DomainRecordEditRequest{
+	drcr := &do.DomainRecordEditRequest{
 		Type:     rType,
 		Name:     rName,
 		Data:     rData,
@@ -356,7 +356,7 @@ func RunRecordUpdate(c *CmdConfig) error {
 		return err
 	}
 
-	rPort, err := c.Doit.GetInt(c.NS, doctl.ArgRecordPort)
+	rPort, err := c.Doit.GetIntPtr(c.NS, doctl.ArgRecordPort)
 	if err != nil {
 		return err
 	}
@@ -381,7 +381,7 @@ func RunRecordUpdate(c *CmdConfig) error {
 		return err
 	}
 
-	drcr := &godo.DomainRecordEditRequest{
+	drcr := &do.DomainRecordEditRequest{
 		Type:     rType,
 		Name:     rName,
 		Data:     rData,

--- a/commands/domains_test.go
+++ b/commands/domains_test.go
@@ -115,12 +115,14 @@ func TestRecordList_RequiredArguments(t *testing.T) {
 
 func TestRecordsCreate(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		dcer := &godo.DomainRecordEditRequest{Type: "A", Name: "foo.example.com.", Data: "192.168.1.1", Priority: 0, Port: 0, TTL: 0, Weight: 0}
+		port := 0
+		dcer := &do.DomainRecordEditRequest{Type: "A", Name: "foo.example.com.", Data: "192.168.1.1", Priority: 0, Port: &port, TTL: 0, Weight: 0}
 		tm.domains.EXPECT().CreateRecord("example.com", dcer).Return(&testRecord, nil)
 
 		config.Doit.Set(config.NS, doctl.ArgRecordType, "A")
 		config.Doit.Set(config.NS, doctl.ArgRecordName, "foo.example.com.")
 		config.Doit.Set(config.NS, doctl.ArgRecordData, "192.168.1.1")
+		config.Doit.Set(config.NS, doctl.ArgRecordPort, "0")
 
 		config.Args = append(config.Args, "example.com")
 
@@ -151,13 +153,15 @@ func TestRecordsDelete(t *testing.T) {
 
 func TestRecordsUpdate(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		dcer := &godo.DomainRecordEditRequest{Type: "A", Name: "foo.example.com.", Data: "192.168.1.1", Priority: 0, Port: 0, TTL: 0, Weight: 0}
+		port := 0
+		dcer := &do.DomainRecordEditRequest{Type: "A", Name: "foo.example.com.", Data: "192.168.1.1", Priority: 0, Port: &port, TTL: 0, Weight: 0}
 		tm.domains.EXPECT().EditRecord("example.com", 1, dcer).Return(&testRecord, nil)
 
 		config.Doit.Set(config.NS, doctl.ArgRecordID, 1)
 		config.Doit.Set(config.NS, doctl.ArgRecordType, "A")
 		config.Doit.Set(config.NS, doctl.ArgRecordName, "foo.example.com.")
 		config.Doit.Set(config.NS, doctl.ArgRecordData, "192.168.1.1")
+		config.Doit.Set(config.NS, doctl.ArgRecordPort, "0")
 
 		config.Args = append(config.Args, "example.com")
 

--- a/do/domains.go
+++ b/do/domains.go
@@ -21,6 +21,11 @@ import (
 	"github.com/digitalocean/godo"
 )
 
+const (
+	domainRecordsPath = "v2/domains/%s/records"
+	domainRecordPath  = "v2/domains/%s/records/%d"
+)
+
 // Domain wraps a godo Domain.
 type Domain struct {
 	*godo.Domain
@@ -192,7 +197,7 @@ func (ds *domainsService) EditRecord(domain string, id int, drer *DomainRecordEd
 		return nil, godo.NewArgError("editRequest", "cannot be nil")
 	}
 
-	path := fmt.Sprintf("v2/domains/%s/records/%d", domain, id)
+	path := fmt.Sprintf(domainRecordPath, domain, id)
 	req, err := ds.client.NewRequest(context.TODO(), http.MethodPut, path, drer)
 	if err != nil {
 		return nil, err
@@ -213,7 +218,7 @@ func (ds *domainsService) CreateRecord(domain string, drer *DomainRecordEditRequ
 		return nil, godo.NewArgError("createRequest", "cannot be nil")
 	}
 
-	path := fmt.Sprintf("v2/domains/%s/records", domain)
+	path := fmt.Sprintf(domainRecordsPath, domain)
 	req, err := ds.client.NewRequest(context.Background(), http.MethodPost, path, drer)
 	if err != nil {
 		return nil, err

--- a/do/domains.go
+++ b/do/domains.go
@@ -15,6 +15,8 @@ package do
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo"
 )
@@ -32,6 +34,21 @@ type DomainRecord struct {
 	*godo.DomainRecord
 }
 
+// A DomainRecordEditRequest is used in place of godo's DomainRecordEditRequest
+// in order to work around the fact that we cannot send a port value of 0 via
+// godo due to Go's JSON encoding logic.
+type DomainRecordEditRequest struct {
+	Type     string `json:"type,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Data     string `json:"data,omitempty"`
+	Priority int    `json:"priority"`
+	Port     *int   `json:"port,omitempty"`
+	TTL      int    `json:"ttl,omitempty"`
+	Weight   int    `json:"weight"`
+	Flags    int    `json:"flags"`
+	Tag      string `json:"tag,omitempty"`
+}
+
 // DomainRecords is a slice of DomainRecord.
 type DomainRecords []DomainRecord
 
@@ -45,8 +62,8 @@ type DomainsService interface {
 	Records(string) (DomainRecords, error)
 	Record(string, int) (*DomainRecord, error)
 	DeleteRecord(string, int) error
-	EditRecord(string, int, *godo.DomainRecordEditRequest) (*DomainRecord, error)
-	CreateRecord(string, *godo.DomainRecordEditRequest) (*DomainRecord, error)
+	EditRecord(string, int, *DomainRecordEditRequest) (*DomainRecord, error)
+	CreateRecord(string, *DomainRecordEditRequest) (*DomainRecord, error)
 }
 
 type domainsService struct {
@@ -157,20 +174,54 @@ func (ds *domainsService) DeleteRecord(domain string, id int) error {
 	return err
 }
 
-func (ds *domainsService) EditRecord(domain string, id int, drer *godo.DomainRecordEditRequest) (*DomainRecord, error) {
-	dr, _, err := ds.client.Domains.EditRecord(context.TODO(), domain, id, drer)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DomainRecord{DomainRecord: dr}, nil
+// domainRecordRoot is the root of an individual Domain Record response.
+//
+// Copied from godo.
+type domainRecordRoot struct {
+	DomainRecord *DomainRecord `json:"domain_record"`
 }
 
-func (ds *domainsService) CreateRecord(domain string, drer *godo.DomainRecordEditRequest) (*DomainRecord, error) {
-	dr, _, err := ds.client.Domains.CreateRecord(context.TODO(), domain, drer)
+func (ds *domainsService) EditRecord(domain string, id int, drer *DomainRecordEditRequest) (*DomainRecord, error) {
+	if len(domain) < 1 {
+		return nil, godo.NewArgError("domain", "cannot be an empty string")
+	}
+	if id < 1 {
+		return nil, godo.NewArgError("id", "cannot be less than 1")
+	}
+	if drer == nil {
+		return nil, godo.NewArgError("editRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf("v2/domains/%s/records/%d", domain, id)
+	req, err := ds.client.NewRequest(context.TODO(), http.MethodPut, path, drer)
 	if err != nil {
 		return nil, err
 	}
 
-	return &DomainRecord{DomainRecord: dr}, nil
+	root := new(domainRecordRoot)
+	if _, err := ds.client.Do(context.TODO(), req, root); err != nil {
+		return nil, err
+	}
+	return root.DomainRecord, nil
+}
+
+func (ds *domainsService) CreateRecord(domain string, drer *DomainRecordEditRequest) (*DomainRecord, error) {
+	if len(domain) < 1 {
+		return nil, godo.NewArgError("domain", "cannot be empty string")
+	}
+	if drer == nil {
+		return nil, godo.NewArgError("createRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf("v2/domains/%s/records", domain)
+	req, err := ds.client.NewRequest(context.Background(), http.MethodPost, path, drer)
+	if err != nil {
+		return nil, err
+	}
+
+	root := new(domainRecordRoot)
+	if _, err := ds.client.Do(context.Background(), req, root); err != nil {
+		return nil, err
+	}
+	return root.DomainRecord, err
 }

--- a/do/mocks/DomainService.go
+++ b/do/mocks/DomainService.go
@@ -138,7 +138,7 @@ func (mr *MockDomainsServiceMockRecorder) DeleteRecord(arg0, arg1 interface{}) *
 }
 
 // EditRecord mocks base method
-func (m *MockDomainsService) EditRecord(arg0 string, arg1 int, arg2 *godo.DomainRecordEditRequest) (*do.DomainRecord, error) {
+func (m *MockDomainsService) EditRecord(arg0 string, arg1 int, arg2 *do.DomainRecordEditRequest) (*do.DomainRecord, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EditRecord", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*do.DomainRecord)
@@ -153,7 +153,7 @@ func (mr *MockDomainsServiceMockRecorder) EditRecord(arg0, arg1, arg2 interface{
 }
 
 // CreateRecord mocks base method
-func (m *MockDomainsService) CreateRecord(arg0 string, arg1 *godo.DomainRecordEditRequest) (*do.DomainRecord, error) {
+func (m *MockDomainsService) CreateRecord(arg0 string, arg1 *do.DomainRecordEditRequest) (*do.DomainRecord, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRecord", arg0, arg1)
 	ret0, _ := ret[0].(*do.DomainRecord)

--- a/integration/domain_records_create_test.go
+++ b/integration/domain_records_create_test.go
@@ -1,0 +1,160 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite.Focus("compute/domain/records/create", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/domains/example.com/records":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				reqBody, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+				expect.JSONEq(domainRecordsCreateRequest, string(reqBody))
+
+				w.Write([]byte(domainRecordsCreateResponse))
+
+			case "/v2/domains/test.com/records":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				reqBody, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+				expect.JSONEq(domainRecordsCreateWithoutPortRequest, string(reqBody))
+
+				w.Write([]byte(domainRecordsCreateWithoutPortResponse))
+
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	when("command is create", func() {
+		it("creates a domain record", func() {
+			aliases := []string{"create", "c"}
+
+			for _, alias := range aliases {
+				cmd := exec.Command(builtBinaryPath,
+					"-t", "some-magic-token",
+					"-u", server.URL,
+					"compute",
+					"domain",
+					"records",
+					alias,
+					"example.com",
+					"--record-name", "example.com",
+					"--record-type", "SRV",
+					"--record-port", "0",
+				)
+
+				output, err := cmd.CombinedOutput()
+				expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+				expect.Equal(strings.TrimSpace(domainRecordsCreateOutput), strings.TrimSpace(string(output)))
+			}
+		})
+	})
+
+	when("command is create without a port", func() {
+		it("creates a domain record without sending the port", func() {
+			aliases := []string{"create", "c"}
+
+			for _, alias := range aliases {
+				cmd := exec.Command(builtBinaryPath,
+					"-t", "some-magic-token",
+					"-u", server.URL,
+					"compute",
+					"domain",
+					"records",
+					alias,
+					"test.com",
+					"--record-type", "A",
+					"--record-name", "www",
+					"--record-data", "1.1.1.1",
+				)
+
+				output, err := cmd.CombinedOutput()
+				expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+				expect.Equal(strings.TrimSpace(domainRecordsCreateWithoutPortOutput), strings.TrimSpace(string(output)))
+			}
+		})
+	})
+})
+
+const (
+	domainRecordsCreateOutput = `
+ID    Type    Name           Data    Priority    Port    TTL    Weight
+0             example.com            0           0       0      0
+`
+	domainRecordsCreateResponse = `
+{
+  "domain_record": {
+	"flags": 0,
+    "name": "example.com",
+    "port": 0
+  }
+}
+`
+	domainRecordsCreateRequest = `
+{"flags":0, "name":"example.com", "port":0, "priority":0, "ttl":1800, "type":"SRV", "weight":0}
+`
+
+	domainRecordsCreateWithoutPortOutput = `
+ID    Type    Name        Data    Priority    Port    TTL    Weight
+0             test.com            0           0       0      0
+`
+	domainRecordsCreateWithoutPortResponse = `
+{
+  "domain_record": {
+	"flags": 0,
+    "name": "test.com",
+    "port": 0
+  }
+}
+`
+	domainRecordsCreateWithoutPortRequest = `
+{"data":"1.1.1.1", "flags":0, "name":"www", "priority":0, "ttl":1800, "type":"A", "weight":0}
+`
+)


### PR DESCRIPTION
Updates the create and edit domain records commands to send a value of zero when the port is set to zero via a flag, and to not send it otherwise.

This required both of these commands not to use `godo`, in order to save us from having to make a breaking change in `godo` to update the port field to be a int pointer instead of just an int.

In the future, this commit should be reverted once we're able to release a v2 of `godo` that addresses this issue properly.

If merged, we should close https://github.com/digitalocean/godo/pull/269.