### PR TITLE
Migrate tests to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
     - name: Ensure code is formatted with gofmt
       run: make gofmt_check
       if: matrix.os == 'ubuntu-latest'
-    - name: Run shellcheck
-      run: make shellcheck
+    - name: Install and run shellcheck
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install shellcheck && make shellcheck
     - name: Run unit tests
       run: make test_unit
     - name: Run integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [ 1.15.x ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Format
+      run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
+      if: matrix.os == 'ubuntu-latest'
+    - name: Run shellcheck
+      run: make shellcheck
+    - name: Run unit tests
+      run: make test_unit
+    - name: Run integration tests
+      run: make test_integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Format
-      run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
+    - name: Ensure code is formatted with gofmt
+      run: make gofmt_check
       if: matrix.os == 'ubuntu-latest'
     - name: Run shellcheck
       run: make shellcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,29 +12,6 @@ notifications:
 
 jobs:
   include:
-  - name: "Testing: Bionic, go 1.15"
-    script:
-    - make shellcheck
-    - make test
-    dist: bionic
-    go: 1.15.x
-    env: CACHE_NAME=BIONIC_1.15
-
-  - name: "Testing: MacOS, go 1.15"
-    before_install: ulimit -n 1024
-    script: make test
-    os: osx
-    go: 1.15.x
-    env: CACHE_NAME=MACOS_1.15
-
-  - name: "Testing: Windows, go 1.15"
-    before_install:
-      - choco install make
-    script: make test
-    os: windows
-    go: 1.15.x
-    env: CACHE_NAME=WINDOWS_1.15
-
   - stage: deploy
     if: type=push
     script: echo "running goreleaser"

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ DOCS_OUT = $(shell echo $${DOCS_OUT:-$(my_d)/builds/docs/yaml})
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 
+GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+
 GOOS = linux
 ifeq ($(UNAME_S),Darwin)
   GOOS = darwin
@@ -102,6 +104,12 @@ shellcheck:
 	@echo "==> analyze shell scripts"
 	@echo ""
 	@scripts/shell_check.sh
+
+.PHONY: gofmt_check
+gofmt_check:
+	@echo "==> ensure code adheres to gofmt (with vendor directory excluded)"
+	@echo ""
+	@gofmt -l ${GOFILES_NOVENDOR} | read && exit 1 || true
 
 .PHONY: snap_image
 snap_image:

--- a/commands/displayers/registry.go
+++ b/commands/displayers/registry.go
@@ -248,7 +248,7 @@ func (t *RegistrySubscriptionTiers) KV() []map[string]interface{} {
 			"IncludedStorageBytes":   BytesToHumanReadibleUnit(tier.IncludedStorageBytes),
 			"AllowStorageOverage":    tier.AllowStorageOverage,
 			"IncludedBandwidthBytes": BytesToHumanReadibleUnit(tier.IncludedBandwidthBytes),
-			"MonthlyPriceInCents":    fmt.Sprintf("$%d", tier.MonthlyPriceInCents / 100),
+			"MonthlyPriceInCents":    fmt.Sprintf("$%d", tier.MonthlyPriceInCents/100),
 			"Eligible":               tier.Eligible,
 			"EligibilityReasons":     tier.EligibilityReasons,
 		})

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -248,10 +248,10 @@ func GarbageCollection() *Command {
 func RegistryOptions() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
-			Use: "options",
+			Use:     "options",
 			Aliases: []string{"opts", "o"},
-			Short: "List available container registry options",
-			Long: "This command lists options available when creating or updating a container registry.",
+			Short:   "List available container registry options",
+			Long:    "This command lists options available when creating or updating a container registry.",
 		},
 	}
 


### PR DESCRIPTION
Migrates the tests from Travis to GitHub Actions.

Also fixes a `gofmt` failure so that those checks would pass.

Tested at https://github.com/bentranter/doctl/pull/1.