### PR TITLE
commands/doit: Prevent creation of config home when using `--config`

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -217,8 +218,17 @@ func writeConfig() error {
 	return nil
 }
 
+// defaultConfigFileWriter returns a writer to a newly created config.yaml file in the default config home.
+// When using the default config file path the default config home directory will be created; Otherwise
+// the custom config home directory must exist and be writable to the user issuing the auth command.
 func defaultConfigFileWriter() (io.WriteCloser, error) {
 	cfgFile := viper.GetString("config")
+
+	defaultCfgFile := filepath.Join(defaultConfigHome(), defaultConfigName)
+	if cfgFile == defaultCfgFile {
+		configHome()
+	}
+
 	f, err := os.Create(cfgFile)
 	if err != nil {
 		return nil, err

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -36,6 +36,15 @@ var (
 		Command: &cobra.Command{
 			Use:   "doctl",
 			Short: "doctl is a command line interface (CLI) for the DigitalOcean API.",
+			PersistentPreRun: func(cmd *cobra.Command, args []string) {
+				defaultCfgFile := filepath.Join(defaultConfigHome(), defaultConfigName)
+				cfgFile := viper.GetString("config")
+				if cfgFile != defaultCfgFile {
+					return
+				}
+
+				configHome()
+			},
 		},
 	}
 
@@ -64,7 +73,7 @@ func init() {
 
 	rootPFlagSet := DoitCmd.PersistentFlags()
 	rootPFlagSet.StringVarP(&cfgFile, "config", "c",
-		filepath.Join(configHome(), defaultConfigName), "Specify a custom config file")
+		filepath.Join(defaultConfigHome(), defaultConfigName), "Specify a custom config file")
 	viper.BindPFlag("config", rootPFlagSet.Lookup("config"))
 
 	rootPFlagSet.StringVarP(&APIURL, "api-url", "u", "", "Override default API endpoint")
@@ -106,14 +115,18 @@ func initConfig() {
 
 // in case we ever want to change this, or let folks configure it...
 func configHome() string {
-	cfgDir, err := os.UserConfigDir()
-	checkErr(err)
-
-	ch := filepath.Join(cfgDir, "doctl")
-	err = os.MkdirAll(ch, 0755)
+	ch := defaultConfigHome()
+	err := os.MkdirAll(ch, 0755)
 	checkErr(err)
 
 	return ch
+}
+
+func defaultConfigHome() string {
+	cfgDir, err := os.UserConfigDir()
+	checkErr(err)
+
+	return filepath.Join(cfgDir, "doctl")
 }
 
 // Execute executes the current command using DoitCmd.

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -36,15 +36,6 @@ var (
 		Command: &cobra.Command{
 			Use:   "doctl",
 			Short: "doctl is a command line interface (CLI) for the DigitalOcean API.",
-			PersistentPreRun: func(cmd *cobra.Command, args []string) {
-				defaultCfgFile := filepath.Join(defaultConfigHome(), defaultConfigName)
-				cfgFile := viper.GetString("config")
-				if cfgFile != defaultCfgFile {
-					return
-				}
-
-				configHome()
-			},
 		},
 	}
 
@@ -108,25 +99,25 @@ func initConfig() {
 
 	if _, err := os.Stat(cfgFile); err == nil {
 		if err := viper.ReadInConfig(); err != nil {
-			log.Fatalln("Reading initialization failed:", err)
+			log.Fatalln("Config initialization failed:", err)
 		}
 	}
 }
 
 // in case we ever want to change this, or let folks configure it...
+func defaultConfigHome() string {
+	cfgDir, err := os.UserConfigDir()
+	checkErr(err)
+
+	return filepath.Join(cfgDir, "doctl")
+}
+
 func configHome() string {
 	ch := defaultConfigHome()
 	err := os.MkdirAll(ch, 0755)
 	checkErr(err)
 
 	return ch
-}
-
-func defaultConfigHome() string {
-	cfgDir, err := os.UserConfigDir()
-	checkErr(err)
-
-	return filepath.Join(cfgDir, "doctl")
 }
 
 // Execute executes the current command using DoitCmd.

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -365,7 +365,7 @@ This command removes the specified cluster's credentials from your local kubecon
 }
 
 func kubeconfigCachePath() string {
-	return filepath.Join(configHome(), "cache", "exec-credential")
+	return filepath.Join(defaultConfigHome(), "cache", "exec-credential")
 }
 
 func kubernetesNodePools() *Command {
@@ -623,7 +623,7 @@ func (s *KubernetesCommandService) RunKubernetesClusterCreate(defaultNodeSize st
 			s.tryUpdateKubeconfig(kube, cluster.ID, clusterName, setCurrentContext)
 		}
 
-		oneClickApps, err := c.Doit.GetStringSlice(c.NS, doctl.ArgOneClicks) 
+		oneClickApps, err := c.Doit.GetStringSlice(c.NS, doctl.ArgOneClicks)
 		if err != nil {
 			return err
 		}
@@ -633,9 +633,9 @@ func (s *KubernetesCommandService) RunKubernetesClusterCreate(defaultNodeSize st
 			if err != nil {
 				warn("Failed to kick off 1-Click Application(s) install")
 			} else {
-			notice(messageResponse)
+				notice(messageResponse)
 			}
-		} 
+		}
 
 		return displayClusters(c, true, *cluster)
 	}


### PR DESCRIPTION
This change adds a PersistentPreRun command hook to only create the default configuration directory if no custom config path is set.

I see that the oconfigHome() is used by the Kubernetes command for the cache directory so I opted to leave the function as is to not break any other commands that might be relying on the function to create the config directory if it doesn't already exist. 

The test were left unmodified as there appears to be coverage for using a custom cfg file path already, but happy to add a test to confirm that the directory is not created when specifying a custom cfg file. 

Closes #833