### PR TITLE
Expose expiry_seconds for Docker config commands.

### DIFF
--- a/args.go
+++ b/args.go
@@ -299,4 +299,6 @@ const (
 
 	// ArgReadWrite indicates a generated token should be read/write.
 	ArgReadWrite = "read-write"
+	// ArgRegistryExpirySeconds indicates the length of time the token will be valid in seconds.
+	ArgRegistryExpirySeconds = "expiry-seconds"
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.7
-	github.com/digitalocean/godo v1.35.1
+	github.com/digitalocean/godo v1.36.0
 	github.com/docker/cli v0.0.0-20200511172450-ab108430b268
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200429205700-c3b3aedfa4ad+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.35.1 h1:3P5timR4LTqcCafzrCgV2j83ck4aWb937ybFC7YQVFw=
-github.com/digitalocean/godo v1.35.1/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
+github.com/digitalocean/godo v1.36.0 h1:eRF8wNzHZyU7/wI3De/MQgiVSWdseDaf27bXj2gnOO0=
+github.com/digitalocean/godo v1.36.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/docker/cli v0.0.0-20200511172450-ab108430b268 h1:qQcFj4AX9xSurO9U9Z+tNVbuSwm323HC1+62B848YSw=
 github.com/docker/cli v0.0.0-20200511172450-ab108430b268/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200429205700-c3b3aedfa4ad+incompatible h1:3VA+ZiIkI6AbYYAP6qvflZQEm1GbAQbuN5VeTf6QEPA=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
-## unreleased
+## [v1.36.0] - 2020-05-12
+
+- #331 Expose expiry_seconds for Registry.DockerCredentials. @andrewsomething
 
 ## [v1.35.1] - 2020-04-21
 

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.35.1"
+	libraryVersion = "1.36.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.35.1
+# github.com/digitalocean/godo v1.36.0
 ## explicit
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util


### PR DESCRIPTION
By default, credential used to access container registries do not expire. When logging into the registry as part of a CI/CD process, this causes a number of issues. This PR exposes the `expiry_seconds` query parameter to the Docker config commands to allow for short lived credential.