### PR TITLE
travis: Use main for Snap candidate builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,3 +69,4 @@ jobs:
       skip_cleanup: true
       on:
         repo: digitalocean/doctl
+        branch: main


### PR DESCRIPTION
We build an publish "candidate" builds of the Ubuntu Snap on each push to `main`.  These packages seem to have fallen behind:

```
$ snap info doctl | grep candidate
  latest/candidate: v1.54.1+git1.1a2b5dd  2021-01-20 (427) 10MB -
```

They are being build, but not actually being uploaded. 

> Skipping a deployment with the snap provider because this branch is not permitted: main

https://travis-ci.org/github/digitalocean/doctl/jobs/760024996#L302

Looks like it defaults to master if not explicitly set: https://docs.travis-ci.com/user/deployment