### PR TITLE
apps: add defaults for deployment id and component name

### DIFF
--- a/args.go
+++ b/args.go
@@ -38,6 +38,8 @@ const (
 	ArgAppSpec = "spec"
 	// ArgAppLogType the type of log.
 	ArgAppLogType = "type"
+	// ArgAppDeployment is the deployment ID.
+	ArgAppDeployment = "deployment"
 	// ArgAppLogFollow follow logs.
 	ArgAppLogFollow = "follow"
 	// ArgClusterName is a cluster name argument.

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -147,7 +147,7 @@ Only basic information is included with the text output format. For complete app
 	logs := CmdBuilder(
 		cmd,
 		RunAppsGetLogs,
-		"logs <app id> <deployment id> <component name>",
+		"logs <app id> <component name (default 'web')>",
 		"Get logs",
 		`Get component logs for a deployment of an app.
 
@@ -158,6 +158,7 @@ Three types of logs are supported and can be configured with --`+doctl.ArgAppLog
 		Writer,
 		aliasOpt("l"),
 	)
+	AddStringFlag(logs, doctl.ArgAppDeployment, "", "", "The deployment ID. Defaults to current deployment.")
 	AddStringFlag(logs, doctl.ArgAppLogType, "", strings.ToLower(string(godo.AppLogTypeRun)), "The type of logs.")
 	AddBoolFlag(logs, doctl.ArgAppLogFollow, "f", false, "Follow logs as they are emitted.")
 
@@ -338,12 +339,26 @@ func RunAppsListDeployments(c *CmdConfig) error {
 
 // RunAppsGetLogs gets app logs for a given component.
 func RunAppsGetLogs(c *CmdConfig) error {
-	if len(c.Args) < 3 {
+	if len(c.Args) < 1 {
 		return doctl.NewMissingArgsErr(c.NS)
 	}
 	appID := c.Args[0]
-	deploymentID := c.Args[1]
-	component := c.Args[2]
+	var component string
+	if len(c.Args) >= 2 {
+		component = c.Args[1]
+	}
+
+	deploymentID, err := c.Doit.GetString(c.NS, doctl.ArgAppDeployment)
+	if err != nil {
+		return err
+	}
+	if deploymentID == "" {
+		app, err := c.Apps().Get(appID)
+		if err != nil {
+			return err
+		}
+		deploymentID = app.ActiveDeployment.ID
+	}
 
 	logTypeStr, err := c.Doit.GetString(c.NS, doctl.ArgAppLogType)
 	if err != nil {

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -147,7 +147,7 @@ Only basic information is included with the text output format. For complete app
 	logs := CmdBuilder(
 		cmd,
 		RunAppsGetLogs,
-		"logs <app id> <component name (default 'web')>",
+		"logs <app id> <component name (defaults to all components)>",
 		"Get logs",
 		`Get component logs for a deployment of an app.
 

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -288,7 +288,8 @@ func TestRunAppsGetLogs(t *testing.T) {
 		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 			tm.apps.EXPECT().GetLogs(appID, deploymentID, component, logType, true).Times(1).Return(&godo.AppLogs{LiveURL: "https://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=..."}, nil)
 
-			config.Args = append(config.Args, appID, deploymentID, component)
+			config.Args = append(config.Args, appID, component)
+			config.Doit.Set(config.NS, doctl.ArgAppDeployment, deploymentID)
 			config.Doit.Set(config.NS, doctl.ArgAppLogType, typeStr)
 			config.Doit.Set(config.NS, doctl.ArgAppLogFollow, true)
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.7
-	github.com/digitalocean/godo v1.43.0
+	github.com/digitalocean/godo v1.44.0
 	github.com/docker/cli v0.0.0-20200622130859-87db43814b48
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,10 +56,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.42.0 h1:xQlEFLhQ1zZUryJAfiWb8meLPPCWnLO901U5Imhh0Mc=
-github.com/digitalocean/godo v1.42.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
-github.com/digitalocean/godo v1.43.0 h1:FzaH9p1KL3etxZ4vlUJ0YDhrXPq6j4qkO5y1CjgHvkQ=
-github.com/digitalocean/godo v1.43.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
+github.com/digitalocean/godo v1.44.0 h1:IMElzMUpO1dVR8qjSg53+5vDkOLzMbhJt4yTAq7NGCQ=
+github.com/digitalocean/godo v1.44.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48 h1:AC8qbhi/SjYf4iN2W3jSsofZGHWPjG8pjf5P143KUM8=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible h1:PmGHHCZ43l6h8aZIi+Xa+z1SWe4dFImd5EK3TNp1jlo=

--- a/integration/apps_test.go
+++ b/integration/apps_test.go
@@ -580,6 +580,19 @@ var _ = suite("apps/get-logs", func(t *testing.T, when spec.G, it spec.S) {
 			w.Header().Add("content-type", "application/json")
 
 			switch req.URL.Path {
+			case "/v2/apps/" + testAppUUID:
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				json.NewEncoder(w).Encode(testAppResponse)
 			case "/v2/apps/" + testAppUUID + "/deployments/" + testDeploymentUUID + "/components/service/logs":
 				auth := req.Header.Get("Authorization")
 				if auth != "Bearer some-magic-token" {
@@ -610,7 +623,7 @@ var _ = suite("apps/get-logs", func(t *testing.T, when spec.G, it spec.S) {
 		logsURL = fmt.Sprintf("%s/fake-logs", server.URL)
 	})
 
-	it("gets an app deployment", func() {
+	it("gets an app's logs", func() {
 		cmd := exec.Command(builtBinaryPath,
 			"-t", "some-magic-token",
 			"-u", server.URL,

--- a/integration/apps_test.go
+++ b/integration/apps_test.go
@@ -593,7 +593,7 @@ var _ = suite("apps/get-logs", func(t *testing.T, when spec.G, it spec.S) {
 				}
 
 				json.NewEncoder(w).Encode(testAppResponse)
-			case "/v2/apps/" + testAppUUID + "/deployments/" + testDeploymentUUID + "/components/service/logs":
+			case "/v2/apps/" + testAppUUID + "/deployments/" + testDeploymentUUID + "/logs":
 				auth := req.Header.Get("Authorization")
 				if auth != "Bearer some-magic-token" {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -607,6 +607,7 @@ var _ = suite("apps/get-logs", func(t *testing.T, when spec.G, it spec.S) {
 
 				assert.Equal(t, "RUN", req.URL.Query().Get("type"))
 				assert.Equal(t, "true", req.URL.Query().Get("follow"))
+				assert.Equal(t, "service", req.URL.Query().Get("component_name"))
 
 				json.NewEncoder(w).Encode(&godo.AppLogs{LiveURL: logsURL})
 			case "/fake-logs":
@@ -630,8 +631,8 @@ var _ = suite("apps/get-logs", func(t *testing.T, when spec.G, it spec.S) {
 			"apps",
 			"logs",
 			testAppUUID,
-			testDeploymentUUID,
 			"service",
+			"--deployment="+testDeploymentUUID,
 			"--type=run",
 			"-f",
 		)

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.44.0] - 2020-09-08
+
+- #364 apps: support aggregate deployment logs - @kamaln7
+
 ## [v1.43.0] - 2020-09-08
 
 - #362 update apps types - @kamaln7

--- a/vendor/github.com/digitalocean/godo/apps.go
+++ b/vendor/github.com/digitalocean/godo/apps.go
@@ -271,7 +271,11 @@ func (s *AppsServiceOp) CreateDeployment(ctx context.Context, appID string) (*De
 
 // GetLogs retrieves app logs.
 func (s *AppsServiceOp) GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool) (*AppLogs, *Response, error) {
-	url := fmt.Sprintf("%s/%s/deployments/%s/components/%s/logs?type=%s&follow=%t", appsBasePath, appID, deploymentID, component, logType, follow)
+	url := fmt.Sprintf("%s/%s/deployments/%s/logs?type=%s&follow=%t", appsBasePath, appID, deploymentID, logType, follow)
+	if component != "" {
+		url = fmt.Sprintf("%s&component_name=%s", url, component)
+	}
+
 	req, err := s.client.NewRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.43.0"
+	libraryVersion = "1.44.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.43.0
+# github.com/digitalocean/godo v1.44.0
 ## explicit
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util


### PR DESCRIPTION
This defaults the deployment ID to the current deployment, and the component name to '' so aggregate logs are used.

APPS-1547