### PR TITLE
Add Make target for godo upgrade

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,11 +166,11 @@ file to see what an integration test typically looks like.
 
 #### `godo` mocks
 
-When you upgrade `godo` you have to re-generate the mocks.
+To upgrade `godo`, run `make upgrade_godo`. This will:
 
-    ```
-    make mocks
-    ```
+* Get the latest release of `godo`, and update the go.mod and go.sum files accordingly.
+* Tidy and vendor the modules that `doctl` depends on.
+* Run `mockgen` to regenerate the mocks we use in the unit test suite.
 
 #### Build Scripts
 

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,15 @@ mocks:
 	@echo ""
 	@scripts/regenmocks.sh
 
+.PHONY: _upgrade_godo
+_upgrade_godo:
+	go get -u github.com/digitalocean/godo
+
+.PHONY: upgrade_godo
+upgrade_godo: _upgrade_godo vendor mocks
+	@echo "==> upgrade the godo version"
+	@echo ""
+
 .PHONY: vendor
 vendor:
 	@echo "==> vendor dependencies"

--- a/do/mocks/BillingHistoryService.go
+++ b/do/mocks/BillingHistoryService.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockBillingHistoryService is a mock of BillingHistoryService interface
+// MockBillingHistoryService is a mock of BillingHistoryService interface.
 type MockBillingHistoryService struct {
 	ctrl     *gomock.Controller
 	recorder *MockBillingHistoryServiceMockRecorder
 }
 
-// MockBillingHistoryServiceMockRecorder is the mock recorder for MockBillingHistoryService
+// MockBillingHistoryServiceMockRecorder is the mock recorder for MockBillingHistoryService.
 type MockBillingHistoryServiceMockRecorder struct {
 	mock *MockBillingHistoryService
 }
 
-// NewMockBillingHistoryService creates a new mock instance
+// NewMockBillingHistoryService creates a new mock instance.
 func NewMockBillingHistoryService(ctrl *gomock.Controller) *MockBillingHistoryService {
 	mock := &MockBillingHistoryService{ctrl: ctrl}
 	mock.recorder = &MockBillingHistoryServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBillingHistoryService) EXPECT() *MockBillingHistoryServiceMockRecorder {
 	return m.recorder
 }
 
-// List mocks base method
+// List mocks base method.
 func (m *MockBillingHistoryService) List() (*do.BillingHistory, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List")
@@ -42,7 +42,7 @@ func (m *MockBillingHistoryService) List() (*do.BillingHistory, error) {
 	return ret0, ret1
 }
 
-// List indicates an expected call of List
+// List indicates an expected call of List.
 func (mr *MockBillingHistoryServiceMockRecorder) List() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockBillingHistoryService)(nil).List))


### PR DESCRIPTION
Adds a Make target for upgrading `godo`. This also updates the CONTRIBUTING.md doc to use this new Make target. I also ran this target as a test, and it looks like it upgraded the BillingHistoryService's mocks, so that change is included here too.