### PR TITLE
Update snap image, improve snap image workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,28 @@ snap_image:
 	@echo ""
 	@scripts/snap_image.sh
 
+.PHONY: _snap_image_version
+_snap_image_version:
+	@ORIGIN=${ORIGIN} SNAP_IMAGE=true scripts/version.sh
+
+.PHONY: build_local_snap
+build_local_snap:
+	@echo "==> build local snap using local image tagged doctl-snap-base"
+	@echo ""
+	@BUILD=local_snap scripts/snap_image.sh
+
+.PHONY: prerelease_snap_image
+prerelease_snap_image:
+	@echo "==> tag doctl-snap-base as a prerelease and push to dockerhub as latest"
+	@echo ""
+	@BUILD=pre scripts/snap_image.sh
+
+.PHONY: finalize_snap_image
+finalize_snap_image:
+	@echo "==> tag latest with most recent doctl version push to dockerhub"
+	@echo ""
+	@ORIGIN=${ORIGIN} BUILD=finalize scripts/snap_image.sh
+
 CHANNEL ?= stable
 
 .PHONY: _build_snap
@@ -112,7 +134,7 @@ _build_snap:
 
 .PHONY: snap
 snap:
-	@echo "=> publish snap (normally done by travis)"
+	@echo "==> publish snap (normally done by travis)"
 	@echo ""
 	@CHANNEL=${CHANNEL} scripts/snap.sh
 
@@ -182,13 +204,13 @@ _tag_and_release: tag
 
 .PHONY: release
 release:
-	@echo "=> release (most recent tag, normally done by travis)"
+	@echo "==> release (most recent tag, normally done by travis)"
 	@echo ""
 	@$(MAKE) _release
 
 .PHONY: docs
 docs:
-	@echo "=> Generate YAML documentation in ${DOCS_OUT}"
+	@echo "==> Generate YAML documentation in ${DOCS_OUT}"
 	@echo ""
 	@mkdir -p ${DOCS_OUT}
 	@DOCS_OUT=${DOCS_OUT} go run scripts/gen-yaml-docs.go

--- a/dockerfiles/Dockerfile.snap
+++ b/dockerfiles/Dockerfile.snap
@@ -1,14 +1,33 @@
 # Note to maintainers: after you make changes to this file, please run `make snap_image`.
+#  The script will gives instructions to complete the update once it finishes. Be patient, it
+#  takes a long time to run.
+#
+# For help with the technical aspects of this Dockerfile, see
+#   https://snapcraft.io/docs/t/creating-docker-images-for-snapcraft/11739
+#   https://raw.githubusercontent.com/snapcore/snapcraft/master/docker/stable.Dockerfile
+# and https://forum.snapcraft.io/. Note that the snapcraft forum does not appear to be indexed
+# effectively (at all?) by google.
+#
+# See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+#  for guidance on the style of this Dockerfile
 FROM ubuntu:xenial as builder
 
-RUN apt update && \
-        apt dist-upgrade --yes && \
-        apt install --yes curl jq squashfs-tools
+# We can afford to be broad here as we only select what we need in the next step, although it
+# is more brittle
+RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
+        curl \
+        jq \
+        squashfs-tools
 
-# Grab the core snap from the stable channel and unpack it in the proper place
+# Grab the core snap (for backwards compatibility) from the stable channel and unpack it in the proper place
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap && \
         mkdir -p /snap/core && \
         unsquashfs -d /snap/core/current core.snap
+
+# Grab the core18 snap (which snapcraft uses as a base) from the stable channel and unpack it in the proper place.
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap && \
+        mkdir -p /snap/core18 && \
+        unsquashfs -d /snap/core18/current core18.snap
 
 # Grab the snapcraft snap from the stable channel and unpack it in the proper place
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap && \
@@ -33,13 +52,11 @@ RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/sna
 FROM ubuntu:xenial
 COPY --from=builder /snap /snap
 
-RUN apt clean && \
-	apt update && \
-        apt dist-upgrade --yes && \
-        apt install --yes \
+RUN apt-get clean && apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
         sudo locales \
         gcc git && \
