### PR TITLE
Perf: Make use of cached binary instead of downloading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,15 @@ ARG GOARCH=amd64
 ENV OUT_D /out
 
 RUN mkdir -p /out
-RUN mkdir -p /go/src/github.com/digitalocean/doctl
-ADD . /go/src/github.com/digitalocean/doctl/
-
 RUN  apk add --update  --no-cache \
      bash \
      coreutils \
      git \
      libc6-compat \
      make
+
+RUN mkdir -p /go/src/github.com/digitalocean/doctl
+ADD . /go/src/github.com/digitalocean/doctl/
 
 RUN cd /go/src/github.com/digitalocean/doctl && \
     make build GOARCH=$GOARCH


### PR DESCRIPTION
Previously, while building docker image, any change in this repo will create new intermediate image and all the binary after that need to be downloaded again. 
`ADD . /go/src/github.com/digitalocean/doctl/`

To avoid this, we can download the binary first and add the code later. 

Pros: This saves significant amount of time where network is slow and doing frequent code changes