### PR TITLE
feat: wait flag for apps create-deployment command

### DIFF
--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -226,6 +226,71 @@ func TestRunAppsCreateDeployment(t *testing.T) {
 	})
 }
 
+func TestRunAppsCreateDeploymentWithWait(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		appID := uuid.New().String()
+		deployment := &godo.Deployment{
+			ID:   uuid.New().String(),
+			Spec: &testAppSpec,
+			Services: []*godo.DeploymentService{{
+				Name:             "service",
+				SourceCommitHash: "commit",
+			}},
+			Cause: "Manual",
+			Phase: godo.DeploymentPhase_PendingDeploy,
+			Progress: &godo.DeploymentProgress{
+				PendingSteps: 1,
+				RunningSteps: 0,
+				SuccessSteps: 0,
+				ErrorSteps:   0,
+				TotalSteps:   1,
+
+				Steps: []*godo.DeploymentProgressStep{{
+					Name:      "name",
+					Status:    "pending",
+					StartedAt: time.Now(),
+				}},
+			},
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		activeDeployment := &godo.Deployment{
+			ID:   uuid.New().String(),
+			Spec: &testAppSpec,
+			Services: []*godo.DeploymentService{{
+				Name:             "service",
+				SourceCommitHash: "commit",
+			}},
+			Cause: "Manual",
+			Phase: godo.DeploymentPhase_Active,
+			Progress: &godo.DeploymentProgress{
+				PendingSteps: 1,
+				RunningSteps: 0,
+				SuccessSteps: 0,
+				ErrorSteps:   0,
+				TotalSteps:   1,
+
+				Steps: []*godo.DeploymentProgressStep{{
+					Name:      "name",
+					Status:    "pending",
+					StartedAt: time.Now(),
+				}},
+			},
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+
+		tm.apps.EXPECT().CreateDeployment(appID, false).Times(1).Return(deployment, nil)
+		tm.apps.EXPECT().GetDeployment(appID, deployment.ID).Times(1).Return(activeDeployment, nil)
+
+		config.Args = append(config.Args, appID)
+		config.Doit.Set(config.NS, doctl.ArgCommandWait, true)
+
+		err := RunAppsCreateDeployment(config)
+		require.NoError(t, err)
+	})
+}
+
 func TestRunAppsGetDeployment(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		appID := uuid.New().String()


### PR DESCRIPTION
In this pull request issue #964 is addressed:
- `--wait` flag was added to the `doctl apps create-deployment`
- defaults to `false`
- waits for deployment to enter `ACTIVE` phase
- on phases `ERROR`, `CANCELED` and `UNKNOWN` returns error