### PR TITLE
travis: Log into Docker before pulling images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ jobs:
         repo: digitalocean/doctl
 
   - if: type=push
+    before_script:
+    - echo "$DOCKER_PASSWORD" | docker login --username sammytheshark --password-stdin
     script:
     - echo "building snap"
     - make _build_snap
@@ -50,6 +52,8 @@ jobs:
         repo: digitalocean/doctl
 
   - if: branch=master and type=push
+    before_script:
+    - echo "$DOCKER_PASSWORD" | docker login --username sammytheshark --password-stdin
     script:
     - echo "building snap"
     - make _build_snap


### PR DESCRIPTION
Docker is rate-limiting pulls. Log into the sammytheshark user before building snaps so that we are not an anonymous user being rate-limited by the shared Travis IP address. 

https://blog.travis-ci.com/docker-rate-limits
https://www.docker.com/increase-rate-limits