### PR TITLE
Support subscription tiers for DOCR

### DIFF
--- a/args.go
+++ b/args.go
@@ -317,6 +317,8 @@ const (
 	ArgReadWrite = "read-write"
 	// ArgRegistryExpirySeconds indicates the length of time the token will be valid in seconds.
 	ArgRegistryExpirySeconds = "expiry-seconds"
+	// ArgSubscriptionTier is a subscription tier slug.
+	ArgSubscriptionTier = "subscription-tier"
 
 	// 1-Click Args
 

--- a/commands/displayers/registry.go
+++ b/commands/displayers/registry.go
@@ -14,6 +14,7 @@ limitations under the License.
 package displayers
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/digitalocean/doctl/do"
@@ -194,6 +195,62 @@ func (g *GarbageCollection) KV() []map[string]interface{} {
 			"UpdatedAt":    gc.UpdatedAt,
 			"BlobsDeleted": gc.BlobsDeleted,
 			"FreedBytes":   gc.FreedBytes,
+		})
+	}
+
+	return out
+}
+
+type RegistrySubscriptionTiers struct {
+	SubscriptionTiers []do.RegistrySubscriptionTier
+}
+
+func (t *RegistrySubscriptionTiers) JSON(out io.Writer) error {
+	return writeJSON(t, out)
+}
+
+func (t *RegistrySubscriptionTiers) Cols() []string {
+	return []string{
+		"Name",
+		"Slug",
+		"IncludedRepositories",
+		"IncludedStorageBytes",
+		"AllowStorageOverage",
+		"IncludedBandwidthBytes",
+		"MonthlyPriceInCents",
+		"Eligible",
+		"EligibilityReasons",
+	}
+}
+
+func (t *RegistrySubscriptionTiers) ColMap() map[string]string {
+	return map[string]string{
+		"Name":                   "Name",
+		"Slug":                   "Slug",
+		"IncludedRepositories":   "Included Repositories",
+		"IncludedStorageBytes":   "Included Storage",
+		"AllowStorageOverage":    "Storage Overage Allowed",
+		"IncludedBandwidthBytes": "Included Bandwidth",
+		"MonthlyPriceInCents":    "Monthly Price",
+		"Eligible":               "Eligible?",
+		"EligibilityReasons":     "Not Eligible Because",
+	}
+}
+
+func (t *RegistrySubscriptionTiers) KV() []map[string]interface{} {
+	out := []map[string]interface{}{}
+
+	for _, tier := range t.SubscriptionTiers {
+		out = append(out, map[string]interface{}{
+			"Name":                   tier.Name,
+			"Slug":                   tier.Slug,
+			"IncludedRepositories":   tier.IncludedRepositories,
+			"IncludedStorageBytes":   BytesToHumanReadibleUnit(tier.IncludedStorageBytes),
+			"AllowStorageOverage":    tier.AllowStorageOverage,
+			"IncludedBandwidthBytes": BytesToHumanReadibleUnit(tier.IncludedBandwidthBytes),
+			"MonthlyPriceInCents":    fmt.Sprintf("$%d", tier.MonthlyPriceInCents / 100),
+			"Eligible":               tier.Eligible,
+			"EligibilityReasons":     tier.EligibilityReasons,
 		})
 	}
 

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -55,8 +55,10 @@ func Registry() *Command {
 	cmd.AddCommand(RegistryOptions())
 
 	createRegDesc := "This command creates a new private container registry with the provided name."
-	CmdBuilder(cmd, RunRegistryCreate, "create <registry-name>",
+	cmdRunRegistryCreate := CmdBuilder(cmd, RunRegistryCreate, "create <registry-name>",
 		"Create a private container registry", createRegDesc, Writer)
+	AddStringFlag(cmdRunRegistryCreate, doctl.ArgSubscriptionTier, "", "basic",
+		"Subscription tier for the new registry. Possible values: see `doctl registry options subscription-tiers`", requiredOpt())
 
 	getRegDesc := "This command retrieves details about a private container registry including its name and the endpoint used to access it."
 	CmdBuilder(cmd, RunRegistryGet, "get", "Retrieve details about a container registry",
@@ -269,9 +271,17 @@ func RunRegistryCreate(c *CmdConfig) error {
 	}
 
 	name := c.Args[0]
+	subscriptionTier, err := c.Doit.GetString(c.NS, doctl.ArgSubscriptionTier)
+	if err != nil {
+		return err
+	}
+
 	rs := c.Registry()
 
-	rcr := &godo.RegistryCreateRequest{Name: name}
+	rcr := &godo.RegistryCreateRequest{
+		Name:                 name,
+		SubscriptionTierSlug: subscriptionTier,
+	}
 	r, err := rs.Create(rcr)
 	if err != nil {
 		return err

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -52,6 +52,7 @@ func Registry() *Command {
 
 	cmd.AddCommand(Repository())
 	cmd.AddCommand(GarbageCollection())
+	cmd.AddCommand(RegistryOptions())
 
 	createRegDesc := "This command creates a new private container registry with the provided name."
 	CmdBuilder(cmd, RunRegistryCreate, "create <registry-name>",
@@ -237,6 +238,23 @@ func GarbageCollection() *Command {
 		Writer,
 		aliasOpt("c"),
 	)
+
+	return cmd
+}
+
+// RegistryOptions creates the registry options subcommand
+func RegistryOptions() *Command {
+	cmd := &Command{
+		Command: &cobra.Command{
+			Use: "options",
+			Aliases: []string{"opts", "o"},
+			Short: "List available container registry options",
+			Long: "This command lists options available when creating or updating a container registry.",
+		},
+	}
+
+	tiersDesc := "List available container registry subscription tiers"
+	CmdBuilder(cmd, RunRegistryOptionsTiers, "subscription-tiers", tiersDesc, tiersDesc, Writer, aliasOpt("tiers"))
 
 	return cmd
 }
@@ -716,6 +734,18 @@ func RunCancelGarbageCollection(c *CmdConfig) error {
 func displayGarbageCollections(c *CmdConfig, garbageCollections ...do.GarbageCollection) error {
 	item := &displayers.GarbageCollection{
 		GarbageCollections: garbageCollections,
+	}
+	return c.Display(item)
+}
+
+func RunRegistryOptionsTiers(c *CmdConfig) error {
+	tiers, err := c.Registry().GetSubscriptionTiers()
+	if err != nil {
+		return err
+	}
+
+	item := &displayers.RegistrySubscriptionTiers{
+		SubscriptionTiers: tiers,
 	}
 	return c.Display(item)
 }

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -45,8 +45,8 @@ func Registry() *Command {
 		Command: &cobra.Command{
 			Use:     "registry",
 			Aliases: []string{"reg", "r"},
-			Short:   "[EA] Display commands for working with container registries",
-			Long:    "[EA] The subcommands of `doctl registry` create, manage, and allow access to your private container registry.",
+			Short:   "Display commands for working with container registries",
+			Long:    "The subcommands of `doctl registry` create, manage, and allow access to your private container registry.",
 		},
 	}
 
@@ -111,8 +111,8 @@ func Repository() *Command {
 		Command: &cobra.Command{
 			Use:     "repository",
 			Aliases: []string{"repo", "r"},
-			Short:   "[EA] Display commands for working with repositories in a container registry",
-			Long:    "[EA] The subcommands of `doctl registry repository` help you command actions related to a repository.",
+			Short:   "Display commands for working with repositories in a container registry",
+			Long:    "The subcommands of `doctl registry repository` help you command actions related to a repository.",
 		},
 	}
 

--- a/commands/registry_test.go
+++ b/commands/registry_test.go
@@ -80,7 +80,7 @@ var (
 func TestRegistryCommand(t *testing.T) {
 	cmd := Registry()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "create", "get", "delete", "login", "logout", "kubernetes-manifest", "repository", "docker-config", "garbage-collection")
+	assertCommandNames(t, cmd, "create", "get", "delete", "login", "logout", "options", "kubernetes-manifest", "repository", "docker-config", "garbage-collection")
 }
 
 func TestRepositoryCommand(t *testing.T) {

--- a/commands/registry_test.go
+++ b/commands/registry_test.go
@@ -31,11 +31,12 @@ import (
 )
 
 var (
-	testRegistryName    = "container-registry"
-	invalidRegistryName = "invalid-container-registry"
-	testRegistry        = do.Registry{Registry: &godo.Registry{Name: testRegistryName}}
-	testRepoName        = "test-repository"
-	testRepositoryTag   = do.RepositoryTag{
+	testRegistryName     = "container-registry"
+	testSubscriptionTier = "basic"
+	invalidRegistryName  = "invalid-container-registry"
+	testRegistry         = do.Registry{Registry: &godo.Registry{Name: testRegistryName}}
+	testRepoName         = "test-repository"
+	testRepositoryTag    = do.RepositoryTag{
 		RepositoryTag: &godo.RepositoryTag{
 			RegistryName:        testRegistryName,
 			Repository:          testRepoName,
@@ -97,9 +98,13 @@ func TestGarbageCollectionCommand(t *testing.T) {
 
 func TestRegistryCreate(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		rcr := godo.RegistryCreateRequest{Name: testRegistryName}
+		rcr := godo.RegistryCreateRequest{
+			Name:                 testRegistryName,
+			SubscriptionTierSlug: testSubscriptionTier,
+		}
 		tm.registry.EXPECT().Create(&rcr).Return(&testRegistry, nil)
 		config.Args = append(config.Args, testRegistryName)
+		config.Doit.Set(config.NS, doctl.ArgSubscriptionTier, "basic")
 
 		err := RunRegistryCreate(config)
 		assert.NoError(t, err)

--- a/do/mocks/RegistryService.go
+++ b/do/mocks/RegistryService.go
@@ -225,3 +225,18 @@ func (mr *MockRegistryServiceMockRecorder) CancelGarbageCollection(arg0, arg1 in
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelGarbageCollection", reflect.TypeOf((*MockRegistryService)(nil).CancelGarbageCollection), arg0, arg1)
 }
+
+// GetSubscriptionTiers mocks base method.
+func (m *MockRegistryService) GetSubscriptionTiers() ([]do.RegistrySubscriptionTier, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubscriptionTiers")
+	ret0, _ := ret[0].([]do.RegistrySubscriptionTier)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubscriptionTiers indicates an expected call of GetSubscriptionTiers.
+func (mr *MockRegistryServiceMockRecorder) GetSubscriptionTiers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubscriptionTiers", reflect.TypeOf((*MockRegistryService)(nil).GetSubscriptionTiers))
+}

--- a/do/registry.go
+++ b/do/registry.go
@@ -43,6 +43,11 @@ type GarbageCollection struct {
 	*godo.GarbageCollection
 }
 
+// RegistrySubscriptionTier wraps a godo RegistrySubscriptionTier
+type RegistrySubscriptionTier struct {
+	*godo.RegistrySubscriptionTier
+}
+
 // Endpoint returns the registry endpoint for image tagging
 func (r *Registry) Endpoint() string {
 	return fmt.Sprintf("%s/%s", RegistryHostname, r.Registry.Name)
@@ -63,6 +68,7 @@ type RegistryService interface {
 	GetGarbageCollection(string) (*GarbageCollection, error)
 	ListGarbageCollections(string) ([]GarbageCollection, error)
 	CancelGarbageCollection(string, string) (*GarbageCollection, error)
+	GetSubscriptionTiers() ([]RegistrySubscriptionTier, error)
 }
 
 type registryService struct {
@@ -241,4 +247,18 @@ func (rs *registryService) CancelGarbageCollection(registry, garbageCollection s
 
 func (rs *registryService) Endpoint() string {
 	return RegistryHostname
+}
+
+func (rs *registryService) GetSubscriptionTiers() ([]RegistrySubscriptionTier, error) {
+	opts, _, err := rs.client.Registry.GetOptions(rs.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]RegistrySubscriptionTier, len(opts.SubscriptionTiers))
+	for i, tier := range opts.SubscriptionTiers {
+		ret[i] = RegistrySubscriptionTier{tier}
+	}
+
+	return ret, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.11
-	github.com/digitalocean/godo v1.50.0
+	github.com/digitalocean/godo v1.51.0
 	github.com/docker/cli v0.0.0-20200622130859-87db43814b48
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.50.0 h1:ynl8HeBl77FCpuCSkBXgkzVLZNPumMGp7PEwYcNqJ1s=
-github.com/digitalocean/godo v1.50.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
+github.com/digitalocean/godo v1.51.0 h1:Hn+O5Hiy7SrRhuJXFaojkPe38OjgQU8L0sIV09ViI3U=
+github.com/digitalocean/godo v1.51.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48 h1:AC8qbhi/SjYf4iN2W3jSsofZGHWPjG8pjf5P143KUM8=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible h1:PmGHHCZ43l6h8aZIi+Xa+z1SWe4dFImd5EK3TNp1jlo=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v1.51.0] - 2020-11-02
+
+- #405 - @adamwg - registry: Support subscription options
+- #398 - @reeseconor - Add support for caching dependencies between GitHub Action runs
+- #404 - @andrewsomething - CONTRIBUTING.md: Suggest using github-changelog-generator.
+
 ## [v1.50.0] - 2020-10-26
 
 - #400 - @waynr - registry: add garbage collection support

--- a/vendor/github.com/digitalocean/godo/CONTRIBUTING.md
+++ b/vendor/github.com/digitalocean/godo/CONTRIBUTING.md
@@ -29,7 +29,7 @@ version number. Any code merged to main is subject to release.
 
 ## Releasing
 
-Releasing a new version of godo is currently a manual process. 
+Releasing a new version of godo is currently a manual process.
 
 Submit a separate pull request for the version change from the pull
 request with your changes.
@@ -38,17 +38,32 @@ request with your changes.
    for the next (unreleased) version does not exist, create one.
    Include one bullet point for each piece of new functionality in the
    release, including the pull request ID, description, and author(s).
+   For example:
 
 ```
 ## [v1.8.0] - 2019-03-13
 
-- #210 Expose tags on storage volume create/list/get. - @jcodybaker
-- #123 Update test dependencies - @digitalocean
+- #210 - @jcodybaker - Expose tags on storage volume create/list/get.
+- #123 - @digitalocean - Update test dependencies
+```
+
+   To generate a list of changes since the previous release in the correct
+   format, you can use [github-changelog-generator](https://github.com/digitalocean/github-changelog-generator).
+   It can be installed from source by running:
+
+```
+go get -u github.com/digitalocean/github-changelog-generator
+```
+
+   Next, list the changes by running:
+
+```
+github-changelog-generator -org digitalocean -repo godo
 ```
 
 2. Update the `libraryVersion` number in `godo.go`.
 3. Make a pull request with these changes.  This PR should be separate from the PR containing the godo changes.
-4. Once the pull request has been merged, [draft a new release](https://github.com/digitalocean/godo/releases/new).  
-5. Update the `Tag version` and `Release title` field with the new godo version.  Be sure the version has a `v` prefixed in both places. Ex `v1.8.0`.  
+4. Once the pull request has been merged, [draft a new release](https://github.com/digitalocean/godo/releases/new).
+5. Update the `Tag version` and `Release title` field with the new godo version.  Be sure the version has a `v` prefixed in both places. Ex `v1.8.0`.
 6. Copy the changelog bullet points to the description field.
 7. Publish the release.

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.50.0"
+	libraryVersion = "1.51.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.50.0
+# github.com/digitalocean/godo v1.51.0
 ## explicit
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util


### PR DESCRIPTION
As of GA, creating a container registry requires specifying a subscription tier. Add support for listing available subscription tiers, and add a `--subscription-tier` option for create, defaulting to the "basic" plan.
