### PR TITLE
load-balancers: add enable-proxy-protocol and enable-backend-keepalive flags

### DIFF
--- a/args.go
+++ b/args.go
@@ -227,6 +227,8 @@ const (
 	ArgRedirectHttpToHttps = "redirect-http-to-https"
 	// ArgEnableProxyProtocol is a flag that indicates whether PROXY protocol should be enabled on the load balancer.
 	ArgEnableProxyProtocol = "enable-proxy-protocol"
+	// ArgEnableBackendKeepalive is a flag that indicates whether keepalive connections should be enabled to target droplets from the load balancer.
+	ArgEnableBackendKeepalive = "enable-backend-keepalive"
 	// ArgStickySessions is a list of sticky sessions settings for the load balancer.
 	ArgStickySessions = "sticky-sessions"
 	// ArgHealthCheck is a list of health check settings for the load balancer.

--- a/args.go
+++ b/args.go
@@ -225,6 +225,8 @@ const (
 	ArgLoadBalancerAlgorithm = "algorithm"
 	// ArgRedirectHttpToHttps is a flag that indicates whether HTTP requests to the load balancer on port 80 should be redirected to HTTPS on port 443.
 	ArgRedirectHttpToHttps = "redirect-http-to-https"
+	// ArgEnableProxyProtocol is a flag that indicates whether PROXY protocol should be enabled on the load balancer.
+	ArgEnableProxyProtocol = "enable-proxy-protocol"
 	// ArgStickySessions is a list of sticky sessions settings for the load balancer.
 	ArgStickySessions = "sticky-sessions"
 	// ArgHealthCheck is a list of health check settings for the load balancer.

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -80,6 +80,8 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 		"Redirects HTTP requests to the load balancer on port 80 to HTTPS on port 443")
 	AddBoolFlag(cmdRecordCreate, doctl.ArgEnableProxyProtocol, "", false,
 		"enable proxy protocol")
+		AddBoolFlag(cmdRecordCreate, doctl.ArgEnableBackendKeepalive, "", false,
+		"enable keepalive connections to backend target droplets")
 	AddStringFlag(cmdRecordCreate, doctl.ArgTagName, "", "", "droplet tag name")
 	AddStringSliceFlag(cmdRecordCreate, doctl.ArgDropletIDs, "", []string{},
 		"A comma-separated list of Droplet IDs to add to the load balancer, e.g.: `12,33`")
@@ -102,6 +104,8 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 		"Flag to redirect HTTP requests to the load balancer on port 80 to HTTPS on port 443")
 	AddBoolFlag(cmdRecordUpdate, doctl.ArgEnableProxyProtocol, "", false,
 		"enable proxy protocol")
+		AddBoolFlag(cmdRecordUpdate, doctl.ArgEnableBackendKeepalive, "", false,
+		"enable keepalive connections to backend target droplets")
 	AddStringFlag(cmdRecordUpdate, doctl.ArgTagName, "", "", "Assigns Droplets with the specified tag to the load balancer")
 	AddStringSliceFlag(cmdRecordUpdate, doctl.ArgDropletIDs, "", []string{},
 		"A comma-separated list of Droplet IDs, e.g.: `215,378`")
@@ -412,6 +416,12 @@ func buildRequestFromArgs(c *CmdConfig, r *godo.LoadBalancerRequest) error {
 		return err
 	}
 	r.EnableProxyProtocol = enableProxyProtocol
+
+	enableBackendKeepalive, err := c.Doit.GetBool(c.NS, doctl.ArgEnableBackendKeepalive)
+	if err != nil {
+		return err
+	}
+	r.EnableBackendKeepalive = enableBackendKeepalive
 
 	dropletIDsList, err := c.Doit.GetStringSlice(c.NS, doctl.ArgDropletIDs)
 	if err != nil {

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -78,6 +78,8 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 		"round_robin", "The algorithm to use when traffic is distributed across your Droplets; possible values: `round_robin` or `least_connections`")
 	AddBoolFlag(cmdRecordCreate, doctl.ArgRedirectHttpToHttps, "", false,
 		"Redirects HTTP requests to the load balancer on port 80 to HTTPS on port 443")
