### PR TITLE
Support kubernetes node pool labels

### DIFF
--- a/args.go
+++ b/args.go
@@ -68,6 +68,8 @@ const (
 	ArgDropletIDs = "droplet-ids"
 	// ArgKernelID is a ekrnel id argument.
 	ArgKernelID = "kernel-id"
+	// ArgKubernetesLabel is a Kubernetes label argument.
+	ArgKubernetesLabel = "label"
 	// ArgImage is an image argument.
 	ArgImage = "image"
 	// ArgImageID is an image id argument.

--- a/commands/displayers/kubernetes.go
+++ b/commands/displayers/kubernetes.go
@@ -131,18 +131,20 @@ func (nodePools *KubernetesNodePools) Cols() []string {
 		"Size",
 		"Count",
 		"Tags",
+		"Labels",
 		"Nodes",
 	}
 }
 
 func (nodePools *KubernetesNodePools) ColMap() map[string]string {
 	return map[string]string{
-		"ID":    "ID",
-		"Name":  "Name",
-		"Size":  "Size",
-		"Count": "Count",
-		"Tags":  "Tags",
-		"Nodes": "Nodes",
+		"ID":     "ID",
+		"Name":   "Name",
+		"Size":   "Size",
+		"Count":  "Count",
+		"Tags":   "Tags",
+		"Labels": "Labels",
+		"Nodes":  "Nodes",
 	}
 }
 
@@ -157,12 +159,13 @@ func (nodePools *KubernetesNodePools) KV() []map[string]interface{} {
 		}
 
 		o := map[string]interface{}{
-			"ID":    nodePools.ID,
-			"Name":  nodePools.Name,
-			"Size":  nodePools.Size,
-			"Count": nodePools.Count,
-			"Tags":  tags,
-			"Nodes": nodes,
+			"ID":     nodePools.ID,
+			"Name":   nodePools.Name,
+			"Size":   nodePools.Size,
+			"Count":  nodePools.Count,
+			"Tags":   tags,
+			"Labels": nodePools.Labels,
+			"Nodes":  nodes,
 		}
 		out = append(out, o)
 	}

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -234,6 +234,17 @@ func AddStringSliceFlag(cmd *Command, name, shorthand string, def []string, desc
 	}
 }
 
