### PR TITLE
Add support for DOKS as Firewalls peers

### DIFF
--- a/commands/firewalls.go
+++ b/commands/firewalls.go
@@ -445,7 +445,7 @@ func extractOutboundRules(s string) (rules []godo.OutboundRule, err error) {
 func extractRule(ruleStr string, sd string) (map[string]interface{}, error) {
 	rule := map[string]interface{}{}
 	var dropletIDs []int
-	var addresses, lbUIDs, tags []string
+	var addresses, lbUIDs, k8sIDs, tags []string
 
 	kvs := strings.Split(ruleStr, ",")
 	for _, v := range kvs {
@@ -465,6 +465,8 @@ func extractRule(ruleStr string, sd string) (map[string]interface{}, error) {
 			dropletIDs = append(dropletIDs, i)
 		case "load_balancer_uid":
 			lbUIDs = append(lbUIDs, pair[1])
+		case "kubernetes_id":
+			k8sIDs = append(k8sIDs, pair[1])
 		case "tag":
 			tags = append(tags, pair[1])
 		default:
@@ -476,6 +478,7 @@ func extractRule(ruleStr string, sd string) (map[string]interface{}, error) {
 		"addresses":          addresses,
 		"droplet_ids":        dropletIDs,
 		"load_balancer_uids": lbUIDs,
+		"kubernetes_ids":     k8sIDs,
 		"tags":               tags,
 	}
 

--- a/commands/firewalls_test.go
+++ b/commands/firewalls_test.go
@@ -94,6 +94,7 @@ func TestFirewallUpdate(t *testing.T) {
 					PortRange: "8080",
 					Destinations: &godo.Destinations{
 						LoadBalancerUIDs: []string{"lb-uuid"},
+						KubernetesIDs:    []string{"doks-01"},
 						Tags:             []string{"new-droplets"},
 					},
 				},
@@ -113,7 +114,7 @@ func TestFirewallUpdate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgFirewallName, "firewall")
 		config.Doit.Set(config.NS, doctl.ArgDropletIDs, []string{"1"})
 		config.Doit.Set(config.NS, doctl.ArgInboundRules, "protocol:tcp,ports:8000-9000,address:127.0.0.0")
-		config.Doit.Set(config.NS, doctl.ArgOutboundRules, "protocol:tcp,ports:8080,load_balancer_uid:lb-uuid,tag:new-droplets protocol:tcp,ports:80,address:192.168.0.0")
+		config.Doit.Set(config.NS, doctl.ArgOutboundRules, "protocol:tcp,ports:8080,load_balancer_uid:lb-uuid,kubernetes_id:doks-01,tag:new-droplets protocol:tcp,ports:80,address:192.168.0.0")
 
 		err := RunFirewallUpdate(config)
 		assert.NoError(t, err)
@@ -224,8 +225,9 @@ func TestFirewallAddRules(t *testing.T) {
 				Protocol:  "tcp",
 				PortRange: "8080",
 				Sources: &godo.Sources{
-					Tags:       []string{"backend"},
-					DropletIDs: []int{1, 2, 3},
+					Tags:          []string{"backend"},
+					DropletIDs:    []int{1, 2, 3},
+					KubernetesIDs: []string{"doks-01"},
 				},
 			},
 		}
@@ -235,6 +237,7 @@ func TestFirewallAddRules(t *testing.T) {
 				PortRange: "22",
 				Destinations: &godo.Destinations{
 					LoadBalancerUIDs: []string{"lb-uuid"},
+					KubernetesIDs:    []string{"doks-02"},
 				},
 			},
 		}
@@ -246,8 +249,8 @@ func TestFirewallAddRules(t *testing.T) {
 		tm.firewalls.EXPECT().AddRules(fID, firewallRulesRequest).Return(nil)
 
 		config.Args = append(config.Args, fID)
-		config.Doit.Set(config.NS, doctl.ArgInboundRules, "protocol:tcp,ports:80,address:127.0.0.0,address:0.0.0.0/0,address:2604:A880:0002:00D0:0000:0000:32F1:E001 protocol:tcp,ports:8080,tag:backend,droplet_id:1,droplet_id:2,droplet_id:3")
-		config.Doit.Set(config.NS, doctl.ArgOutboundRules, "protocol:tcp,ports:22,load_balancer_uid:lb-uuid")
+		config.Doit.Set(config.NS, doctl.ArgInboundRules, "protocol:tcp,ports:80,address:127.0.0.0,address:0.0.0.0/0,address:2604:A880:0002:00D0:0000:0000:32F1:E001 protocol:tcp,ports:8080,tag:backend,droplet_id:1,droplet_id:2,droplet_id:3,kubernetes_id:doks-01")
+		config.Doit.Set(config.NS, doctl.ArgOutboundRules, "protocol:tcp,ports:22,load_balancer_uid:lb-uuid,kubernetes_id:doks-02")
 
 		err := RunFirewallAddRules(config)
 		assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.11
-	github.com/digitalocean/godo v1.60.0
+	github.com/digitalocean/godo v1.61.0
 	github.com/docker/cli v0.0.0-20200622130859-87db43814b48
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.60.0 h1:o/vimtn/HKtYSakFAAZ59Zc5ASORd41S4z1X7pAXPn8=
-github.com/digitalocean/godo v1.60.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
+github.com/digitalocean/godo v1.61.0 h1:PChvUn5+Ajwvl7caOJoFbcM9r+y91ssQbM0W0k3pnZU=
+github.com/digitalocean/godo v1.61.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48 h1:AC8qbhi/SjYf4iN2W3jSsofZGHWPjG8pjf5P143KUM8=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible h1:PmGHHCZ43l6h8aZIi+Xa+z1SWe4dFImd5EK3TNp1jlo=
@@ -186,7 +186,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -241,11 +240,9 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
@@ -564,7 +561,6 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -648,7 +644,6 @@ gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -665,9 +660,7 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
-gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/integration/floating_ip_create_test.go
+++ b/integration/floating_ip_create_test.go
@@ -109,7 +109,7 @@ IP             Region    Droplet ID    Droplet Name
 }
 `
 	floatingIPCreateRequest = `
-{"region":"","droplet_id":1212}
+{"droplet_id":1212}
 `
 	floatingIPRegionCreateRequest = `
 {"region":"newark"}

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [v1.61.0] - 2021-05-12
+
+- #452 - @caiofilipini - Add support for DOKS clusters as peers in Firewall rules
+- #448 - @andrewsomething - flip: Set omitempty for Region in FloatingIPCreateRequest.
+- #451 - @andrewsomething - CheckResponse: Add RequestID from header to ErrorResponse when missing from body.
+- #450 - @nanzhong - dbaas: handle ca certificates as base64 encoded
+- #449 - @nanzhong - dbaas: add support for getting cluster CA
+- #446 - @kamaln7 - app spec: update cors policy
+
 ## [v1.60.0] - 2021-04-04
 
 - #443 - @andrewsomething - apps: Support pagination.

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -12,6 +12,7 @@ type App struct {
 	ID                      string       `json:"id,omitempty"`
 	OwnerUUID               string       `json:"owner_uuid,omitempty"`
 	Spec                    *AppSpec     `json:"spec"`
+	LastDeploymentActiveAt  time.Time    `json:"last_deployment_active_at,omitempty"`
 	DefaultIngress          string       `json:"default_ingress,omitempty"`
 	CreatedAt               time.Time    `json:"created_at,omitempty"`
 	UpdatedAt               time.Time    `json:"updated_at,omitempty"`
@@ -257,8 +258,18 @@ type AppWorkerSpec struct {
 
 // AppCORSPolicy struct for AppCORSPolicy
 type AppCORSPolicy struct {
-	// The set of allowed CORS origins.
+	// The set of allowed CORS origins. This configures the Access-Control-Allow-Origin header.
 	AllowOrigins []*AppStringMatch `json:"allow_origins,omitempty"`
+	// The set of allowed HTTP methods. This configures the Access-Control-Allow-Methods header.
+	AllowMethods []string `json:"allow_methods,omitempty"`
+	// The set of allowed HTTP request headers. This configures the Access-Control-Allow-Headers header.
+	AllowHeaders []string `json:"allow_headers,omitempty"`
+	// The set of HTTP response headers that browsers are allowed to access. This configures the Access-Control-Expose-Headers  header.
+	ExposeHeaders []string `json:"expose_headers,omitempty"`
+	// An optional duration specifiying how long browsers can cache the results of a preflight request. This configures the Access-Control-Max-Age header. Example: `5h30m`.
+	MaxAge string `json:"max_age,omitempty"`
+	// Whether browsers should expose the response to the client-side JavaScript code when the request's credentials mode is `include`. This configures the Access-Control-Allow-Credentials header.
+	AllowCredentials bool `json:"allow_credentials,omitempty"`
 }
 
 // Deployment struct for Deployment
@@ -437,7 +448,7 @@ type GitSourceSpec struct {
 // ImageSourceSpec struct for ImageSourceSpec
 type ImageSourceSpec struct {
 	RegistryType ImageSourceSpecRegistryType `json:"registry_type,omitempty"`
-	// The registry name. Must be left empty for the `DOCR` registry type. Required for the `DOCKER_HUB` registry type.
+	// The registry name. Must be left empty for the `DOCR` registry type.  Required for the `DOCKER_HUB` registry type.
 	Registry string `json:"registry,omitempty"`
 	// The repository name.
 	Repository string `json:"repository,omitempty"`
@@ -482,7 +493,7 @@ const (
 // AppProposeRequest struct for AppProposeRequest
 type AppProposeRequest struct {
 	Spec *AppSpec `json:"spec"`
-	// An optional ID of an existing app. If set, the proposed spec will be treated as an update against the specified app.
+	// An optional ID of an existing app. If set, the spec will be treated as a proposed update to the specified app. The existing app is not modified using this method.
 	AppID string `json:"app_id,omitempty"`
 }
 
@@ -495,11 +506,13 @@ type AppProposeResponse struct {
 	// The number of existing static apps the account has.
 	ExistingStaticApps string `json:"existing_static_apps,omitempty"`
 	// The maximum number of free static apps the account can have. Any additional static apps will be charged for.
-	MaxFreeStaticApps    string   `json:"max_free_static_apps,omitempty"`
-	Spec                 *AppSpec `json:"spec,omitempty"`
-	AppCost              float32  `json:"app_cost,omitempty"`
-	AppTierUpgradeCost   float32  `json:"app_tier_upgrade_cost,omitempty"`
-	AppTierDowngradeCost float32  `json:"app_tier_downgrade_cost,omitempty"`
+	MaxFreeStaticApps string   `json:"max_free_static_apps,omitempty"`
+	Spec              *AppSpec `json:"spec,omitempty"`
+	AppCost           float32  `json:"app_cost,omitempty"`
+	// The monthly cost of the proposed app in USD using the next pricing plan tier. For example, if you propose an app that uses the Basic tier, the `app_tier_upgrade_cost` field displays the monthly cost of the app if it were to use the Professional tier. If the proposed app already uses the most expensive tier, the field is empty.
+	AppTierUpgradeCost float32 `json:"app_tier_upgrade_cost,omitempty"`
+	// The monthly cost of the proposed app in USD using the previous pricing plan tier. For example, if you propose an app that uses the Professional tier, the `app_tier_downgrade_cost` field displays the monthly cost of the app if it were to use the Basic tier. If the proposed app already uses the lest expensive tier, the field is empty.
+	AppTierDowngradeCost float32 `json:"app_tier_downgrade_cost,omitempty"`
 }
 
 // AppRegion struct for AppRegion

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -11,6 +11,7 @@ import (
 const (
 	databaseBasePath           = "/v2/databases"
 	databaseSinglePath         = databaseBasePath + "/%s"
+	databaseCAPath             = databaseBasePath + "/%s/ca"
 	databaseResizePath         = databaseBasePath + "/%s/resize"
 	databaseMigratePath        = databaseBasePath + "/%s/migrate"
 	databaseMaintenancePath    = databaseBasePath + "/%s/maintenance"
@@ -91,6 +92,7 @@ const (
 type DatabasesService interface {
 	List(context.Context, *ListOptions) ([]Database, *Response, error)
 	Get(context.Context, string) (*Database, *Response, error)
+	GetCA(context.Context, string) (*DatabaseCA, *Response, error)
 	Create(context.Context, *DatabaseCreateRequest) (*Database, *Response, error)
 	Delete(context.Context, string) (*Response, error)
 	Resize(context.Context, string, *DatabaseResizeRequest) (*Response, error)
@@ -152,6 +154,11 @@ type Database struct {
 	CreatedAt          time.Time                  `json:"created_at,omitempty"`
 	PrivateNetworkUUID string                     `json:"private_network_uuid,omitempty"`
 	Tags               []string                   `json:"tags,omitempty"`
+}
+
+// DatabaseCA represents a database ca.
+type DatabaseCA struct {
+	Certificate []byte `json:"certificate"`
 }
 
 // DatabaseConnection represents a database connection
@@ -333,6 +340,10 @@ type databaseRoot struct {
 	Database *Database `json:"database"`
 }
 
+type databaseCARoot struct {
+	CA *DatabaseCA `json:"ca"`
+}
+
 type databaseBackupsRoot struct {
 	Backups []DatabaseBackup `json:"backups"`
 }
@@ -402,6 +413,21 @@ func (svc *DatabasesServiceOp) Get(ctx context.Context, databaseID string) (*Dat
 		return nil, resp, err
 	}
 	return root.Database, resp, nil
+}
+
+// GetCA retrieves the CA of a database cluster.
+func (svc *DatabasesServiceOp) GetCA(ctx context.Context, databaseID string) (*DatabaseCA, *Response, error) {
+	path := fmt.Sprintf(databaseCAPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databaseCARoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.CA, resp, nil
 }
 
 // Create creates a database cluster

--- a/vendor/github.com/digitalocean/godo/firewalls.go
+++ b/vendor/github.com/digitalocean/godo/firewalls.go
@@ -89,6 +89,7 @@ type Sources struct {
 	Tags             []string `json:"tags,omitempty"`
 	DropletIDs       []int    `json:"droplet_ids,omitempty"`
 	LoadBalancerUIDs []string `json:"load_balancer_uids,omitempty"`
+	KubernetesIDs    []string `json:"kubernetes_ids,omitempty"`
 }
 
 // PendingChange represents a DigitalOcean Firewall status details.
@@ -104,6 +105,7 @@ type Destinations struct {
 	Tags             []string `json:"tags,omitempty"`
 	DropletIDs       []int    `json:"droplet_ids,omitempty"`
 	LoadBalancerUIDs []string `json:"load_balancer_uids,omitempty"`
+	KubernetesIDs    []string `json:"kubernetes_ids,omitempty"`
 }
 
 var _ FirewallsService = &FirewallsServiceOp{}

--- a/vendor/github.com/digitalocean/godo/floating_ips.go
+++ b/vendor/github.com/digitalocean/godo/floating_ips.go
@@ -54,10 +54,10 @@ type floatingIPRoot struct {
 }
 
 // FloatingIPCreateRequest represents a request to create a floating IP.
-// If DropletID is not empty, the floating IP will be assigned to the
-// droplet.
+// Specify DropletID to assign the floating IP to a Droplet or Region
+// to reserve it to the region.
 type FloatingIPCreateRequest struct {
-	Region    string `json:"region"`
+	Region    string `json:"region,omitempty"`
 	DropletID int    `json:"droplet_id,omitempty"`
 }
 

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.60.0"
+	libraryVersion = "1.61.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -433,6 +433,7 @@ func (r *ErrorResponse) Error() string {
 // CheckResponse checks the API response for errors, and returns them if present. A response is considered an
 // error if it has a status code outside the 200 range. API error responses are expected to have either no response
 // body, or a JSON response body that maps to ErrorResponse. Any other response body will be silently ignored.
+// If the API error response does not include the request ID in its body, the one from its header will be used.
 func CheckResponse(r *http.Response) error {
 	if c := r.StatusCode; c >= 200 && c <= 299 {
 		return nil
@@ -445,6 +446,10 @@ func CheckResponse(r *http.Response) error {
 		if err != nil {
 			errorResponse.Message = string(data)
 		}
+	}
+
+	if errorResponse.RequestID == "" {
+		errorResponse.RequestID = r.Header.Get("x-request-id")
 	}
 
 	return errorResponse

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.60.0
+# github.com/digitalocean/godo v1.61.0
 ## explicit
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util


### PR DESCRIPTION
This PR updates `godo` to `v1.61.0` to be able to add support for DOKS clusters as peers in Cloud Firewalls rules.