### PR TITLE
New Command - remove account from config file

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -77,7 +77,9 @@ func Auth() *Command {
 
 If you work with a just one account, you can call ` + "`" + `doctl auth init` + "`" + ` and supply the token when prompted. This creates an authentication context named ` + "`" + `default` + "`" + `.
 
-To switch between multiple DigitalOcean accounts, including team accounts, you can create named contexts by using ` + "`" + `doctl auth init --context <name>` + "`" + `, then providing a token when prompted. This saves the token under the name you provide. To switch between accounts, use ` + "`" + `doctl auth switch --context <name>` + "`" + `.`,
+To switch between multiple DigitalOcean accounts, including team accounts, you can create named contexts by using ` + "`" + `doctl auth init --context <name>` + "`" + `, then providing a token when prompted. This saves the token under the name you provide. To switch between accounts, use ` + "`" + `doctl auth switch --context <name>` + "`" + `.,
+
+To remove accounts from the configuration file, you can run ` + "`" + `doctl auth remove --context <name>` + "`" + `. This removes the token under the name you provide.`,
 		},
 	}
 
@@ -91,6 +93,11 @@ If the `+"`"+`--context`+"`"+` flag is not specified, a default authentication c
 
 If doctl is never initialized, you will need to specify an API token whenever you use a `+"`"+`doctl`+"`"+` command via the `+"`"+`--access-token`+"`"+` flag.`, Writer, false)
 	cmdBuilderWithInit(cmd, RunAuthSwitch, "switch", "Switches between authentication contexts", `This command allows you to switch between accounts with authentication contexts you've already created.
+
+To see a list of available authentication contexts, call `+"`"+`doctl auth list`+"`"+`.
+
+For details on creating an authentication context, see the help for `+"`"+`doctl auth init`+"`"+`.`, Writer, false)
+	cmdBuilderWithInit(cmd, RunAuthRemove, "remove", "Remove authentication contexts ", `This command allows you to remove authentication contexts you've already created.
 
 To see a list of available authentication contexts, call `+"`"+`doctl auth list`+"`"+`.
 
@@ -146,6 +153,25 @@ func RunAuthInit(retrieveUserTokenFunc func() (string, error)) func(c *CmdConfig
 
 		return writeConfig()
 	}
+}
+
+// RunAuthRemove remove available auth contexts from the user's doctl config.
+func RunAuthRemove(c *CmdConfig) error {
+	context := Context
+
+	if context == "" {
+		return fmt.Errorf("You must provide a context name")
+	}
+
+	err := c.removeContext(context)
+
+	if err != nil {
+		return fmt.Errorf("Context not found")
+	}
+
+	fmt.Println("Context deleted successfully")
+
+	return writeConfig()
 }
 
 // RunAuthList lists all available auth contexts from the user's doctl config.

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -30,7 +30,7 @@ import (
 func TestAuthCommand(t *testing.T) {
 	cmd := Auth()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "init", "list", "switch")
+	assertCommandNames(t, cmd, "init", "list", "remove", "switch")
 }
 
 func TestAuthInit(t *testing.T) {

--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -33,6 +33,7 @@ type CmdConfig struct {
 	initServices          func(*CmdConfig) error
 	getContextAccessToken func() string
 	setContextAccessToken func(string)
+	removeContext         func(string) error
 
 	// services
 	Keys              func() do.KeysService
@@ -151,6 +152,22 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 
 				viper.Set("auth-contexts", contexts)
 			}
+		},
+
+		removeContext: func(context string) error {
+			contexts := viper.GetStringMapString("auth-contexts")
+
+			_, ok := contexts[context]
+
+			if !ok {
+				return fmt.Errorf("Context not found")
+			}
+
+			delete(contexts, context)
+
+			viper.Set("auth-contexts", contexts)
+
+			return nil
 		},
 	}
 


### PR DESCRIPTION
Hello,

From the issue #965, I've created a command to remove an account from the list account:

Before:
![image](https://user-images.githubusercontent.com/15023064/116249567-55427c00-a743-11eb-801d-15b617050a07.png)

After:
![image](https://user-images.githubusercontent.com/15023064/116249852-976bbd80-a743-11eb-8f27-3e11e88ad358.png)

Feedbacks are welcome