### PR TITLE
apps: Improve help for create-deployment.

### DIFF
--- a/commands/apps.go
+++ b/commands/apps.go
@@ -111,7 +111,7 @@ This permanently deletes the app and all its associated deployments.`,
 		"Create a deployment",
 		`Create a deployment for an app.
 
-The deployment will be created using the provided app spec.  For more information about app specs, see https://www.digitalocean.com/docs/app-platform/concepts/app-spec`,
+Creating an app deployment will pull the latest changes from your repository and schedule a new deployment for your app.`,
 		Writer,
 		aliasOpt("cd"),
 		displayerType(&displayers.Deployments{}),


### PR DESCRIPTION
This description felt misleading. You do not provide a spec as an argument. It uses the existing spec. I've replaced it with the description for the endpoint in the API docs:

https://developers.digitalocean.com/documentation/v2/#create-an-app-deployment