### PR TITLE
registry - generate a DOSecret operator friendly secret manifest

### DIFF
--- a/commands/registry.go
+++ b/commands/registry.go
@@ -39,6 +39,10 @@ type dockerConfig struct {
 	} `json:"auths"`
 }
 
+// DOSecretOperatorAnnotation is the annotation key so that dosecret operator can do it's magic
+// and help users pull private images automatically in their DOKS clusters
+const DOSecretOperatorAnnotation = "digitalocean.com/dosecret-identifier"
+
 // Registry creates the registry command
 func Registry() *Command {
 	cmd := &Command{
@@ -86,12 +90,12 @@ Redirect the command's output to a file to save the manifest for later use or pi
     doctl registry kubernetes-manifest | kubectl apply -f -
 `
 	cmdRunKubernetesManifest := CmdBuilder(cmd, RunKubernetesManifest, "kubernetes-manifest",
-		"Generate a Kubernetes secret manifest for a registry",
+		"Generate a Kubernetes secret manifest for a registry. By default, the secret manifest will be applied to all the namespaces for the Kubernetes cluster using the DOSecret operator. The DOSecret operator is available on clusters running version 1.15.12-do.2 or greater. For older clusters or to restrict the secret to a specific namespace, use the --namespace flag.",
 		kubeManifestDesc, Writer, aliasOpt("k8s"))
 	AddStringFlag(cmdRunKubernetesManifest, doctl.ArgObjectName, "", "",
 		"The secret name to create. Defaults to the registry name prefixed with \"registry-\"")
 	AddStringFlag(cmdRunKubernetesManifest, doctl.ArgObjectNamespace, "",
-		"default", "The Kubernetes namespace to hold the secret")
+		"kube-system", "The Kubernetes namespace to hold the secret")
 
 	dockerConfigDesc := `This command outputs a JSON-formatted Docker configuration that can be used to configure a Docker client to authenticate with your private container registry. This configuration is useful for configuring third-party tools that need access to your registry. For configuring your local Docker client use "doctl registry login" instead, as it will preserve the configuration of any other registries you have authenticated to.
 
@@ -413,6 +417,11 @@ func RunKubernetesManifest(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
+	annotations := map[string]string{}
+
+	if secretNamespace == k8smetav1.NamespaceSystem {
+		annotations[DOSecretOperatorAnnotation] = secretName
+	}
 
 	// create the manifest for the secret
 	secret := &k8sapiv1.Secret{
@@ -421,8 +430,9 @@ func RunKubernetesManifest(c *CmdConfig) error {
 			APIVersion: "v1",
 		},
 		ObjectMeta: k8smetav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: secretNamespace,
+			Name:        secretName,
+			Namespace:   secretNamespace,
+			Annotations: annotations,
 		},
 		Type: k8sapiv1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -85,12 +85,14 @@ func Registry() *Command {
 
 	kubeManifestDesc := `This command outputs a YAML-formatted Kubernetes secret manifest that can be used to grant a Kubernetes cluster pull access to your private container registry.
 
+By default, the secret manifest will be applied to all the namespaces for the Kubernetes cluster using the DOSecret operator. The DOSecret operator is available on clusters running version 1.15.12-do.2 or greater. For older clusters or to restrict the secret to a specific namespace, use the --namespace flag.
+
 Redirect the command's output to a file to save the manifest for later use or pipe it directly to kubectl to create the secret in your cluster:
 
     doctl registry kubernetes-manifest | kubectl apply -f -
 `
 	cmdRunKubernetesManifest := CmdBuilder(cmd, RunKubernetesManifest, "kubernetes-manifest",
-		"Generate a Kubernetes secret manifest for a registry. By default, the secret manifest will be applied to all the namespaces for the Kubernetes cluster using the DOSecret operator. The DOSecret operator is available on clusters running version 1.15.12-do.2 or greater. For older clusters or to restrict the secret to a specific namespace, use the --namespace flag.",
+		"Generate a Kubernetes secret manifest for a registry.",
 		kubeManifestDesc, Writer, aliasOpt("k8s"))
 	AddStringFlag(cmdRunKubernetesManifest, doctl.ArgObjectName, "", "",
 		"The secret name to create. Defaults to the registry name prefixed with \"registry-\"")

--- a/integration/registry_kubernetes_manifest_test.go
+++ b/integration/registry_kubernetes_manifest_test.go
@@ -89,7 +89,9 @@ kind: Secret
 metadata:
   creationTimestamp: null
   name: registry-my-registry
-  namespace: default
+  annotations:
+    digitalocean.com/dosecret-identifier: "registry-my-registry"
+  namespace: kube-system
 type: kubernetes.io/dockerconfigjson
 `
 )


### PR DESCRIPTION
The Kubernetes secret manifest  we generate makes it easy for users to pull private images into their DOKS cluster. Now that we have the dosecret-operator to make the secret available in all namespaces, generate operator friendly manifests for users to apply into their DOKS cluster. Applying the manifest generated here to a DOKS cluster is the same as doing:

```
doctl kubernetes cluster registry add
```

cc @adamwg , @timoreimann 