### PR TITLE
registry: add support for garbage collection types

### DIFF
--- a/args.go
+++ b/args.go
@@ -321,6 +321,12 @@ const (
 	ArgRegistryExpirySeconds = "expiry-seconds"
 	// ArgSubscriptionTier is a subscription tier slug.
 	ArgSubscriptionTier = "subscription-tier"
+	// ArgGCIncludeUntaggedManifests indicates that a garbage collection should delete
+	// all untagged manifests.
+	ArgGCIncludeUntaggedManifests = "include-untagged-manifests"
+	// ArgGCExcludeUnreferencedBlobs indicates that a garbage collection should
+	// not delete unreferenced blobs.
+	ArgGCExcludeUnreferencedBlobs = "exclude-unreferenced-blobs"
 
 	// 1-Click Args
 

--- a/do/mocks/RegistryService.go
+++ b/do/mocks/RegistryService.go
@@ -167,18 +167,18 @@ func (mr *MockRegistryServiceMockRecorder) Endpoint() *gomock.Call {
 }
 
 // StartGarbageCollection mocks base method.
-func (m *MockRegistryService) StartGarbageCollection(arg0 string) (*do.GarbageCollection, error) {
+func (m *MockRegistryService) StartGarbageCollection(arg0 string, arg1 *godo.StartGarbageCollectionRequest) (*do.GarbageCollection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartGarbageCollection", arg0)
+	ret := m.ctrl.Call(m, "StartGarbageCollection", arg0, arg1)
 	ret0, _ := ret[0].(*do.GarbageCollection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StartGarbageCollection indicates an expected call of StartGarbageCollection.
-func (mr *MockRegistryServiceMockRecorder) StartGarbageCollection(arg0 interface{}) *gomock.Call {
+func (mr *MockRegistryServiceMockRecorder) StartGarbageCollection(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartGarbageCollection", reflect.TypeOf((*MockRegistryService)(nil).StartGarbageCollection), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartGarbageCollection", reflect.TypeOf((*MockRegistryService)(nil).StartGarbageCollection), arg0, arg1)
 }
 
 // GetGarbageCollection mocks base method.

--- a/do/registry.go
+++ b/do/registry.go
@@ -64,7 +64,7 @@ type RegistryService interface {
 	DeleteTag(string, string, string) error
 	DeleteManifest(string, string, string) error
 	Endpoint() string
-	StartGarbageCollection(string) (*GarbageCollection, error)
+	StartGarbageCollection(string, *godo.StartGarbageCollectionRequest) (*GarbageCollection, error)
 	GetGarbageCollection(string) (*GarbageCollection, error)
 	ListGarbageCollections(string) ([]GarbageCollection, error)
 	CancelGarbageCollection(string, string) (*GarbageCollection, error)
@@ -186,8 +186,8 @@ func (rs *registryService) DeleteManifest(registry, repository, digest string) e
 	return err
 }
 
-func (rs *registryService) StartGarbageCollection(registry string) (*GarbageCollection, error) {
-	gc, _, err := rs.client.Registry.StartGarbageCollection(rs.ctx, registry)
+func (rs *registryService) StartGarbageCollection(registry string, gcRequest *godo.StartGarbageCollectionRequest) (*GarbageCollection, error) {
+	gc, _, err := rs.client.Registry.StartGarbageCollection(rs.ctx, registry, gcRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.11
-	github.com/digitalocean/godo v1.52.0
+	github.com/digitalocean/godo v1.54.0
 	github.com/docker/cli v0.0.0-20200622130859-87db43814b48
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.52.0 h1:1QSUC0w5T1wS1d/1uvPtG8GLeD0p/4zhx1Q+Fxtna+k=
-github.com/digitalocean/godo v1.52.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
+github.com/digitalocean/godo v1.54.0 h1:KP0Nv87pgViR8k/7De3VrmflCL5pJqXbNnkcw0bwG10=
+github.com/digitalocean/godo v1.54.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48 h1:AC8qbhi/SjYf4iN2W3jSsofZGHWPjG8pjf5P143KUM8=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible h1:PmGHHCZ43l6h8aZIi+Xa+z1SWe4dFImd5EK3TNp1jlo=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [v1.54.0] - 2020-11-24
+
+- #417 - @waynr - registry: add support for garbage collection types
+
+## [v1.53.0] - 2020-11-20
+
+- #414 - @varshavaradarajan - kubernetes: add clusterlint support
+- #413 - @andrewsomething - images: Support updating distribution and description.
+
 ## [v1.52.0] - 2020-11-05
 
 - #411 - @nicktate - apps: add unspecified type to image source registry types

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.52.0"
+	libraryVersion = "1.54.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/images.go
+++ b/vendor/github.com/digitalocean/godo/images.go
@@ -52,7 +52,9 @@ type Image struct {
 
 // ImageUpdateRequest represents a request to update an image.
 type ImageUpdateRequest struct {
-	Name string `json:"name"`
+	Name         string `json:"name,omitempty"`
+	Distribution string `json:"distribution,omitempty"`
+	Description  string `json:"description,omitempty"`
 }
 
 // CustomImageCreateRequest represents a request to create a custom image.

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -48,6 +48,9 @@ type KubernetesService interface {
 	GetOptions(context.Context) (*KubernetesOptions, *Response, error)
 	AddRegistry(ctx context.Context, req *KubernetesClusterRegistryRequest) (*Response, error)
 	RemoveRegistry(ctx context.Context, req *KubernetesClusterRegistryRequest) (*Response, error)
+
+	RunClusterlint(ctx context.Context, clusterID string, req *KubernetesRunClusterlintRequest) (string, *Response, error)
+	GetClusterlintResults(ctx context.Context, clusterID string, req *KubernetesGetClusterlintRequest) ([]*ClusterlintDiagnostic, *Response, error)
 }
 
 var _ KubernetesService = &KubernetesServiceOp{}
@@ -151,6 +154,17 @@ type KubernetesClusterCredentialsGetRequest struct {
 // KubernetesClusterRegistryRequest represents clusters to integrate with docr registry
 type KubernetesClusterRegistryRequest struct {
 	ClusterUUIDs []string `json:"cluster_uuids,omitempty"`
+}
+
+type KubernetesRunClusterlintRequest struct {
+	IncludeGroups []string `json:"include_groups"`
+	ExcludeGroups []string `json:"exclude_groups"`
+	IncludeChecks []string `json:"include_checks"`
+	ExcludeChecks []string `json:"exclude_checks"`
+}
+
+type KubernetesGetClusterlintRequest struct {
+	RunId string `json:"run_id"`
 }
 
 // KubernetesCluster represents a Kubernetes cluster.
@@ -407,6 +421,28 @@ type KubernetesNodeSize struct {
 type KubernetesRegion struct {
 	Name string `json:"name"`
 	Slug string `json:"slug"`
+}
+
+// ClusterlintDiagnostic is a diagnostic returned from clusterlint.
+type ClusterlintDiagnostic struct {
+	CheckName string             `json:"check_name"`
+	Severity  string             `json:"severity"`
+	Message   string             `json:"message"`
+	Object    *ClusterlintObject `json:"object"`
+}
+
+// ClusterlintObject is the object a clusterlint diagnostic refers to.
+type ClusterlintObject struct {
+	Kind      string              `json:"kind"`
+	Name      string              `json:"name"`
+	Namespace string              `json:"namespace"`
+	Owners    []*ClusterlintOwner `json:"owners,omitempty"`
+}
+
+// ClusterlintOwner indicates the resource that owns the offending object.
+type ClusterlintOwner struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
 }
 
 type kubernetesClustersRoot struct {
@@ -798,4 +834,52 @@ func (svc *KubernetesServiceOp) RemoveRegistry(ctx context.Context, req *Kuberne
 		return resp, err
 	}
 	return resp, nil
+}
+
+type runClusterlintRoot struct {
+	RunID string `json:"run_id"`
+}
+
+// RunClusterlint schedules a clusterlint run for the specified cluster
+func (svc *KubernetesServiceOp) RunClusterlint(ctx context.Context, clusterID string, req *KubernetesRunClusterlintRequest) (string, *Response, error) {
+	path := fmt.Sprintf("%s/%s/clusterlint", kubernetesClustersPath, clusterID)
+	request, err := svc.client.NewRequest(ctx, http.MethodPost, path, req)
+	if err != nil {
+		return "", nil, err
+	}
+	root := new(runClusterlintRoot)
+	resp, err := svc.client.Do(ctx, request, root)
+	if err != nil {
+		return "", resp, err
+	}
+	return root.RunID, resp, nil
+}
+
+type clusterlintDiagnosticsRoot struct {
+	Diagnostics []*ClusterlintDiagnostic
+}
+
+// GetClusterlintResults fetches the diagnostics after clusterlint run completes
+func (svc *KubernetesServiceOp) GetClusterlintResults(ctx context.Context, clusterID string, req *KubernetesGetClusterlintRequest) ([]*ClusterlintDiagnostic, *Response, error) {
+	path := fmt.Sprintf("%s/%s/clusterlint", kubernetesClustersPath, clusterID)
+	if req != nil {
+		v := make(url.Values)
+		if req.RunId != "" {
+			v.Set("run_id", req.RunId)
+		}
+		if query := v.Encode(); query != "" {
+			path = path + "?" + query
+		}
+	}
+
+	request, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(clusterlintDiagnosticsRoot)
+	resp, err := svc.client.Do(ctx, request, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Diagnostics, resp, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.52.0
+# github.com/digitalocean/godo v1.54.0
 ## explicit
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util


### PR DESCRIPTION
The intent here is to provide users of DOCR a way to optionally garbage collection untagged manifests while retaining the previous default behavior of only garbage collecting unreferenced blobs.