### PR TITLE
kubernetes: add support for optional cascading deletes

### DIFF
--- a/args.go
+++ b/args.go
@@ -216,6 +216,10 @@ const (
 	ArgVolumeFilesystemLabel = "fs-label"
 	// ArgVolumeList is the IDs of many volumes.
 	ArgVolumeList = "volumes"
+	// ArgVolumeSnapshotList is the IDs of many volume snapshots.
+	ArgVolumeSnapshotList = "snapshots"
+	// ArgLoadBalancerList is the IDs of many load balancers.
+	ArgLoadBalancerList = "load-balancers"
 
 	// ArgCDNTTL is a cdn ttl argument
 	ArgCDNTTL = "ttl"
@@ -335,4 +339,7 @@ const (
 
 	// ArgOneClickType is the type of 1-Click
 	ArgOneClickType = "type"
+
+	//ArgDangerous indicates whether to delete the cluster and all it's associated resources
+	ArgDangerous = "dangerous"
 )

--- a/commands/displayers/kubernetes.go
+++ b/commands/displayers/kubernetes.go
@@ -292,3 +292,40 @@ func (nodeSizes *KubernetesNodeSizes) KV() []map[string]interface{} {
 
 	return out
 }
+
+type KubernetesAssociatedResources struct {
+	KubernetesAssociatedResources *do.KubernetesAssociatedResources
+}
+
+var _ Displayable = &KubernetesAssociatedResources{}
+
+func (ar *KubernetesAssociatedResources) JSON(out io.Writer) error {
+	return writeJSON(ar.KubernetesAssociatedResources, out)
+}
+
+func (ar *KubernetesAssociatedResources) Cols() []string {
+	return []string{
+		"Volumes",
+		"VolumeSnapshots",
+		"LoadBalancers",
+	}
+}
+
+func (ar *KubernetesAssociatedResources) ColMap() map[string]string {
+	return map[string]string{
+		"Volumes":         "Volumes",
+		"VolumeSnapshots": "Volume Snapshots",
+		"LoadBalancers":   "Load Balancers",
+	}
+}
+
+func (ar *KubernetesAssociatedResources) KV() []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, 1)
+	o := map[string]interface{}{
+		"Volumes":         ar.KubernetesAssociatedResources.Volumes,
+		"VolumeSnapshots": ar.KubernetesAssociatedResources.VolumeSnapshots,
+		"LoadBalancers":   ar.KubernetesAssociatedResources.LoadBalancers,
+	}
+	out = append(out, o)
+	return out
+}

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -104,6 +104,9 @@ var (
 				ID:            volumeID.String(),
 				Name:          "vol-1",
 				SizeGigaBytes: 4,
+				Region: &godo.Region{
+					Slug: testCluster.RegionSlug,
+				},
 			},
 		},
 	}
@@ -116,6 +119,7 @@ var (
 				SizeGigaBytes: 3,
 				ResourceType:  "volume",
 				ResourceID:    volumeID.String(),
+				Regions:       []string{testCluster.RegionSlug},
 			},
 		},
 	}
@@ -702,6 +706,7 @@ func TestKubernetesDeleteSelective(t *testing.T) {
 			VolumeSnapshots: []string{snapshotID.String()},
 			LoadBalancers:   []string{lbID.String()},
 		}
+		tm.kubernetes.EXPECT().Get(testCluster.ID).Return(&testCluster, nil)
 		tm.kubernetes.EXPECT().DeleteSelective(testCluster.ID, r).Return(nil)
 
 		config.Args = append(config.Args, testCluster.ID)
@@ -721,6 +726,7 @@ func TestKubernetesDeleteSelective(t *testing.T) {
 			LoadBalancers:   []string{lbID.String()},
 		}
 		tm.kubernetes.EXPECT().List().Return(testClusterList, nil)
+		tm.kubernetes.EXPECT().Get(testCluster.ID).Return(&testCluster, nil)
 		tm.volumes.EXPECT().List().Return(testVolumes, nil)
 		tm.snapshots.EXPECT().ListVolume().Return(testSnapshots, nil)
 		tm.loadBalancers.EXPECT().List().Return(testLoadBalancers, nil)

--- a/do/mocks/KubernetesService.go
+++ b/do/mocks/KubernetesService.go
@@ -35,6 +35,120 @@ func (m *MockKubernetesService) EXPECT() *MockKubernetesServiceMockRecorder {
 	return m.recorder
 }
 
