### PR TITLE
vpc: add default option to vpc update

### DIFF
--- a/args.go
+++ b/args.go
@@ -306,6 +306,8 @@ const (
 	ArgVPCName = "name"
 	// ArgVPCDescription is a VPC description.
 	ArgVPCDescription = "description"
+	// ArgVPCDefault is the VPC default argument, to update a specific VPC to the default VPC.
+	ArgVPCDefault = "default"
 	// ArgVPCIPRange is a VPC range of IP addresses in CIDR notation.
 	ArgVPCIPRange = "ip-range"
 

--- a/commands/vpcs.go
+++ b/commands/vpcs.go
@@ -15,6 +15,7 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/commands/displayers"
 	"github.com/digitalocean/doctl/do"
@@ -65,6 +66,8 @@ With the vpcs command, you can list, create, or delete VPCs, and manage their co
 		"The VPC's name", requiredOpt())
 	AddStringFlag(cmdRecordUpdate, doctl.ArgVPCDescription, "", "",
 		"The VPC's description")
+	AddBoolFlag(cmdRecordUpdate, doctl.ArgVPCDefault, "", false,
+		"The VPC's default state")
 
 	CmdBuilder(cmd, RunVPCList, "list", "List VPCs", "Use this command to get a list of the VPCs on your account, including the following information for each:"+vpcDetail, Writer,
 		aliasOpt("ls"), displayerType(&displayers.VPC{}))
@@ -162,6 +165,15 @@ func RunVPCUpdate(c *CmdConfig) error {
 		return err
 	}
 	r.Description = desc
+
+	def, err := c.Doit.GetBoolPtr(c.NS, doctl.ArgVPCDefault)
+	if err != nil {
+		return err
+	}
+
+	if def != nil {
+		r.Default = boolPtr(true)
+	}
 
 	vpcs := c.VPCs()
 	vpc, err := vpcs.Update(vpcUUID, r)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.7
-	github.com/digitalocean/godo v1.49.0
+	github.com/digitalocean/godo v1.49.1-0.20201026144029-48e3dced040e
 	github.com/docker/cli v0.0.0-20200622130859-87db43814b48
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.7
-	github.com/digitalocean/godo v1.49.1-0.20201026144029-48e3dced040e
+	github.com/digitalocean/godo v1.50.0
 	github.com/docker/cli v0.0.0-20200622130859-87db43814b48
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/digitalocean/godo v1.49.0 h1:68C9I16mNk0tNGJ5ViMauj9JImvPLR4gtsty0LCr3Ak=
 github.com/digitalocean/godo v1.49.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
+github.com/digitalocean/godo v1.49.1-0.20201026144029-48e3dced040e h1:P7DaioPslTfjd8hqxCcqgs2xGq1e+/ilA8Wi5fp9Akc=
+github.com/digitalocean/godo v1.49.1-0.20201026144029-48e3dced040e/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48 h1:AC8qbhi/SjYf4iN2W3jSsofZGHWPjG8pjf5P143KUM8=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible h1:PmGHHCZ43l6h8aZIi+Xa+z1SWe4dFImd5EK3TNp1jlo=

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/digitalocean/godo v1.49.0 h1:68C9I16mNk0tNGJ5ViMauj9JImvPLR4gtsty0LCr
 github.com/digitalocean/godo v1.49.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/digitalocean/godo v1.49.1-0.20201026144029-48e3dced040e h1:P7DaioPslTfjd8hqxCcqgs2xGq1e+/ilA8Wi5fp9Akc=
 github.com/digitalocean/godo v1.49.1-0.20201026144029-48e3dced040e/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
+github.com/digitalocean/godo v1.50.0 h1:ynl8HeBl77FCpuCSkBXgkzVLZNPumMGp7PEwYcNqJ1s=
+github.com/digitalocean/godo v1.50.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48 h1:AC8qbhi/SjYf4iN2W3jSsofZGHWPjG8pjf5P143KUM8=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible h1:PmGHHCZ43l6h8aZIi+Xa+z1SWe4dFImd5EK3TNp1jlo=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v1.50.0] - 2020-10-26
+
+- #400 - @waynr - registry: add garbage collection support
+- #402 - @snormore - apps: add catchall_document static site spec field and failed-deploy job type
+- #401 - @andrewlouis93 - VPC: adds option to set a VPC as the regional default
+
 ## [v1.49.0] - 2020-10-21
 
 - #383 - @kamaln7 - apps: add ListRegions, Get/ListTiers, Get/ListInstanceSizes

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -62,7 +62,8 @@ type AppDomainSpec struct {
 	Domain string            `json:"domain"`
 	Type   AppDomainSpecType `json:"type,omitempty"`
 	// Whether the domain includes all sub-domains, in addition to the given domain.
-	Wildcard bool `json:"wildcard,omitempty"`
+	Wildcard bool   `json:"wildcard,omitempty"`
+	Zone     string `json:"zone,omitempty"`
 }
 
 // AppDomainSpecType  - DEFAULT: The default .ondigitalocean.app domain assigned to this app.  - PRIMARY: The primary domain for this app. This is the domain that is displayed as the default in the control panel, used in bindable environment variables, and any other places that reference an app's live URL. Only one domain may be set as primary.  - ALIAS: A non-primary domain.
