### PR TITLE
Improve delete confirmation messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test_unit:
 test_integration:
 	@echo "==> run integration tests"
 	@echo ""
-	go test -v -count=1 -mod=vendor ./integration
+	go test -v -mod=vendor ./integration
 
 .PHONY: test
 test: test_unit test_integration

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test_unit:
 test_integration:
 	@echo "==> run integration tests"
 	@echo ""
-	go test -v -mod=vendor ./integration
+	go test -v -count=1 -mod=vendor ./integration
 
 .PHONY: test
 test: test_unit test_integration

--- a/commands/cdns.go
+++ b/commands/cdns.go
@@ -242,7 +242,7 @@ func RunCDNDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete CDN?") == nil {
+	if force || AskForConfirmDelete("CDN", 1) == nil {
 		id := c.Args[0]
 		return c.CDNs().Delete(id)
 	}

--- a/commands/certificates.go
+++ b/commands/certificates.go
@@ -203,7 +203,7 @@ func RunCertificateDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete this certificate?") == nil {
+	if force || AskForConfirmDelete("certificate", 1) == nil {
 		cs := c.Certificates()
 		if err := cs.Delete(cID); err != nil {
 			return err

--- a/commands/confirmation.go
+++ b/commands/confirmation.go
@@ -43,3 +43,19 @@ func AskForConfirm(message string) error {
 
 	return nil
 }
+
+// AskForConfirmDelete builds a message to ask the user to confirm deleteing
+// one or multiple resources and then sends it through to AskForConfirm to
+// parses and verifies user input.
+func AskForConfirmDelete(resourceType string, count int) error {
+	if count > 1 {
+		resourceType = resourceType + "s"
+	}
+	message := fmt.Sprintf("delete %d %s?", count, resourceType)
+	err := AskForConfirm(message)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/commands/confirmation.go
+++ b/commands/confirmation.go
@@ -48,10 +48,12 @@ func AskForConfirm(message string) error {
 // one or multiple resources and then sends it through to AskForConfirm to
 // parses and verifies user input.
 func AskForConfirmDelete(resourceType string, count int) error {
+	message := fmt.Sprintf("delete this %s?", resourceType)
 	if count > 1 {
 		resourceType = resourceType + "s"
+		message = fmt.Sprintf("delete %d %s?", count, resourceType)
 	}
-	message := fmt.Sprintf("delete %d %s?", count, resourceType)
+
 	err := AskForConfirm(message)
 	if err != nil {
 		return err

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -223,7 +223,7 @@ func RunDatabaseDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete this database cluster?") == nil {
+	if force || AskForConfirmDelete("database cluster", 1) == nil {
 		id := c.Args[0]
 		return c.Databases().Delete(id)
 	}
@@ -595,7 +595,7 @@ func RunDatabaseUserDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete this database user?") == nil {
+	if force || AskForConfirmDelete("database user", 1) == nil {
 		databaseID := c.Args[0]
 		userID := c.Args[1]
 		return c.Databases().DeleteUser(databaseID, userID)
@@ -780,7 +780,7 @@ func RunDatabasePoolDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete this database pool?") == nil {
+	if force || AskForConfirmDelete("database pool", 1) == nil {
 		databaseID := c.Args[0]
 		poolID := c.Args[1]
 		return c.Databases().DeletePool(databaseID, poolID)
@@ -893,7 +893,7 @@ func RunDatabaseDBDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete this database?") == nil {
+	if force || AskForConfirmDelete("database", 1) == nil {
 		databaseID := c.Args[0]
 		dbID := c.Args[1]
 		return c.Databases().DeleteDB(databaseID, dbID)
@@ -1058,7 +1058,7 @@ func RunDatabaseReplicaDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete this database replica?") == nil {
+	if force || AskForConfirmDelete("database replica", 1) == nil {
 		databaseID := c.Args[0]
 		replicaID := c.Args[1]
 		return c.Databases().DeleteReplica(databaseID, replicaID)

--- a/commands/domains.go
+++ b/commands/domains.go
@@ -167,7 +167,7 @@ func RunDomainDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete domain?") == nil {
+	if force || AskForConfirmDelete("domain", 1) == nil {
 		ds := c.Domains()
 
 		if len(name) < 1 {

--- a/commands/domains.go
+++ b/commands/domains.go
@@ -295,12 +295,12 @@ func RunRecordDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete record(s)?") == nil {
-		domainName, ids := c.Args[0], c.Args[1:]
-		if len(ids) < 1 {
-			return doctl.NewMissingArgsErr(c.NS)
-		}
+	domainName, ids := c.Args[0], c.Args[1:]
+	if len(ids) < 1 {
+		return doctl.NewMissingArgsErr(c.NS)
+	}
 
+	if force || AskForConfirmDelete("domain record", len(ids)) == nil {
 		ds := c.Domains()
 
 		for _, i := range ids {
@@ -315,7 +315,7 @@ func RunRecordDelete(c *CmdConfig) error {
 			}
 		}
 	} else {
-		return fmt.Errorf("Opertaion aborted.")
+		return fmt.Errorf("Operation aborted.")
 	}
 
 	return nil

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -471,19 +471,27 @@ func RunDropletDelete(c *CmdConfig) error {
 			ids = append(ids, strconv.Itoa(droplet.ID))
 		}
 		affectedIDs = strings.Join(ids, " ")
+		resourceType := "Droplet"
+		if len(list) > 1 {
+			resourceType = "Droplets"
+		}
 
-		if force || AskForConfirm(fmt.Sprintf("Delete droplet(s) by \"%s\" tag? [affected ID(s): %s]", tagName, affectedIDs)) == nil {
+		if force || AskForConfirm(fmt.Sprintf("delete %d %s tagged \"%s\"? [affected %s: %s]", len(list), resourceType, tagName, resourceType, affectedIDs)) == nil {
 			return ds.DeleteByTag(tagName)
 		}
-		return nil
+		return fmt.Errorf("Operation aborted.")
 	}
 
-	if force || AskForConfirm(fmt.Sprintf("Delete %d droplet(s)?", len(c.Args))) == nil {
+	resourceType := "Droplet"
+	if len(c.Args) > 1 {
+		resourceType = "Droplets"
+	}
+	if force || AskForConfirm(fmt.Sprintf("delete %d %s?", len(c.Args), resourceType)) == nil {
 
 		fn := func(ids []int) error {
 			for _, id := range ids {
 				if err := ds.Delete(id); err != nil {
-					return fmt.Errorf("Unable to delete droplet %d: %v", id, err)
+					return fmt.Errorf("Unable to delete Droplet %d: %v", id, err)
 				}
 			}
 			return nil

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -482,11 +482,7 @@ func RunDropletDelete(c *CmdConfig) error {
 		return fmt.Errorf("Operation aborted.")
 	}
 
-	resourceType := "Droplet"
-	if len(c.Args) > 1 {
-		resourceType = "Droplets"
-	}
-	if force || AskForConfirm(fmt.Sprintf("delete %d %s?", len(c.Args), resourceType)) == nil {
+	if force || AskForConfirmDelete("Droplet", len(c.Args)) == nil {
 
 		fn := func(ids []int) error {
 			for _, id := range ids {

--- a/commands/firewalls.go
+++ b/commands/firewalls.go
@@ -206,7 +206,7 @@ func RunFirewallDelete(c *CmdConfig) error {
 	}
 
 	fs := c.Firewalls()
-	if force || AskForConfirm(fmt.Sprintf("Delete %d firewall(s)?", len(c.Args))) == nil {
+	if force || AskForConfirmDelete("firewall", len(c.Args)) == nil {
 		for _, id := range c.Args {
 			if err := fs.Delete(id); err != nil {
 				return err

--- a/commands/floating_ips.go
+++ b/commands/floating_ips.go
@@ -128,7 +128,7 @@ func RunFloatingIPDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete floating IP?") == nil {
+	if force || AskForConfirmDelete("floating IP", 1) == nil {
 		ip := c.Args[0]
 		return fis.Delete(ip)
 	}

--- a/commands/images.go
+++ b/commands/images.go
@@ -244,7 +244,7 @@ func RunImagesDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete image(s)?") == nil {
+	if force || AskForConfirmDelete("image", len(c.Args)) == nil {
 
 		for _, el := range c.Args {
 			id, err := strconv.Atoi(el)

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -767,7 +767,7 @@ func (s *KubernetesCommandService) RunKubernetesClusterDelete(c *CmdConfig) erro
 			return err
 		}
 
-		if force || AskForConfirm("Delete this Kubernetes cluster") == nil {
+		if force || AskForConfirmDelete("Kubernetes cluster", 1) == nil {
 			// continue
 		} else {
 			return fmt.Errorf("Operation aborted")
@@ -1112,7 +1112,7 @@ func (s *KubernetesCommandService) RunKubernetesNodePoolDelete(c *CmdConfig) err
 	if err != nil {
 		return err
 	}
-	if force || AskForConfirm("Delete this Kubernetes node pool?") == nil {
+	if force || AskForConfirmDelete("Kubernetes node pool", 1) == nil {
 		kube := c.Kubernetes()
 		if err := kube.DeleteNodePool(clusterID, poolID); err != nil {
 			return err
@@ -1152,9 +1152,9 @@ func kubernetesNodeDelete(replace bool, c *CmdConfig) error {
 		return err
 	}
 
-	msg := "Delete this Kubernetes node?"
+	msg := "delete this Kubernetes node?"
 	if replace {
-		msg = "Replace this Kubernetes node?"
+		msg = "replace this Kubernetes node?"
 	}
 
 	if !(force || AskForConfirm(msg) == nil) {

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -80,7 +80,7 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 		"Redirects HTTP requests to the load balancer on port 80 to HTTPS on port 443")
 	AddBoolFlag(cmdRecordCreate, doctl.ArgEnableProxyProtocol, "", false,
 		"enable proxy protocol")
-		AddBoolFlag(cmdRecordCreate, doctl.ArgEnableBackendKeepalive, "", false,
+	AddBoolFlag(cmdRecordCreate, doctl.ArgEnableBackendKeepalive, "", false,
 		"enable keepalive connections to backend target droplets")
 	AddStringFlag(cmdRecordCreate, doctl.ArgTagName, "", "", "droplet tag name")
 	AddStringSliceFlag(cmdRecordCreate, doctl.ArgDropletIDs, "", []string{},
@@ -104,7 +104,7 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 		"Flag to redirect HTTP requests to the load balancer on port 80 to HTTPS on port 443")
 	AddBoolFlag(cmdRecordUpdate, doctl.ArgEnableProxyProtocol, "", false,
 		"enable proxy protocol")
-		AddBoolFlag(cmdRecordUpdate, doctl.ArgEnableBackendKeepalive, "", false,
+	AddBoolFlag(cmdRecordUpdate, doctl.ArgEnableBackendKeepalive, "", false,
 		"enable keepalive connections to backend target droplets")
 	AddStringFlag(cmdRecordUpdate, doctl.ArgTagName, "", "", "Assigns Droplets with the specified tag to the load balancer")
 	AddStringSliceFlag(cmdRecordUpdate, doctl.ArgDropletIDs, "", []string{},
@@ -224,7 +224,7 @@ func RunLoadBalancerDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete this load balancer?") == nil {
+	if force || AskForConfirmDelete("load balancer", 1) == nil {
 		lbs := c.LoadBalancers()
 		if err := lbs.Delete(lbID); err != nil {
 			return err

--- a/commands/projects.go
+++ b/commands/projects.go
@@ -208,11 +208,7 @@ func RunProjectsDelete(c *CmdConfig) error {
 	}
 
 	ps := c.Projects()
-	var suffix string
-	if len(c.Args) != 1 {
-		suffix = "s"
-	}
-	if force || AskForConfirm(fmt.Sprintf("delete %d project%s", len(c.Args), suffix)) == nil {
+	if force || AskForConfirmDelete("project", len(c.Args)) == nil {
 		for _, id := range c.Args {
 			if err := ps.Delete(id); err != nil {
 				return err

--- a/commands/snapshots.go
+++ b/commands/snapshots.go
@@ -180,7 +180,7 @@ func RunSnapshotDelete(c *CmdConfig) error {
 	ss := c.Snapshots()
 	ids := c.Args
 
-	if force || AskForConfirm("Delete snapshot(s)?") == nil {
+	if force || AskForConfirmDelete("snapshot", len(ids)) == nil {
 		for _, id := range ids {
 			err := ss.Delete(id)
 			if err != nil {

--- a/commands/sshkeys.go
+++ b/commands/sshkeys.go
@@ -188,7 +188,7 @@ func RunKeyDelete(c *CmdConfig) error {
 		return nil
 	}
 
-	if force || AskForConfirm("Delete SSH key?") == nil {
+	if force || AskForConfirmDelete("SSH key", 1) == nil {
 		rawKey := c.Args[0]
 		return ks.Delete(rawKey)
 	}

--- a/commands/tags.go
+++ b/commands/tags.go
@@ -112,7 +112,7 @@ func RunCmdTagDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete tag(s)?") == nil {
+	if force || AskForConfirmDelete("tag", len(c.Args)) == nil {
 		for id := range c.Args {
 			name := c.Args[id]
 			ts := c.Tags()

--- a/commands/volumes.go
+++ b/commands/volumes.go
@@ -215,7 +215,7 @@ func RunVolumeDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete volume?") == nil {
+	if force || AskForConfirmDelete("volume", 1) == nil {
 		id := c.Args[0]
 		return c.Volumes().DeleteVolume(id)
 	}

--- a/commands/vpcs.go
+++ b/commands/vpcs.go
@@ -185,7 +185,7 @@ func RunVPCDelete(c *CmdConfig) error {
 		return err
 	}
 
-	if force || AskForConfirm("Delete this VPC?") == nil {
+	if force || AskForConfirmDelete("VPC", 1) == nil {
 		vpcs := c.VPCs()
 		if err := vpcs.Delete(vpcUUID); err != nil {
 			return err

--- a/integration/domain_records_delete_test.go
+++ b/integration/domain_records_delete_test.go
@@ -154,6 +154,6 @@ var _ = suite("compute/domain/records/delete", func(t *testing.T, when spec.G, i
 })
 
 const (
-	domainRecDelOutput      = "Warning: Are you sure you want to delete 1 domain record? (y/N) ? Error: Operation aborted."
+	domainRecDelOutput      = "Warning: Are you sure you want to delete this domain record? (y/N) ? Error: Operation aborted."
 	multiDomainRecDelOutput = "Warning: Are you sure you want to delete 2 domain records? (y/N) ? Error: Operation aborted."
 )

--- a/integration/domain_records_delete_test.go
+++ b/integration/domain_records_delete_test.go
@@ -1,0 +1,159 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite("compute/domain/records/delete", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/domains/example.com/records/1337":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodDelete {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				reqBody, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+				expect.Empty(string(reqBody))
+
+				w.WriteHeader(http.StatusNoContent)
+
+			case "/v2/domains/example.com/records/7331":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodDelete {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				reqBody, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+				expect.Empty(string(reqBody))
+
+				w.WriteHeader(http.StatusNoContent)
+
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	when("all required flags are passed", func() {
+		it("deletes the right domain record", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"domain",
+				"records",
+				"delete",
+				"example.com",
+				"1337",
+				"--force",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Empty(output)
+		})
+	})
+
+	when("multiple records are provided and all required flags are passed", func() {
+		it("deletes the right domain records", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"domain",
+				"records",
+				"delete",
+				"example.com",
+				"1337",
+				"7331",
+				"--force",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Empty(output)
+		})
+	})
+
+	when("deleting one domain record without force flag", func() {
+		it("correctly promts for confirmation", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"domain",
+				"records",
+				"delete",
+				"example.com",
+				"1337",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expect.Equal(strings.TrimSpace(domainRecDelOutput), strings.TrimSpace(string(output)))
+		})
+	})
+
+	when("deleting two domain records without force flag", func() {
+		it("correctly promts for confirmation", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"domain",
+				"records",
+				"delete",
+				"example.com",
+				"1337",
+				"7331",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expect.Equal(strings.TrimSpace(multiDomainRecDelOutput), strings.TrimSpace(string(output)))
+		})
+	})
+})
+
+const (
+	domainRecDelOutput      = "Warning: Are you sure you want to delete 1 domain record? (y/N) ? Error: Operation aborted."
+	multiDomainRecDelOutput = "Warning: Are you sure you want to delete 2 domain records? (y/N) ? Error: Operation aborted."
+)

--- a/integration/droplet_delete_test.go
+++ b/integration/droplet_delete_test.go
@@ -206,7 +206,7 @@ var _ = suite("compute/droplet/delete", func(t *testing.T, when spec.G, it spec.
 })
 
 const (
-	dropletDelOutput         = "Warning: Are you sure you want to delete 1 Droplet? (y/N) ? Error: Operation aborted."
+	dropletDelOutput         = "Warning: Are you sure you want to delete this Droplet? (y/N) ? Error: Operation aborted."
 	multiDropletDelOutput    = "Warning: Are you sure you want to delete 2 Droplets? (y/N) ? Error: Operation aborted."
 	tagDropletDelOutput      = `Warning: Are you sure you want to delete 1 Droplet tagged "one"? [affected Droplet: 1337] (y/N) ? Error: Operation aborted.`
 	tagMultiDropletDelOutput = `Warning: Are you sure you want to delete 2 Droplets tagged "two"? [affected Droplets: 1337 7331] (y/N) ? Error: Operation aborted.`

--- a/integration/droplet_delete_test.go
+++ b/integration/droplet_delete_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/sclevine/spec"
@@ -29,13 +30,42 @@ var _ = suite("compute/droplet/delete", func(t *testing.T, when spec.G, it spec.
 					w.WriteHeader(http.StatusUnauthorized)
 					return
 				}
+				if req.URL.RawQuery == "page=1&per_page=200&tag_name=one" {
+					if req.Method != http.MethodGet {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
 
-				if req.Method != http.MethodGet {
-					w.WriteHeader(http.StatusMethodNotAllowed)
-					return
+					w.Write([]byte(`{"droplets":[{"name":"some-droplet-name", "id": 1337}]}`))
+				} else if req.URL.RawQuery == "tag_name=one" {
+					if req.Method == http.MethodDelete {
+						w.WriteHeader(http.StatusNoContent)
+					} else {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+				} else if req.URL.RawQuery == "page=1&per_page=200&tag_name=two" {
+					if req.Method != http.MethodGet {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+
+					w.Write([]byte(`{"droplets":[{"name":"some-droplet-name", "id": 1337}, {"name":"another-droplet-name", "id": 7331}]}`))
+				} else if req.URL.RawQuery == "tag_name=two" {
+					if req.Method == http.MethodDelete {
+						w.WriteHeader(http.StatusNoContent)
+					} else {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+				} else {
+					if req.Method != http.MethodGet {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+
+					w.Write([]byte(`{"droplets":[{"name":"some-droplet-name", "id": 1337}]}`))
 				}
-
-				w.Write([]byte(`{"droplets":[{"name":"some-droplet-name", "id": 1337}]}`))
 			case "/v2/droplets/1337":
 				if req.Method != http.MethodDelete {
 					w.WriteHeader(http.StatusMethodNotAllowed)
@@ -86,4 +116,98 @@ var _ = suite("compute/droplet/delete", func(t *testing.T, when spec.G, it spec.
 			})
 		}
 	})
+
+	when("deleting by tag name", func() {
+		it("deletes the right Droplet", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"droplet",
+				"delete",
+				"--tag-name", "one",
+				"--force",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Empty(output)
+		})
+	})
+
+	when("deleting one Droplet without force flag", func() {
+		it("correctly promts for confirmation", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"droplet",
+				"delete",
+				"some-droplet-name",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expect.Equal(strings.TrimSpace(dropletDelOutput), strings.TrimSpace(string(output)))
+		})
+	})
+
+	when("deleting two Droplet without force flag", func() {
+		it("correctly promts for confirmation", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"droplet",
+				"delete",
+				"some-droplet-name",
+				"another-droplet-name",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expect.Equal(strings.TrimSpace(multiDropletDelOutput), strings.TrimSpace(string(output)))
+		})
+	})
+
+	when("deleting one Droplet by tag without force flag", func() {
+		it("correctly promts for confirmation", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"droplet",
+				"delete",
+				"--tag-name", "one",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expect.Equal(strings.TrimSpace(tagDropletDelOutput), strings.TrimSpace(string(output)))
+		})
+	})
+
+	when("deleting two Droplet by tag without force flag", func() {
+		it("correctly promts for confirmation", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"droplet",
+				"delete",
+				"--tag-name", "two",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expect.Equal(strings.TrimSpace(tagMultiDropletDelOutput), strings.TrimSpace(string(output)))
+		})
+	})
 })
+
+const (
+	dropletDelOutput         = "Warning: Are you sure you want to delete 1 Droplet? (y/N) ? Error: Operation aborted."
+	multiDropletDelOutput    = "Warning: Are you sure you want to delete 2 Droplets? (y/N) ? Error: Operation aborted."
+	tagDropletDelOutput      = `Warning: Are you sure you want to delete 1 Droplet tagged "one"? [affected Droplet: 1337] (y/N) ? Error: Operation aborted.`
+	tagMultiDropletDelOutput = `Warning: Are you sure you want to delete 2 Droplets tagged "two"? [affected Droplets: 1337 7331] (y/N) ? Error: Operation aborted.`
+)

--- a/integration/firewall_delete_test.go
+++ b/integration/firewall_delete_test.go
@@ -1,0 +1,139 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite("compute/firewall/delete", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/firewalls/e4b9c960-d385-4950-84f3-d102162e6be5":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodDelete {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				w.WriteHeader(http.StatusNoContent)
+			case "/v2/firewalls/aaa-bbb-ccc-ddd-eee":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodDelete {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	when("all the required flags are passed", func() {
+		it("deletes the firewall", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"firewall",
+				"delete",
+				"e4b9c960-d385-4950-84f3-d102162e6be5",
+				"--force",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received unexpected error: %s", output))
+			expect.Empty(output)
+		})
+	})
+
+	when("multiple firewalls are provided and all the required flags are passed", func() {
+		it("deletes the firewalls", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"firewall",
+				"delete",
+				"e4b9c960-d385-4950-84f3-d102162e6be5",
+				"aaa-bbb-ccc-ddd-eee",
+				"--force",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received unexpected error: %s", output))
+			expect.Empty(output)
+		})
+	})
+
+	when("deleting one firewall without force flag", func() {
+		it("correctly promts for confirmation", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"firewall",
+				"delete",
+				"e4b9c960-d385-4950-84f3-d102162e6be5",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expect.Equal(strings.TrimSpace(fwDelOutput), strings.TrimSpace(string(output)))
+		})
+	})
+
+	when("deleting two firewalls without force flag", func() {
+		it("correctly promts for confirmation", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"firewall",
+				"delete",
+				"e4b9c960-d385-4950-84f3-d102162e6be5",
+				"aaa-bbb-ccc-ddd-eee",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expect.Equal(strings.TrimSpace(multiFwDelOutput), strings.TrimSpace(string(output)))
+		})
+	})
+})
+
+const (
+	fwDelOutput      = "Warning: Are you sure you want to delete 1 firewall? (y/N) ? Error: Operation aborted."
+	multiFwDelOutput = "Warning: Are you sure you want to delete 2 firewalls? (y/N) ? Error: Operation aborted."
+)

--- a/integration/firewall_delete_test.go
+++ b/integration/firewall_delete_test.go
@@ -134,6 +134,6 @@ var _ = suite("compute/firewall/delete", func(t *testing.T, when spec.G, it spec
 })
 
 const (
-	fwDelOutput      = "Warning: Are you sure you want to delete 1 firewall? (y/N) ? Error: Operation aborted."
+	fwDelOutput      = "Warning: Are you sure you want to delete this firewall? (y/N) ? Error: Operation aborted."
 	multiFwDelOutput = "Warning: Are you sure you want to delete 2 firewalls? (y/N) ? Error: Operation aborted."
 )

--- a/integration/image_delete_test.go
+++ b/integration/image_delete_test.go
@@ -134,6 +134,6 @@ var _ = suite("compute/image/delete", func(t *testing.T, when spec.G, it spec.S)
 })
 
 const (
-	imageDelOutput      = "Warning: Are you sure you want to delete 1 image? (y/N) ? Error: Operation aborted."
+	imageDelOutput      = "Warning: Are you sure you want to delete this image? (y/N) ? Error: Operation aborted."
 	multiImageDelOutput = "Warning: Are you sure you want to delete 2 images? (y/N) ? Error: Operation aborted."
 )

--- a/integration/tags_delete_test.go
+++ b/integration/tags_delete_test.go
@@ -146,6 +146,6 @@ var _ = suite("compute/tags/delete", func(t *testing.T, when spec.G, it spec.S) 
 })
 
 const (
-	tagDelOutput      = "Warning: Are you sure you want to delete 1 tag? (y/N) ? Error: Operation aborted."
+	tagDelOutput      = "Warning: Are you sure you want to delete this tag? (y/N) ? Error: Operation aborted."
 	multiTagDelOutput = "Warning: Are you sure you want to delete 2 tags? (y/N) ? Error: Operation aborted."
 )

--- a/integration/tags_delete_test.go
+++ b/integration/tags_delete_test.go
@@ -1,0 +1,151 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite("compute/tags/delete", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/tags/foo":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodDelete {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				reqBody, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+				expect.Empty(string(reqBody))
+
+				w.WriteHeader(http.StatusNoContent)
+
+			case "/v2/tags/bar":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodDelete {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				reqBody, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+				expect.Empty(string(reqBody))
+
+				w.WriteHeader(http.StatusNoContent)
+
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	when("all required flags are passed", func() {
+		it("deletes the right tag", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"tag",
+				"delete",
+				"foo",
+				"--force",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Empty(output)
+		})
+	})
+
+	when("multiple tags are provided and all required flags are passed", func() {
+		it("deletes the right tagss", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"tag",
+				"delete",
+				"foo",
+				"bar",
+				"--force",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Empty(output)
+		})
+	})
+
+	when("deleting one tag without force flag", func() {
+		it("correctly promts for confirmation", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"tag",
+				"delete",
+				"foo",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expect.Equal(strings.TrimSpace(tagDelOutput), strings.TrimSpace(string(output)))
+		})
+	})
+
+	when("deleting two tags without force flag", func() {
+		it("correctly promts for confirmation", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"tag",
+				"delete",
+				"foo",
+				"bar",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expect.Equal(strings.TrimSpace(multiTagDelOutput), strings.TrimSpace(string(output)))
+		})
+	})
+})
+
+const (
+	tagDelOutput      = "Warning: Are you sure you want to delete 1 tag? (y/N) ? Error: Operation aborted."
+	multiTagDelOutput = "Warning: Are you sure you want to delete 2 tags? (y/N) ? Error: Operation aborted."
+)


### PR DESCRIPTION
This started as wanting to quickly improve the delete confirmation messages for Droplets, and then I went down a bit of a rabbit hole... 

We have a lot of prompts like:

> Are you sure you want to Delete 1 droplet(s)? (y/N) ?

This updates them not have strange capitalization in the middle of sentences and pluralize things correctly. Eg:

> Are you sure you want to delete this Droplet? (y/N) ?
> Are you sure you want to delete 2 Droplets? (y/N) ?

It adds a new `AskForConfirmDelete` method for normal cases but leaves the more generic `AskForConfirm` for ones that need more customization.

It also adds missing integration tests for commands that can delete multiple resources at the same time.