### PR TITLE
Fix gofmt_check makefile target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,10 @@ shellcheck:
 gofmt_check:
 	@echo "==> ensure code adheres to gofmt (with vendor directory excluded)"
 	@echo ""
-	@gofmt -l ${GOFILES_NOVENDOR} | read && exit 1 || true
+	@GOFMT=$$(gofmt -l ${GOFILES_NOVENDOR}); \
+	if [ -n "$${GOFMT}" ]; then \
+		echo "gofmt checking failed:\n"; echo "$${GOFMT} \n"; exit 1; \
+	fi
 
 .PHONY: snap_image
 snap_image:

--- a/commands/validations.go
+++ b/commands/validations.go
@@ -23,7 +23,7 @@ func ContextualAtoi(s, resource string) (int, error) {
 	n, err := strconv.Atoi(s)
 	if err == nil {
 		if n < 0 {
-		    return 0, fmt.Errorf("expected %d to be a positive integer", n)
+			return 0, fmt.Errorf("expected %d to be a positive integer", n)
 		}
 		return n, nil
 	}


### PR DESCRIPTION
Happened to notice that our gofmt_check makefile target is not running correctly in CI:

https://github.com/digitalocean/doctl/runs/1751541753?check_suite_focus=true#step:5:8

Output before change:

```
asb@asb-home:~/development/gocode/src/github.com/digitalocean/doctl$ make gofmt_check
==> ensure code adheres to gofmt (with vendor directory excluded)

/bin/sh: 1: read: arg count
asb@asb-home:~/development/gocode/src/github.com/digitalocean/doctl$ echo $?
0
```

Output after change:
```
asb@asb-home:~/development/gocode/src/github.com/digitalocean/doctl$ make gofmt_check
==> ensure code adheres to gofmt (with vendor directory excluded)

gofmt checking failed:

./commands/validations.go 

make: *** [Makefile:112: gofmt_check] Error 1
asb@asb-home:~/development/gocode/src/github.com/digitalocean/doctl$ echo $?
2
```