### PR TITLE
Add support for getting Droplets by name

### DIFF
--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -575,6 +575,9 @@ func RunDropletGet(c *CmdConfig) error {
 					matches = append(matches, d.ID)
 				}
 			}
+			if len(matches) == 1 {
+				id = matches[0]
+			}
 			return nil
 		}
 

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -556,6 +556,14 @@ func matchDroplets(ids []string, ds do.DropletsService, fn matchDropletsFn) erro
 
 // RunDropletGet returns a droplet.
 func RunDropletGet(c *CmdConfig) error {
+	if len(c.Args) != 1 {
+		return doctl.NewMissingArgsErr(c.NS)
+	}
+
+	getTemplate, err := c.Doit.GetString(c.NS, doctl.ArgTemplate)
+	if err != nil {
+		return err
+	}
 
 	ds := c.Droplets()
 	fn := func(ids []int) error {
@@ -566,7 +574,7 @@ func RunDropletGet(c *CmdConfig) error {
 			}
 
 			item := &displayers.Droplet{Droplets: do.Droplets{*d}}
-			getTemplate, err := c.Doit.GetString(c.NS, doctl.ArgTemplate)
+
 			if getTemplate != "" {
 				t := template.New("Get template")
 				t, err = t.Parse(getTemplate)


### PR DESCRIPTION
Might fix #895 -- I'm not very experienced in Golang.

```
❯ ./builds/doctl compute droplet list
ID           Name             Public IPv4       Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region    Image                     VPC UUID                                Status    Tags    Features              Volumes
213635352    hacktoberfest    142.93.240.125    10.116.0.2                     1024      1        25      nyc1      Ubuntu 20.04 (LTS) x64    0c20a2e6-b9ca-43fd-8b22-def8741321ac    active            private_networking    
213653028    hacktoberfest    142.93.5.117      10.116.0.3                     1024      1        25      nyc1      Ubuntu 20.04 (LTS) x64    0c20a2e6-b9ca-43fd-8b22-def8741321ac    active            private_networking
```

```
❯ ./builds/doctl compute droplet get hacktoberfest
Error: Multiple Droplets with the name "hacktoberfest" found.
```

```
❯ ./builds/doctl compute droplet delete 213653028
Warning: Are you sure you want to delete this Droplet? (y/N) ? y
```

New functionality:
```
❯ ./builds/doctl compute droplet get hacktoberfest
ID           Name             Public IPv4       Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region    Image                     VPC UUID                                Status    Tags    Features              Volumes
213635352    hacktoberfest    142.93.240.125    10.116.0.2                     1024      1        25      nyc1      Ubuntu 20.04 (LTS) x64    0c20a2e6-b9ca-43fd-8b22-def8741321ac    active            private_networking
```

```
❯ ./builds/doctl compute droplet delete 213635352
Warning: Are you sure you want to delete this Droplet? (y/N) ? y
```

```
❯ ./builds/doctl compute droplet get hacktoberfest
Error: Droplet with the name "hacktoberfest" could not be found.
```