### PR TITLE
registry: improve formatting on repositories long desc

### DIFF
--- a/commands/registry.go
+++ b/commands/registry.go
@@ -115,14 +115,13 @@ func Repository() *Command {
 		},
 	}
 
-	listRepositoriesDesc := `
-	This command retrieves information about repositories in a registry, including:
-	- The repository name
-	- The latest tag of the repository
-	- The compressed size for the latest tag
-	- The manifest digest for the latest tag
-	- The last updated timestamp
-	`
+	listRepositoriesDesc := `This command retrieves information about repositories in a registry, including:
+  - The repository name
+  - The latest tag of the repository
+  - The compressed size for the latest tag
+  - The manifest digest for the latest tag
+  - The last updated timestamp
+`
 	CmdBuilder(
 		cmd,
 		RunListRepositories, "list",
@@ -130,13 +129,12 @@ func Repository() *Command {
 		Writer, aliasOpt("ls"), displayerType(&displayers.Repository{}),
 	)
 
-	listRepositoryTagsDesc := `
-	This command retrieves information about tags in a repository, including:
-	- The tag name
-	- The compressed size 
-	- The manifest digest 
-	- The last updated timestamp
-	`
+	listRepositoryTagsDesc := `This command retrieves information about tags in a repository, including:
+  - The tag name
+  - The compressed size
+  - The manifest digest
+  - The last updated timestamp
+`
 	CmdBuilder(
 		cmd,
 		RunListRepositoryTags, "list-tags <repository>",


### PR DESCRIPTION
before:
```
zsh/4 10008  (git)-[docr/add-gc-subcommands]-% ./doctl registry repository list -h

        This command retrieves information about repositories in a registry, including:
        - The repository name
        - The latest tag of the repository
        - The compressed size for the latest tag
        - The manifest digest for the latest tag
        - The last updated timestamp

Usage:
  doctl registry repository list [flags]

Aliases:
  list, ls

Flags:
      --format Name   Columns for output in a comma-separated list. Possible values: Name, `LatestTag`, `TagCount`, `UpdatedAt`
  -h, --help          help for list
      --no-header     Return raw data with no headers

Global Flags:
  -t, --access-token string   API V2 access token
  -u, --api-url string        Override default API endpoint
  -c, --config string         Specify a custom config file (default "/home/wayne/.config/doctl/config.yaml")
      --context string        Specify a custom authentication context name
  -o, --output string         Desired output format [text|json] (default "text")
      --trace                 Show a log of network activity while performing a command
  -v, --verbose               Enable verbose output
```

after
```
zsh/4 10011  (git)-[docr/add-gc-subcommands]-% ./doctl registry repository list -h
This command retrieves information about repositories in a registry, including:
  - The repository name
  - The latest tag of the repository
  - The compressed size for the latest tag
  - The manifest digest for the latest tag
  - The last updated timestamp

Usage:
  doctl registry repository list [flags]

Aliases:
  list, ls

Flags:
      --format Name   Columns for output in a comma-separated list. Possible values: Name, `LatestTag`, `TagCount`, `UpdatedAt`
  -h, --help          help for list
      --no-header     Return raw data with no headers

Global Flags:
  -t, --access-token string   API V2 access token
  -u, --api-url string        Override default API endpoint
  -c, --config string         Specify a custom config file (default "/home/wayne/.config/doctl/config.yaml")
      --context string        Specify a custom authentication context name
  -o, --output string         Desired output format [text|json] (default "text")
      --trace                 Show a log of network activity while performing a command
  -v, --verbose               Enable verbose output
```

I include more than just the long description here to demonstrate my rationale for rejecting the use of tabs for indentation -- this makes it obvious that the use of spaces in the long description fits better with the auto-generated flag and alias help text.