### PR TITLE
Only show SSH public key for list operation

### DIFF
--- a/commands/displayers/key.go
+++ b/commands/displayers/key.go
@@ -19,6 +19,7 @@ import (
 	"github.com/digitalocean/doctl/do"
 )
 
+// Key is used to display the SSH Key results from a `list` operation.
 type Key struct {
 	Keys do.SSHKeys
 }
@@ -31,17 +32,56 @@ func (ke *Key) JSON(out io.Writer) error {
 
 func (ke *Key) Cols() []string {
 	return []string{
-		"ID", "Name", "FingerPrint", "PublicKey",
+		"ID", "Name", "FingerPrint",
 	}
 }
 
 func (ke *Key) ColMap() map[string]string {
 	return map[string]string{
-		"ID": "ID", "Name": "Name", "FingerPrint": "FingerPrint", "PublicKey": "Public Key",
+		"ID": "ID", "Name": "Name", "FingerPrint": "FingerPrint",
 	}
 }
 
 func (ke *Key) KV() []map[string]interface{} {
+	out := []map[string]interface{}{}
+
+	for _, k := range ke.Keys {
+		o := map[string]interface{}{
+			"ID": k.ID, "Name": k.Name, "FingerPrint": k.Fingerprint,
+		}
+
+		out = append(out, o)
+	}
+
+	return out
+}
+
+// KeyGet is used to display the SSH Key results from a `get` operation. This
+// separate displayer is required in order to include the public key in this
+// operation.
+type KeyGet struct {
+	Keys do.SSHKeys
+}
+
+var _ Displayable = &KeyGet{}
+
+func (ke *KeyGet) JSON(out io.Writer) error {
+	return writeJSON(ke.Keys, out)
+}
+
+func (ke *KeyGet) Cols() []string {
+	return []string{
+		"ID", "Name", "FingerPrint", "PublicKey",
+	}
+}
+
+func (ke *KeyGet) ColMap() map[string]string {
+	return map[string]string{
+		"ID": "ID", "Name": "Name", "FingerPrint": "FingerPrint", "PublicKey": "Public Key",
+	}
+}
+
+func (ke *KeyGet) KV() []map[string]interface{} {
 	out := []map[string]interface{}{}
 
 	for _, k := range ke.Keys {

--- a/commands/sshkeys.go
+++ b/commands/sshkeys.go
@@ -99,7 +99,7 @@ func RunKeyGet(c *CmdConfig) error {
 		return err
 	}
 
-	item := &displayers.Key{Keys: do.SSHKeys{*k}}
+	item := &displayers.KeyGet{Keys: do.SSHKeys{*k}}
 	return c.Display(item)
 }
 


### PR DESCRIPTION
Updates the SSH key operations so that we're only showing the SSH public key for the GET operation.

Below is an example output after these changes,

```
> doctl compute ssh-key list
ID          Name        FingerPrint
18077907    Test Key    fc:46:a6:64:41:e5:80:a4:17:53:ae:02:4f:29:a4:8e

> doctl compute ssh-key get 18077907
ID          Name        FingerPrint                                        Public Key
18077907    Test Key    fc:46:a6:64:41:e5:80:a4:17:53:ae:02:4f:29:a4:8e    ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBykkcZtToFp7nNUM6RQS5XqXWRhFSzcZTftrqTFMH45QZZb1MNk4yB3p1OFszlC30/O5mWRujryJjuyZ7H+tca96Chh1rJpwOFscVoame6YThPt9+nrAq30VY2tM6nR8d4iDD+1fXx5wa95CNH+Ns/r8dO/vfxSJaGe5Brn6JQOSsjvI/J5n8S7Q7B7csz03MHW+rpwyg6NhVDJHwMGdHU6bG+QyC18G8e8cWz2p0AiUIuaVaZfghx5B2WiibDnxZfh/p5VWgs85FasAQ7HClCo9KYOes6H3UlnIe6MV2W4duPlG43e6BahXqFeZQwQjp87IvcwgmKlvCSfn4Lqyc test@test.local
```