### PR TITLE
Add OS info to user agent string

### DIFF
--- a/doit.go
+++ b/doit.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -207,7 +208,7 @@ func (c *LiveConfig) GetGodoClient(trace bool, accessToken string) (*godo.Client
 }
 
 func userAgent() string {
-	return "doctl/" + DoitVersion.String()
+	return fmt.Sprintf("doctl/%s-%s/%s", runtime.GOOS, runtime.GOARCH, DoitVersion.String())
 }
 
 // SSH creates a ssh connection to a host.

--- a/doit.go
+++ b/doit.go
@@ -208,7 +208,7 @@ func (c *LiveConfig) GetGodoClient(trace bool, accessToken string) (*godo.Client
 }
 
 func userAgent() string {
-	return fmt.Sprintf("doctl/%s-%s/%s", runtime.GOOS, runtime.GOARCH, DoitVersion.String())
+	return fmt.Sprintf("doctl/%s (%s %s)", DoitVersion.String(), runtime.GOOS, runtime.GOARCH)
 }
 
 // SSH creates a ssh connection to a host.

--- a/doit_test.go
+++ b/doit_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestUserAgent(t *testing.T) {
-	pattern := `doctl\/([0-9]+\.?){3}(-dev)? \(([0-9a-zA-Z ]\w+){2}\)`
+	pattern := `doctl\/([0-9]+\.?){3}(-dev)? \(([\w ]+){2}\)`
 	re := regexp.MustCompile(pattern)
 
 	t.Run("release version", func(t *testing.T) {

--- a/doit_test.go
+++ b/doit_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestUserAgent(t *testing.T) {
-	pattern := `doctl\/([a-zA-Z-]\w+){2}\/([0-9]\.?){3}(-dev)?`
+	pattern := `doctl\/([0-9]+\.?){3}(-dev)? \(([a-zA-Z ]\w+){2}\)`
 	re := regexp.MustCompile(pattern)
 
 	t.Run("release version", func(t *testing.T) {

--- a/doit_test.go
+++ b/doit_test.go
@@ -15,9 +15,8 @@ package doctl
 
 import (
 	"os"
+	"regexp"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -25,14 +24,26 @@ func TestMain(m *testing.M) {
 }
 
 func TestUserAgent(t *testing.T) {
-	dv := DoitVersion
-	defer func() {
+	pattern := `doctl\/([a-zA-Z-]\w+){2}\/([0-9]\.?){3}(-dev)?`
+	re := regexp.MustCompile(pattern)
+
+	t.Run("release version", func(t *testing.T) {
+		dv := DoitVersion
+		DoitVersion = Version{Major: 0, Minor: 1, Patch: 2}
+
+		ua := userAgent()
+		if !re.MatchString(ua) {
+			t.Errorf("expected %s to match %s", ua, pattern)
+		}
 		DoitVersion = dv
-	}()
+	})
 
-	DoitVersion = Version{Major: 0, Minor: 1, Patch: 2}
-
-	assert.Equal(t, "doctl/0.1.2", userAgent())
+	t.Run("dev version", func(t *testing.T) {
+		ua := userAgent()
+		if !re.MatchString(ua) {
+			t.Errorf("expected %s to match %s", ua, pattern)
+		}
+	})
 }
 
 func TestVersion(t *testing.T) {

--- a/doit_test.go
+++ b/doit_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestUserAgent(t *testing.T) {
-	pattern := `doctl\/([0-9]+\.?){3}(-dev)? \(([a-zA-Z ]\w+){2}\)`
+	pattern := `doctl\/([0-9]+\.?){3}(-dev)? \(([0-9a-zA-Z ]\w+){2}\)`
 	re := regexp.MustCompile(pattern)
 
 	t.Run("release version", func(t *testing.T) {


### PR DESCRIPTION
Adds the OS info to the user agent string that we set on our `godo` client. The OS info is pulled from the runtime's `GOOS` and `GOARCH` variables. The new user agent string will now look like,

```
doctl/1.22.3 (darwin amd64)
```

or

```
doctl/0.0.0-dev (windows 386)
```

---

If the regex in the test is too much, I can remove it.