### PR TITLE
Upgrade doctl to Go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,34 +12,34 @@ notifications:
 
 jobs:
   include:
-  - name: "Testing: Bionic, go 1.13"
+  - name: "Testing: Bionic, go 1.14"
     script:
     - make shellcheck
     - make test
     dist: bionic
-    go: 1.13.x
-    env: CACHE_NAME=BIONIC_1.13
+    go: 1.14.x
+    env: CACHE_NAME=BIONIC_1.14
 
-  - name: "Testing: MacOS, go 1.13"
+  - name: "Testing: MacOS, go 1.14"
     script: make test
     os: osx
-    go: 1.13.x
-    env: CACHE_NAME=MACOS_1.13
+    go: 1.14.x
+    env: CACHE_NAME=MACOS_1.14
 
-  - name: "Testing: Windows, go 1.13"
+  - name: "Testing: Windows, go 1.14"
     before_install:
       - choco install make
     script: make test
     os: windows
-    go: 1.13.x
-    env: CACHE_NAME=WINDOWS_1.13
+    go: 1.14.x
+    env: CACHE_NAME=WINDOWS_1.14
 
   - stage: deploy
     if: type=push
     script: echo "running goreleaser"
     os: linux
     dist: bionic
-    go: 1.13.x
+    go: 1.14.x
     services: docker
     env: CACHE_NAME=DEPLOY_GORELEASER
     before_deploy:
@@ -58,7 +58,7 @@ jobs:
     - echo "building snap"
     - make _build_snap
     dist: bionic
-    go: 1.13.x
+    go: 1.14.x
     os: linux
     services: docker
     env: CACHE_NAME=DEPLOY_STABLE_SNAP
@@ -77,7 +77,7 @@ jobs:
     - make _build_snap
     dist: bionic
     os: linux
-    go: 1.13.x
+    go: 1.14.x
     services: docker
     env: CACHE_NAME=DEPLOY_CANDIDATE_SNAP
     deploy:
@@ -87,4 +87,3 @@ jobs:
       skip_cleanup: true
       on:
         repo: digitalocean/doctl
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ or `make help` for a list of available commands with descriptions.
 
 ### Go environment
 
