### PR TITLE
apps: add `apps propose` command, expand spec validation

### DIFF
--- a/args.go
+++ b/args.go
@@ -34,6 +34,8 @@ const (
 	ArgActionStatus = "status"
 	// ArgActionType is an action type argument.
 	ArgActionType = "action-type"
+	// ArgApp is the app ID.
+	ArgApp = "app"
 	// ArgAppSpec is a path to an app spec.
 	ArgAppSpec = "spec"
 	// ArgAppLogType the type of log.
@@ -140,6 +142,8 @@ const (
 	ArgRecordTag = "record-tag"
 	// ArgRegionSlug is a region slug argument.
 	ArgRegionSlug = "region"
+	// ArgSchemaOnly is a schema only argument.
+	ArgSchemaOnly = "schema-only"
 	// ArgSizeSlug is a size slug argument.
 	ArgSizeSlug = "size"
 	// ArgsSSHKeyPath is a ssh argument.

--- a/commands/displayers/apps.go
+++ b/commands/displayers/apps.go
@@ -302,7 +302,7 @@ func (r AppProposeResponse) Cols() []string {
 
 	cols = append(cols, []string{
 		"AppIsStatic",
-		"StaticSites",
+		"StaticApps",
 		"AppCost",
 		"AppTierUpgradeCost",
 		"AppTierDowngradeCost",
@@ -316,7 +316,7 @@ func (r AppProposeResponse) ColMap() map[string]string {
 		"AppNameAvailable":     "App Name Available?",
 		"AppNameSuggestion":    "Suggested App Name",
 		"AppIsStatic":          "Is Static?",
-		"StaticSites":          "Free Static Site Usage",
+		"StaticApps":           "Static App Usage",
 		"AppCost":              "$/month",
 		"AppTierUpgradeCost":   "$/month on higher tier",
 		"AppTierDowngradeCost": "$/month on lower tier",
@@ -324,7 +324,20 @@ func (r AppProposeResponse) ColMap() map[string]string {
 }
 
 func (r AppProposeResponse) KV() []map[string]interface{} {
-	staticSites := fmt.Sprintf("%s of %s", r.Res.ExistingStaticApps, r.Res.MaxFreeStaticApps)
+	existingStatic, _ := strconv.ParseInt(r.Res.ExistingStaticApps, 10, 64)
+	maxFreeStatic, _ := strconv.ParseInt(r.Res.MaxFreeStaticApps, 10, 64)
+	var paidStatic int64
+	freeStatic := existingStatic
+	if existingStatic > maxFreeStatic {
+		paidStatic = existingStatic - maxFreeStatic
+		freeStatic = maxFreeStatic
+	}
+
+	staticApps := fmt.Sprintf("%d of %d free", freeStatic, maxFreeStatic)
+	if paidStatic > 0 {
+		staticApps = fmt.Sprintf("%s, %d paid", staticApps, paidStatic)
+	}
+
 	downgradeCost := "n/a"
 	upgradeCost := "n/a"
 
@@ -338,7 +351,7 @@ func (r AppProposeResponse) KV() []map[string]interface{} {
 	out := map[string]interface{}{
 		"AppNameAvailable":     boolToYesNo(r.Res.AppNameAvailable),
 		"AppIsStatic":          boolToYesNo(r.Res.AppIsStatic),
-		"StaticSites":          staticSites,
+		"StaticApps":           staticApps,
 		"AppCost":              fmt.Sprintf("%0.2f", r.Res.AppCost),
 		"AppTierUpgradeCost":   upgradeCost,
 		"AppTierDowngradeCost": downgradeCost,

--- a/commands/displayers/util.go
+++ b/commands/displayers/util.go
@@ -28,3 +28,11 @@ func bytesToHumanReadibleUnit(bytes uint64, baseUnit uint64, units []string) str
 	}
 	return fmt.Sprintf("%.2f %sB", float64(bytes)/float64(div), units[exp])
 }
+
+func boolToYesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+
+	return "no"
+}

--- a/do/apps.go
+++ b/do/apps.go
@@ -26,6 +26,7 @@ type AppsService interface {
 	List() ([]*godo.App, error)
 	Update(appID string, req *godo.AppUpdateRequest) (*godo.App, error)
 	Delete(appID string) error
+	Propose(req *godo.AppProposeRequest) (*godo.AppProposeResponse, error)
 
 	CreateDeployment(appID string, forceRebuild bool) (*godo.Deployment, error)
 	GetDeployment(appID, deploymentID string) (*godo.Deployment, error)
@@ -113,6 +114,14 @@ func (s *appsService) Update(appID string, req *godo.AppUpdateRequest) (*godo.Ap
 func (s *appsService) Delete(appID string) error {
 	_, err := s.client.Apps.Delete(s.ctx, appID)
 	return err
+}
+
+func (s *appsService) Propose(req *godo.AppProposeRequest) (*godo.AppProposeResponse, error) {
+	res, _, err := s.client.Apps.Propose(s.ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 func (s *appsService) CreateDeployment(appID string, forceRebuild bool) (*godo.Deployment, error) {

--- a/do/mocks/AppsService.go
+++ b/do/mocks/AppsService.go
@@ -108,6 +108,21 @@ func (mr *MockAppsServiceMockRecorder) Delete(appID interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockAppsService)(nil).Delete), appID)
 }
 
+// Propose mocks base method.
+func (m *MockAppsService) Propose(req *godo.AppProposeRequest) (*godo.AppProposeResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Propose", req)
+	ret0, _ := ret[0].(*godo.AppProposeResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Propose indicates an expected call of Propose.
+func (mr *MockAppsServiceMockRecorder) Propose(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Propose", reflect.TypeOf((*MockAppsService)(nil).Propose), req)
+}
+
 // CreateDeployment mocks base method.
 func (m *MockAppsService) CreateDeployment(appID string, forceRebuild bool) (*godo.Deployment, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
1. Added `doctl apps propose`
2. Updated `doctl apps spec validate`
3. Updated other commands to accept reading app specs from stdin by setting the path to `-`

### `doctl apps propose`

API docs: https://developers.digitalocean.com/documentation/v2/#propose-an-app-spec

Usage: `doctl apps propose --spec spec.yaml [--app app-id]`

#### available app name
```
App Name Available?    Is Static?    Free Static Site Usage    $/month    $/month on higher tier    $/month on lower tier
yes                    no            3 of 3                    5.00       17.00                     n/a
```

#### unavailable app name

```
App Name Available?    Suggested App Name     Is Static?    Free Static Site Usage    $/month    $/month on higher tier    $/month on lower tier
no                     sample-dockerfile-2    no            3 of 3                    5.00       17.00                     n/a
```

### `doctl apps spec validate`

Added a `--schema-only` flag. Defaults to false. If set, the old behavior of only validating that the spec marshals into a `godo.AppSpec` object is retained.

If not set, it calls the `ProposeApp` API endpoint.

In both cases the command now prints the validated spec instead of a `The app spec is valid` message.

#### some file that's not a spec
```
Error: Failed to parse app spec: json: cannot unmarshal string into Go value of type godo.AppSpec
exit status 1
```

#### valid yaml but invalid spec
```
Error: POST https://api.digitalocean.com/v2/apps/propose: 400 error validating app spec field "services.git.repo_clone_url": services.git.repo_clone_url in body is required
exit status 1
```

#### happy path - valid spec

The spec I passed in doesn't set the `routes` field
```
name: sample-hugo
region: nyc
static_sites:
- build_command: hugo
  environment_slug: hugo
  envs:
  - key: HUGO_VERSION
    scope: BUILD_TIME
    value: 0.74.3
  git:
    branch: main
    repo_clone_url: https://github.com/digitalocean/sample-hugo.git
  name: hugo
  routes:
  - path: /
```