### PR TITLE
Add to README - available in Arch Linux repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ This allows `doctl` to add DigitalOcean container registry credentials to your D
 
 #### Arch Linux
 
-Arch users not using a package manager can install from the [AUR](https://aur.archlinux.org/packages/doctl-bin/).
+`doctl` is available in the official Arch Linux repository:
+
+    sudo pacman -S doctl
+
+As an alternative you can install it from the [AUR](https://aur.archlinux.org/packages/doctl-bin/).
 
 #### Nix supported OS
 


### PR DESCRIPTION
`doctl` is available in the official repo (it's a community repo but official non the less).

proof: https://www.archlinux.org/packages/community/x86_64/doctl/