### PR TITLE
Clean up overzealous use of backticks for strings.

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -43,7 +43,7 @@ func Databases() *Command {
 			Use:     "databases",
 			Aliases: []string{"db", "dbs", "d", "database"},
 			Short:   "Display commands that manage databases",
-			Long:    `The commands under ` + "`" + `doctl databases` + "`" + ` are for managing your MySQL, Redis, and PostgreSQL database services.`,
+			Long:    "The commands under `doctl databases` are for managing your MySQL, Redis, and PostgreSQL database services.",
 		},
 	}
 

--- a/commands/domains.go
+++ b/commands/domains.go
@@ -31,7 +31,7 @@ func Domain() *Command {
 		Command: &cobra.Command{
 			Use:   "domain",
 			Short: "Display commands that manage domains",
-			Long:  `Use the subcommands of ` + "`" + `doctl compute domain` + "`" + ` to manage domains you have purchased from a domain name registrar that you are managing through the DigitalOcean DNS interface.`,
+			Long:  "Use the subcommands of `doctl compute domain` to manage domains you have purchased from a domain name registrar that you are managing through the DigitalOcean DNS interface.",
 		},
 	}
 
@@ -52,7 +52,7 @@ func Domain() *Command {
 		Command: &cobra.Command{
 			Use:   "records",
 			Short: "Manage DNS records",
-			Long:  `Use the subcommands of ` + "`" + `doctl compute domain records` + "`" + ` to manage the DNS records for your domains.`,
+			Long:  "Use the subcommands of `doctl compute domain records` to manage the DNS records for your domains.",
 		},
 	}
 	cmd.AddCommand(cmdRecord)

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -37,7 +37,7 @@ func Droplet() *Command {
 			Use:     "droplet",
 			Aliases: []string{"d"},
 			Short:   "Manage virtual machines (Droplets)",
-			Long:    `A Droplet is a DigitalOcean virtual machine. Use the subcommands of ` + "`" + `doctl compute droplet` + "`" + ` to list, create, or delete Droplets.`,
+			Long:    "A Droplet is a DigitalOcean virtual machine. Use the subcommands of `doctl compute droplet` to list, create, or delete Droplets.",
 		},
 	}
 	dropletDetails := `

--- a/commands/image_actions.go
+++ b/commands/image_actions.go
@@ -30,7 +30,7 @@ func ImageAction() *Command {
 		Command: &cobra.Command{
 			Use:   "image-action",
 			Short: "Display commands to perform actions on images",
-			Long:  `The sub-commands of ` + "`" + `doctl compute image-actions` + "`" + ` can be used to perform actions on images.`,
+			Long:  "The sub-commands of `doctl compute image-actions` can be used to perform actions on images.",
 		},
 	}
 	actionDetail := `

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -103,7 +103,7 @@ func Kubernetes() *Command {
 			Use:     "kubernetes",
 			Aliases: []string{"kube", "k8s", "k"},
 			Short:   "Displays comamnds to manage Kubernetes clusters and configurations",
-			Long:    `The commands under ` + "`" + `doctl kubernetes` + "`" + ` are for managing Kubernetes clusters and viewing configuration options relating to clusters.` + workflowDesc + optionsDesc,
+			Long:    "The commands under `doctl kubernetes` are for managing Kubernetes clusters and viewing configuration options relating to clusters." + workflowDesc + optionsDesc,
 		},
 	}
 
@@ -206,7 +206,7 @@ func kubernetesCluster() *Command {
 			Use:     "cluster",
 			Aliases: []string{"clusters", "c"},
 			Short:   "Display commands for managing Kubernetes clusters",
-			Long:    `The commands under ` + "`" + `doctl kubernetes cluster` + "`" + ` are for the management of Kubernetes clusters.` + workflowDesc,
+			Long:    "The commands under `doctl kubernetes cluster` are for the management of Kubernetes clusters." + workflowDesc,
 		},
 	}
 