-        locale-gen en_US.UTF-8
+        locale-gen en_US.UTF-8 && \
+        rm -rf /var/lib/apt/lists/*
 
 # Set the proper environment
 ENV LANG en_US.UTF-8

--- a/dockerfiles/Dockerfile.snap
+++ b/dockerfiles/Dockerfile.snap
@@ -12,9 +12,7 @@
 #  for guidance on the style of this Dockerfile
 FROM ubuntu:xenial as builder
 
-# We can afford to be broad here as we only select what we need in the next step, although it
-# is more brittle
-RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
+RUN apt-get update && apt-get install --yes \
         curl \
         jq \
         squashfs-tools
@@ -52,9 +50,27 @@ RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/sna
 FROM ubuntu:xenial
 COPY --from=builder /snap /snap
 
-RUN apt-get clean && apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
-        sudo locales \
-        gcc git && \
+# The first set (build-essential through xz-utils) would otherwise be installed later
+RUN apt-get clean && apt-get update && apt-get install --yes \
+        build-essential \
+	bzip2 \
+	dpkg-dev \
+	fakeroot \
+	g++ g++-5 \
+	golang-1.6-go golang-1.6-race-detector-runtime golang-1.6-src golang-go golang-race-detector-runtime golang-src \
+	libalgorithm-diff-perl libalgorithm-diff-xs-perl libalgorithm-merge-perl libdpkg-perl \
+	libfakeroot libfile-fcntllock-perl libglib2.0-0 libglib2.0-data libicu55 libstdc++-5-dev libxml2 \
+	make \
+	pkg-config \
+	sgml-base \
+	shared-mime-info \
+	xdg-user-dirs \
+	xml-core \
+	xz-utils \
+        sudo \
+	locales \
+        gcc \
+	git && \
         locale-gen en_US.UTF-8 && \
         rm -rf /var/lib/apt/lists/*
 

--- a/scripts/snap_image.sh
+++ b/scripts/snap_image.sh
@@ -16,6 +16,7 @@ repo_missing() {
 
 build_local_snap() {
   docker tag "$REPO_NAME" "sammytheshark/$REPO_NAME"
+  cd "$DIR" && sudo make clean
   make _build_snap
 }
 

--- a/scripts/snap_image.sh
+++ b/scripts/snap_image.sh
@@ -4,37 +4,117 @@ set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../"
 
-< "$DIR/dockerfiles/Dockerfile.snap" docker build -t doctl-snap-base -
+ORIGIN=${ORIGIN:-origin}
 
-cat <<INSTRUCTIONS
-Next,
+REPO_NAME=${REPO_NAME:-doctl-snap-base}
+LATEST="${REPO_NAME}:latest"
+SAMMY_LATEST="sammytheshark/${LATEST}"
 
-1. tag the image you just built
-  - docker tag doctl-snap-base sammytheshark/doctl-snap-base
-2. make _build_snap
-3. test the resulting snap
-  a. install resulting snap locally, e.g., sudo snap install doctl_vX.XX.XXX*.snap --dangerous
-  b. wire up your snap:
-     - sudo snap connect doctl:doctl-config
-     - sudo snap connect doctl:kube-config
-  c. take it for a spin
+repo_missing() {
+  [[ $(docker images --format "{{.ID}}" "$1" | wc -l) -eq 0 ]]
+}
 
-Assuming it passes the test, continue!
+build_local_snap() {
+  docker tag "$REPO_NAME" "sammytheshark/$REPO_NAME"
+  make _build_snap
+}
 
-Push a prerelease version of the image to dockerhub. To get the version number run
-'make version'. Take the entire result and add 'pre', e.g., '1.31.2-automate-snap-image-b1582d49-pre'
-to get your version.
+build_pre() {
+  version="$(ORIGIN=${ORIGIN:-origin} SNAP_IMAGE=true "$DIR/scripts/version.sh")"
+  prerelease="sammytheshark/${REPO_NAME}:${version}"
 
-1. login to dockerhub as sammytheshark (credentials in LastPass)
+  docker tag "$REPO_NAME" "$prerelease" && \
+    docker push "$prerelease" && \
+    docker rename "$prerelease" "$SAMMY_LATEST" && \
+    docker push "$SAMMY_LATEST"
+}
+
+build_finalize() {
+  version=$("ORIGIN=${ORIGIN} $DIR/scripts/version.sh" -s)
+  release="sammytheshark/${REPO_NAME}:$version"
+
+  docker rename "$SAMMY_LATEST" "$release" && \
+    docker push "$release"
+}
+
+build_snap_image() {
+  < "$DIR/dockerfiles/Dockerfile.snap" docker build --no-cache -t "$REPO_NAME" -
+
+  cat <<INSTRUCTIONS
+######################################################################
+######################################################################
+
+Congrats! You built a new docker image for building snaps!
+
+Now you need to:
+A. Test your image
+B. Push a prerelease version of that image to Dockerhub
+C. Release a new version of doctl with any changes, e.g., to Dockerfile.snap
+D. Rename the prerelease image to a released version.
+
+Step by step, in detail:
+
+###
+A: Test your image
+
+1. Build a local snap from your image: make build_local_snap
+
+3. install the resulting snap locally
+
+   sudo snap install doctl_vX.XX.XXX*.snap --dangerous
+   sudo snap connect doctl:doctl-config
+   sudo snap connect doctl:kube-config
+
+4. take it for a spin.
+
+###
+B. Push a prerelease version of that image to Dockerhub
+
+Login to dockerhub as sammytheshark (credentials in LastPass) and
+tag and push the image using the make target
+
    docker login -u sammytheshark -p <from LastPass>
-2. docker tag doctl-snap-base sammytheshark/doctl-snap-base:<version>-<sha>-pre
-3. docker push sammytheshark/doctl-snap-base:<version>-<sha>-pre
-4. docker rename sammytheshark/doctl-snap-base:<version>-<sha>-pre sammytheshark/doctl-snap-base:latest
-5. docker push sammytheshark/doctl-snap-base:latest
+   make prerelease_snap_image
 
-submit your PR and merge. But wait! You aren't done yet!
+Check your work:
+- Visit https://hub.docker.com/repository/registry-1.docker.io/sammytheshark/doctl-snap-base/tags?page=1
+- Check the last updated date on the image tagged 'latest'
 
-Release a new version and get a new version number.
+###
+C. Release a new version of doctl with any changes
 
-Finally, docker rename and docker push your image from pre to the new version.
+If the only change is a new snap image, fixing a broken snap build,
+that's a patch, by the way. :)
+
+###
+D. Rename the prerelease image to the new released version.
+
+make finalize_snap_image
+
+######################################################################
+######################################################################
 INSTRUCTIONS
+}
+
+hash docker 2>/dev/null ||
+  { echo >&2 "I require the docker CLI but it's not installed. Please see https://docs.docker.com/install/. Aborting."; exit 1; }
+
+BUILD=${BUILD:-snap_image}
+
+case "$BUILD" in
+  local_snap | pre)
+    if repo_missing "$LATEST"; then
+      echo "Could not find ${LATEST}. Did you run 'make snap_image'?"
+      exit 1
+    fi
+    ;;
+  
+  finalize)
+    if repo_missing "$SAMMY_LATEST"; then
+      echo "Could not find ${SAMMY_LATEST}. Did you run 'make prerelease_snap_image'?"
+      exit 1
+    fi
+    ;;
+esac
+
+"build_${BUILD}"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -15,6 +15,7 @@ Options:
 
   -h, --help   Show this help information.
   -s, --short  major.minor.patch only
+  -i, --image  snap image version
   -b, --branch branch only
   -c, --commit commit only
 "
@@ -37,12 +38,23 @@ commit() {
   fi
 }
 
+image() {
+  echo "$(semver)-$(commit)-pre"
+}
+
 ORIGIN=${ORIGIN:-origin}
 set +e
 git fetch --tags "${ORIGIN}" &>/dev/null
 set -e
 
 if [[ "$#" -eq 0 ]]; then
+
+  SNAP_IMAGE=${SNAP_IMAGE:-false}
+  if [[ "${SNAP_IMAGE}" != 'false' ]]; then
+    image
+    exit 0
+  fi
+
   version=$(semver)
 
   br=$(branch)
@@ -70,6 +82,10 @@ case "$1" in
 
   "-s"|"--short")
     version=$(semver)
+    ;;
+
+  "-i"|"--image")
+    version=$(image)
     ;;
 
   *)


### PR DESCRIPTION
There are two aspects two this PR, improving the workflow for maintaining the snap image, and fixing the `Dockerfile.snap`. In the end, I decided to leave them in a single PR, in several commits, because I think that provides a better history.

Ultimately, I had to adopt Docker's recommended practice for apt-get usage in RUN statements in a Dockerfile in order to stabilize the build. Nifty!