### PR TITLE
Check error in RoundTrip.

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -43,6 +43,9 @@ func (rec *recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 	rec.req <- string(reqBytes)
 
 	resp, rerr := rec.wrap.RoundTrip(req)
+	if rerr != nil {
+		return nil, rerr
+	}
 
 	respBytes, err := httputil.DumpResponse(resp, true)
 	if err != nil {
@@ -50,5 +53,5 @@ func (rec *recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	rec.resp <- string(respBytes)
 
-	return resp, rerr
+	return resp, nil
 }


### PR DESCRIPTION
In https://github.com/digitalocean/doctl/issues/908, when the reporter tried to produce a trace, it resulted in a panic. We're not checking this error.