+	AddBoolFlag(cmdRecordCreate, doctl.ArgEnableProxyProtocol, "", false,
+		"enable proxy protocol")
 	AddStringFlag(cmdRecordCreate, doctl.ArgTagName, "", "", "droplet tag name")
 	AddStringSliceFlag(cmdRecordCreate, doctl.ArgDropletIDs, "", []string{},
 		"A comma-separated list of Droplet IDs to add to the load balancer, e.g.: `12,33`")
@@ -98,6 +100,8 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 		"round_robin", "The algorithm to use when traffic is distributed across your Droplets; possible values: `round_robin` or `least_connections`")
 	AddBoolFlag(cmdRecordUpdate, doctl.ArgRedirectHttpToHttps, "", false,
 		"Flag to redirect HTTP requests to the load balancer on port 80 to HTTPS on port 443")
+	AddBoolFlag(cmdRecordUpdate, doctl.ArgEnableProxyProtocol, "", false,
+		"enable proxy protocol")
 	AddStringFlag(cmdRecordUpdate, doctl.ArgTagName, "", "", "Assigns Droplets with the specified tag to the load balancer")
 	AddStringSliceFlag(cmdRecordUpdate, doctl.ArgDropletIDs, "", []string{},
 		"A comma-separated list of Droplet IDs, e.g.: `215,378`")
@@ -402,6 +406,12 @@ func buildRequestFromArgs(c *CmdConfig, r *godo.LoadBalancerRequest) error {
 		return err
 	}
 	r.RedirectHttpToHttps = redirectHTTPToHTTPS
+
+	enableProxyProtocol, err := c.Doit.GetBool(c.NS, doctl.ArgEnableProxyProtocol)
+	if err != nil {
+		return err
+	}
+	r.EnableProxyProtocol = enableProxyProtocol
 
 	dropletIDsList, err := c.Doit.GetStringSlice(c.NS, doctl.ArgDropletIDs)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.7
-	github.com/digitalocean/godo v1.32.0
+	github.com/digitalocean/godo v1.33.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.7.0
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.32.0 h1:ljfhYi/IqDYiZcBYV7nUPzw1Q7NlmPSFDtI69UeRThk=
-github.com/digitalocean/godo v1.32.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
+github.com/digitalocean/godo v1.33.0 h1:JNZ/0v/Wp//UAIh84YWZ/x5neB3V5lKgcCHzyqErMJQ=
+github.com/digitalocean/godo v1.33.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/integration/lb_create_test.go
+++ b/integration/lb_create_test.go
@@ -67,6 +67,7 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 			"--name", "my-lb-name",
 			"--region", "venus",
 			"--redirect-http-to-https",
+			"--enable-proxy-protocol",
 			"--tag-name", "magic-lb",
 		}
 	})
@@ -96,8 +97,8 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 
 const (
 	lbCreateOutput = `
-ID                                      IP    Name             Status    Created At              Algorithm      Region    Tag    Droplet IDs        SSL      Sticky Sessions                                Health Check                                                                                                            Forwarding Rules
-4de7ac8b-495b-4884-9a69-1050c6793cd6          example-lb-01    new       2017-02-01T22:22:58Z    round_robin    nyc3             3164444,3164445    false    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:,port:0,path:,check_interval_seconds:0,response_timeout_seconds:0,healthy_threshold:0,unhealthy_threshold:0
+ID                                      IP    Name             Status    Created At              Algorithm      Region    Tag    Droplet IDs        SSL     Sticky Sessions                                Health Check                                                                                                            Forwarding Rules
+4de7ac8b-495b-4884-9a69-1050c6793cd6          example-lb-01    new       2017-02-01T22:22:58Z    round_robin    nyc3             3164444,3164445    true    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:,port:0,path:,check_interval_seconds:0,response_timeout_seconds:0,healthy_threshold:0,unhealthy_threshold:0
 `
 	lbCreateResponse = `
 {
@@ -129,8 +130,8 @@ ID                                      IP    Name             Status    Created
       3164444,
       3164445
     ],
-    "redirect_http_to_https": false,
-    "enable_proxy_protocol": false
+    "redirect_http_to_https": true,
+    "enable_proxy_protocol": true
   }
 }`
 	lbCreateRequest = `
@@ -141,6 +142,8 @@ ID                                      IP    Name             Status    Created
   "health_check":{},
   "sticky_sessions":{},
   "droplet_ids":[22,66],
-  "tag":"magic-lb","redirect_http_to_https":true
+  "tag":"magic-lb",
+  "redirect_http_to_https":true,
+  "enable_proxy_protocol":true
 }`
 )

