### PR TITLE
apps: display tier units in base-1024

### DIFF
--- a/commands/displayers/apps.go
+++ b/commands/displayers/apps.go
@@ -205,7 +205,7 @@ func (t AppTiers) KV() []map[string]interface{} {
 		out[i] = map[string]interface{}{
 			"Name":                 tier.Name,
 			"Slug":                 tier.Slug,
-			"EgressBandwidthBytes": BytesToHumanReadibleUnit(egressBandwidth),
+			"EgressBandwidthBytes": BytesToHumanReadibleUnitBinary(egressBandwidth),
 			"BuildSeconds":         tier.BuildSeconds,
 		}
 	}
@@ -269,7 +269,7 @@ func (is AppInstanceSizes) KV() []map[string]interface{} {
 			"Name":                     instanceSize.Name,
 			"Slug":                     instanceSize.Slug,
 			"CPUs":                     cpus,
-			"Memory":                   BytesToHumanReadibleUnit(memory),
+			"Memory":                   BytesToHumanReadibleUnitBinary(memory),
 			"USDPerMonth":              instanceSize.USDPerMonth,
 			"USDPerSecond":             fmt.Sprintf("%.7f", usdPerSecond),
 			"TierSlug":                 instanceSize.TierSlug,

--- a/commands/displayers/util.go
+++ b/commands/displayers/util.go
@@ -2,14 +2,21 @@ package displayers
 
 import "fmt"
 
-const (
-	baseUnit = 1000
-	units    = "kMGTPE"
-)
+// BytesToHumanReadibleUnit converts byte input to a human-readable
+// form using the largest notation possible in decimal base.
+func BytesToHumanReadibleUnit(bytes uint64) string {
+	return bytesToHumanReadibleUnit(bytes, 1000, []string{"K", "M", "G", "T", "P", "E"})
+}
+
+// BytesToHumanReadibleUnitBinary converts byte input to a human-readable
+// form using the largest notation possible in binary base.
+func BytesToHumanReadibleUnitBinary(bytes uint64) string {
+	return bytesToHumanReadibleUnit(bytes, 1024, []string{"Ki", "Mi", "Gi", "Ti", "Pi", "Ei"})
+}
 
 // BytesToHumanReadibleUnit converts byte input to a human-readable
 // form using the largest notation possible.
-func BytesToHumanReadibleUnit(bytes uint64) string {
+func bytesToHumanReadibleUnit(bytes uint64, baseUnit uint64, units []string) string {
 	if bytes < baseUnit {
 		return fmt.Sprintf("%d B", bytes)
 	}
@@ -19,5 +26,5 @@ func BytesToHumanReadibleUnit(bytes uint64) string {
 		div *= baseUnit
 		exp++
 	}
-	return fmt.Sprintf("%.2f %cB", float64(bytes)/float64(div), units[exp])
+	return fmt.Sprintf("%.2f %sB", float64(bytes)/float64(div), units[exp])
 }

--- a/commands/displayers/util.go
+++ b/commands/displayers/util.go
@@ -5,7 +5,7 @@ import "fmt"
 // BytesToHumanReadibleUnit converts byte input to a human-readable
 // form using the largest notation possible in decimal base.
 func BytesToHumanReadibleUnit(bytes uint64) string {
-	return bytesToHumanReadibleUnit(bytes, 1000, []string{"K", "M", "G", "T", "P", "E"})
+	return bytesToHumanReadibleUnit(bytes, 1000, []string{"k", "M", "G", "T", "P", "E"})
 }
 
 // BytesToHumanReadibleUnitBinary converts byte input to a human-readable

--- a/integration/apps_tier_test.go
+++ b/integration/apps_tier_test.go
@@ -30,7 +30,7 @@ var (
 	}{[]*godo.AppTier{testAppTier}}
 
 	testAppTierOutput = `Name    Slug    Egress Bandwidth    Build Seconds
-Test    test    10.24 kB            3000`
+Test    test    10.00 KiB           3000`
 
 	testAppInstanceSize = &godo.AppInstanceSize{
 		Name:            "Basic XXS",
@@ -52,8 +52,8 @@ Test    test    10.24 kB            3000`
 		InstanceSizes []*godo.AppInstanceSize `json:"instance_sizes"`
 	}{[]*godo.AppInstanceSize{testAppInstanceSize}}
 
-	testAppInstanceSizeOutput = `Name         Slug         CPUs           Memory       $/month    $/second     Tier     Tier Downgrade/Upgrade Path
-Basic XXS    basic-xxs    1 dedicated    536.87 MB    5          0.0000019    basic    basic-xxxs <- basic-xxs -> professional-xs`
+	testAppInstanceSizeOutput = `Name         Slug         CPUs           Memory        $/month    $/second     Tier     Tier Downgrade/Upgrade Path
+Basic XXS    basic-xxs    1 dedicated    512.00 MiB    5          0.0000019    basic    basic-xxxs <- basic-xxs -> professional-xs`
 )
 
 var _ = suite("apps/tier/get", func(t *testing.T, when spec.G, it spec.S) {


### PR DESCRIPTION
Makes the output look a little nicer 😄 

before:
```
❯ go run ./cmd/doctl apps tier list
Name            Slug            Egress Bandwidth    Build Seconds
Starter         starter         1.07 GB             6000
Basic           basic           42.95 GB            24000
Professional    professional    107.37 GB           60000
```

after:
```
❯ go run ./cmd/doctl apps tier list
Name            Slug            Egress Bandwidth    Build Seconds
Starter         starter         1.00 GiB            6000
Basic           basic           40.00 GiB           24000
Professional    professional    100.00 GiB          60000
```