### PR TITLE
Add mp 1 click to k8s and droplet

### DIFF
--- a/commands/1_clicks_test.go
+++ b/commands/1_clicks_test.go
@@ -28,9 +28,9 @@ func TestOneClickCommand(t *testing.T) {
 	assertCommandNames(t, cmd, "list")
 }
 
-func TesOneClickListNoType(t *testing.T) {
+func TestOneClickListNoType(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.oneClick.EXPECT().List("").Return(testOneClickList)
+		tm.oneClick.EXPECT().List("").Return(testOneClickList, nil)
 		err := RunOneClickList(config)
 		assert.NoError(t, err)
 	})

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -120,6 +120,8 @@ func Droplet() *Command {
 	cmdRunDropletUntag := CmdBuilder(cmd, RunDropletUntag, "untag <droplet-id|droplet-name>", "Remove a tag from a Droplet", "Use this command to remove a tag from a Droplet, specified with the `--tag-name` flag.", Writer)
 	AddStringSliceFlag(cmdRunDropletUntag, doctl.ArgTagName, "", []string{}, "Tag name to remove from Droplet")
 
+	cmd.AddCommand(dropletOneClicks())
+
 	return cmd
 }
 
@@ -734,4 +736,33 @@ func buildDropletSummary(ds do.DropletsService) (*dropletSummary, error) {
 	}
 
 	return &sum, nil
+}
+
+// kubernetesOneClicks creates the 1-click command.
+func dropletOneClicks() *Command {
+	cmd := &Command{
+		Command: &cobra.Command{
+			Use:   "1-click",
+			Short: "Display commands that pertain to droplet 1-click applications",
+			Long:  "The commands under `doctl kubernetes 1-click` are for interacting with DigitalOcean Droplet 1-Click applications.",
+		},
+	}
+
+	CmdBuilder(cmd, RunDropletOneClickList, "list", "Retrieve a list of Droplet 1-Click applications", "Use this command to retrieve a list of Droplet 1-Click applications.", Writer,
+		aliasOpt("ls"), displayerType(&displayers.OneClick{}))
+
+	return cmd
+}
+
+// RunDropletOneClickList retrieves a list of 1-clicks for Droplets.
+func RunDropletOneClickList(c *CmdConfig) error {
+	oneClicks := c.OneClicks()
+	oneClickList, err := oneClicks.List("droplet")
+	if err != nil {
+		return err
+	}
+
+	items := &displayers.OneClick{OneClicks: oneClickList}
+
+	return c.Display(items)
 }

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -38,6 +38,17 @@ var (
 		Regions: []string{"test0"},
 	}}
 	testImageList = do.Images{testImage, testImageSecondary}
+
+	testDropletOneClick = do.OneClick{
+		OneClick: &godo.OneClick{
+			Slug: "test-slug",
+			Type: "droplet",
+		},
+	}
+
+	testDropletOneClickList = do.OneClicks{
+		testOneClick,
+	}
 )
 
 func TestDropletCommand(t *testing.T) {
@@ -482,4 +493,12 @@ func Test_extractSSHKey(t *testing.T) {
 		got := extractSSHKeys(c.in)
 		assert.Equal(t, c.expected, got)
 	}
+}
+
+func TestDropletOneClickListNoType(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.oneClick.EXPECT().List("droplet").Return(testDropletOneClickList, nil)
+		err := RunDropletOneClickList(config)
+		assert.NoError(t, err)
+	})
 }

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -43,7 +43,7 @@ var (
 func TestDropletCommand(t *testing.T) {
 	cmd := Droplet()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "actions", "backups", "create", "delete", "get", "kernels", "list", "neighbors", "snapshots", "tag", "untag")
+	assertCommandNames(t, cmd, "1-click", "actions", "backups", "create", "delete", "get", "kernels", "list", "neighbors", "snapshots", "tag", "untag")
 }
 
 func TestDropletActionList(t *testing.T) {

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -109,6 +109,8 @@ func Kubernetes() *Command {
 
 	cmd.AddCommand(kubernetesCluster())
 	cmd.AddCommand(kubernetesOptions())
+	cmd.AddCommand(kubernetesOneClicks())
+
 	return cmd
 }
 
@@ -463,6 +465,35 @@ This command deletes the specified node in the specified node pool, and then cre
 	AddBoolFlag(cmdKubeNodeReplace, "skip-drain", "", false, "Skip draining the node before replacement")
 
 	return cmd
+}
+
+// kubernetesOneClicks creates the 1-click command.
+func kubernetesOneClicks() *Command {
+	cmd := &Command{
+		Command: &cobra.Command{
+			Use:   "1-click",
+			Short: "Display commands that pertain to kubernetes 1-click applications",
+			Long:  "The commands under `doctl kubernetes 1-click` are for interacting with DigitalOcean Kubernetes 1-Click applications.",
+		},
+	}
+
+	CmdBuilder(cmd, RunKubernetesOneClickList, "list", "Retrieve a list of Kubernetes 1-Click applications", "Use this command to retrieve a list of Kubernetes 1-Click applications.", Writer,
+		aliasOpt("ls"), displayerType(&displayers.OneClick{}))
+
+	return cmd
+}
+
+// RunKubernetesOneClickList retrieves a list of 1-clicks for kubernetes.
+func RunKubernetesOneClickList(c *CmdConfig) error {
+	oneClicks := c.OneClicks()
+	oneClickList, err := oneClicks.List("kubernetes")
+	if err != nil {
+		return err
+	}
+
+	items := &displayers.OneClick{OneClicks: oneClickList}
+
+	return c.Display(items)
 }
 
 func kubernetesOptions() *Command {

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -80,6 +80,17 @@ var (
 		},
 		AuthInfos: make(map[string]*clientcmdapi.AuthInfo),
 	}
+
+	testK8sOneClick = do.OneClick{
+		OneClick: &godo.OneClick{
+			Slug: "test-slug",
+			Type: "droplet",
+		},
+	}
+
+	testK8sOneClickList = do.OneClicks{
+		testOneClick,
+	}
 )
 
 type mockKubeconfigProvider struct {
@@ -118,6 +129,7 @@ func TestKubernetesCommand(t *testing.T) {
 	assertCommandNames(t, cmd,
 		"cluster",
 		"options",
+		"1-click",
 	)
 }
 
@@ -1101,4 +1113,12 @@ func Test_looksLikeUUID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestK8sOneClickListNoType(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.oneClick.EXPECT().List("kubernetes").Return(testOneClickList, nil)
+		err := RunKubernetesOneClickList(config)
+		assert.NoError(t, err)
+	})
 }

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -1117,7 +1117,7 @@ func Test_looksLikeUUID(t *testing.T) {
 
 func TestK8sOneClickListNoType(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.oneClick.EXPECT().List("kubernetes").Return(testOneClickList, nil)
+		tm.oneClick.EXPECT().List("kubernetes").Return(testK8sOneClickList, nil)
 		err := RunKubernetesOneClickList(config)
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
This adds the 1-click list command to both kubernetes and droplet with the "type" specified depending on context.