### PR TITLE
Add integration test for DIGITALOCEAN_CONTEXT

### DIFF
--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -212,4 +212,33 @@ context: default
 			expect.NoError(err)
 		})
 	})
+
+	when("the DIGITALOCEAN_CONTEXT variable is set", func() {
+		it("uses that context for commands", func() {
+			var testConfigBytes = []byte(`access-token: first-token
+auth-contexts:
+  next: second-token
+context: default
+`)
+
+			tmpDir, err := ioutil.TempDir("", "")
+			expect.NoError(err)
+			testConfig := filepath.Join(tmpDir, "test-config.yml")
+			expect.NoError(ioutil.WriteFile(testConfig, testConfigBytes, 0644))
+
+			cmd := exec.Command(builtBinaryPath,
+				"-u", server.URL,
+				"auth",
+				"list",
+				"--config", testConfig,
+			)
+			cmd.Env = os.Environ()
+			cmd.Env = append(cmd.Env, "DIGITALOCEAN_CONTEXT=next")
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, string(output))
+
+			expect.Contains(string(output), "next (current)")
+		})
+	})
 })


### PR DESCRIPTION
Adds an integration test for `DIGITALOCEAN_CONTEXT`, an environment variable used to set the name of the current context for a command. This is essentially what the `--context` flag already does.