### PR TITLE
Improve error messaging when more args than expected are passed.

### DIFF
--- a/commands/actions.go
+++ b/commands/actions.go
@@ -189,8 +189,9 @@ func isZeroTime(t time.Time) bool {
 
 // RunCmdActionGet runs action get.
 func RunCmdActionGet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	id, err := strconv.Atoi(c.Args[0])
@@ -209,8 +210,9 @@ func RunCmdActionGet(c *CmdConfig) error {
 
 // RunCmdActionWait waits for an action to complete or error.
 func RunCmdActionWait(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	id, err := strconv.Atoi(c.Args[0])

--- a/commands/certificates.go
+++ b/commands/certificates.go
@@ -89,8 +89,9 @@ Use `+"`"+`doctl compute certificate list`+"`"+` to see all available certificat
 
 // RunCertificateGet retrieves an existing certificate by its identifier.
 func RunCertificateGet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	cID := c.Args[0]
 
@@ -193,8 +194,9 @@ func RunCertificateList(c *CmdConfig) error {
 
 // RunCertificateDelete deletes a certificate by its identifier.
 func RunCertificateDelete(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	cID := c.Args[0]
 

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -1110,7 +1110,7 @@ func sqlMode() *Command {
 	CmdBuilder(cmd, RunDatabaseGetSQLModes, "get <database-id>",
 		"Get a MySQL database cluster's SQL modes", getSqlModeDesc, Writer,
 		displayerType(&displayers.DatabaseSQLModes{}), aliasOpt("g"))
-	setSqlModeDesc := `This command configures the SQL modes for the specified MySQL database cluster. The SQL modes should be provided as a space separated list. 
+	setSqlModeDesc := `This command configures the SQL modes for the specified MySQL database cluster. The SQL modes should be provided as a space separated list.
 
 This will replace the existing SQL mode configuration completely. Include all of the current values when adding a new one.
 `
@@ -1122,8 +1122,9 @@ This will replace the existing SQL mode configuration completely. Include all of
 
 // RunDatabaseGetSQLModes gets the sql modes set on the database
 func RunDatabaseGetSQLModes(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	databaseID := c.Args[0]

--- a/commands/domains.go
+++ b/commands/domains.go
@@ -94,8 +94,9 @@ func Domain() *Command {
 
 // RunDomainCreate runs domain create.
 func RunDomainCreate(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	domainName := c.Args[0]
 
@@ -135,8 +136,9 @@ func RunDomainList(c *CmdConfig) error {
 
 // RunDomainGet retrieves a domain by name.
 func RunDomainGet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	id := c.Args[0]
 
@@ -157,8 +159,9 @@ func RunDomainGet(c *CmdConfig) error {
 
 // RunDomainDelete deletes a domain by name.
 func RunDomainDelete(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	name := c.Args[0]
 
@@ -183,8 +186,9 @@ func RunDomainDelete(c *CmdConfig) error {
 
 // RunRecordList list records for a domain.
 func RunRecordList(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	name := c.Args[0]
 
@@ -206,8 +210,9 @@ func RunRecordList(c *CmdConfig) error {
 
 // RunRecordCreate creates a domain record.
 func RunRecordCreate(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	name := c.Args[0]
 
@@ -324,8 +329,9 @@ func RunRecordDelete(c *CmdConfig) error {
 
 // RunRecordUpdate updates a domain record.
 func RunRecordUpdate(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	domainName := c.Args[0]
 

--- a/commands/droplet_actions.go
+++ b/commands/droplet_actions.go
@@ -167,8 +167,9 @@ In order to resize a Droplet, it must first be powered off.`
 // RunDropletActionGet returns a droplet action by id.
 func RunDropletActionGet(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		dropletID, err := strconv.Atoi(c.Args[0])
 		if err != nil {
@@ -190,8 +191,9 @@ func RunDropletActionGet(c *CmdConfig) error {
 // RunDropletActionEnableBackups disables backups for a droplet.
 func RunDropletActionEnableBackups(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 		if err != nil {
@@ -208,8 +210,9 @@ func RunDropletActionEnableBackups(c *CmdConfig) error {
 // RunDropletActionDisableBackups disables backups for a droplet.
 func RunDropletActionDisableBackups(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 		if err != nil {
@@ -226,8 +229,9 @@ func RunDropletActionDisableBackups(c *CmdConfig) error {
 // RunDropletActionReboot reboots a droplet.
 func RunDropletActionReboot(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 		if err != nil {
@@ -244,8 +248,9 @@ func RunDropletActionReboot(c *CmdConfig) error {
 // RunDropletActionPowerCycle power cycles a droplet.
 func RunDropletActionPowerCycle(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 
@@ -263,8 +268,9 @@ func RunDropletActionPowerCycle(c *CmdConfig) error {
 // RunDropletActionShutdown shuts a droplet down.
 func RunDropletActionShutdown(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 		if err != nil {
@@ -281,8 +287,9 @@ func RunDropletActionShutdown(c *CmdConfig) error {
 // RunDropletActionPowerOff turns droplet power off.
 func RunDropletActionPowerOff(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 
@@ -300,8 +307,9 @@ func RunDropletActionPowerOff(c *CmdConfig) error {
 // RunDropletActionPowerOn turns droplet power on.
 func RunDropletActionPowerOn(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 
@@ -319,8 +327,9 @@ func RunDropletActionPowerOn(c *CmdConfig) error {
 // RunDropletActionPasswordReset resets the droplet root password.
 func RunDropletActionPasswordReset(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 
@@ -338,8 +347,9 @@ func RunDropletActionPasswordReset(c *CmdConfig) error {
 // RunDropletActionEnableIPv6 enables IPv6 for a droplet.
 func RunDropletActionEnableIPv6(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 
@@ -357,8 +367,9 @@ func RunDropletActionEnableIPv6(c *CmdConfig) error {
 // RunDropletActionEnablePrivateNetworking enables private networking for a droplet.
 func RunDropletActionEnablePrivateNetworking(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 
@@ -376,8 +387,9 @@ func RunDropletActionEnablePrivateNetworking(c *CmdConfig) error {
 // RunDropletActionRestore restores a droplet using an image id.
 func RunDropletActionRestore(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 
@@ -401,8 +413,9 @@ func RunDropletActionRestore(c *CmdConfig) error {
 // optionally expands the disk.
 func RunDropletActionResize(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 
@@ -430,8 +443,9 @@ func RunDropletActionResize(c *CmdConfig) error {
 // RunDropletActionRebuild rebuilds a droplet using an image id or slug.
 func RunDropletActionRebuild(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 
@@ -459,8 +473,9 @@ func RunDropletActionRebuild(c *CmdConfig) error {
 // RunDropletActionRename renames a droplet.
 func RunDropletActionRename(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 
@@ -483,8 +498,9 @@ func RunDropletActionRename(c *CmdConfig) error {
 // RunDropletActionChangeKernel changes the kernel for a droplet.
 func RunDropletActionChangeKernel(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 
@@ -507,8 +523,9 @@ func RunDropletActionChangeKernel(c *CmdConfig) error {
 // RunDropletActionSnapshot creates a snapshot for a droplet.
 func RunDropletActionSnapshot(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
 		id, err := strconv.Atoi(c.Args[0])
 

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -556,8 +556,9 @@ func matchDroplets(ids []string, ds do.DropletsService, fn matchDropletsFn) erro
 
 // RunDropletGet returns a droplet.
 func RunDropletGet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	getTemplate, err := c.Doit.GetString(c.NS, doctl.ArgTemplate)

--- a/commands/errors.go
+++ b/commands/errors.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/digitalocean/doctl"
 	"github.com/fatih/color"
 	"github.com/shiena/ansicolor"
 	"github.com/spf13/viper"
@@ -68,6 +69,17 @@ func checkErr(err error) {
 	}
 
 	errAction()
+}
+
+func ensureOneArg(c *CmdConfig) error {
+	switch count := len(c.Args); {
+	case count == 0:
+		return doctl.NewMissingArgsErr(c.NS)
+	case count > 1:
+		return doctl.NewTooManyArgsErr(c.NS)
+	default:
+		return nil
+	}
 }
 
 func warn(msg string, args ...interface{}) {

--- a/commands/firewalls.go
+++ b/commands/firewalls.go
@@ -108,8 +108,9 @@ Inbound access rules specify the protocol (TCP, UDP, or ICMP), ports, and source
 
 // RunFirewallGet retrieves an existing Firewall by its identifier.
 func RunFirewallGet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	id := c.Args[0]
 
@@ -176,8 +177,9 @@ func RunFirewallList(c *CmdConfig) error {
 
 // RunFirewallListByDroplet lists Firewalls for a given Droplet.
 func RunFirewallListByDroplet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	dID, err := strconv.Atoi(c.Args[0])
 	if err != nil {
@@ -221,8 +223,9 @@ func RunFirewallDelete(c *CmdConfig) error {
 
 // RunFirewallAddDroplets adds droplets to a Firewall.
 func RunFirewallAddDroplets(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	fID := c.Args[0]
 
@@ -241,8 +244,9 @@ func RunFirewallAddDroplets(c *CmdConfig) error {
 
 // RunFirewallRemoveDroplets removes droplets from a Firewall.
 func RunFirewallRemoveDroplets(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	fID := c.Args[0]
 
@@ -261,8 +265,9 @@ func RunFirewallRemoveDroplets(c *CmdConfig) error {
 
 // RunFirewallAddTags adds tags to a Firewall.
 func RunFirewallAddTags(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	fID := c.Args[0]
 
@@ -276,8 +281,9 @@ func RunFirewallAddTags(c *CmdConfig) error {
 
 // RunFirewallRemoveTags removes tags from a Firewall.
 func RunFirewallRemoveTags(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	fID := c.Args[0]
 
@@ -291,8 +297,9 @@ func RunFirewallRemoveTags(c *CmdConfig) error {
 
 // RunFirewallAddRules adds rules to a Firewall.
 func RunFirewallAddRules(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	fID := c.Args[0]
 
@@ -306,8 +313,9 @@ func RunFirewallAddRules(c *CmdConfig) error {
 
 // RunFirewallRemoveRules removes rules from a Firewall.
 func RunFirewallRemoveRules(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	fID := c.Args[0]
 

--- a/commands/floating_ip_actions.go
+++ b/commands/floating_ip_actions.go
@@ -109,8 +109,9 @@ func RunFloatingIPActionsAssign(c *CmdConfig) error {
 
 // RunFloatingIPActionsUnassign unassigns a floating IP to a droplet.
 func RunFloatingIPActionsUnassign(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	ip := c.Args[0]

--- a/commands/floating_ips.go
+++ b/commands/floating_ips.go
@@ -96,8 +96,9 @@ func RunFloatingIPCreate(c *CmdConfig) error {
 func RunFloatingIPGet(c *CmdConfig) error {
 	fis := c.FloatingIPs()
 
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	ip := c.Args[0]
@@ -119,8 +120,9 @@ func RunFloatingIPGet(c *CmdConfig) error {
 func RunFloatingIPDelete(c *CmdConfig) error {
 	fis := c.FloatingIPs()
 
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	force, err := c.Doit.GetBool(c.NS, doctl.ArgForce)

--- a/commands/image_actions.go
+++ b/commands/image_actions.go
@@ -62,8 +62,9 @@ func ImageAction() *Command {
 func RunImageActionsGet(c *CmdConfig) error {
 	ias := c.ImageActions()
 
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	imageID, err := strconv.Atoi(c.Args[0])
@@ -89,8 +90,9 @@ func RunImageActionsGet(c *CmdConfig) error {
 func RunImageActionsTransfer(c *CmdConfig) error {
 	ias := c.ImageActions()
 
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	id, err := strconv.Atoi(c.Args[0])

--- a/commands/images.go
+++ b/commands/images.go
@@ -177,14 +177,14 @@ func RunImagesListUser(c *CmdConfig) error {
 func RunImagesGet(c *CmdConfig) error {
 	is := c.Images()
 
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	rawID := c.Args[0]
 
 	var i *do.Image
-	var err error
 
 	if id, cerr := strconv.Atoi(rawID); cerr == nil {
 		i, err = is.GetByID(id)
@@ -208,8 +208,9 @@ func RunImagesGet(c *CmdConfig) error {
 func RunImagesUpdate(c *CmdConfig) error {
 	is := c.Images()
 
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	id, err := strconv.Atoi(c.Args[0])

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -227,7 +227,6 @@ func kubernetesCluster() *Command {
 
 	cmd.AddCommand(kubernetesRegistryIntegration())
 
-
 	nodePoolDeatils := `- A list of node pools available inside the cluster`
 	clusterDetails := `
 
@@ -576,8 +575,9 @@ func kubernetesOptions() *Command {
 
 // RunKubernetesClusterGet retrieves an existing kubernetes cluster by its identifier.
 func (s *KubernetesCommandService) RunKubernetesClusterGet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	clusterIDorName := c.Args[0]
 
@@ -601,8 +601,9 @@ func (s *KubernetesCommandService) RunKubernetesClusterList(c *CmdConfig) error 
 
 // RunKubernetesClusterGetUpgrades retrieves available upgrade versions for a cluster.
 func (s *KubernetesCommandService) RunKubernetesClusterGetUpgrades(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	clusterIDorName := c.Args[0]
 	clusterID, err := clusterIDize(c.Kubernetes(), clusterIDorName)
@@ -624,8 +625,9 @@ func (s *KubernetesCommandService) RunKubernetesClusterGetUpgrades(c *CmdConfig)
 // RunKubernetesClusterCreate creates a new kubernetes with a given configuration.
 func (s *KubernetesCommandService) RunKubernetesClusterCreate(defaultNodeSize string, defaultNodeCount int) func(*CmdConfig) error {
 	return func(c *CmdConfig) error {
-		if len(c.Args) != 1 {
-			return doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return err
 		}
 		clusterName := c.Args[0]
 		r := &godo.KubernetesClusterCreateRequest{Name: clusterName}
@@ -899,8 +901,9 @@ func (s *KubernetesCommandService) RunKubernetesClusterDelete(c *CmdConfig) erro
 
 // RunKubernetesKubeconfigShow retrieves an existing kubernetes config and prints it.
 func (s *KubernetesCommandService) RunKubernetesKubeconfigShow(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	expirySeconds, err := c.Doit.GetInt(c.NS, doctl.ArgKubeConfigExpirySeconds)
 	if err != nil {
@@ -990,8 +993,9 @@ func cacheExecCredential(id string, execCredential *clientauthentication.ExecCre
 
 // RunKubernetesKubeconfigExecCredential displays the exec credential. It is for internal use only.
 func (s *KubernetesCommandService) RunKubernetesKubeconfigExecCredential(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	version, err := c.Doit.GetString(c.NS, doctl.ArgVersion)
@@ -1048,8 +1052,9 @@ func (s *KubernetesCommandService) RunKubernetesKubeconfigExecCredential(c *CmdC
 
 // RunKubernetesKubeconfigSave retrieves an existing kubernetes config and saves it to your local kubeconfig.
 func (s *KubernetesCommandService) RunKubernetesKubeconfigSave(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	expirySeconds, err := c.Doit.GetInt(c.NS, doctl.ArgKubeConfigExpirySeconds)
 	if err != nil {
@@ -1083,8 +1088,9 @@ func (s *KubernetesCommandService) RunKubernetesKubeconfigSave(c *CmdConfig) err
 
 // RunKubernetesKubeconfigRemove retrieves an existing kubernetes config and removes it from your local kubeconfig.
 func (s *KubernetesCommandService) RunKubernetesKubeconfigRemove(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	kube := c.Kubernetes()
 	clusterID, err := clusterIDize(kube, c.Args[0])
@@ -1119,8 +1125,9 @@ func (s *KubernetesCommandService) RunKubernetesNodePoolGet(c *CmdConfig) error 
 
 // RunKubernetesNodePoolList lists cluster node pool.
 func (s *KubernetesCommandService) RunKubernetesNodePoolList(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	clusterID, err := clusterIDize(c.Kubernetes(), c.Args[0])
 	if err != nil {
@@ -1137,8 +1144,9 @@ func (s *KubernetesCommandService) RunKubernetesNodePoolList(c *CmdConfig) error
 
 // RunKubernetesNodePoolCreate creates a new cluster node pool with a given configuration.
 func (s *KubernetesCommandService) RunKubernetesNodePoolCreate(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	clusterID, err := clusterIDize(c.Kubernetes(), c.Args[0])
 	if err != nil {

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -152,8 +152,9 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 
 // RunLoadBalancerGet retrieves an existing load balancer by its identifier.
 func RunLoadBalancerGet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	id := c.Args[0]
 
@@ -220,8 +221,9 @@ func RunLoadBalancerUpdate(c *CmdConfig) error {
 
 // RunLoadBalancerDelete deletes a load balancer by its identifier.
 func RunLoadBalancerDelete(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	lbID := c.Args[0]
 
@@ -244,8 +246,9 @@ func RunLoadBalancerDelete(c *CmdConfig) error {
 
 // RunLoadBalancerAddDroplets adds droplets to a load balancer.
 func RunLoadBalancerAddDroplets(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	lbID := c.Args[0]
 
@@ -264,8 +267,9 @@ func RunLoadBalancerAddDroplets(c *CmdConfig) error {
 
 // RunLoadBalancerRemoveDroplets removes droplets from a load balancer.
 func RunLoadBalancerRemoveDroplets(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	lbID := c.Args[0]
 
@@ -284,8 +288,9 @@ func RunLoadBalancerRemoveDroplets(c *CmdConfig) error {
 
 // RunLoadBalancerAddForwardingRules adds forwarding rules to a load balancer.
 func RunLoadBalancerAddForwardingRules(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	lbID := c.Args[0]
 
@@ -304,8 +309,9 @@ func RunLoadBalancerAddForwardingRules(c *CmdConfig) error {
 
 // RunLoadBalancerRemoveForwardingRules removes forwarding rules from a load balancer.
 func RunLoadBalancerRemoveForwardingRules(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	lbID := c.Args[0]
 

--- a/commands/projects.go
+++ b/commands/projects.go
@@ -145,8 +145,9 @@ func RunProjectsList(c *CmdConfig) error {
 // RunProjectsGet retrieves an existing Project by its identifier. Use "default"
 // as an identifier to retrieve your default project.
 func RunProjectsGet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	id := c.Args[0]
 
@@ -177,8 +178,9 @@ func RunProjectsCreate(c *CmdConfig) error {
 
 // RunProjectsUpdate updates an existing Project with a given configuration.
 func RunProjectsUpdate(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	id := c.Args[0]
 
@@ -223,8 +225,9 @@ func RunProjectsDelete(c *CmdConfig) error {
 
 // RunProjectResourcesList lists the Projects.
 func RunProjectResourcesList(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	id := c.Args[0]
 
@@ -239,8 +242,9 @@ func RunProjectResourcesList(c *CmdConfig) error {
 
 // RunProjectResourcesGet retrieves a Project Resource.
 func RunProjectResourcesGet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	urn := c.Args[0]
 
@@ -268,8 +272,9 @@ func RunProjectResourcesGet(c *CmdConfig) error {
 
 // RunProjectResourcesAssign assigns a Project Resource.
 func RunProjectResourcesAssign(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	projectUUID := c.Args[0]
 

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -245,8 +245,9 @@ func GarbageCollection() *Command {
 
 // RunRegistryCreate creates a registry
 func RunRegistryCreate(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	name := c.Args[0]
@@ -475,8 +476,9 @@ func RunListRepositories(c *CmdConfig) error {
 
 // RunListRepositoryTags lists tags for the repository in a registry
 func RunListRepositoryTags(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	registry, err := c.Registry().Get()

--- a/commands/sshkeys.go
+++ b/commands/sshkeys.go
@@ -88,8 +88,9 @@ func RunKeyList(c *CmdConfig) error {
 func RunKeyGet(c *CmdConfig) error {
 	ks := c.Keys()
 
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	rawKey := c.Args[0]
@@ -107,8 +108,9 @@ func RunKeyGet(c *CmdConfig) error {
 func RunKeyCreate(c *CmdConfig) error {
 	ks := c.Keys()
 
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	name := c.Args[0]
@@ -136,8 +138,9 @@ func RunKeyCreate(c *CmdConfig) error {
 func RunKeyImport(c *CmdConfig) error {
 	ks := c.Keys()
 
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	keyPath, err := c.Doit.GetString(c.NS, doctl.ArgKeyPublicKeyFile)
@@ -179,8 +182,9 @@ func RunKeyImport(c *CmdConfig) error {
 func RunKeyDelete(c *CmdConfig) error {
 	ks := c.Keys()
 
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	force, err := c.Doit.GetBool(c.NS, doctl.ArgForce)
@@ -200,8 +204,9 @@ func RunKeyDelete(c *CmdConfig) error {
 func RunKeyUpdate(c *CmdConfig) error {
 	ks := c.Keys()
 
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	rawKey := c.Args[0]

--- a/commands/tags.go
+++ b/commands/tags.go
@@ -58,8 +58,9 @@ Deleting a tag also removes the tag from all the resources that had been tagged 
 
 // RunCmdTagCreate runs tag create.
 func RunCmdTagCreate(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	name := c.Args[0]
@@ -76,8 +77,9 @@ func RunCmdTagCreate(c *CmdConfig) error {
 
 // RunCmdTagGet runs tag get.
 func RunCmdTagGet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 
 	name := c.Args[0]

--- a/commands/volume_actions.go
+++ b/commands/volume_actions.go
@@ -126,10 +126,10 @@ func RunVolumeDetach(c *CmdConfig) error {
 // RunVolumeResize resizes a volume
 func RunVolumeResize(c *CmdConfig) error {
 	fn := func(das do.VolumeActionsService) (*do.Action, error) {
-		if len(c.Args) != 1 {
-			return nil, doctl.NewMissingArgsErr(c.NS)
+		err := ensureOneArg(c)
+		if err != nil {
+			return nil, err
 		}
-
 		volumeID := c.Args[0]
 
 		size, err := c.Doit.GetInt(c.NS, doctl.ArgSizeSlug)

--- a/commands/vpcs.go
+++ b/commands/vpcs.go
@@ -82,8 +82,9 @@ With the vpcs command, you can list, create, or delete VPCs, and manage their co
 
 // RunVPCGet retrieves an existing VPC by its identifier.
 func RunVPCGet(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	vpcUUID := c.Args[0]
 
@@ -187,8 +188,9 @@ func RunVPCUpdate(c *CmdConfig) error {
 
 // RunVPCDelete deletes a VPC by its identifier.
 func RunVPCDelete(c *CmdConfig) error {
-	if len(c.Args) != 1 {
-		return doctl.NewMissingArgsErr(c.NS)
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
 	}
 	vpcUUID := c.Args[0]
 


### PR DESCRIPTION
When a user provides multiple arguments to a command then only accepts one, we provide unclear error messaging. For example:

```
$ doctl databases sql-mode get aaa-bbb-ccc ddd-eee-fff
Error: (sql-mode.get) command is missing required arguments
```

This PR adds a new helper method, `ensureOneArg`, that returns a `MissingArgsErr` if no args are passed or a `TooManyArgsErr` (introduced in https://github.com/digitalocean/doctl/pull/902) if more than one is passed. This allows for clearer messaging:

```
$ ./builds/doctl databases sql-mode get aaa-bbb-ccc ddd-eee-fff
Error: (sql-mode.get) command contains unsupported arguments

$ ./builds/doctl databases sql-mode get
Error: (sql-mode.get) command is missing required arguments
```