### PR TITLE
apps: fix yaml spec handling and add support for log following

### DIFF
--- a/args.go
+++ b/args.go
@@ -36,8 +36,10 @@ const (
 	ArgActionType = "action-type"
 	// ArgAppSpec is a path to an app spec.
 	ArgAppSpec = "spec"
-	// ArgAppLogType the type of log..
+	// ArgAppLogType the type of log.
 	ArgAppLogType = "type"
+	// ArgAppLogFollow follow logs.
+	ArgAppLogFollow = "follow"
 	// ArgClusterName is a cluster name argument.
 	ArgClusterName = "cluster-name"
 	// ArgClusterVersionSlug is a cluster version argument.

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -27,7 +27,7 @@ import (
 	"github.com/digitalocean/doctl/commands/displayers"
 	"github.com/digitalocean/godo"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // Apps creates the apps command.
@@ -379,13 +379,13 @@ func RunAppsGetLogs(c *CmdConfig) error {
 }
 
 func parseAppSpec(spec []byte) (*godo.AppSpec, error) {
-	var appSpec godo.AppSpec
-	err := json.Unmarshal(spec, &appSpec)
-	if err == nil {
-		return &appSpec, nil
+	jsonSpec, err := yaml.YAMLToJSON(spec)
+	if err != nil {
+		return nil, err
 	}
 
-	err = yaml.Unmarshal(spec, &appSpec)
+	var appSpec godo.AppSpec
+	err = json.Unmarshal(jsonSpec, &appSpec)
 	if err == nil {
 		return &appSpec, nil
 	}

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -158,6 +158,7 @@ Three types of logs are supported and can be configured with --`+doctl.ArgAppLog
 		aliasOpt("l"),
 	)
 	AddStringFlag(logs, doctl.ArgAppLogType, "", strings.ToLower(string(godo.AppLogTypeRun)), "The type of logs.")
+	AddBoolFlag(logs, doctl.ArgAppLogFollow, "f", false, "Follow logs as they are emitted.")
 
 	return cmd
 }
@@ -349,8 +350,12 @@ func RunAppsGetLogs(c *CmdConfig) error {
 	default:
 		return fmt.Errorf("Invalid log type %s", logTypeStr)
 	}
+	logFollow, err := c.Doit.GetBool(c.NS, doctl.ArgAppLogFollow)
+	if err != nil {
+		return err
+	}
 
-	logs, err := c.Apps().GetLogs(appID, deploymentID, component, logType)
+	logs, err := c.Apps().GetLogs(appID, deploymentID, component, logType, logFollow)
 	if err != nil {
 		return err
 	}

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -311,9 +311,9 @@ func Test_parseAppSpec(t *testing.T) {
 		StaticSites: []godo.AppStaticSiteSpec{
 			{
 				Name: "static",
-				GitHub: godo.GitHubSourceSpec{
-					Repo:   "digitalocean/sample-gatsby",
-					Branch: "master",
+				Git: godo.GitSourceSpec{
+					RepoCloneURL: "git@github.com:digitalocean/sample-gatsby.git",
+					Branch:       "master",
 				},
 				Routes: []godo.AppRouteSpec{
 					{Path: "/static"},
@@ -337,8 +337,8 @@ func Test_parseAppSpec(t *testing.T) {
   "static_sites": [
     {
       "name": "static",
-      "github": {
-        "repo": "digitalocean/sample-gatsby",
+      "git": {
+        "repo_clone_url": "git@github.com:digitalocean/sample-gatsby.git",
         "branch": "master"
       },
       "routes": [
@@ -362,8 +362,8 @@ services:
     branch: master
 static_sites:
 - name: static
-  github:
-    repo: digitalocean/sample-gatsby
+  git:
+    repo_clone_url: git@github.com:digitalocean/sample-gatsby.git
     branch: master
   routes:
   - path: /static

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -285,10 +285,11 @@ func TestRunAppsGetLogs(t *testing.T) {
 
 	for typeStr, logType := range types {
 		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-			tm.apps.EXPECT().GetLogs(appID, deploymentID, component, logType).Times(1).Return(&godo.AppLogs{LiveURL: "https://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=..."}, nil)
+			tm.apps.EXPECT().GetLogs(appID, deploymentID, component, logType, true).Times(1).Return(&godo.AppLogs{LiveURL: "https://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=..."}, nil)
 
 			config.Args = append(config.Args, appID, deploymentID, component)
 			config.Doit.Set(config.NS, doctl.ArgAppLogType, typeStr)
+			config.Doit.Set(config.NS, doctl.ArgAppLogFollow, true)
 
 			err := RunAppsGetLogs(config)
 			require.NoError(t, err)

--- a/do/apps.go
+++ b/do/apps.go
@@ -31,7 +31,7 @@ type AppsService interface {
 	GetDeployment(appID, deploymentID string) (*godo.Deployment, error)
 	ListDeployments(appID string) ([]*godo.Deployment, error)
 
-	GetLogs(appID, deploymentID, component string, logType godo.AppLogType) (*godo.AppLogs, error)
+	GetLogs(appID, deploymentID, component string, logType godo.AppLogType, follow bool) (*godo.AppLogs, error)
 }
 
 type appsService struct {
@@ -110,8 +110,8 @@ func (s *appsService) ListDeployments(appID string) ([]*godo.Deployment, error) 
 	return deployments, nil
 }
 
-func (s *appsService) GetLogs(appID, deploymentID, component string, logType godo.AppLogType) (*godo.AppLogs, error) {
-	logs, _, err := s.client.Apps.GetLogs(s.ctx, appID, deploymentID, component, logType)
+func (s *appsService) GetLogs(appID, deploymentID, component string, logType godo.AppLogType, follow bool) (*godo.AppLogs, error) {
+	logs, _, err := s.client.Apps.GetLogs(s.ctx, appID, deploymentID, component, logType, follow)
 	if err != nil {
 		return nil, err
 	}

--- a/do/mocks/AppsService.go
+++ b/do/mocks/AppsService.go
@@ -153,16 +153,16 @@ func (mr *MockAppsServiceMockRecorder) ListDeployments(appID interface{}) *gomoc
 }
 
 // GetLogs mocks base method.
-func (m *MockAppsService) GetLogs(appID, deploymentID, component string, logType godo.AppLogType) (*godo.AppLogs, error) {
+func (m *MockAppsService) GetLogs(appID, deploymentID, component string, logType godo.AppLogType, follow bool) (*godo.AppLogs, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLogs", appID, deploymentID, component, logType)
+	ret := m.ctrl.Call(m, "GetLogs", appID, deploymentID, component, logType, follow)
 	ret0, _ := ret[0].(*godo.AppLogs)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLogs indicates an expected call of GetLogs.
-func (mr *MockAppsServiceMockRecorder) GetLogs(appID, deploymentID, component, logType interface{}) *gomock.Call {
+func (mr *MockAppsServiceMockRecorder) GetLogs(appID, deploymentID, component, logType, follow interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockAppsService)(nil).GetLogs), appID, deploymentID, component, logType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockAppsService)(nil).GetLogs), appID, deploymentID, component, logType, follow)
 }

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.7
-	github.com/digitalocean/godo v1.41.0
+	github.com/digitalocean/godo v1.42.0
 	github.com/docker/cli v0.0.0-20200622130859-87db43814b48
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -443,3 +443,5 @@ rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.41.0 h1:WYy7MIVVhTMZUNB+UA3irl2V9FyDJeDttsifYyn7jYA=
-github.com/digitalocean/godo v1.41.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
+github.com/digitalocean/godo v1.42.0 h1:xQlEFLhQ1zZUryJAfiWb8meLPPCWnLO901U5Imhh0Mc=
+github.com/digitalocean/godo v1.42.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48 h1:AC8qbhi/SjYf4iN2W3jSsofZGHWPjG8pjf5P143KUM8=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible h1:PmGHHCZ43l6h8aZIi+Xa+z1SWe4dFImd5EK3TNp1jlo=

--- a/integration/apps_test.go
+++ b/integration/apps_test.go
@@ -537,6 +537,7 @@ var _ = suite("apps/get-logs", func(t *testing.T, when spec.G, it spec.S) {
 				}
 
 				assert.Equal(t, "RUN", req.URL.Query().Get("type"))
+				assert.Equal(t, "true", req.URL.Query().Get("follow"))
 
 				json.NewEncoder(w).Encode(&godo.AppLogs{LiveURL: logsURL})
 			case "/fake-logs":
@@ -562,6 +563,8 @@ var _ = suite("apps/get-logs", func(t *testing.T, when spec.G, it spec.S) {
 			testAppUUID,
 			testDeploymentUUID,
 			"service",
+			"--type=run",
+			"-f",
 		)
 
 		output, err := cmd.CombinedOutput()

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v1.42.0] - 2020-07-22
+
+- #357 invoices: add category to InvoiceItem - @rbutler
+- #358 apps: add support for following logs - @nanzhong
+
 ## [v1.41.0] - 2020-07-17
 
 - #355 kubernetes: Add support for surge upgrades - @varshavaradarajan

--- a/vendor/github.com/digitalocean/godo/apps.go
+++ b/vendor/github.com/digitalocean/godo/apps.go
@@ -36,7 +36,7 @@ type AppsService interface {
 	ListDeployments(ctx context.Context, appID string, opts *ListOptions) ([]*Deployment, *Response, error)
 	CreateDeployment(ctx context.Context, appID string) (*Deployment, *Response, error)
 
-	GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType) (*AppLogs, *Response, error)
+	GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool) (*AppLogs, *Response, error)
 }
 
 // App represents an app.
@@ -263,8 +263,8 @@ func (s *AppsServiceOp) CreateDeployment(ctx context.Context, appID string) (*De
 }
 
 // GetLogs retrieves app logs.
-func (s *AppsServiceOp) GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType) (*AppLogs, *Response, error) {
-	url := fmt.Sprintf("%s/%s/deployments/%s/components/%s/logs?type=%s", appsBasePath, appID, deploymentID, component, logType)
+func (s *AppsServiceOp) GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool) (*AppLogs, *Response, error) {
+	url := fmt.Sprintf("%s/%s/deployments/%s/components/%s/logs?type=%s&follow=%t", appsBasePath, appID, deploymentID, component, logType, follow)
 	req, err := s.client.NewRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.41.0"
+	libraryVersion = "1.42.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/invoices.go
+++ b/vendor/github.com/digitalocean/godo/invoices.go
@@ -49,6 +49,7 @@ type InvoiceItem struct {
 	StartTime        time.Time `json:"start_time"`
 	EndTime          time.Time `json:"end_time"`
 	ProjectName      string    `json:"project_name"`
+	Category         string    `json:"category"`
 }
 
 // InvoiceList contains a paginated list of all of a customer's invoices.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.41.0
+# github.com/digitalocean/godo v1.42.0
 ## explicit
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -347,7 +347,8 @@ k8s.io/client-go/util/keyutil
 k8s.io/klog
 # k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 k8s.io/utils/integer
-# sigs.k8s.io/yaml v1.1.0
+# sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
 # github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200420201142-3c4aac89819a

--- a/vendor/sigs.k8s.io/yaml/.travis.yml
+++ b/vendor/sigs.k8s.io/yaml/.travis.yml
@@ -1,14 +1,13 @@
 language: go
 dist: xenial
 go:
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
+  - 1.12.x
+  - 1.13.x
 script:
-  - go get -t -v ./...
-  - diff -u <(echo -n) <(gofmt -d .)
+  - diff -u <(echo -n) <(gofmt -d *.go)
   - diff -u <(echo -n) <(golint $(go list -e ./...) | grep -v YAMLToJSON)
-  - go tool vet .
-  - go test -v -race ./...
+  - GO111MODULE=on go vet .
+  - GO111MODULE=on go test -v -race ./...
+  - git diff --exit-code
 install:
-  - go get golang.org/x/lint/golint
+  - GO111MODULE=off go get golang.org/x/lint/golint

--- a/vendor/sigs.k8s.io/yaml/OWNERS
+++ b/vendor/sigs.k8s.io/yaml/OWNERS
@@ -1,3 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
 approvers:
 - dims
 - lavalamp

--- a/vendor/sigs.k8s.io/yaml/README.md
+++ b/vendor/sigs.k8s.io/yaml/README.md
@@ -1,12 +1,14 @@
 # YAML marshaling and unmarshaling support for Go
 
-[![Build Status](https://travis-ci.org/ghodss/yaml.svg)](https://travis-ci.org/ghodss/yaml)
+[![Build Status](https://travis-ci.org/kubernetes-sigs/yaml.svg)](https://travis-ci.org/kubernetes-sigs/yaml)
+
+kubernetes-sigs/yaml is a permanent fork of [ghodss/yaml](https://github.com/ghodss/yaml).
 
 ## Introduction
 
 A wrapper around [go-yaml](https://github.com/go-yaml/yaml) designed to enable a better way of handling YAML when marshaling to and from structs.
 
-In short, this library first converts YAML to JSON using go-yaml and then uses `json.Marshal` and `json.Unmarshal` to convert to or from the struct. This means that it effectively reuses the JSON struct tags as well as the custom JSON methods `MarshalJSON` and `UnmarshalJSON` unlike go-yaml. For a detailed overview of the rationale behind this method, [see this blog post](http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/).
+In short, this library first converts YAML to JSON using go-yaml and then uses `json.Marshal` and `json.Unmarshal` to convert to or from the struct. This means that it effectively reuses the JSON struct tags as well as the custom JSON methods `MarshalJSON` and `UnmarshalJSON` unlike go-yaml. For a detailed overview of the rationale behind this method, [see this blog post](http://web.archive.org/web/20190603050330/http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/).
 
 ## Compatibility
 
@@ -32,13 +34,13 @@ GOOD:
 To install, run:
 
 ```
-$ go get github.com/ghodss/yaml
+$ go get sigs.k8s.io/yaml
 ```
 
 And import using:
 
 ```
-import "github.com/ghodss/yaml"
+import "sigs.k8s.io/yaml"
 ```
 
 Usage is very similar to the JSON library:
@@ -49,7 +51,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 type Person struct {
@@ -93,7 +95,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 func main() {

--- a/vendor/sigs.k8s.io/yaml/go.mod
+++ b/vendor/sigs.k8s.io/yaml/go.mod
@@ -1,0 +1,8 @@
+module sigs.k8s.io/yaml
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.1
+	gopkg.in/yaml.v2 v2.2.8
+)

--- a/vendor/sigs.k8s.io/yaml/go.sum
+++ b/vendor/sigs.k8s.io/yaml/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
+gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This depends on https://github.com/digitalocean/godo/pull/358 and will need to be updated with a vendor change once a godo release is cut; it's currently pointing directly at that commit.

This PR fixes incorrect handling of yaml specs and also adds support for following logs.