### PR TITLE
Fix integration test focus.

### DIFF
--- a/commands/apps.go
+++ b/commands/apps.go
@@ -429,7 +429,13 @@ func RunAppsGetLogs(c *CmdConfig) error {
 		}
 
 		token := url.Query().Get("token")
-		url.Scheme = "wss"
+		switch url.Scheme {
+		case "http":
+			url.Scheme = "ws"
+		default:
+			url.Scheme = "wss"
+		}
+
 		listener := c.Doit.Listen(url, token, schemaFunc, c.Out)
 		err = listener.Start()
 		if err != nil {

--- a/integration/database_firewall_remove_test.go
+++ b/integration/database_firewall_remove_test.go
@@ -47,7 +47,7 @@ func (ms *mockServer) Remove(t *testing.T, w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusNoContent)
 }
 
-var _ = suite.Focus("database/firewalls", func(t *testing.T, when spec.G, it spec.S) {
+var _ = suite("database/firewalls", func(t *testing.T, when spec.G, it spec.S) {
 	var (
 		expect *require.Assertions
 		server *httptest.Server

--- a/integration/database_firewall_update_test.go
+++ b/integration/database_firewall_update_test.go
@@ -32,6 +32,8 @@ var _ = suite("database/firewalls", func(t *testing.T, when spec.G, it spec.S) {
 				if req.Method == http.MethodPut {
 					reqBody, err := ioutil.ReadAll(req.Body)
 					expect.NoError(err)
+					t.Log(string(reqBody))
+					t.Log(databasesUpdateFirewallUpdateRequest)
 					expect.JSONEq(databasesUpdateFirewallUpdateRequest, string(reqBody))
 					w.Write([]byte(databasesUpdateFirewallRuleResponse))
 				} else if req.Method == http.MethodGet {
@@ -78,7 +80,7 @@ var _ = suite("database/firewalls", func(t *testing.T, when spec.G, it spec.S) {
 })
 
 const (
-	databasesUpdateFirewallUpdateRequest = `{"rules": [{"type": "ip_addr","value": "192.168.1.1"}]}`
+	databasesUpdateFirewallUpdateRequest = `{"rules":[{"uuid":"","cluster_uuid":"","type":"ip_addr","value":"192.168.1.1","created_at":"0001-01-01T00:00:00Z"}]}`
 	databasesUpdateFirewallRuleOutput    = `
 UUID                                    ClusterUUID                             Type       Value
 82ebbbd4-437c-4e11-bfd2-644ccb555de0    d168d635-1c88-4616-b9b4-793b7c573927    ip_addr    192.168.1.1`

--- a/integration/kubernetes_clusters_create_test.go
+++ b/integration/kubernetes_clusters_create_test.go
@@ -225,7 +225,7 @@ some-cluster-id    some-cluster-name    mars      some-kube-version    false    
   "region": "mars",
   "version": "some-kube-version",
   "auto_upgrade": false,
-  "surge_upgrade": false,
+  "surge_upgrade": true,
   "maintenance_policy": {
     "day": "any",
     "duration": "",
@@ -246,7 +246,7 @@ some-cluster-id    some-cluster-name    mars      some-kube-version    false    
   "region": "mars",
   "version": "some-kube-version",
   "auto_upgrade": false,
-  "surge_upgrade": false,
+  "surge_upgrade": true,
   "maintenance_policy": {
     "day": "any",
     "duration": "",


### PR DESCRIPTION
Reviewing https://github.com/digitalocean/doctl/pull/966, I realized that the integration tests were not running. They were inadvertently set to focus on one test, preventing the others from running:

https://github.com/digitalocean/doctl/blob/9b40e1a24c0b12a02c2fd971320d23e4ce3a2db1/integration/database_firewall_remove_test.go#L50

This PR fixes that and updates tests that should have seen changes.