### PR TITLE
Set higher ulmit on macOS builds to prevent "too many open files" error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ jobs:
     env: CACHE_NAME=BIONIC_1.14
 
   - name: "Testing: MacOS, go 1.14"
+    before_install: ulimit -n 1024
     script: make test
     os: osx
     go: 1.14.x


### PR DESCRIPTION
I've noticed seemingly random integration test failures on macOS recently when reviewing/merging PRs. These failures all look like:

```
=== CONT  TestRun/doctl/compute/firewall/update/an_updated_name_and_the_old_inbound_rules_are_provided/updates_a_firewall
    TestRun/doctl/compute/firewall/update/an_updated_name_and_the_old_inbound_rules_are_provided/updates_a_firewall: firewall_update_test.go:74: 
        	Error Trace:	firewall_update_test.go:74
        	            				spec.go:269
        	            				spec.go:262
        	            				parser.go:133
        	Error:      	Received unexpected error:
        	            	fork/exec /var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/integration-doctl191387348/doctl: too many open files
        	Test:       	TestRun/doctl/compute/firewall/update/an_updated_name_and_the_old_inbound_rules_are_provided/updates_a_firewall
        	Messages:   	received error output from command update: 
```

This seems to be a common issue with Travis. E.g. https://github.com/travis-ci/travis-ci/issues/7728

The common suggestion it to run `ulimit -n 1024` Sure enough, it looks like the default on macOS hosts for Travis is set to 256 which feels extremely low to me. See: https://travis-ci.org/github/andrewsomething/doctl/jobs/685840656#L113