### PR TITLE
Allow node-pool args to be empty

### DIFF
--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1720,7 +1720,8 @@ func parseNodePoolString(nodePool, defaultName, defaultSize string, defaultCount
 		Labels: map[string]string{},
 		Taints: []godo.Taint{},
 	}
-	for _, arg := range strings.Split(nodePool, argSeparator) {
+	trimmedPool := strings.TrimSuffix(nodePool, argSeparator)
+	for _, arg := range strings.Split(trimmedPool, argSeparator) {
 		if arg == "" {
 			continue
 		}

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1722,9 +1722,6 @@ func parseNodePoolString(nodePool, defaultName, defaultSize string, defaultCount
 	}
 	trimmedPool := strings.TrimSuffix(nodePool, argSeparator)
 	for _, arg := range strings.Split(trimmedPool, argSeparator) {
-		if arg == "" {
-			continue
-		}
 		kvs := strings.SplitN(arg, kvSeparator, 2)
 		if len(kvs) < 2 {
 			return nil, fmt.Errorf("A node pool string argument must be of the form `key=value`. Provided KVs: %v", kvs)

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1721,6 +1721,9 @@ func parseNodePoolString(nodePool, defaultName, defaultSize string, defaultCount
 		Taints: []godo.Taint{},
 	}
 	for _, arg := range strings.Split(nodePool, argSeparator) {
+		if arg == "" {
+			continue
+		}
 		kvs := strings.SplitN(arg, kvSeparator, 2)
 		if len(kvs) < 2 {
 			return nil, fmt.Errorf("A node pool string argument must be of the form `key=value`. Provided KVs: %v", kvs)


### PR DESCRIPTION
This PR adds the capability of ignoring empty node-pool arguments. Some background to motivate this:

The documentation doesn't mention that the --num-nodes string should not terminate with a `;` character. Therefore, when trying to use an argument like `--num-nodes:"name=pool-name;count=3;"` the command fails with an error, because the trailing `;` character results in an empty arg. 