### PR TITLE
SSH Key: make public key accessible

### DIFF
--- a/commands/displayers/key.go
+++ b/commands/displayers/key.go
@@ -31,13 +31,13 @@ func (ke *Key) JSON(out io.Writer) error {
 
 func (ke *Key) Cols() []string {
 	return []string{
-		"ID", "Name", "FingerPrint",
+		"ID", "Name", "FingerPrint", "PublicKey",
 	}
 }
 
 func (ke *Key) ColMap() map[string]string {
 	return map[string]string{
-		"ID": "ID", "Name": "Name", "FingerPrint": "FingerPrint",
+		"ID": "ID", "Name": "Name", "FingerPrint": "FingerPrint", "PublicKey": "Public Key",
 	}
 }
 
@@ -46,7 +46,7 @@ func (ke *Key) KV() []map[string]interface{} {
 
 	for _, k := range ke.Keys {
 		o := map[string]interface{}{
-			"ID": k.ID, "Name": k.Name, "FingerPrint": k.Fingerprint,
+			"ID": k.ID, "Name": k.Name, "FingerPrint": k.Fingerprint, "PublicKey": k.PublicKey,
 		}
 
 		out = append(out, o)


### PR DESCRIPTION
Displays public key. Previously it's not showing public key information.
<img width="583" alt="Screen Shot 2020-10-24 at 3 03 20 AM" src="https://user-images.githubusercontent.com/10576292/97053849-7e702d00-15a5-11eb-8e8e-34aa2f63e9d4.png">

With this PR, it shows Public key as well.
<img width="835" alt="Screen Shot 2020-10-24 at 3 04 41 AM" src="https://user-images.githubusercontent.com/10576292/97053953-afe8f880-15a5-11eb-8762-a7878cbd1935.png">

Fixes #894