+// AddStringMapStringFlag adds a map of strings by strings flag to a command.
+func AddStringMapStringFlag(cmd *Command, name, shorthand string, def map[string]string, desc string, opts ...flagOpt) {
+	fn := flagName(cmd, name)
+	cmd.Flags().StringToStringP(name, shorthand, def, desc)
+	viper.BindPFlag(fn, cmd.Flags().Lookup(name))
+
+	for _, o := range opts {
+		o(cmd, name, fn)
+	}
+}
+
 func flagName(cmd *Command, name string) string {
 	if cmd.Parent() != nil {
 		return fmt.Sprintf("%s.%s.%s", cmd.Parent().Name(), cmd.Name(), name)

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/digitalocean/doctl"
@@ -36,12 +37,13 @@ var (
 
 	testNodePool = do.KubernetesNodePool{
 		KubernetesNodePool: &godo.KubernetesNodePool{
-			ID:    "ede2c0d6-41e3-479e-ba60-ad9712272324",
-			Name:  "antoine_s_pool",
-			Size:  "c8",
-			Count: 3,
-			Tags:  []string{"hello", "bye"},
-			Nodes: testNodes,
+			ID:     "ede2c0d6-41e3-479e-ba60-ad9712272324",
+			Name:   "antoine_s_pool",
+			Size:   "c8",
+			Count:  3,
+			Tags:   []string{"hello", "bye"},
+			Labels: map[string]string{},
+			Nodes:  testNodes,
 		},
 	}
 
@@ -323,6 +325,15 @@ func TestKubernetesList(t *testing.T) {
 
 func TestKubernetesCreate(t *testing.T) {
 	testNodePool := testNodePool
+	testNodePool.Labels = map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	var inputLabels []string
+	for key, val := range testNodePool.Labels {
+		inputLabels = append(inputLabels, fmt.Sprintf("%s=%s", key, val))
+	}
+	sort.Strings(inputLabels)
 	testNodePool.AutoScale = true
 	testNodePool.MinNodes = 1
 	testNodePool.MaxNodes = 10
@@ -339,15 +350,17 @@ func TestKubernetesCreate(t *testing.T) {
 					Size:      testNodePool.Size,
 					Count:     testNodePool.Count,
 					Tags:      testNodePool.Tags,
+					Labels:    testNodePool.Labels,
 					AutoScale: testNodePool.AutoScale,
 					MinNodes:  testNodePool.MinNodes,
 					MaxNodes:  testNodePool.MaxNodes,
 				},
 				{
-					Name:  testNodePool.Name + "2",
-					Size:  testNodePool.Size,
-					Count: testNodePool.Count,
-					Tags:  testNodePool.Tags,
+					Name:   testNodePool.Name + "2",
+					Size:   testNodePool.Size,
+					Count:  testNodePool.Count,
+					Tags:   testNodePool.Tags,
+					Labels: map[string]string{},
 				},
 			},
 			MaintenancePolicy: &godo.KubernetesMaintenancePolicy{
@@ -365,9 +378,9 @@ func TestKubernetesCreate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgTag, testCluster.Tags)
 		config.Doit.Set(config.NS, doctl.ArgMaintenanceWindow, "any=00:00")
 		config.Doit.Set(config.NS, doctl.ArgClusterNodePool, []string{
-			fmt.Sprintf("name=%s;size=%s;count=%d;tag=%s;tag=%s;auto-scale=%v;min-nodes=%d;max-nodes=%d",
+			fmt.Sprintf("name=%s;size=%s;count=%d;tag=%s;tag=%s;label=%s;label=%s;auto-scale=%v;min-nodes=%d;max-nodes=%d",
 				testNodePool.Name+"1", testNodePool.Size, testNodePool.Count, testNodePool.Tags[0], testNodePool.Tags[1],
-				testNodePool.AutoScale, testNodePool.MinNodes, testNodePool.MaxNodes,
+				inputLabels[0], inputLabels[1], testNodePool.AutoScale, testNodePool.MinNodes, testNodePool.MaxNodes,
 			),
 			fmt.Sprintf("name=%s;size=%s;count=%d;tag=%s;tag=%s",
 				testNodePool.Name+"2", testNodePool.Size, testNodePool.Count, testNodePool.Tags[0], testNodePool.Tags[1],
@@ -618,6 +631,10 @@ func TestKubernetesNodePool_List(t *testing.T) {
 
 func TestKubernetesNodePool_Create(t *testing.T) {
 	testNodePool := testNodePool
+	testNodePool.Labels = map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
 	testNodePool.AutoScale = true
 	testNodePool.MinNodes = 1
 	testNodePool.MaxNodes = 10
@@ -629,6 +646,7 @@ func TestKubernetesNodePool_Create(t *testing.T) {
 			Size:      testNodePool.Size,
 			Count:     testNodePool.Count,
 			Tags:      testNodePool.Tags,
+			Labels:    testNodePool.Labels,
 			AutoScale: testNodePool.AutoScale,
 			MinNodes:  testNodePool.MinNodes,
 			MaxNodes:  testNodePool.MaxNodes,
@@ -641,6 +659,7 @@ func TestKubernetesNodePool_Create(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgSizeSlug, testNodePool.Size)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
 		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+		config.Doit.Set(config.NS, doctl.ArgKubernetesLabel, testNodePool.Labels)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolAutoScale, testNodePool.AutoScale)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolMinNodes, testNodePool.MinNodes)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolMaxNodes, testNodePool.MaxNodes)
@@ -655,6 +674,7 @@ func TestKubernetesNodePool_Create(t *testing.T) {
 			Size:      testNodePool.Size,
 			Count:     testNodePool.Count,
 			Tags:      testNodePool.Tags,
+			Labels:    testNodePool.Labels,
 			AutoScale: testNodePool.AutoScale,
 			MinNodes:  testNodePool.MinNodes,
 			MaxNodes:  testNodePool.MaxNodes,
@@ -668,6 +688,7 @@ func TestKubernetesNodePool_Create(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgSizeSlug, testNodePool.Size)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
 		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+		config.Doit.Set(config.NS, doctl.ArgKubernetesLabel, testNodePool.Labels)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolAutoScale, testNodePool.AutoScale)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolMinNodes, testNodePool.MinNodes)
 		config.Doit.Set(config.NS, doctl.ArgNodePoolMaxNodes, testNodePool.MaxNodes)
@@ -677,110 +698,137 @@ func TestKubernetesNodePool_Create(t *testing.T) {
 	})
 }
 
+func createTestNodePoolUpdateRequest() godo.KubernetesNodePoolUpdateRequest {
+	return godo.KubernetesNodePoolUpdateRequest{
+		Name:   testNodePool.Name,
+		Count:  &testNodePool.Count,
+		Tags:   testNodePool.Tags,
+		Labels: map[string]string{},
+	}
+}
+
 func TestKubernetesNodePool_Update(t *testing.T) {
-	// by cluster ID
-	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		r := godo.KubernetesNodePoolUpdateRequest{
-			Name:  testNodePool.Name,
-			Count: &testNodePool.Count,
-			Tags:  testNodePool.Tags,
-		}
-		tm.kubernetes.EXPECT().UpdateNodePool(testCluster.ID, testNodePool.ID, &r).Return(&testNodePool, nil)
+	t.Run("by cluster ID", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			r := createTestNodePoolUpdateRequest()
 
-		config.Args = append(config.Args, testCluster.ID, testNodePool.ID)
+			tm.kubernetes.EXPECT().UpdateNodePool(testCluster.ID, testNodePool.ID, &r).Return(&testNodePool, nil)
 
-		config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
-		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
-		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+			config.Args = append(config.Args, testCluster.ID, testNodePool.ID)
 
-		err := testK8sCmdService().RunKubernetesNodePoolUpdate(config)
-		assert.NoError(t, err)
+			config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
+			config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
+			config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+
+			err := testK8sCmdService().RunKubernetesNodePoolUpdate(config)
+			assert.NoError(t, err)
+		})
 	})
-	// by cluster name, pool ID
-	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		r := godo.KubernetesNodePoolUpdateRequest{
-			Name:  testNodePool.Name,
-			Count: &testNodePool.Count,
-			Tags:  testNodePool.Tags,
-		}
-		tm.kubernetes.EXPECT().List().Return(testClusterList, nil)
-		tm.kubernetes.EXPECT().UpdateNodePool(testCluster.ID, testNodePool.ID, &r).Return(&testNodePool, nil)
+	t.Run("by cluster name and pool ID", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			r := createTestNodePoolUpdateRequest()
 
-		config.Args = append(config.Args, testCluster.Name, testNodePool.ID)
+			tm.kubernetes.EXPECT().List().Return(testClusterList, nil)
+			tm.kubernetes.EXPECT().UpdateNodePool(testCluster.ID, testNodePool.ID, &r).Return(&testNodePool, nil)
 
-		config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
-		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
-		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+			config.Args = append(config.Args, testCluster.Name, testNodePool.ID)
 
-		err := testK8sCmdService().RunKubernetesNodePoolUpdate(config)
-		assert.NoError(t, err)
+			config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
+			config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
+			config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+
+			err := testK8sCmdService().RunKubernetesNodePoolUpdate(config)
+			assert.NoError(t, err)
+		})
 	})
