### PR TITLE
kubernetes: Add support for specifying vpc-uuid

### DIFF
--- a/args.go
+++ b/args.go
@@ -38,6 +38,8 @@ const (
 	ArgClusterName = "cluster-name"
 	// ArgClusterVersionSlug is a cluster version argument.
 	ArgClusterVersionSlug = "version"
+	// ArgClusterVPCUUID is a cluster vpc-uuid argument.
+	ArgClusterVPCUUID = "vpc-uuid"
 	// ArgClusterNodePool are a cluster's node pools arguments.
 	ArgClusterNodePool = "node-pool"
 	// ArgClusterUpdateKubeconfig updates the local kubeconfig.

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -256,6 +256,8 @@ After creating a cluster, a configuration context will be added to kubectl and m
 		"Cluster region. Possible values: see `doctl kubernetes options regions`", requiredOpt())
 	AddStringFlag(cmdKubeClusterCreate, doctl.ArgClusterVersionSlug, "", "latest",
 		"Kubernetes version. Possible values: see `doctl kubernetes options versions`")
+	AddStringFlag(cmdKubeClusterCreate, doctl.ArgClusterVPCUUID, "", "",
+		"Kubernetes UUID. Must be the UUID of a valid VPC in the same region specified for the cluster.")
 	AddBoolFlag(cmdKubeClusterCreate, doctl.ArgAutoUpgrade, "", false,
 		"Boolean specifying whether to enable auto-upgrade for the cluster")
 	AddStringSliceFlag(cmdKubeClusterCreate, doctl.ArgTag, "", nil,
@@ -1212,6 +1214,13 @@ func buildClusterCreateRequestFromArgs(c *CmdConfig, r *godo.KubernetesClusterCr
 		return err
 	}
 	r.RegionSlug = region
+
+	vpcUUID, err := c.Doit.GetString(c.NS, doctl.ArgClusterVPCUUID)
+	if err != nil {
+		return err
+	}
+	// empty "" is fine, the default region VPC will be resolved
+	r.VPCUUID = vpcUUID
 
 	version, err := getVersionOrLatest(c)
 	if err != nil {

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -369,7 +369,6 @@ func TestKubernetesCreate(t *testing.T) {
 			},
 			AutoUpgrade: true,
 		}
-		//
 		tm.kubernetes.EXPECT().Create(&r).Return(&testCluster, nil)
 
 		config.Args = append(config.Args, testCluster.Name)
@@ -388,7 +387,16 @@ func TestKubernetesCreate(t *testing.T) {
 		})
 		config.Doit.Set(config.NS, doctl.ArgAutoUpgrade, testCluster.AutoUpgrade)
 
+		// Test with no vpc-uuid specified
 		err := testK8sCmdService().RunKubernetesClusterCreate("c-8", 3)(config)
+		assert.NoError(t, err)
+
+		// Test with vpc-uuid specified
+		config.Doit.Set(config.NS, doctl.ArgClusterVPCUUID, "vpc-uuid")
+		r.VPCUUID = "vpc-uuid"
+		testCluster.VPCUUID = "vpc-uuid"
+		tm.kubernetes.EXPECT().Create(&r).Return(&testCluster, nil)
+		err = testK8sCmdService().RunKubernetesClusterCreate("c-8", 3)(config)
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
### Description

#### What does this pull request accomplish

Adds `--vpc-uuid` flag to DOKS cluster create