@@ -100,14 +101,15 @@ type AppJobSpec struct {
 	Kind             AppJobSpecKind `json:"kind,omitempty"`
 }
 
-// AppJobSpecKind  - UNSPECIFIED: Default job type, will auto-complete to POST_DEPLOY kind.  - PRE_DEPLOY: Indicates a job that runs before an app deployment.  - POST_DEPLOY: Indicates a job that runs after an app deployment.
+// AppJobSpecKind  - UNSPECIFIED: Default job type, will auto-complete to POST_DEPLOY kind.  - PRE_DEPLOY: Indicates a job that runs before an app deployment.  - POST_DEPLOY: Indicates a job that runs after an app deployment.  - FAILED_DEPLOY: Indicates a job that runs after a component fails to deploy.
 type AppJobSpecKind string
 
 // List of AppJobSpecKind
 const (
-	AppJobSpecKind_Unspecified AppJobSpecKind = "UNSPECIFIED"
-	AppJobSpecKind_PreDeploy   AppJobSpecKind = "PRE_DEPLOY"
-	AppJobSpecKind_PostDeploy  AppJobSpecKind = "POST_DEPLOY"
+	AppJobSpecKind_Unspecified  AppJobSpecKind = "UNSPECIFIED"
+	AppJobSpecKind_PreDeploy    AppJobSpecKind = "PRE_DEPLOY"
+	AppJobSpecKind_PostDeploy   AppJobSpecKind = "POST_DEPLOY"
+	AppJobSpecKind_FailedDeploy AppJobSpecKind = "FAILED_DEPLOY"
 )
 
 // AppRouteSpec struct for AppRouteSpec
@@ -207,6 +209,8 @@ type AppStaticSiteSpec struct {
 	// A list of HTTP routes that should be routed to this component.
 	Routes []*AppRouteSpec `json:"routes,omitempty"`
 	CORS   *AppCORSPolicy  `json:"cors,omitempty"`
+	// The name of the document to use as the fallback for any requests to documents that are not found when serving this static site. Only 1 of `catchall_document` or `error_document` can be set.
+	CatchallDocument string `json:"catchall_document,omitempty"`
 }
 
 // AppVariableDefinition struct for AppVariableDefinition

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.49.0"
+	libraryVersion = "1.50.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/registry.go
+++ b/vendor/github.com/digitalocean/godo/registry.go
@@ -28,6 +28,10 @@ type RegistryService interface {
 	ListRepositoryTags(context.Context, string, string, *ListOptions) ([]*RepositoryTag, *Response, error)
 	DeleteTag(context.Context, string, string, string) (*Response, error)
 	DeleteManifest(context.Context, string, string, string) (*Response, error)
+	StartGarbageCollection(context.Context, string) (*GarbageCollection, *Response, error)
+	GetGarbageCollection(context.Context, string) (*GarbageCollection, *Response, error)
+	ListGarbageCollections(context.Context, string, *ListOptions) ([]*GarbageCollection, *Response, error)
+	UpdateGarbageCollection(context.Context, string, string, *UpdateGarbageCollectionRequest) (*GarbageCollection, *Response, error)
 }
 
 var _ RegistryService = &RegistryServiceOp{}