-	// by cluster ID, pool name
-	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		r := godo.KubernetesNodePoolUpdateRequest{
-			Name:  testNodePool.Name,
-			Count: &testNodePool.Count,
-			Tags:  testNodePool.Tags,
-		}
-		tm.kubernetes.EXPECT().ListNodePools(testCluster.ID).Return(testNodePools, nil)
-		tm.kubernetes.EXPECT().UpdateNodePool(testCluster.ID, testNodePool.ID, &r).Return(&testNodePool, nil)
 
-		config.Args = append(config.Args, testCluster.ID, testNodePool.Name)
+	t.Run("by cluster ID and pool name", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			r := createTestNodePoolUpdateRequest()
 
-		config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
-		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
-		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+			tm.kubernetes.EXPECT().ListNodePools(testCluster.ID).Return(testNodePools, nil)
+			tm.kubernetes.EXPECT().UpdateNodePool(testCluster.ID, testNodePool.ID, &r).Return(&testNodePool, nil)
 
-		err := testK8sCmdService().RunKubernetesNodePoolUpdate(config)
-		assert.NoError(t, err)
+			config.Args = append(config.Args, testCluster.ID, testNodePool.Name)
+
+			config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
+			config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
+			config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+
+			err := testK8sCmdService().RunKubernetesNodePoolUpdate(config)
+			assert.NoError(t, err)
+		})
 	})
-	// by cluster name, pool name
-	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		r := godo.KubernetesNodePoolUpdateRequest{
-			Name:  testNodePool.Name,
-			Count: &testNodePool.Count,
-			Tags:  testNodePool.Tags,
-		}
-		tm.kubernetes.EXPECT().List().Return(testClusterList, nil)
-		tm.kubernetes.EXPECT().ListNodePools(testCluster.ID).Return(testNodePools, nil)
-		tm.kubernetes.EXPECT().UpdateNodePool(testCluster.ID, testNodePool.ID, &r).Return(&testNodePool, nil)
 