-The minimal version of Golang for `doctl` is 1.13. `doctl` uses [Go
+The minimal version of Golang for `doctl` is 1.14. `doctl` uses [Go
 modules](https://github.com/golang/go/wiki/Modules) for dependency
 management [with vendoring](https://github.com/golang/go/wiki/Modules#how-do-i-use-vendoring-with-modules-is-vendoring-going-away).
 Please run `make vendor` after any dependency modifications.
@@ -180,7 +180,7 @@ to do so. Travis also runs shellcheck.
 
 ## Releasing
 
-To cut a release, push a new tag (versioning discussed below). The actual release is orchestrated 
+To cut a release, push a new tag (versioning discussed below). The actual release is orchestrated
 by [Travis CI](https://docs.travis-ci.com/user/deployment/).
 
 ### Tagging a release
@@ -240,7 +240,7 @@ snap manually.
 ##### Building a new snap base image
 
 Occasionally, the snap build will break. When it does, it usually means that you need to update
-the custom base image we use to build the snap. The Dockerfile for that image lives in 
+the custom base image we use to build the snap. The Dockerfile for that image lives in
 [dockerfiles/Dockerfile.snap](https://github.com/digitalocean/doctl/blob/master/dockerfiles/Dockerfile.snap).
 The header of the Dockerfile has hints for updating the image, as well as instructions for building
 the image using `make snap_image`. Once you've built the image, the snap_image target will provide

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.14-alpine
 
 ENV MAKE_TARGET linux_amd64
 

--- a/dockerfiles/Dockerfile.snap
+++ b/dockerfiles/Dockerfile.snap
@@ -41,7 +41,7 @@ RUN mkdir -p /snap/bin && \
         chmod +x /snap/bin/snapcraft
 
 # Grab the golang snap from the stable channel, unpack it in the proper place, and create a runner for it
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/go?channel=1.13/stable' | jq '.download_url' -r) --output go.snap && \
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/go?channel=1.14/stable' | jq '.download_url' -r) --output go.snap && \
         mkdir -p /snap/go && \
         unsquashfs -d /snap/go/current go.snap && \
         cd /snap/bin && \
@@ -85,6 +85,3 @@ ENV SNAP_ARCH amd64
 
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT "snapcraft"
-
-
-

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/digitalocean/doctl
 
-go 1.13
+go 1.14
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,21 +1,28 @@
 # github.com/blang/semver v3.5.1+incompatible
+## explicit
 github.com/blang/semver
 # github.com/cpuguy83/go-md2man v1.0.10
+## explicit
 github.com/cpuguy83/go-md2man/md2man
 # github.com/creack/pty v1.1.7
+## explicit
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/digitalocean/godo v1.34.0
+## explicit
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util
 # github.com/dustin/go-humanize v1.0.0
+## explicit
 github.com/dustin/go-humanize
 # github.com/fatih/color v1.7.0
+## explicit
 github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.7
 github.com/fsnotify/fsnotify
 # github.com/gobwas/glob v0.2.3
+## explicit
 github.com/gobwas/glob
 github.com/gobwas/glob/compiler
 github.com/gobwas/glob/match
@@ -28,14 +35,17 @@ github.com/gobwas/glob/util/strings
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
 # github.com/golang/mock v1.4.0
+## explicit
 github.com/golang/mock/gomock
 # github.com/golang/protobuf v1.3.5
+## explicit
 github.com/golang/protobuf/proto
 # github.com/google/go-querystring v1.0.0
 github.com/google/go-querystring/query
 # github.com/google/gofuzz v1.0.0
 github.com/google/gofuzz
 # github.com/google/uuid v1.1.1
+## explicit
 github.com/google/uuid
 # github.com/hashicorp/hcl v1.0.0
 github.com/hashicorp/hcl
@@ -49,16 +59,21 @@ github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
 # github.com/imdario/mergo v0.3.6
+## explicit
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
+## explicit
 github.com/inconshreveable/mousetrap
 # github.com/json-iterator/go v1.1.8
 github.com/json-iterator/go
 # github.com/magiconair/properties v1.8.1
+## explicit
 github.com/magiconair/properties
 # github.com/mattn/go-colorable v0.0.9
+## explicit
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.4
+## explicit
 github.com/mattn/go-isatty
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
@@ -67,17 +82,21 @@ github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
 # github.com/natefinch/pie v0.0.0-20170715172608-9a0d72014007
+## explicit
 github.com/natefinch/pie
 # github.com/pelletier/go-toml v1.6.0
+## explicit
 github.com/pelletier/go-toml
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/russross/blackfriday v1.5.2
 github.com/russross/blackfriday
 # github.com/sclevine/spec v1.3.0
+## explicit
 github.com/sclevine/spec
 github.com/sclevine/spec/report
 # github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644
+## explicit
 github.com/shiena/ansicolor
 # github.com/spf13/afero v1.2.2
 github.com/spf13/afero
@@ -85,18 +104,23 @@ github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.0
 github.com/spf13/cast
 # github.com/spf13/cobra v0.0.3
+## explicit
 github.com/spf13/cobra
 github.com/spf13/cobra/doc
 # github.com/spf13/jwalterweatherman v1.1.0
+## explicit
 github.com/spf13/jwalterweatherman
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
 # github.com/spf13/viper v1.4.0
+## explicit
 github.com/spf13/viper
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
+## explicit
 golang.org/x/crypto/curve25519
 golang.org/x/crypto/ed25519
 golang.org/x/crypto/ed25519/internal/edwards25519
@@ -106,6 +130,7 @@ golang.org/x/crypto/poly1305
 golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
@@ -113,6 +138,7 @@ golang.org/x/net/http2
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 # golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
 # golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
@@ -127,6 +153,7 @@ golang.org/x/text/unicode/norm
 # golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 golang.org/x/time/rate
 # google.golang.org/appengine v1.6.5
+## explicit
 google.golang.org/appengine/internal
 google.golang.org/appengine/internal/base
 google.golang.org/appengine/internal/datastore
@@ -137,8 +164,10 @@ google.golang.org/appengine/urlfetch
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.4
+## explicit
 gopkg.in/yaml.v2
 # k8s.io/api v0.17.0
+## explicit
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1
@@ -180,6 +209,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.17.0
+## explicit
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/apis/meta/v1
@@ -214,6 +244,7 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v0.17.0
+## explicit
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/pkg/apis/clientauthentication
 k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1
@@ -240,3 +271,4 @@ k8s.io/klog
 k8s.io/utils/integer
 # sigs.k8s.io/yaml v1.1.0
 sigs.k8s.io/yaml
+# github.com/stretchr/objx => github.com/stretchr/objx v0.2.0


### PR DESCRIPTION
Upgrades doctl, as well as our build infrastructure, to Go 1.14.

You might notice that the `vendor/modules.txt` file looks strange. In Go 1.14, the release notes state the following:

> When -mod=vendor is set (explicitly or by default), the go command now verifies that the main module's vendor/modules.txt file is consistent with its go.mod file.

Our `vendor/modules.txt` file was out of date, so I had to update it with `go mod vendor`. As a result of that, the `go.mod` file was changed, hence the new (and weird looking) comments in there.

I've also verified that the new Docker image and Snap base exist.

---

Finally, it looks like my editor removed some extra whitespace on save.