### PR TITLE
registry: confirm user wishes to start garbage collection

### DIFF
--- a/commands/registry_test.go
+++ b/commands/registry_test.go
@@ -555,6 +555,7 @@ func TestGarbageCollectionStart(t *testing.T) {
 				testRegistryName,
 			},
 			expect: func(m *mocks.MockRegistryService, config *CmdConfig) {
+				config.Doit.Set(config.NS, doctl.ArgForce, true)
 				m.EXPECT().StartGarbageCollection(testRegistry.Name, defaultStartGCRequest).Return(testGarbageCollection, nil)
 			},
 		},
@@ -564,6 +565,7 @@ func TestGarbageCollectionStart(t *testing.T) {
 				testRegistryName,
 			},
 			expect: func(m *mocks.MockRegistryService, config *CmdConfig) {
+				config.Doit.Set(config.NS, doctl.ArgForce, true)
 				config.Doit.Set(config.NS, doctl.ArgGCIncludeUntaggedManifests, true)
 				config.Doit.Set(config.NS, doctl.ArgGCExcludeUnreferencedBlobs, false)
 				m.EXPECT().StartGarbageCollection(testRegistry.Name, &godo.StartGarbageCollectionRequest{
@@ -577,6 +579,7 @@ func TestGarbageCollectionStart(t *testing.T) {
 				testRegistryName,
 			},
 			expect: func(m *mocks.MockRegistryService, config *CmdConfig) {
+				config.Doit.Set(config.NS, doctl.ArgForce, true)
 				config.Doit.Set(config.NS, doctl.ArgGCIncludeUntaggedManifests, true)
 				config.Doit.Set(config.NS, doctl.ArgGCExcludeUnreferencedBlobs, true)
 				m.EXPECT().StartGarbageCollection(testRegistry.Name, &godo.StartGarbageCollectionRequest{
@@ -590,6 +593,7 @@ func TestGarbageCollectionStart(t *testing.T) {
 				invalidRegistryName,
 			},
 			expect: func(m *mocks.MockRegistryService, config *CmdConfig) {
+				config.Doit.Set(config.NS, doctl.ArgForce, true)
 				config.Doit.Set(config.NS, doctl.ArgGCIncludeUntaggedManifests, false)
 				config.Doit.Set(config.NS, doctl.ArgGCExcludeUnreferencedBlobs, true)
 			},
@@ -601,6 +605,7 @@ func TestGarbageCollectionStart(t *testing.T) {
 				invalidRegistryName,
 			},
 			expect: func(m *mocks.MockRegistryService, config *CmdConfig) {
+				config.Doit.Set(config.NS, doctl.ArgForce, true)
 				m.EXPECT().StartGarbageCollection(invalidRegistryName, defaultStartGCRequest).Return(nil, fmt.Errorf("meow"))
 			},
 			expectError: fmt.Errorf("meow"),
@@ -614,6 +619,14 @@ func TestGarbageCollectionStart(t *testing.T) {
 			expect:      func(m *mocks.MockRegistryService, config *CmdConfig) {},
 			expectError: fmt.Errorf("(test) command contains unsupported arguments"),
 		},
+		{
+			name: "prompt to confirm without --force argument",
+			extraArgs: []string{
+				testRegistryName,
+			},
+			expect:      func(m *mocks.MockRegistryService, config *CmdConfig) {},
+			expectError: fmt.Errorf("Operation aborted."),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -621,6 +634,7 @@ func TestGarbageCollectionStart(t *testing.T) {
 				if test.expect != nil {
 					test.expect(tm.registry, config)
 				} else {
+					config.Doit.Set(config.NS, doctl.ArgForce, true)
 					tm.registry.EXPECT().Get().Return(&testRegistry, nil)
 					tm.registry.EXPECT().StartGarbageCollection(testRegistry.Name, defaultStartGCRequest).Return(testGarbageCollection, nil)
 				}

--- a/integration/registry_garbagecollection_test.go
+++ b/integration/registry_garbagecollection_test.go
@@ -157,7 +157,7 @@ var _ = suite("registry/garbage-collection", func(t *testing.T, when spec.G, it 
 			"-u", server.URL,
 			"registry",
 			"garbage-collection",
-			"start",
+			"start", "--force",
 		)
 		output, err := cmd.CombinedOutput()
 		expect.Equal(strings.TrimSpace(gcGetOutput), strings.TrimSpace(string(output)))


### PR DESCRIPTION
In the [product docs for garbage collection](https://www.digitalocean.com/docs/container-registry/how-to/clean-up-container-registry/) we mention a confirmation prompt when initiating a garbage collection but I neglected to include this behavior during the initial implementation. This PR addresses that.