### PR TITLE
apps: disallow unknown fields during spec parsing

### DIFF
--- a/commands/apps.go
+++ b/commands/apps.go
@@ -14,6 +14,7 @@ limitations under the License.
 package commands
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -436,13 +437,15 @@ func parseAppSpec(spec []byte) (*godo.AppSpec, error) {
 		return nil, err
 	}
 
+	dec := json.NewDecoder(bytes.NewReader(jsonSpec))
+	dec.DisallowUnknownFields()
+
 	var appSpec godo.AppSpec
-	err = json.Unmarshal(jsonSpec, &appSpec)
-	if err == nil {
-		return &appSpec, nil
+	if err := dec.Decode(&appSpec); err != nil {
+		return nil, fmt.Errorf("Failed to parse app spec: %v", err)
 	}
 
-	return nil, fmt.Errorf("Failed to parse app spec: %v", err)
+	return &appSpec, nil
 }
 
 func appsSpec() *Command {

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -365,6 +365,22 @@ static_sites:
   routes:
   - path: /static
 `
+	unknownFieldSpec = `
+name: test
+bugField: bad
+services:
+- name: web
+  github:
+    repo: digitalocean/sample-golang
+    branch: main
+static_sites:
+- name: static
+  git:
+    repo_clone_url: git@github.com:digitalocean/sample-gatsby.git
+    branch: main
+  routes:
+  - path: /static
+`
 )
 
 func Test_parseAppSpec(t *testing.T) {
@@ -405,6 +421,10 @@ func Test_parseAppSpec(t *testing.T) {
 	})
 	t.Run("invalid", func(t *testing.T) {
 		_, err := parseAppSpec([]byte("invalid spec"))
+		require.Error(t, err)
+	})
+	t.Run("unknown fields", func(t *testing.T) {
+		_, err := parseAppSpec([]byte(unknownFieldSpec))
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
### Description

#### What does this pull request accomplish

* Updates decoding for `app spec` to ignore unknown fields. 

#### Additional Context

This should help alleviate confusion where the user is on an older version of doctl before the relevant godo models were updated for a particular feature. Previously, the create/update would succeed but the values would be stripped from the payload.