### PR TITLE
Support deleting multiple Kubernetes clusters

### DIFF
--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -521,6 +521,19 @@ func TestKubernetesDelete(t *testing.T) {
 		err := testK8sCmdService().RunKubernetesClusterDelete(config)
 		assert.NoError(t, err)
 	})
+	// multiple clusters
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		id2 := "ce69d914-ae08-4c91-8a4b-383f58b47e6f"
+
+		tm.kubernetes.EXPECT().Delete(testCluster.ID).Return(nil)
+		tm.kubernetes.EXPECT().Delete(id2).Return(nil)
+
+		config.Args = append(config.Args, testCluster.ID, id2)
+		config.Doit.Set(config.NS, doctl.ArgForce, "true")
+
+		err := testK8sCmdService().RunKubernetesClusterDelete(config)
+		assert.NoError(t, err)
+	})
 }
 
 func TestKubernetesNodePool_Get(t *testing.T) {


### PR DESCRIPTION
This change adds support for deleting multiple Kubernetes clusters in a single doctl invocation.

Having the frequent need to spin up and subsequently tear down multiple clusters, I find this addition convenient. Additionally, it aligns us closer with some of the other APIs that also support operating on multiple objects at once.