-		config.Args = append(config.Args, testCluster.Name, testNodePool.Name)
+	t.Run("by cluster name and pool name", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			r := createTestNodePoolUpdateRequest()
 
-		config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
-		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
-		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+			tm.kubernetes.EXPECT().List().Return(testClusterList, nil)
+			tm.kubernetes.EXPECT().ListNodePools(testCluster.ID).Return(testNodePools, nil)
+			tm.kubernetes.EXPECT().UpdateNodePool(testCluster.ID, testNodePool.ID, &r).Return(&testNodePool, nil)
 
-		err := testK8sCmdService().RunKubernetesNodePoolUpdate(config)
-		assert.NoError(t, err)
+			config.Args = append(config.Args, testCluster.Name, testNodePool.Name)
+
+			config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
+			config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
+			config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+
+			err := testK8sCmdService().RunKubernetesNodePoolUpdate(config)
+			assert.NoError(t, err)
+		})
 	})
-	// with autoscale config
-	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		testNodePool := testNodePool
-		testNodePool.AutoScale = true
-		testNodePool.MinNodes = 1
-		testNodePool.MaxNodes = 10
-		r := godo.KubernetesNodePoolUpdateRequest{
-			Name:      testNodePool.Name,
-			Count:     &testNodePool.Count,
-			Tags:      testNodePool.Tags,
-			AutoScale: &testNodePool.AutoScale,
-			MinNodes:  &testNodePool.MinNodes,
-			MaxNodes:  &testNodePool.MaxNodes,
-		}
-		tm.kubernetes.EXPECT().UpdateNodePool(testCluster.ID, testNodePool.ID, &r).Return(&testNodePool, nil)
 
-		config.Args = append(config.Args, testCluster.ID, testNodePool.ID)
+	t.Run("with autoscale config", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			testNodePool := testNodePool
+			testNodePool.AutoScale = true
+			testNodePool.MinNodes = 1
+			testNodePool.MaxNodes = 10
 
-		config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
-		config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
-		config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
-		config.Doit.Set(config.NS, doctl.ArgNodePoolAutoScale, testNodePool.AutoScale)
-		config.Doit.Set(config.NS, doctl.ArgNodePoolMinNodes, testNodePool.MinNodes)
-		config.Doit.Set(config.NS, doctl.ArgNodePoolMaxNodes, testNodePool.MaxNodes)
+			r := createTestNodePoolUpdateRequest()
+			r.AutoScale = &testNodePool.AutoScale
+			r.MinNodes = &testNodePool.MinNodes
+			r.MaxNodes = &testNodePool.MaxNodes
 
-		err := testK8sCmdService().RunKubernetesNodePoolUpdate(config)
-		assert.NoError(t, err)
+			tm.kubernetes.EXPECT().UpdateNodePool(testCluster.ID, testNodePool.ID, &r).Return(&testNodePool, nil)
+
+			config.Args = append(config.Args, testCluster.ID, testNodePool.ID)
+
+			config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
+			config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
+			config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+			config.Doit.Set(config.NS, doctl.ArgNodePoolAutoScale, testNodePool.AutoScale)
+			config.Doit.Set(config.NS, doctl.ArgNodePoolMinNodes, testNodePool.MinNodes)
+			config.Doit.Set(config.NS, doctl.ArgNodePoolMaxNodes, testNodePool.MaxNodes)
+
+			err := testK8sCmdService().RunKubernetesNodePoolUpdate(config)
+			assert.NoError(t, err)
+		})
+	})
+	t.Run("with labels", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			testNodePool := testNodePool
+			testNodePool.Labels = map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			}
+
+			r := createTestNodePoolUpdateRequest()
+			r.Labels = testNodePool.Labels
+
+			tm.kubernetes.EXPECT().UpdateNodePool(testCluster.ID, testNodePool.ID, &r).Return(&testNodePool, nil)
+
+			config.Args = append(config.Args, testCluster.ID, testNodePool.ID)
+
+			config.Doit.Set(config.NS, doctl.ArgNodePoolName, testNodePool.Name)
+			config.Doit.Set(config.NS, doctl.ArgNodePoolCount, testNodePool.Count)
+			config.Doit.Set(config.NS, doctl.ArgTag, testNodePool.Tags)
+			config.Doit.Set(config.NS, doctl.ArgKubernetesLabel, testNodePool.Labels)
+
+			err := testK8sCmdService().RunKubernetesNodePoolUpdate(config)
+			assert.NoError(t, err)
+		})
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.7
-	github.com/digitalocean/godo v1.29.0
+	github.com/digitalocean/godo v1.30.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.7.0
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.29.0 h1:KgNNU0k9SZqVgn7m8NN9iDsq0+nluHBe8HR9QE0QVmA=
-github.com/digitalocean/godo v1.29.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
+github.com/digitalocean/godo v1.30.0 h1:4Zb+xBlKMXKg772eyQk6px3sk9RhWj/CR75tQ375A/U=
+github.com/digitalocean/godo v1.30.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/vendor/github.com/digitalocean/godo/.whitesource
+++ b/vendor/github.com/digitalocean/godo/.whitesource
@@ -1,0 +1,8 @@
+{
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW"
+  }
+}

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
-## unreleased
+## [v1.30.0] - 2020-02-03
+
+- #295 registry: support the created_at field - @adamwg
+- #293 doks: node pool labels - @snormore
 
 ## [v1.29.0] - 2019-12-13
 

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.29.0"
+	libraryVersion = "1.30.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -84,24 +84,26 @@ type KubernetesClusterUpgradeRequest struct {
 // KubernetesNodePoolCreateRequest represents a request to create a node pool for a
 // Kubernetes cluster.
 type KubernetesNodePoolCreateRequest struct {
-	Name      string   `json:"name,omitempty"`
-	Size      string   `json:"size,omitempty"`
-	Count     int      `json:"count,omitempty"`
-	Tags      []string `json:"tags,omitempty"`
-	AutoScale bool     `json:"auto_scale,omitempty"`
-	MinNodes  int      `json:"min_nodes,omitempty"`
-	MaxNodes  int      `json:"max_nodes,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	Size      string            `json:"size,omitempty"`
+	Count     int               `json:"count,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	AutoScale bool              `json:"auto_scale,omitempty"`
+	MinNodes  int               `json:"min_nodes,omitempty"`
+	MaxNodes  int               `json:"max_nodes,omitempty"`
 }
 
 // KubernetesNodePoolUpdateRequest represents a request to update a node pool in a
 // Kubernetes cluster.
 type KubernetesNodePoolUpdateRequest struct {
-	Name      string   `json:"name,omitempty"`
-	Count     *int     `json:"count,omitempty"`
-	Tags      []string `json:"tags,omitempty"`
-	AutoScale *bool    `json:"auto_scale,omitempty"`
-	MinNodes  *int     `json:"min_nodes,omitempty"`
-	MaxNodes  *int     `json:"max_nodes,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	Count     *int              `json:"count,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	AutoScale *bool             `json:"auto_scale,omitempty"`
+	MinNodes  *int              `json:"min_nodes,omitempty"`
+	MaxNodes  *int              `json:"max_nodes,omitempty"`
 }
 
 // KubernetesNodePoolRecycleNodesRequest is DEPRECATED please use DeleteNode
