### PR TITLE
Add integration test for new remove auth command

### DIFF
--- a/integration/auth_remove_context_test.go
+++ b/integration/auth_remove_context_test.go
@@ -68,7 +68,7 @@ context: default
 
 			fileBytes, err := ioutil.ReadFile(testConfig)
 			expect.NoError(err)
-			expect.NotContains(string(fileBytes), "context: second")
+			expect.NotContains(string(fileBytes), "second-token")
 		})
 	})
 })

--- a/integration/auth_remove_context_test.go
+++ b/integration/auth_remove_context_test.go
@@ -1,0 +1,74 @@
+// +build !windows
+
+package integration
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite("auth/remove", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect     *require.Assertions
+		tmpDir     string
+		testConfig string
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+
+		var err error
+		tmpDir, err = ioutil.TempDir("", "")
+		expect.NoError(err)
+
+		testConfig = filepath.Join(tmpDir, "test-config.yml")
+		var testConfigBytes = []byte(`access-token: first-token
+auth-contexts:
+  second: second-token
+context: default
+`)
+
+		expect.NoError(ioutil.WriteFile(testConfig, testConfigBytes, 0644))
+
+	})
+
+	when("a context is not provided", func() {
+		it("should error", func() {
+
+			cmd := exec.Command(builtBinaryPath,
+				"auth",
+				"remove",
+				"--config", testConfig,
+			)
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+
+			expect.Equal("Error: You must provide a context name\n", string(output[:]))
+		})
+	})
+
+	when("a valid context is provided", func() {
+		it("allows you to remove that context", func() {
+			removeContext := "second"
+
+			cmd := exec.Command(builtBinaryPath,
+				"auth",
+				"remove",
+				"--config", testConfig,
+				"--context",
+				removeContext,
+			)
+			_, err := cmd.CombinedOutput()
+			expect.NoError(err)
+
+			fileBytes, err := ioutil.ReadFile(testConfig)
+			expect.NoError(err)
+			expect.NotContains(string(fileBytes), "context: second")
+		})
+	})
+})


### PR DESCRIPTION
This adds integration tests for the new command added in #981

Edit: To run just this new test (locally), I used: 

`go test -v -mod=vendor ./integration/init_test.go ./integration/auth_remove_context_test.go`

Results:
```
=== RUN   TestRun
Suite: doctl
Total: 2 | Focused: 0 | Pending: 0
=== RUN   TestRun/doctl
=== RUN   TestRun/doctl/auth/remove/a_context_is_not_provided/should_error
=== PAUSE TestRun/doctl/auth/remove/a_context_is_not_provided/should_error
=== RUN   TestRun/doctl/auth/remove/a_valid_context_is_provided/allows_you_to_remove_that_context
=== PAUSE TestRun/doctl/auth/remove/a_valid_context_is_provided/allows_you_to_remove_that_context
=== CONT  TestRun/doctl/auth/remove/a_context_is_not_provided/should_error
=== CONT  TestRun/doctl/auth/remove/a_valid_context_is_provided/allows_you_to_remove_that_context

Passed: 2 | Failed: 0 | Skipped: 0

--- PASS: TestRun (1.18s)
    --- PASS: TestRun/doctl (0.00s)
        --- PASS: TestRun/doctl/auth/remove/a_context_is_not_provided/should_error (0.58s)
        --- PASS: TestRun/doctl/auth/remove/a_valid_context_is_provided/allows_you_to_remove_that_context (1.18s)
PASS
ok  	command-line-arguments	4.457s
```