### PR TITLE
Fix typos

### DIFF
--- a/vendor/github.com/opencontainers/go-digest/README.md
+++ b/vendor/github.com/opencontainers/go-digest/README.md
@@ -66,7 +66,7 @@ out when using this package.
     This may seem inconvenient but it allows you replace the hash 
     implementations with others, such as https://github.com/stevvooe/resumable.
  
-2. Even though `digest.Digest` may be assemable as a string, _always_ 
+2. Even though `digest.Digest` may be acceptable as a string, _always_ 
     verify your input with `digest.Parse` or use `Digest.Validate`
     when accepting untrusted input. While there are measures to 
     avoid common problems, this will ensure you have valid digests

--- a/vendor/github.com/pelletier/go-toml/README.md
+++ b/vendor/github.com/pelletier/go-toml/README.md
@@ -18,7 +18,7 @@ Go-toml provides the following features for using data parsed from TOML document
 
 * Load TOML documents from files and string data
 * Easily navigate TOML structure using Tree
-* Mashaling and unmarshaling to and from data structures
+* Marshaling and unmarshaling to and from data structures
 * Line & column position data for all parsed elements
 * [Query support similar to JSON-Path](query/)
 * Syntax errors contain line and column numbers
@@ -109,7 +109,7 @@ Go-toml provides two handy command line tools:
 
 ### Docker image
 
-Those tools are also availble as a Docker image from
+Those tools are also available as a Docker image from
 [dockerhub](https://hub.docker.com/r/pelletier/go-toml). For example, to
 use `tomljson`:
 

--- a/vendor/github.com/russross/blackfriday/README.md
+++ b/vendor/github.com/russross/blackfriday/README.md
@@ -225,7 +225,7 @@ Extensions
 In addition to the standard markdown syntax, this package
 implements the following extensions:
 
-*   **Intra-word emphasis supression**. The `_` character is
+*   **Intra-word emphasis suppression**. The `_` character is
     commonly used inside words when discussing code, so having
     markdown interpret it as an emphasis command is usually the
     wrong thing. Blackfriday lets you treat all emphasis markers as

--- a/vendor/github.com/sirupsen/logrus/CHANGELOG.md
+++ b/vendor/github.com/sirupsen/logrus/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.6.0
 Fixes:
   * end of line cleanup
-  * revert the entry concurrency bug fix whic leads to deadlock under some circumstances
+  * revert the entry concurrency bug fix which leads to deadlock under some circumstances
   * update dependency on go-windows-terminal-sequences to fix a crash with go 1.14
 
 Features:
@@ -84,7 +84,7 @@ This new release introduces:
   * an indent configuration for the json formatter
   * output colour support for windows
   * the field sort function is now configurable for text formatter
-  * the CLICOLOR and CLICOLOR\_FORCE environment variable support in text formater
+  * the CLICOLOR and CLICOLOR\_FORCE environment variable support in text formatter
 
 # 1.0.6
 
@@ -93,9 +93,9 @@ This new release introduces:
     which is mostly useful for logger wrapper
   * a fix reverting the immutability of the entry given as parameter to the hooks
     a new configuration field of the json formatter in order to put all the fields
-    in a nested dictionnary
+    in a nested dictionary
   * a new SetOutput method in the Logger
-  * a new configuration of the textformatter to configure the name of the default keys
+  * a new configuration of the text formatter to configure the name of the default keys
   * a new configuration of the text formatter to disable the level truncation
 
 # 1.0.5

--- a/vendor/github.com/spf13/afero/README.md
+++ b/vendor/github.com/spf13/afero/README.md
@@ -322,7 +322,7 @@ layer into the overlay. Subsequent reads will be pulled from the overlay
 directly permitting the request is within the cache duration of when it was
 created in the overlay.
 
-If the base filesystem is writeable, any changes to files will be
+If the base filesystem is writable, any changes to files will be
 done first to the base, then to the overlay layer. Write calls to open file
 handles like `Write()` or `Truncate()` to the overlay first.
 
@@ -345,7 +345,7 @@ ufs := afero.NewCacheOnReadFs(base, layer, 100 * time.Second)
 ### CopyOnWriteFs()
 
 The CopyOnWriteFs is a read only base file system with a potentially
-writeable layer on top.
+writable layer on top.
 
 Read operations will first look in the overlay and if not found there, will
 serve the file from the base.

--- a/vendor/github.com/spf13/jwalterweatherman/README.md
+++ b/vendor/github.com/spf13/jwalterweatherman/README.md
@@ -18,7 +18,7 @@ provides a few advantages over using the standard log library alone.
 I really wanted a very straightforward library that could seamlessly do
 the following things.
 
-1. Replace all the println, printf, etc statements thoughout my code with
+1. Replace all the println, printf, etc statements throughout my code with
    something more useful
 2. Allow the user to easily control what levels are printed to stdout
 3. Allow the user to easily control what levels are logged

--- a/vendor/github.com/spf13/viper/README.md
+++ b/vendor/github.com/spf13/viper/README.md
@@ -619,7 +619,7 @@ if err != nil {
 
 ### Marshalling to string
 
-You may need to marhsal all the settings held in viper into a string rather than write them to a file. 
+You may need to marshal all the settings held in viper into a string rather than write them to a file. 
 You can use your favorite format's marshaller with the config returned by `AllSettings()`.
 
 ```go

--- a/vendor/golang.org/x/sys/unix/README.md
+++ b/vendor/golang.org/x/sys/unix/README.md
@@ -156,7 +156,7 @@ from the generated architecture-specific files listed below, and merge these
 into a common file for each OS.
 
 The merge is performed in the following steps:
-1. Construct the set of common code that is idential in all architecture-specific files.
+1. Construct the set of common code that is identical in all architecture-specific files.
 2. Write this common code to the merged file.
 3. Remove the common code from all architecture-specific files.
 

--- a/vendor/k8s.io/klog/README.md
+++ b/vendor/k8s.io/klog/README.md
@@ -34,7 +34,7 @@ How to use klog
 - For more logging conventions (See [Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md))
 
 ### Coexisting with glog
-This package can be used side by side with glog. [This example](examples/coexist_glog/coexist_glog.go) shows how to initialize and syncronize flags from the global `flag.CommandLine` FlagSet. In addition, the example makes use of stderr as combined output by setting `alsologtostderr` (or `logtostderr`) to `true`.
+This package can be used side by side with glog. [This example](examples/coexist_glog/coexist_glog.go) shows how to initialize and synchronize flags from the global `flag.CommandLine` FlagSet. In addition, the example makes use of stderr as combined output by setting `alsologtostderr` (or `logtostderr`) to `true`.
 
 ## Community, discussion, contribution, and support
 


### PR DESCRIPTION
This PR fixes some typos in vendored dependencies. **I'm guessing that you don't want these changes, but maybe this PR will prompt a much-needed migration away from vendoring.** I'm not a Golang developer, but don't Go Modules (which are [already implemented](https://github.com/digitalocean/doctl/blob/master/go.mod)) improve upon vendoring?