### PR TITLE
plugin: deprecate and hide from compute menu

### DIFF
--- a/commands/plugin.go
+++ b/commands/plugin.go
@@ -28,10 +28,12 @@ import (
 func Plugin() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
-			Use:     "plugin",
-			Short:   "plugin commands",
-			Long:    "plugin is used to access plugin commands",
-			Aliases: []string{"p"},
+			Use:        "plugin",
+			Short:      "plugin commands",
+			Long:       "plugin is used to access plugin commands",
+			Aliases:    []string{"p"},
+			Hidden:     true,
+			Deprecated: "this command will be removed in a future version of doctl",
 		},
 	}
 


### PR DESCRIPTION
we are going to remove this functionality in a future release of doctl, for now it is just hidden.