### PR TITLE
app logs: Protect against panic when no deployment is found.

### DIFF
--- a/commands/apps.go
+++ b/commands/apps.go
@@ -357,7 +357,13 @@ func RunAppsGetLogs(c *CmdConfig) error {
 		if err != nil {
 			return err
 		}
-		deploymentID = app.ActiveDeployment.ID
+		if app.ActiveDeployment != nil {
+			deploymentID = app.ActiveDeployment.ID
+		} else if app.InProgressDeployment != nil {
+			deploymentID = app.InProgressDeployment.ID
+		} else {
+			return fmt.Errorf("unable to retrieve logs; no deployment found for app %s", appID)
+		}
 	}
 
 	logTypeStr, err := c.Doit.GetString(c.NS, doctl.ArgAppLogType)


### PR DESCRIPTION
This checks that `app.ActiveDeployment` is not nil before assigning `deploymentID`. It also looks for an in progress deployment which is useful in the case someone is running `doctl apps logs --type build $ID` on a newly created app.

Closes: #878 