### PR TITLE
k8s list-associated-resources: Output strings.

### DIFF
--- a/commands/displayers/kubernetes.go
+++ b/commands/displayers/kubernetes.go
@@ -321,11 +321,20 @@ func (ar *KubernetesAssociatedResources) ColMap() map[string]string {
 
 func (ar *KubernetesAssociatedResources) KV() []map[string]interface{} {
 	out := make([]map[string]interface{}, 0, 1)
+
 	o := map[string]interface{}{
-		"Volumes":         ar.KubernetesAssociatedResources.Volumes,
-		"VolumeSnapshots": ar.KubernetesAssociatedResources.VolumeSnapshots,
-		"LoadBalancers":   ar.KubernetesAssociatedResources.LoadBalancers,
+		"Volumes":         flattenAssociatedResourceIDs(ar.KubernetesAssociatedResources.Volumes),
+		"VolumeSnapshots": flattenAssociatedResourceIDs(ar.KubernetesAssociatedResources.VolumeSnapshots),
+		"LoadBalancers":   flattenAssociatedResourceIDs(ar.KubernetesAssociatedResources.LoadBalancers),
 	}
 	out = append(out, o)
+	return out
+}
+
+func flattenAssociatedResourceIDs(resources []*godo.AssociatedResource) (out []string) {
+	for _, r := range resources {
+		out = append(out, r.ID)
+	}
+
 	return out
 }


### PR DESCRIPTION
After merging https://github.com/digitalocean/doctl/pull/956, I discovered additional changes were required. The changes to `godo.KubernetesAssociatedResources` meant we were not outputting pointers to a struct rather than strings. `main` currently outputs:

```
$ ./builds/doctl kubernetes c list-associated-resources 087d13f4-a226-4ee4-92b9-35d6b3d9ebb1
Volumes           Volume Snapshots    Load Balancers
[0xc0007170e0]    []                  [0xc000717180]
```

After the changes in the PR, it correctly outputs:

```
$ ./builds/doctl kubernetes c list-associated-resources 087d13f4-a226-4ee4-92b9-35d6b3d9ebb1
Volumes                                   Volume Snapshots    Load Balancers
[28db039f-43bd-11eb-8cf0-0a58ac1467fa]    []                  [a91a98de-9b5f-4198-91cd-f852e36f8265]
```

Better integration test coverage for the Kubernetes sub-commands would have caught this earlier.