### PR TITLE
consolidate logic, droplet create --tagName(s)

### DIFF
--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -205,6 +205,9 @@ func RunDropletCreate(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
+	if len(tagName) > 0 {
+		tagNames = append(tagNames, tagName)
+	}
 
 	sshKeys := extractSSHKeys(keys)
 
@@ -247,7 +250,6 @@ func RunDropletCreate(c *CmdConfig) error {
 	}
 
 	ds := c.Droplets()
-	ts := c.Tags()
 
 	var wg sync.WaitGroup
 	var createdList do.Droplets
@@ -272,36 +274,10 @@ func RunDropletCreate(c *CmdConfig) error {
 		go func() {
 			defer wg.Done()
 
-			if tagName != "" {
-				tag, err := ts.Get(tagName)
-				if err != nil {
-					errs <- err
-					return
-				}
-				if tag == nil {
-					errs <- fmt.Errorf("Specified tag does not exist.")
-					return
-				}
-			}
-
 			d, err := ds.Create(dcr, wait)
 			if err != nil {
 				errs <- err
 				return
-			}
-
-			if tagName != "" {
-				trr := &godo.TagResourcesRequest{
-					Resources: []godo.Resource{
-						{ID: strconv.Itoa(d.ID), Type: godo.DropletResourceType},
-					},
-				}
-
-				err := ts.TagResources(tagName, trr)
-				if err != nil {
-					errs <- err
-				}
-
 			}
 
 			createdList = append(createdList, *d)

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -106,16 +106,18 @@ func TestDropletCreate(t *testing.T) {
 
 func TestDropletCreateWithTag(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		dcr := &godo.DropletCreateRequest{Name: "droplet", Region: "dev0", Size: "1gb", Image: godo.DropletCreateImage{ID: 0, Slug: "image"}, SSHKeys: []godo.DropletCreateSSHKey{}, Backups: false, IPv6: false, PrivateNetworking: false, UserData: "#cloud-config"}
+		dcr := &godo.DropletCreateRequest{
+			Name:              "droplet",
+			Region:            "dev0",
+			Size:              "1gb",
+			Image:             godo.DropletCreateImage{ID: 0, Slug: "image"},
+			SSHKeys:           []godo.DropletCreateSSHKey{},
+			Backups:           false,
+			IPv6:              false,
+			PrivateNetworking: false,
+			UserData:          "#cloud-config",
+			Tags:              []string{"my-tag"}}
 		tm.droplets.EXPECT().Create(dcr, false).Return(&testDroplet, nil)
-		tm.tags.EXPECT().Get("my-tag").Return(&testTag, nil)
-
-		trr := &godo.TagResourcesRequest{
-			Resources: []godo.Resource{
-				{ID: "1", Type: godo.DropletResourceType},
-			},
-		}
-		tm.tags.EXPECT().TagResources("my-tag", trr).Return(nil)
 
 		config.Args = append(config.Args, "droplet")
 


### PR DESCRIPTION
Per @andrewsomething

"A bit of context: For Droplet --tag-name first checks that the tag
exists since, when first introduced, that was a prerequisite. If the
user had not already created that tag, the Droplet create request
would fail. These days, we will automatically create the tag for the
user if they attempt to create a Droplet using a tag that did not
previously exist. So that check is now redundant and just adds an
unnecessary API call."

In fact, it adds three unnecessary API calls!

We should look at pulling --tagName from the docs at a later time.