### PR TITLE
Add notice to 'compute image list' output about '--public' flag when response empty.

### DIFF
--- a/commands/images.go
+++ b/commands/images.go
@@ -110,6 +110,10 @@ func RunImagesList(c *CmdConfig) error {
 		return err
 	}
 
+	if !public && len(list) < 1 {
+		notice("Listing private images. Use '--public' to include all images.")
+	}
+
 	item := &displayers.Image{Images: list}
 	return c.Display(item)
 }

--- a/integration/image_list_test.go
+++ b/integration/image_list_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -25,12 +26,6 @@ var _ = suite("compute/image/list", func(t *testing.T, when spec.G, it spec.S) {
 		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			switch req.URL.Path {
 			case "/v2/images":
-				auth := req.Header.Get("Authorization")
-				if auth != "Bearer some-magic-token" {
-					w.WriteHeader(http.StatusUnauthorized)
-					return
-				}
-
 				if req.Method != http.MethodGet {
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
@@ -43,10 +38,18 @@ var _ = suite("compute/image/list", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				// Test uses the same return from ListApplication
-				// as the JSON returned is identical and it appears
-				// most of the filtering logic happens via the API
-				w.Write([]byte(imageListApplicationResponse))
+				auth := req.Header.Get("Authorization")
+				if auth == "Bearer some-magic-token" {
+					// Test uses the same return from ListApplication
+					// as the JSON returned is identical
+					w.Write([]byte(imageListApplicationResponse))
+				} else if auth == "Bearer token-for-account-with-no-images" {
+					w.Write([]byte(`{"images":[]}`))
+				} else {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
 			default:
 				dump, err := httputil.DumpRequest(req, true)
 				if err != nil {
@@ -56,10 +59,9 @@ var _ = suite("compute/image/list", func(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf("received unknown request: %s", dump)
 			}
 		}))
-
 	})
 
-	when("passing no flags", func() {
+	when("passing public flag", func() {
 		it("lists all images", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
@@ -75,4 +77,88 @@ var _ = suite("compute/image/list", func(t *testing.T, when spec.G, it spec.S) {
 			expect.Equal(strings.TrimSpace(imageListApplicationOutput), strings.TrimSpace(string(output)))
 		})
 	})
+
+	when("passing no flags", func() {
+		it("lists private images", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"image",
+				"list",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Equal(strings.TrimSpace(imageListPrivateOutput), strings.TrimSpace(string(output)))
+		})
+	})
+
+	when("no private images exist and public flag not passed", func() {
+		it("print notice", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "token-for-account-with-no-images",
+				"-u", server.URL,
+				"compute",
+				"image",
+				"list",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Equal(strings.TrimSpace(imageListNoticeWithHeader), strings.TrimSpace(string(output)))
+		})
+	})
+
+	when("no private images exist and no-header is passed", func() {
+		it("notice does not go to stdout", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "token-for-account-with-no-images",
+				"-u", server.URL,
+				"compute",
+				"image",
+				"list",
+				"--no-header",
+			)
+
+			stdout, err := cmd.StdoutPipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			stderr, err := cmd.StderrPipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+
+			stdoutString, err := ioutil.ReadAll(stdout)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			stderrString, err := ioutil.ReadAll(stderr)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expect.Empty(stdoutString)
+			expect.Equal(strings.TrimSpace(imageListNotice), strings.TrimSpace(string(stderrString)))
+		})
+	})
 })
+
+const (
+	imageListPrivateOutput = `
+ID         Name                                        Type    Distribution    Slug             Public    Min Disk
+6376602    Ruby on Rails on 14.04 (Nginx + Unicorn)            Ubuntu          ruby-on-rails    false     20
+	`
+	imageListNoticeWithHeader = `
+Notice: Listing private images. Use '--public' to include all images.
+ID    Name    Type    Distribution    Slug    Public    Min Disk
+`
+	imageListNotice = `
+Notice: Listing private images. Use '--public' to include all images.
+`
+)


### PR DESCRIPTION
We've been reluctant to change this behavior due to the potential to break scripting for existing users, but it is clear that this can be confusing, especially when no private images exist. This PR adds a notice to `compute image list` output about the `--public` flag when the response is empty.

See: https://github.com/digitalocean/doctl/issues/314 & https://github.com/digitalocean/doctl/issues/784