### PR TITLE
Add VPC UUID flag to Droplet creates

### DIFF
--- a/args.go
+++ b/args.go
@@ -38,6 +38,8 @@ const (
 	ArgClusterName = "cluster-name"
 	// ArgClusterVersionSlug is a cluster version argument.
 	ArgClusterVersionSlug = "version"
+	// ArgVPCUUID is a VPC UUID argument.
+	ArgVPCUUID = "vpc-uuid"
 	// ArgClusterVPCUUID is a cluster vpc-uuid argument.
 	ArgClusterVPCUUID = "vpc-uuid"
 	// ArgClusterNodePool are a cluster's node pools arguments.

--- a/commands/displayers/droplet.go
+++ b/commands/displayers/droplet.go
@@ -42,7 +42,7 @@ func (d *Droplet) ColMap() map[string]string {
 	return map[string]string{
 		"ID": "ID", "Name": "Name", "PublicIPv4": "Public IPv4", "PrivateIPv4": "Private IPv4", "PublicIPv6": "Public IPv6",
 		"Memory": "Memory", "VCPUs": "VCPUs", "Disk": "Disk",
-		"Region": "Region", "Image": "Image", "VPCUUID": "VPCUUID", "Status": "Status",
+		"Region": "Region", "Image": "Image", "VPCUUID": "VPC UUID", "Status": "Status",
 		"Tags": "Tags", "Features": "Features", "Volumes": "Volumes",
 		"SizeSlug": "Size Slug",
 	}

--- a/commands/displayers/droplet.go
+++ b/commands/displayers/droplet.go
@@ -33,7 +33,7 @@ func (d *Droplet) JSON(out io.Writer) error {
 
 func (d *Droplet) Cols() []string {
 	cols := []string{
-		"ID", "Name", "PublicIPv4", "PrivateIPv4", "PublicIPv6", "Memory", "VCPUs", "Disk", "Region", "Image", "Status", "Tags", "Features", "Volumes",
+		"ID", "Name", "PublicIPv4", "PrivateIPv4", "PublicIPv6", "Memory", "VCPUs", "Disk", "Region", "Image", "VPCUUID", "Status", "Tags", "Features", "Volumes",
 	}
 	return cols
 }
@@ -42,7 +42,7 @@ func (d *Droplet) ColMap() map[string]string {
 	return map[string]string{
 		"ID": "ID", "Name": "Name", "PublicIPv4": "Public IPv4", "PrivateIPv4": "Private IPv4", "PublicIPv6": "Public IPv6",
 		"Memory": "Memory", "VCPUs": "VCPUs", "Disk": "Disk",
-		"Region": "Region", "Image": "Image", "Status": "Status",
+		"Region": "Region", "Image": "Image", "VPCUUID": "VPCUUID", "Status": "Status",
 		"Tags": "Tags", "Features": "Features", "Volumes": "Volumes",
 		"SizeSlug": "Size Slug",
 	}
@@ -61,7 +61,7 @@ func (d *Droplet) KV() []map[string]interface{} {
 		m := map[string]interface{}{
 			"ID": d.ID, "Name": d.Name, "PublicIPv4": ip, "PrivateIPv4": privIP, "PublicIPv6": ip6,
 			"Memory": d.Memory, "VCPUs": d.Vcpus, "Disk": d.Disk,
-			"Region": d.Region.Slug, "Image": image, "Status": d.Status,
+			"Region": d.Region.Slug, "Image": image, "VPCUUID": d.VPCUUID, "Status": d.Status,
 			"Tags": tags, "Features": features, "Volumes": volumes,
 			"SizeSlug": d.SizeSlug,
 		}

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -80,6 +80,7 @@ func Droplet() *Command {
 	AddStringFlag(cmdDropletCreate, doctl.ArgImage, "", "", "Droplet image",
 		requiredOpt())
 	AddStringFlag(cmdDropletCreate, doctl.ArgTagName, "", "", "Tag name")
+	AddStringFlag(cmdDropletCreate, doctl.ArgVPCUUID, "", "", "The UUID of the VPC to create the Droplet in")
 	AddStringSliceFlag(cmdDropletCreate, doctl.ArgTagNames, "", []string{}, "Tag names applied to the Droplet")
 
 	AddStringSliceFlag(cmdDropletCreate, doctl.ArgVolumeList, "", []string{}, "Block storage volumes attached to the Droplet")
@@ -201,6 +202,11 @@ func RunDropletCreate(c *CmdConfig) error {
 		return err
 	}
 
+	vpcUUID, err := c.Doit.GetString(c.NS, doctl.ArgVPCUUID)
+	if err != nil {
+		return err
+	}
+
 	tagNames, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTagNames)
 	if err != nil {
 		return err
@@ -267,6 +273,7 @@ func RunDropletCreate(c *CmdConfig) error {
 			Monitoring:        monitoring,
 			SSHKeys:           sshKeys,
 			UserData:          userData,
+			VPCUUID:           vpcUUID,
 			Tags:              tagNames,
 		}
 

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -71,6 +71,7 @@ func TestDropletBackupList(t *testing.T) {
 func TestDropletCreate(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		volumeUUID := "00000000-0000-4000-8000-000000000000"
+		vpcUUID := "00000000-0000-4000-8000-000000000000"
 		dcr := &godo.DropletCreateRequest{
 			Name:    "droplet",
 			Region:  "dev0",
@@ -85,6 +86,7 @@ func TestDropletCreate(t *testing.T) {
 			IPv6:              false,
 			PrivateNetworking: false,
 			Monitoring:        false,
+			VPCUUID:           vpcUUID,
 			UserData:          "#cloud-config",
 			Tags:              []string{"one", "two"},
 		}
@@ -96,6 +98,7 @@ func TestDropletCreate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgSizeSlug, "1gb")
 		config.Doit.Set(config.NS, doctl.ArgImage, "image")
 		config.Doit.Set(config.NS, doctl.ArgUserData, "#cloud-config")
+		config.Doit.Set(config.NS, doctl.ArgVPCUUID, vpcUUID)
 		config.Doit.Set(config.NS, doctl.ArgVolumeList, []string{"test-volume", volumeUUID})
 		config.Doit.Set(config.NS, doctl.ArgTagNames, []string{"one", "two"})
 

--- a/integration/droplet_create_test.go
+++ b/integration/droplet_create_test.go
@@ -87,6 +87,7 @@ var _ = suite("compute/droplet/create", func(t *testing.T, when spec.G, it spec.
 				"--image", "a-test-image",
 				"--region", "a-test-region",
 				"--size", "a-test-size",
+				"--vpc-uuid", "00000000-0000-4000-8000-000000000000",
 			)
 
 			output, err := cmd.CombinedOutput()
@@ -94,10 +95,11 @@ var _ = suite("compute/droplet/create", func(t *testing.T, when spec.G, it spec.
 			expect.Equal(strings.TrimSpace(dropletCreateOutput), strings.TrimSpace(string(output)))
 
 			request := &struct {
-				Name   string
-				Image  string
-				Region string
-				Size   string
+				Name    string
+				Image   string
+				Region  string
+				Size    string
+				VPCUUID string `json:"vpc_uuid"`
 			}{}
 
 			err = json.Unmarshal(reqBody, request)
@@ -107,6 +109,7 @@ var _ = suite("compute/droplet/create", func(t *testing.T, when spec.G, it spec.
 			expect.Equal("a-test-image", request.Image)
 			expect.Equal("a-test-region", request.Region)
 			expect.Equal("a-test-size", request.Size)
+			expect.Equal("00000000-0000-4000-8000-000000000000", request.VPCUUID)
 		})
 	})
 
@@ -192,7 +195,8 @@ const (
     "region": {
       "slug": "some-region-slug"
     },
-    "status": "active",
+	"status": "active",
+	"vpc_uuid": "00000000-0000-4000-8000-000000000000",
     "tags": ["yes"],
     "features": ["remotes"],
     "volume_ids": ["some-volume-id"]
@@ -206,7 +210,7 @@ const (
 {"action": "id": 1, "status": "completed"}
 `
 	dropletCreateOutput = `
-ID      Name                 Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region              Image                          Status    Tags    Features    Volumes
-1111    some-droplet-name    1.2.3.4        7.7.7.7                        12        13       15      some-region-slug    some-distro some-image-name    active    yes     remotes     some-volume-id
+ID      Name                 Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region              Image                          VPCUUID                                 Status    Tags    Features    Volumes
+1111    some-droplet-name    1.2.3.4        7.7.7.7                        12        13       15      some-region-slug    some-distro some-image-name    00000000-0000-4000-8000-000000000000    active    yes     remotes     some-volume-id
 `
 )

--- a/integration/droplet_create_test.go
+++ b/integration/droplet_create_test.go
@@ -210,7 +210,7 @@ const (
 {"action": "id": 1, "status": "completed"}
 `
 	dropletCreateOutput = `
-ID      Name                 Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region              Image                          VPCUUID                                 Status    Tags    Features    Volumes
+ID      Name                 Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region              Image                          VPC UUID                                Status    Tags    Features    Volumes
 1111    some-droplet-name    1.2.3.4        7.7.7.7                        12        13       15      some-region-slug    some-distro some-image-name    00000000-0000-4000-8000-000000000000    active    yes     remotes     some-volume-id
 `
 )

--- a/integration/droplet_get_test.go
+++ b/integration/droplet_get_test.go
@@ -125,8 +125,8 @@ const (
 access-token: special-broken
 `
 	dropletGetOutput = `
-ID      Name                 Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region              Image                          Status    Tags    Features    Volumes
-5555    some-droplet-name                                                  0         0        0       some-region-slug    some-distro some-image-name    active    yes     remotes     some-volume-id
+ID      Name                 Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region              Image                          VPC UUID    Status    Tags    Features    Volumes
+5555    some-droplet-name                                                  0         0        0       some-region-slug    some-distro some-image-name                active    yes     remotes     some-volume-id
 `
 	dropletGetFormatOutput = `
 ID      Name

--- a/integration/droplet_list_test.go
+++ b/integration/droplet_list_test.go
@@ -164,16 +164,16 @@ const (
 }`
 
 	dropletListOutput = `
-ID      Name                 Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region              Image                          Status    Tags    Features    Volumes
-1111    some-droplet-name                                                  0         0        0       some-region-slug    some-distro some-image-name    active    yes     remotes     some-volume-id
+ID      Name                 Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region              Image                          VPC UUID    Status    Tags    Features    Volumes
+1111    some-droplet-name                                                  0         0        0       some-region-slug    some-distro some-image-name                active    yes     remotes     some-volume-id
 `
 
 	dropletListRegionOutput = `
-ID      Name    Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region       Image                          Status    Tags    Features    Volumes
-1440                                                          0         0        0       my-region    some-distro some-image-name    active    yes     remotes     some-volume-id
+ID      Name    Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region       Image                          VPC UUID    Status    Tags    Features    Volumes
+1440                                                          0         0        0       my-region    some-distro some-image-name                active    yes     remotes     some-volume-id
 `
 
 	dropletListEmptyOutput = `
-ID    Name    Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region    Image    Status    Tags    Features    Volumes
+ID    Name    Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region    Image    VPC UUID    Status    Tags    Features    Volumes
 `
 )

--- a/integration/droplet_neighbors_test.go
+++ b/integration/droplet_neighbors_test.go
@@ -113,9 +113,9 @@ const (
 access-token: some-extra-token
 `
 	dropletNeighborsOutput = `
-ID      Name    Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region       Image                          Status    Tags    Features    Volumes
-2222                                                          0         0        0       some-slug    some-distro some-image-name    active    yes     remotes     some-volume-id
-1440                                                          0         0        0       some-slug    some-distro some-image-name    active    yes     remotes     some-volume-id
+ID      Name    Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region       Image                          VPC UUID    Status    Tags    Features    Volumes
+2222                                                          0         0        0       some-slug    some-distro some-image-name                active    yes     remotes     some-volume-id
+1440                                                          0         0        0       some-slug    some-distro some-image-name                active    yes     remotes     some-volume-id
 `
 
 	dropletNeighborsHeadersOutput = `

--- a/integration/projects_resources_get_test.go
+++ b/integration/projects_resources_get_test.go
@@ -188,8 +188,8 @@ var _ = suite("projects/resources/get", func(t *testing.T, when spec.G, it spec.
 
 const (
 	projectsResourcesGetDropletOutput = `
-ID      Name                 Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region              Image                          Status    Tags    Features    Volumes
-5555    some-droplet-name                                                  0         0        0       some-region-slug    some-distro some-image-name    active    yes     remotes     some-volume-id
+ID      Name                 Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region              Image                          VPC UUID    Status    Tags    Features    Volumes
+5555    some-droplet-name                                                  0         0        0       some-region-slug    some-distro some-image-name                active    yes     remotes     some-volume-id
 `
 	projectsResourcesGetFloatingIPOutput = `
 IP             Region    Droplet ID    Droplet Name


### PR DESCRIPTION
Adds the VPC UUID flag for Droplet creates. I paired on this with Cesar as an intro to `doctl`.

Closes #802