--- a/integration/lb_create_test.go
+++ b/integration/lb_create_test.go
@@ -68,6 +68,7 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 			"--region", "venus",
 			"--redirect-http-to-https",
 			"--enable-proxy-protocol",
+			"--enable-backend-keepalive",
 			"--tag-name", "magic-lb",
 		}
 	})
@@ -131,7 +132,8 @@ ID                                      IP    Name             Status    Created
       3164445
     ],
     "redirect_http_to_https": true,
-    "enable_proxy_protocol": true
+	"enable_proxy_protocol": true,
+	"enable_backend_keepalive": true
   }
 }`
 	lbCreateRequest = `
@@ -144,6 +146,7 @@ ID                                      IP    Name             Status    Created
   "droplet_ids":[22,66],
   "tag":"magic-lb",
   "redirect_http_to_https":true,
-  "enable_proxy_protocol":true
+  "enable_proxy_protocol":true,
+  "enable_backend_keepalive":true
 }`
 )

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -2,15 +2,21 @@
 
 ## unreleased
 
-## [v1.32.0] -2020-03-04
+## [v1.33.0] - 2020-03-20
 
-- #300 Add reset database user auth method - @zbarahal-do
+- #310 Add BillingHistory service and List endpoint - @rbutler
+- #316 load balancers: add new enable_backend_keepalive field - @anitgandhi
+
+## [v1.32.0] - 2020-03-04
+
+- #311 Add reset database user auth method - @zbarahal-do
 
 ## [v1.31.0] - 2020-02-28
 
 - #305 invoices: GetPDF and GetCSV methods - @rbutler
 - #304 Add NewFromToken convenience method to init client - @bentranter
 - #301 invoices: Get, Summary, and List methods - @rbutler
+- #299 Fix param expiry_seconds for kubernetes.GetCredentials request - @velp
 
 ## [v1.30.0] - 2020-02-03
 

--- a/vendor/github.com/digitalocean/godo/README.md
+++ b/vendor/github.com/digitalocean/godo/README.md
@@ -43,35 +43,15 @@ You can then use your token to create a new client:
 package main
 
 import (
-	"context"
-	"github.com/digitalocean/godo"
-	"golang.org/x/oauth2"
+    "github.com/digitalocean/godo"
 )
-
-const (
-    pat = "mytoken"
-)
-
-type TokenSource struct {
-	AccessToken string
-}
-
-func (t *TokenSource) Token() (*oauth2.Token, error) {
-	token := &oauth2.Token{
-		AccessToken: t.AccessToken,
-	}
-	return token, nil
-}
 
 func main() {
-	tokenSource := &TokenSource{
-		AccessToken: pat,
-	}
-
-	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
-	client := godo.NewClient(oauthClient)
+    client := godo.NewFromToken("my-digitalocean-api-token")
 }
 ```