@@ -297,14 +299,15 @@ type KubernetesClusterStatus struct {
 
 // KubernetesNodePool represents a node pool in a Kubernetes cluster.
 type KubernetesNodePool struct {
-	ID        string   `json:"id,omitempty"`
-	Name      string   `json:"name,omitempty"`
-	Size      string   `json:"size,omitempty"`
-	Count     int      `json:"count,omitempty"`
-	Tags      []string `json:"tags,omitempty"`
-	AutoScale bool     `json:"auto_scale,omitempty"`
-	MinNodes  int      `json:"min_nodes,omitempty"`
-	MaxNodes  int      `json:"max_nodes,omitempty"`
+	ID        string            `json:"id,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	Size      string            `json:"size,omitempty"`
+	Count     int               `json:"count,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	AutoScale bool              `json:"auto_scale,omitempty"`
+	MinNodes  int               `json:"min_nodes,omitempty"`
+	MaxNodes  int               `json:"max_nodes,omitempty"`
 
 	Nodes []*KubernetesNode `json:"nodes,omitempty"`
 }

--- a/vendor/github.com/digitalocean/godo/registry.go
+++ b/vendor/github.com/digitalocean/godo/registry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 const (
@@ -41,7 +42,8 @@ type RegistryDockerCredentialsRequest struct {
 
 // Registry represents a registry.
 type Registry struct {
-	Name string `json:"name,omitempty"`
+	Name      string    `json:"name,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
 }
 
 type registryRoot struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.29.0
+# github.com/digitalocean/godo v1.30.0
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util
 # github.com/dustin/go-humanize v1.0.0


### PR DESCRIPTION
~The PR depends on the latest (yet unreleased) master version of godo to set labels on Kubernetes requests. **It is only meant to allow the PR to be shared and gather early feedback; the dependency will be reverted to the next godo release once it is out (and block merging until that has happend).**~ (godo has been released and this PR updated accordingly.)