+// AddRegistry mocks base method.
+func (m *MockKubernetesService) AddRegistry(req *godo.KubernetesClusterRegistryRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddRegistry", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddRegistry indicates an expected call of AddRegistry.
+func (mr *MockKubernetesServiceMockRecorder) AddRegistry(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRegistry", reflect.TypeOf((*MockKubernetesService)(nil).AddRegistry), req)
+}
+
+// Create mocks base method.
+func (m *MockKubernetesService) Create(create *godo.KubernetesClusterCreateRequest) (*do.KubernetesCluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", create)
+	ret0, _ := ret[0].(*do.KubernetesCluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockKubernetesServiceMockRecorder) Create(create interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockKubernetesService)(nil).Create), create)
+}
+
+// CreateNodePool mocks base method.
+func (m *MockKubernetesService) CreateNodePool(clusterID string, req *godo.KubernetesNodePoolCreateRequest) (*do.KubernetesNodePool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNodePool", clusterID, req)
+	ret0, _ := ret[0].(*do.KubernetesNodePool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNodePool indicates an expected call of CreateNodePool.
+func (mr *MockKubernetesServiceMockRecorder) CreateNodePool(clusterID, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNodePool", reflect.TypeOf((*MockKubernetesService)(nil).CreateNodePool), clusterID, req)
+}
+
+// Delete mocks base method.
+func (m *MockKubernetesService) Delete(clusterID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", clusterID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockKubernetesServiceMockRecorder) Delete(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockKubernetesService)(nil).Delete), clusterID)
+}
+
+// DeleteDangerous mocks base method.
+func (m *MockKubernetesService) DeleteDangerous(clusterID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDangerous", clusterID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteDangerous indicates an expected call of DeleteDangerous.
+func (mr *MockKubernetesServiceMockRecorder) DeleteDangerous(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDangerous", reflect.TypeOf((*MockKubernetesService)(nil).DeleteDangerous), clusterID)
+}
+
+// DeleteNode mocks base method.
+func (m *MockKubernetesService) DeleteNode(clusterID, poolID, nodeID string, req *godo.KubernetesNodeDeleteRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNode", clusterID, poolID, nodeID, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNode indicates an expected call of DeleteNode.
+func (mr *MockKubernetesServiceMockRecorder) DeleteNode(clusterID, poolID, nodeID, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockKubernetesService)(nil).DeleteNode), clusterID, poolID, nodeID, req)
+}
+
+// DeleteNodePool mocks base method.
+func (m *MockKubernetesService) DeleteNodePool(clusterID, poolID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNodePool", clusterID, poolID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNodePool indicates an expected call of DeleteNodePool.
+func (mr *MockKubernetesServiceMockRecorder) DeleteNodePool(clusterID, poolID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodePool", reflect.TypeOf((*MockKubernetesService)(nil).DeleteNodePool), clusterID, poolID)
+}
+
+// DeleteSelective mocks base method.
+func (m *MockKubernetesService) DeleteSelective(clusterID string, deleteReq *godo.KubernetesClusterDeleteSelectiveRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSelective", clusterID, deleteReq)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSelective indicates an expected call of DeleteSelective.
+func (mr *MockKubernetesServiceMockRecorder) DeleteSelective(clusterID, deleteReq interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSelective", reflect.TypeOf((*MockKubernetesService)(nil).DeleteSelective), clusterID, deleteReq)
+}
+
 // Get mocks base method.
 func (m *MockKubernetesService) Get(clusterID string) (*do.KubernetesCluster, error) {
 	m.ctrl.T.Helper()
@@ -48,6 +162,21 @@ func (m *MockKubernetesService) Get(clusterID string) (*do.KubernetesCluster, er
 func (mr *MockKubernetesServiceMockRecorder) Get(clusterID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockKubernetesService)(nil).Get), clusterID)
+}
+
+// GetCredentials mocks base method.
+func (m *MockKubernetesService) GetCredentials(clusterID string) (*do.KubernetesClusterCredentials, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCredentials", clusterID)
+	ret0, _ := ret[0].(*do.KubernetesClusterCredentials)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCredentials indicates an expected call of GetCredentials.
+func (mr *MockKubernetesServiceMockRecorder) GetCredentials(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentials", reflect.TypeOf((*MockKubernetesService)(nil).GetCredentials), clusterID)
 }
 
 // GetKubeConfig mocks base method.
@@ -80,124 +209,6 @@ func (mr *MockKubernetesServiceMockRecorder) GetKubeConfigWithExpiry(clusterID, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKubeConfigWithExpiry", reflect.TypeOf((*MockKubernetesService)(nil).GetKubeConfigWithExpiry), clusterID, expirySeconds)
 }
 
-// GetCredentials mocks base method.
-func (m *MockKubernetesService) GetCredentials(clusterID string) (*do.KubernetesClusterCredentials, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCredentials", clusterID)
-	ret0, _ := ret[0].(*do.KubernetesClusterCredentials)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCredentials indicates an expected call of GetCredentials.
-func (mr *MockKubernetesServiceMockRecorder) GetCredentials(clusterID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentials", reflect.TypeOf((*MockKubernetesService)(nil).GetCredentials), clusterID)
-}
-
-// GetUpgrades mocks base method.
-func (m *MockKubernetesService) GetUpgrades(clusterID string) (do.KubernetesVersions, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUpgrades", clusterID)
-	ret0, _ := ret[0].(do.KubernetesVersions)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUpgrades indicates an expected call of GetUpgrades.
-func (mr *MockKubernetesServiceMockRecorder) GetUpgrades(clusterID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpgrades", reflect.TypeOf((*MockKubernetesService)(nil).GetUpgrades), clusterID)
-}
-
-// List mocks base method.
-func (m *MockKubernetesService) List() (do.KubernetesClusters, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List")
-	ret0, _ := ret[0].(do.KubernetesClusters)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// List indicates an expected call of List.
-func (mr *MockKubernetesServiceMockRecorder) List() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockKubernetesService)(nil).List))
-}
-
-// Create mocks base method.
-func (m *MockKubernetesService) Create(create *godo.KubernetesClusterCreateRequest) (*do.KubernetesCluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", create)
-	ret0, _ := ret[0].(*do.KubernetesCluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Create indicates an expected call of Create.
-func (mr *MockKubernetesServiceMockRecorder) Create(create interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockKubernetesService)(nil).Create), create)
-}
-
-// Update mocks base method.
-func (m *MockKubernetesService) Update(clusterID string, update *godo.KubernetesClusterUpdateRequest) (*do.KubernetesCluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", clusterID, update)
-	ret0, _ := ret[0].(*do.KubernetesCluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Update indicates an expected call of Update.
-func (mr *MockKubernetesServiceMockRecorder) Update(clusterID, update interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockKubernetesService)(nil).Update), clusterID, update)
-}
-
-// Upgrade mocks base method.
-func (m *MockKubernetesService) Upgrade(clusterID, versionSlug string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", clusterID, versionSlug)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Upgrade indicates an expected call of Upgrade.
-func (mr *MockKubernetesServiceMockRecorder) Upgrade(clusterID, versionSlug interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockKubernetesService)(nil).Upgrade), clusterID, versionSlug)
-}
-
-// Delete mocks base method.
-func (m *MockKubernetesService) Delete(clusterID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", clusterID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete.
-func (mr *MockKubernetesServiceMockRecorder) Delete(clusterID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockKubernetesService)(nil).Delete), clusterID)
-}
-
-// CreateNodePool mocks base method.
-func (m *MockKubernetesService) CreateNodePool(clusterID string, req *godo.KubernetesNodePoolCreateRequest) (*do.KubernetesNodePool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNodePool", clusterID, req)
-	ret0, _ := ret[0].(*do.KubernetesNodePool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateNodePool indicates an expected call of CreateNodePool.
-func (mr *MockKubernetesServiceMockRecorder) CreateNodePool(clusterID, req interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNodePool", reflect.TypeOf((*MockKubernetesService)(nil).CreateNodePool), clusterID, req)
-}
-
 // GetNodePool mocks base method.
 func (m *MockKubernetesService) GetNodePool(clusterID, poolID string) (*do.KubernetesNodePool, error) {
 	m.ctrl.T.Helper()
@@ -211,108 +222,6 @@ func (m *MockKubernetesService) GetNodePool(clusterID, poolID string) (*do.Kuber
 func (mr *MockKubernetesServiceMockRecorder) GetNodePool(clusterID, poolID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodePool", reflect.TypeOf((*MockKubernetesService)(nil).GetNodePool), clusterID, poolID)
-}
-
-// ListNodePools mocks base method.
-func (m *MockKubernetesService) ListNodePools(clusterID string) (do.KubernetesNodePools, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodePools", clusterID)
-	ret0, _ := ret[0].(do.KubernetesNodePools)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodePools indicates an expected call of ListNodePools.
-func (mr *MockKubernetesServiceMockRecorder) ListNodePools(clusterID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodePools", reflect.TypeOf((*MockKubernetesService)(nil).ListNodePools), clusterID)
-}
-
-// UpdateNodePool mocks base method.
-func (m *MockKubernetesService) UpdateNodePool(clusterID, poolID string, req *godo.KubernetesNodePoolUpdateRequest) (*do.KubernetesNodePool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateNodePool", clusterID, poolID, req)
-	ret0, _ := ret[0].(*do.KubernetesNodePool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateNodePool indicates an expected call of UpdateNodePool.
-func (mr *MockKubernetesServiceMockRecorder) UpdateNodePool(clusterID, poolID, req interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNodePool", reflect.TypeOf((*MockKubernetesService)(nil).UpdateNodePool), clusterID, poolID, req)
-}
-
-// RecycleNodePoolNodes mocks base method.
-func (m *MockKubernetesService) RecycleNodePoolNodes(clusterID, poolID string, req *godo.KubernetesNodePoolRecycleNodesRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecycleNodePoolNodes", clusterID, poolID, req)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RecycleNodePoolNodes indicates an expected call of RecycleNodePoolNodes.
-func (mr *MockKubernetesServiceMockRecorder) RecycleNodePoolNodes(clusterID, poolID, req interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecycleNodePoolNodes", reflect.TypeOf((*MockKubernetesService)(nil).RecycleNodePoolNodes), clusterID, poolID, req)
-}
-
-// DeleteNodePool mocks base method.
-func (m *MockKubernetesService) DeleteNodePool(clusterID, poolID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNodePool", clusterID, poolID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteNodePool indicates an expected call of DeleteNodePool.
-func (mr *MockKubernetesServiceMockRecorder) DeleteNodePool(clusterID, poolID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodePool", reflect.TypeOf((*MockKubernetesService)(nil).DeleteNodePool), clusterID, poolID)
-}
-
-// DeleteNode mocks base method.
-func (m *MockKubernetesService) DeleteNode(clusterID, poolID, nodeID string, req *godo.KubernetesNodeDeleteRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNode", clusterID, poolID, nodeID, req)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteNode indicates an expected call of DeleteNode.
-func (mr *MockKubernetesServiceMockRecorder) DeleteNode(clusterID, poolID, nodeID, req interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockKubernetesService)(nil).DeleteNode), clusterID, poolID, nodeID, req)
-}
-
-// GetVersions mocks base method.
-func (m *MockKubernetesService) GetVersions() (do.KubernetesVersions, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVersions")
-	ret0, _ := ret[0].(do.KubernetesVersions)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVersions indicates an expected call of GetVersions.
-func (mr *MockKubernetesServiceMockRecorder) GetVersions() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersions", reflect.TypeOf((*MockKubernetesService)(nil).GetVersions))
-}
-
-// GetRegions mocks base method.
-func (m *MockKubernetesService) GetRegions() (do.KubernetesRegions, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegions")
-	ret0, _ := ret[0].(do.KubernetesRegions)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRegions indicates an expected call of GetRegions.
-func (mr *MockKubernetesServiceMockRecorder) GetRegions() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegions", reflect.TypeOf((*MockKubernetesService)(nil).GetRegions))
 }
 
 // GetNodeSizes mocks base method.
@@ -330,18 +239,108 @@ func (mr *MockKubernetesServiceMockRecorder) GetNodeSizes() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeSizes", reflect.TypeOf((*MockKubernetesService)(nil).GetNodeSizes))
 }
 
-// AddRegistry mocks base method.
-func (m *MockKubernetesService) AddRegistry(req *godo.KubernetesClusterRegistryRequest) error {
+// GetRegions mocks base method.
+func (m *MockKubernetesService) GetRegions() (do.KubernetesRegions, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddRegistry", req)
+	ret := m.ctrl.Call(m, "GetRegions")
+	ret0, _ := ret[0].(do.KubernetesRegions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegions indicates an expected call of GetRegions.
+func (mr *MockKubernetesServiceMockRecorder) GetRegions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegions", reflect.TypeOf((*MockKubernetesService)(nil).GetRegions))
+}
+
+// GetUpgrades mocks base method.
+func (m *MockKubernetesService) GetUpgrades(clusterID string) (do.KubernetesVersions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUpgrades", clusterID)
+	ret0, _ := ret[0].(do.KubernetesVersions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUpgrades indicates an expected call of GetUpgrades.
+func (mr *MockKubernetesServiceMockRecorder) GetUpgrades(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpgrades", reflect.TypeOf((*MockKubernetesService)(nil).GetUpgrades), clusterID)
+}
+
+// GetVersions mocks base method.
+func (m *MockKubernetesService) GetVersions() (do.KubernetesVersions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVersions")
+	ret0, _ := ret[0].(do.KubernetesVersions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVersions indicates an expected call of GetVersions.
+func (mr *MockKubernetesServiceMockRecorder) GetVersions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersions", reflect.TypeOf((*MockKubernetesService)(nil).GetVersions))
+}
+
+// List mocks base method.
+func (m *MockKubernetesService) List() (do.KubernetesClusters, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List")
+	ret0, _ := ret[0].(do.KubernetesClusters)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockKubernetesServiceMockRecorder) List() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockKubernetesService)(nil).List))
+}
+
+// ListAssociatedResourcesForDeletion mocks base method.
+func (m *MockKubernetesService) ListAssociatedResourcesForDeletion(clusterID string) (*do.KubernetesAssociatedResources, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAssociatedResourcesForDeletion", clusterID)
+	ret0, _ := ret[0].(*do.KubernetesAssociatedResources)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAssociatedResourcesForDeletion indicates an expected call of ListAssociatedResourcesForDeletion.
+func (mr *MockKubernetesServiceMockRecorder) ListAssociatedResourcesForDeletion(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAssociatedResourcesForDeletion", reflect.TypeOf((*MockKubernetesService)(nil).ListAssociatedResourcesForDeletion), clusterID)
+}
+
+// ListNodePools mocks base method.
+func (m *MockKubernetesService) ListNodePools(clusterID string) (do.KubernetesNodePools, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodePools", clusterID)
+	ret0, _ := ret[0].(do.KubernetesNodePools)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodePools indicates an expected call of ListNodePools.
+func (mr *MockKubernetesServiceMockRecorder) ListNodePools(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodePools", reflect.TypeOf((*MockKubernetesService)(nil).ListNodePools), clusterID)
+}
+
+// RecycleNodePoolNodes mocks base method.
+func (m *MockKubernetesService) RecycleNodePoolNodes(clusterID, poolID string, req *godo.KubernetesNodePoolRecycleNodesRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RecycleNodePoolNodes", clusterID, poolID, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AddRegistry indicates an expected call of AddRegistry.
-func (mr *MockKubernetesServiceMockRecorder) AddRegistry(req interface{}) *gomock.Call {
+// RecycleNodePoolNodes indicates an expected call of RecycleNodePoolNodes.
+func (mr *MockKubernetesServiceMockRecorder) RecycleNodePoolNodes(clusterID, poolID, req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRegistry", reflect.TypeOf((*MockKubernetesService)(nil).AddRegistry), req)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecycleNodePoolNodes", reflect.TypeOf((*MockKubernetesService)(nil).RecycleNodePoolNodes), clusterID, poolID, req)
 }
 
 // RemoveRegistry mocks base method.
@@ -356,4 +355,48 @@ func (m *MockKubernetesService) RemoveRegistry(req *godo.KubernetesClusterRegist
 func (mr *MockKubernetesServiceMockRecorder) RemoveRegistry(req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRegistry", reflect.TypeOf((*MockKubernetesService)(nil).RemoveRegistry), req)
+}
+
+// Update mocks base method.
+func (m *MockKubernetesService) Update(clusterID string, update *godo.KubernetesClusterUpdateRequest) (*do.KubernetesCluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", clusterID, update)
+	ret0, _ := ret[0].(*do.KubernetesCluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockKubernetesServiceMockRecorder) Update(clusterID, update interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockKubernetesService)(nil).Update), clusterID, update)
+}
+
+// UpdateNodePool mocks base method.
+func (m *MockKubernetesService) UpdateNodePool(clusterID, poolID string, req *godo.KubernetesNodePoolUpdateRequest) (*do.KubernetesNodePool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateNodePool", clusterID, poolID, req)
+	ret0, _ := ret[0].(*do.KubernetesNodePool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateNodePool indicates an expected call of UpdateNodePool.
+func (mr *MockKubernetesServiceMockRecorder) UpdateNodePool(clusterID, poolID, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNodePool", reflect.TypeOf((*MockKubernetesService)(nil).UpdateNodePool), clusterID, poolID, req)
+}
+
+// Upgrade mocks base method.
+func (m *MockKubernetesService) Upgrade(clusterID, versionSlug string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Upgrade", clusterID, versionSlug)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Upgrade indicates an expected call of Upgrade.
+func (mr *MockKubernetesServiceMockRecorder) Upgrade(clusterID, versionSlug interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockKubernetesService)(nil).Upgrade), clusterID, versionSlug)
 }


### PR DESCRIPTION
This PR vendors godo v1.57.0 and adds subcommands and flags to support optional cascading deletes for a Kubernetes cluster. 

cc @adamwg , @MorrisLaw 