@@ -363,7 +363,7 @@ func kubernetesNodePools() *Command {
 			Use:     "node-pool",
 			Aliases: []string{"node-pools", "nodepool", "nodepools", "pool", "pools", "np", "p"},
 			Short:   "Display commands for managing node pools",
-			Long:    `The commands under ` + "`" + `node-pool` + "`" + ` are for performing actions on a Kubernetes cluster's node pools. You can use these commands to create or delete node pools, enable autoscaling for a node pool, and more.`,
+			Long:    "The commands under `node-pool` are for performing actions on a Kubernetes cluster's node pools. You can use these commands to create or delete node pools, enable autoscaling for a node pool, and more.",
 		},
 	}
 

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -32,7 +32,7 @@ func LoadBalancer() *Command {
 		Command: &cobra.Command{
 			Use:   "load-balancer",
 			Short: "Display commands to manage load balancers",
-			Long: `The sub-commands of ` + "`" + `doctl compute volume` + "`" + ` manage your load balancers.
+			Long: `The sub-commands of ` + "`" + `doctl compute load-balancer` + "`" + ` manage your load balancers.
 
 With the load-balancer command, you can list, create, or delete load balancers, and manage their configuration details.`,
 		},

--- a/commands/projects.go
+++ b/commands/projects.go
@@ -48,7 +48,7 @@ Projects allow you to organize your DigitalOcean resources (like Droplets, Space
 		Command: &cobra.Command{
 			Use:   "projects",
 			Short: "Manage projects and assign resources to them",
-			Long:  `The subcommands of ` + "`" + `doctl projects` + "`" + ` allow you to create, manage, and assign resources to your projects.` + projectsDesc,
+			Long:  "The subcommands of `doctl projects` allow you to create, manage, and assign resources to your projects." + projectsDesc,
 		},
 	}
 
@@ -101,7 +101,7 @@ func ProjectResourcesCmd() *Command {
 		Command: &cobra.Command{
 			Use:   "resources",
 			Short: "Manage resources assigned to a project",
-			Long:  `The subcommands of ` + "`" + `doctl projects resources` + "`" + ` allow you to list and assign resources to your projects.`,
+			Long:  "The subcommands of `doctl projects resources` allow you to list and assign resources to your projects.",
 		},
 	}
 

--- a/commands/regions.go
+++ b/commands/regions.go
@@ -24,7 +24,7 @@ func Region() *Command {
 		Command: &cobra.Command{
 			Use:   "region",
 			Short: "Display commands to list datacenter regions",
-			Long:  `The subcommands of ` + "`" + `doctl compute region` + "`" + ` retrieve information about DigitalOcean datacenter regions.`,
+			Long:  "The subcommands of `doctl compute region` retrieve information about DigitalOcean datacenter regions.",
 		},
 	}
 

--- a/commands/sizes.go
+++ b/commands/sizes.go
@@ -24,7 +24,7 @@ func Size() *Command {
 		Command: &cobra.Command{
 			Use:   "size",
 			Short: "List available Droplet sizes",
-			Long:  `The subcommands of ` + "`" + `doctl compute size` + "`" + ` retrieve information about Droplet sizes.`,
+			Long:  "The subcommands of `doctl compute size` retrieve information about Droplet sizes.",
 		},
 	}
 

--- a/commands/snapshots.go
+++ b/commands/snapshots.go
@@ -30,7 +30,7 @@ func Snapshot() *Command {
 			Use:     "snapshot",
 			Aliases: []string{"s"},
 			Short:   "Access and manage snapshots",
-			Long:    `The subcommands of ` + "`" + `doctl compute snapshot` + "`" + ` allow you to manage and retrieve information about Droplet and block storage volume snapshots.`,
+			Long:    "The subcommands of `doctl compute snapshot` allow you to manage and retrieve information about Droplet and block storage volume snapshots.",
 		},
 	}
 

--- a/commands/volume_actions.go
+++ b/commands/volume_actions.go
@@ -55,7 +55,7 @@ func VolumeAction() *Command {
 		Command: &cobra.Command{
 			Use:   "volume-action",
 			Short: "Display commands to perform actions on a volume",
-			Long:  `Block storage volume action commands allow you to attach, detach, and resize existing volumes.`,
+			Long:  "Block storage volume action commands allow you to attach, detach, and resize existing volumes.",
 		},
 	}
 


### PR DESCRIPTION
There's no need to use backticks for single line strings. It creates some unnecessary complications.