@@ -88,6 +92,33 @@ type repositoryTagsRoot struct {
 	Tags  []*RepositoryTag `json:"tags,omitempty"`
 	Links *Links           `json:"links,omitempty"`
 	Meta  *Meta            `json:"meta"`
+}
+
+// GarbageCollection represents a garbage collection.
+type GarbageCollection struct {
+	UUID         string    `json:"uuid"`
+	RegistryName string    `json:"registry_name"`
+	Status       string    `json:"status"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	BlobsDeleted uint64    `json:"blobs_deleted"`
+	FreedBytes   uint64    `json:"freed_bytes"`
+}
+
+type garbageCollectionRoot struct {
+	GarbageCollection *GarbageCollection `json:"garbage_collection,omitempty"`
+}
+
+type garbageCollectionsRoot struct {
+	GarbageCollections []*GarbageCollection `json:"garbage_collections,omitempty"`
+	Links              *Links               `json:"links,omitempty"`
+	Meta               *Meta                `json:"meta"`
+}
+
+// UpdateGarbageCollectionRequest represents a request to update a garbage
+// collection.
+type UpdateGarbageCollectionRequest struct {
+	Cancel bool `json:"cancel"`
 }
 
 // Get retrieves the details of a Registry.
@@ -250,4 +281,93 @@ func (svc *RegistryServiceOp) DeleteManifest(ctx context.Context, registry, repo
 	}
 
 	return resp, nil
+}
+
+// StartGarbageCollection requests a garbage collection for the specified
+// registry.
+func (svc *RegistryServiceOp) StartGarbageCollection(ctx context.Context, registry string) (*GarbageCollection, *Response, error) {
+	path := fmt.Sprintf("%s/%s/garbage-collection", registryPath, registry)
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(garbageCollectionRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.GarbageCollection, resp, err
+}
+
+// GetGarbageCollection retrieves the currently-active garbage collection for
+// the specified registry; if there are no active garbage collections, then
+// return a 404/NotFound error. There can only be one active garbage
+// collection on a registry.
+func (svc *RegistryServiceOp) GetGarbageCollection(ctx context.Context, registry string) (*GarbageCollection, *Response, error) {
+	path := fmt.Sprintf("%s/%s/garbage-collection", registryPath, registry)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(garbageCollectionRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.GarbageCollection, resp, nil
+}
+
+// ListGarbageCollection retrieves all garbage collections (active and
+// inactive) for the specified registry.
+func (svc *RegistryServiceOp) ListGarbageCollections(ctx context.Context, registry string, opts *ListOptions) ([]*GarbageCollection, *Response, error) {
+	path := fmt.Sprintf("%s/%s/garbage-collections", registryPath, registry)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(garbageCollectionsRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if root.Links != nil {
+		resp.Links = root.Links
+	}
+	if root.Meta != nil {
+		resp.Meta = root.Meta
+	}
+
+	return root.GarbageCollections, resp, nil
+}
+
+// UpdateGarbageCollection updates the specified garbage collection for the
+// specified registry. While only the currently-active garbage collection can
+// be updated we still require the exact garbage collection to be specified to
+// avoid race conditions that might may arise from issuing an update to the
+// implicit "currently-active" garbage collection. Returns the updated garbage
+// collection.
+func (svc *RegistryServiceOp) UpdateGarbageCollection(ctx context.Context, registry, gcUUID string, request *UpdateGarbageCollectionRequest) (*GarbageCollection, *Response, error) {
+	path := fmt.Sprintf("%s/%s/garbage-collection/%s", registryPath, registry, gcUUID)
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(garbageCollectionRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.GarbageCollection, resp, nil
 }

--- a/vendor/github.com/digitalocean/godo/vpcs.go
+++ b/vendor/github.com/digitalocean/godo/vpcs.go
@@ -39,6 +39,7 @@ type VPCCreateRequest struct {
 type VPCUpdateRequest struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
+	Default     *bool  `json:"default,omitempty"`
 }
 
 // VPCSetField allows one to set individual fields within a VPC configuration.
@@ -53,6 +54,16 @@ type VPCSetName string
 // VPCSetDescription is used when one want to set the `description` field of a VPC.
 // Ex.: VPCs.Set(..., VPCSetDescription("vpc description"))
 type VPCSetDescription string
+
+// VPCSetDefault is used when one wants to enable the `default` field of a VPC, to
+// set a VPC as the default one in the region
+// Ex.: VPCs.Set(..., VPCSetDefault())
+func VPCSetDefault() VPCSetField {
+	return &vpcSetDefault{}
+}
+
+// vpcSetDefault satisfies the VPCSetField interface
+type vpcSetDefault struct{}
 
 // VPC represents a DigitalOcean Virtual Private Cloud configuration.
 type VPC struct {
@@ -159,6 +170,10 @@ func (n VPCSetName) vpcSetField(in map[string]interface{}) {
 
 func (n VPCSetDescription) vpcSetField(in map[string]interface{}) {
 	in["description"] = n
+}
+
+func (*vpcSetDefault) vpcSetField(in map[string]interface{}) {
+	in["default"] = true
 }
 
 // Set updates specific properties of a Virtual Private Cloud.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.49.0
+# github.com/digitalocean/godo v1.49.1-0.20201026144029-48e3dced040e
 ## explicit
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util
@@ -349,8 +349,6 @@ k8s.io/client-go/util/keyutil
 k8s.io/klog
 # k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 k8s.io/utils/integer
-# sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e
-## explicit
 # sigs.k8s.io/yaml v1.2.0
 ## explicit
 sigs.k8s.io/yaml

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.49.1-0.20201026144029-48e3dced040e
+# github.com/digitalocean/godo v1.50.0
 ## explicit
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util


### PR DESCRIPTION
Also updates godo to v1.50.0; required here to use the new `default` fields in `VPCUpdateRequest`.
