### PR TITLE
Correct misspellings in the codebase

### DIFF
--- a/commands/account.go
+++ b/commands/account.go
@@ -24,7 +24,7 @@ func Account() *Command {
 		Command: &cobra.Command{
 			Use:   "account",
 			Short: "Display commands that retrieve account details",
-			Long: `The subcommands of ` + "`" + `doctl account` + "`" + ` retreive information about DigitalOcean accounts.
+			Long: `The subcommands of ` + "`" + `doctl account` + "`" + ` retrieve information about DigitalOcean accounts.
 
 For example, ` + "`" + `doctl account get` + "`" + ` retrieves account profile details, and ` + "`" + `doctl account ratelimit` + "`" + ` retrieves API usage details.`,
 		},

--- a/commands/certificates.go
+++ b/commands/certificates.go
@@ -82,7 +82,7 @@ To upload a custom certificate, you'll need to provide a certificate name, the p
 
 Use `+"`"+`doctl compute certificate list`+"`"+` to see all available certificates associated with your account.`, Writer, aliasOpt("d", "rm"))
 	AddBoolFlag(cmdCertificateDelete, doctl.ArgForce, doctl.ArgShortForce, false,
-		"Delete the certificate without a comfirmation prompt")
+		"Delete the certificate without a confirmation prompt")
 
 	return cmd
 }

--- a/commands/completion.go
+++ b/commands/completion.go
@@ -162,7 +162,7 @@ complete -c doctl -n '__fish_seen_subcommand_from account get' -l no-header -d "
 complete -c doctl -n '__fish_seen_subcommand_from account ratelimit' -l format    -d "Columns for output"
 complete -c doctl -n '__fish_seen_subcommand_from account ratelimit' -l no-header -d "Return raw data with no headers"
 
-# Completions for the 'doctl auth' commmand
+# Completions for the 'doctl auth' command
 complete -c doctl -n '__fish_seen_subcommand_from auth' -a init   -d "Initialize doctl"
 complete -c doctl -n '__fish_seen_subcommand_from auth' -a list   -d "List available authentication context"
 complete -c doctl -n '__fish_seen_subcommand_from auth' -a switch -d "Switches between authentication contexts"

--- a/commands/image_actions.go
+++ b/commands/image_actions.go
@@ -45,7 +45,7 @@ func ImageAction() *Command {
 - The slug for the region where the action occurred.
 `
 	cmdImageActionsGet := CmdBuilder(cmd, RunImageActionsGet,
-		"get <image-id>", "Retrieve the status of an image action", `Use this command to retrieve the status of an image action, inlcuding the following details:`+actionDetail, Writer,
+		"get <image-id>", "Retrieve the status of an image action", `Use this command to retrieve the status of an image action, including the following details:`+actionDetail, Writer,
 		displayerType(&displayers.Action{}))
 	AddIntFlag(cmdImageActionsGet, doctl.ArgActionID, "", 0, "action id", requiredOpt())
 

--- a/integration/cdn_create_test.go
+++ b/integration/cdn_create_test.go
@@ -81,7 +81,7 @@ var _ = suite("compute/cdn/create", func(t *testing.T, when spec.G, it spec.S) {
 				"compute",
 				"cdn",
 				"create",
-				"magic-orgin",
+				"magic-origin",
 				"--certificate-id", "some-cert-id",
 				"--domain", "example.com",
 				"--ttl", "60",
@@ -97,7 +97,7 @@ var _ = suite("compute/cdn/create", func(t *testing.T, when spec.G, it spec.S) {
 const (
 	cdnCreateOutput = `
 ID                                      Origin         Endpoint                                         TTL    CustomDomain    CertificateID    CreatedAt
-19f06b6a-3ace-4315-b086-499a0e521b76    magic-orgin    static-images.nyc3.cdn.digitaloceanspaces.com    60     example.com     some-cert-id     2018-07-19 15:04:16 +0000 UTC
+19f06b6a-3ace-4315-b086-499a0e521b76    magic-origin    static-images.nyc3.cdn.digitaloceanspaces.com    60     example.com     some-cert-id     2018-07-19 15:04:16 +0000 UTC
 `
 	cdnCreateResponse = `
 {

--- a/integration/cdn_create_test.go
+++ b/integration/cdn_create_test.go
@@ -96,8 +96,8 @@ var _ = suite("compute/cdn/create", func(t *testing.T, when spec.G, it spec.S) {
 
 const (
 	cdnCreateOutput = `
-ID                                      Origin         Endpoint                                         TTL    CustomDomain    CertificateID    CreatedAt
-19f06b6a-3ace-4315-b086-499a0e521b76    magic-origin   static-images.nyc3.cdn.digitaloceanspaces.com    60     example.com     some-cert-id     2018-07-19 15:04:16 +0000 UTC
+ID                                      Origin          Endpoint                                         TTL    CustomDomain    CertificateID    CreatedAt
+19f06b6a-3ace-4315-b086-499a0e521b76    magic-origin    static-images.nyc3.cdn.digitaloceanspaces.com    60     example.com     some-cert-id     2018-07-19 15:04:16 +0000 UTC
 `
 	cdnCreateResponse = `
 {

--- a/integration/cdn_create_test.go
+++ b/integration/cdn_create_test.go
@@ -97,7 +97,7 @@ var _ = suite("compute/cdn/create", func(t *testing.T, when spec.G, it spec.S) {
 const (
 	cdnCreateOutput = `
 ID                                      Origin         Endpoint                                         TTL    CustomDomain    CertificateID    CreatedAt
-19f06b6a-3ace-4315-b086-499a0e521b76    magic-origin    static-images.nyc3.cdn.digitaloceanspaces.com    60     example.com     some-cert-id     2018-07-19 15:04:16 +0000 UTC
+19f06b6a-3ace-4315-b086-499a0e521b76    magic-origin   static-images.nyc3.cdn.digitaloceanspaces.com    60     example.com     some-cert-id     2018-07-19 15:04:16 +0000 UTC
 `
 	cdnCreateResponse = `
 {


### PR DESCRIPTION
Corrected all the misspellings in the codebase based on `misspell`. Closes #870.