### PR TITLE
Remove focus call from integration tests

### DIFF
--- a/integration/domain_records_create_test.go
+++ b/integration/domain_records_create_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ = suite.Focus("compute/domain/records/create", func(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("compute/domain/records/create", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server


### PR DESCRIPTION
Removes the focus call from integration tests so that they run again.