+
+If you need to provide a `context.Context` to your new client, you should use [`godo.NewClient`](https://godoc.org/github.com/digitalocean/godo#NewClient) to manually construct a client instead.
 
 ## Examples
 

--- a/vendor/github.com/digitalocean/godo/billing_history.go
+++ b/vendor/github.com/digitalocean/godo/billing_history.go
@@ -1,0 +1,72 @@
+package godo
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+const billingHistoryBasePath = "v2/customers/my/billing_history"
+
+// BillingHistoryService is an interface for interfacing with the BillingHistory
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2/#billing_history
+type BillingHistoryService interface {
+	List(context.Context, *ListOptions) (*BillingHistory, *Response, error)
+}
+
+// BillingHistoryServiceOp handles communication with the BillingHistory related methods of
+// the DigitalOcean API.
+type BillingHistoryServiceOp struct {
+	client *Client
+}
+
+var _ BillingHistoryService = &BillingHistoryServiceOp{}
+
+// BillingHistory represents a DigitalOcean Billing History
+type BillingHistory struct {
+	BillingHistory []BillingHistoryEntry `json:"billing_history"`
+	Links          *Links                `json:"links"`
+	Meta           *Meta                 `json:"meta"`
+}
+
+// BillingHistoryEntry represents an entry in a customer's Billing History
+type BillingHistoryEntry struct {
+	Description string    `json:"description"`
+	Amount      string    `json:"amount"`
+	InvoiceID   *string   `json:"invoice_id"`
+	InvoiceUUID *string   `json:"invoice_uuid"`
+	Date        time.Time `json:"date"`
+	Type        string    `json:"type"`
+}
+
+func (b BillingHistory) String() string {
+	return Stringify(b)
+}
+
+// List the Billing History for a customer
+func (s *BillingHistoryServiceOp) List(ctx context.Context, opt *ListOptions) (*BillingHistory, *Response, error) {
+	path, err := addOptions(billingHistoryBasePath, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(BillingHistory)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root, resp, err
+}

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.32.0"
+	libraryVersion = "1.33.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -47,6 +47,7 @@ type Client struct {
 	Account           AccountService
 	Actions           ActionsService
 	Balance           BalanceService
+	BillingHistory    BillingHistoryService
 	CDNs              CDNService
 	Domains           DomainsService
 	Droplets          DropletsService
@@ -168,7 +169,12 @@ func NewFromToken(token string) *Client {
 	return NewClient(oauth2.NewClient(ctx, ts))
 }
 
-// NewClient returns a new DigitalOcean API client.
+// NewClient returns a new DigitalOcean API client, using the given
+// http.Client to perform all requests.
+//
+// Users who wish to pass their own http.Client should use this method. If
+// you're in need of further customization, the godo.New method allows more
+// options, such as setting a custom URL or a custom user agent string.
 func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
@@ -180,6 +186,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Account = &AccountServiceOp{client: c}
 	c.Actions = &ActionsServiceOp{client: c}
 	c.Balance = &BalanceServiceOp{client: c}
+	c.BillingHistory = &BillingHistoryServiceOp{client: c}
 	c.CDNs = &CDNServiceOp{client: c}
 	c.Certificates = &CertificatesServiceOp{client: c}
 	c.Domains = &DomainsServiceOp{client: c}

--- a/vendor/github.com/digitalocean/godo/load_balancers.go
+++ b/vendor/github.com/digitalocean/godo/load_balancers.go
@@ -28,22 +28,23 @@ type LoadBalancersService interface {
 // LoadBalancer represents a DigitalOcean load balancer configuration.
 // Tags can only be provided upon the creation of a Load Balancer.
 type LoadBalancer struct {
-	ID                  string           `json:"id,omitempty"`
-	Name                string           `json:"name,omitempty"`
-	IP                  string           `json:"ip,omitempty"`
-	Algorithm           string           `json:"algorithm,omitempty"`
-	Status              string           `json:"status,omitempty"`
-	Created             string           `json:"created_at,omitempty"`
-	ForwardingRules     []ForwardingRule `json:"forwarding_rules,omitempty"`
-	HealthCheck         *HealthCheck     `json:"health_check,omitempty"`
-	StickySessions      *StickySessions  `json:"sticky_sessions,omitempty"`
-	Region              *Region          `json:"region,omitempty"`
-	DropletIDs          []int            `json:"droplet_ids,omitempty"`
-	Tag                 string           `json:"tag,omitempty"`
-	Tags                []string         `json:"tags,omitempty"`
-	RedirectHttpToHttps bool             `json:"redirect_http_to_https,omitempty"`
-	EnableProxyProtocol bool             `json:"enable_proxy_protocol,omitempty"`
-	VPCUUID             string           `json:"vpc_uuid,omitempty"`
+	ID                     string           `json:"id,omitempty"`
+	Name                   string           `json:"name,omitempty"`
+	IP                     string           `json:"ip,omitempty"`
+	Algorithm              string           `json:"algorithm,omitempty"`
+	Status                 string           `json:"status,omitempty"`
+	Created                string           `json:"created_at,omitempty"`
+	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
+	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`
+	StickySessions         *StickySessions  `json:"sticky_sessions,omitempty"`
+	Region                 *Region          `json:"region,omitempty"`
+	DropletIDs             []int            `json:"droplet_ids,omitempty"`
+	Tag                    string           `json:"tag,omitempty"`
+	Tags                   []string         `json:"tags,omitempty"`
+	RedirectHttpToHttps    bool             `json:"redirect_http_to_https,omitempty"`
+	EnableProxyProtocol    bool             `json:"enable_proxy_protocol,omitempty"`
+	EnableBackendKeepalive bool             `json:"enable_backend_keepalive,omitempty"`
+	VPCUUID                string           `json:"vpc_uuid,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancer.
@@ -59,15 +60,16 @@ func (l LoadBalancer) URN() string {
 // Modifying the returned LoadBalancerRequest will not modify the original LoadBalancer.
 func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 	r := LoadBalancerRequest{
-		Name:                l.Name,
-		Algorithm:           l.Algorithm,
-		ForwardingRules:     append([]ForwardingRule(nil), l.ForwardingRules...),
-		DropletIDs:          append([]int(nil), l.DropletIDs...),
-		Tag:                 l.Tag,
-		RedirectHttpToHttps: l.RedirectHttpToHttps,
-		EnableProxyProtocol: l.EnableProxyProtocol,
-		HealthCheck:         l.HealthCheck,
-		VPCUUID:             l.VPCUUID,
+		Name:                   l.Name,
+		Algorithm:              l.Algorithm,
+		ForwardingRules:        append([]ForwardingRule(nil), l.ForwardingRules...),
+		DropletIDs:             append([]int(nil), l.DropletIDs...),
+		Tag:                    l.Tag,
+		RedirectHttpToHttps:    l.RedirectHttpToHttps,
+		EnableProxyProtocol:    l.EnableProxyProtocol,
+		EnableBackendKeepalive: l.EnableBackendKeepalive,
+		HealthCheck:            l.HealthCheck,
+		VPCUUID:                l.VPCUUID,
 	}
 
 	if l.HealthCheck != nil {
@@ -129,18 +131,19 @@ func (s StickySessions) String() string {
 
 // LoadBalancerRequest represents the configuration to be applied to an existing or a new load balancer.
 type LoadBalancerRequest struct {
-	Name                string           `json:"name,omitempty"`
-	Algorithm           string           `json:"algorithm,omitempty"`
-	Region              string           `json:"region,omitempty"`
-	ForwardingRules     []ForwardingRule `json:"forwarding_rules,omitempty"`
-	HealthCheck         *HealthCheck     `json:"health_check,omitempty"`
-	StickySessions      *StickySessions  `json:"sticky_sessions,omitempty"`
-	DropletIDs          []int            `json:"droplet_ids,omitempty"`
-	Tag                 string           `json:"tag,omitempty"`
-	Tags                []string         `json:"tags,omitempty"`
-	RedirectHttpToHttps bool             `json:"redirect_http_to_https,omitempty"`
-	EnableProxyProtocol bool             `json:"enable_proxy_protocol,omitempty"`
-	VPCUUID             string           `json:"vpc_uuid,omitempty"`
+	Name                   string           `json:"name,omitempty"`
+	Algorithm              string           `json:"algorithm,omitempty"`
+	Region                 string           `json:"region,omitempty"`
+	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
+	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`
+	StickySessions         *StickySessions  `json:"sticky_sessions,omitempty"`
+	DropletIDs             []int            `json:"droplet_ids,omitempty"`
+	Tag                    string           `json:"tag,omitempty"`
+	Tags                   []string         `json:"tags,omitempty"`
+	RedirectHttpToHttps    bool             `json:"redirect_http_to_https,omitempty"`
+	EnableProxyProtocol    bool             `json:"enable_proxy_protocol,omitempty"`
+	EnableBackendKeepalive bool             `json:"enable_backend_keepalive,omitempty"`
+	VPCUUID                string           `json:"vpc_uuid,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancerRequest.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.32.0
+# github.com/digitalocean/godo v1.33.0
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util
 # github.com/dustin/go-humanize v1.0.0


### PR DESCRIPTION
`enable-proxy-protocol` is/has been GA, but seems like it just wasn't bubbled up to `doctl` from `godo` previously. 

`enable-backend-keepalive` is a new feature, currently in beta.

This also bumps `godo` to v1.33.0.