### PR TITLE
adding the --wait flag to the apps create command

### DIFF
--- a/commands/apps.go
+++ b/commands/apps.go
@@ -374,7 +374,7 @@ func RunAppsCreateDeployment(c *CmdConfig) error {
 }
 
 func waitForActiveDeployment(apps do.AppsService, appID string, deploymentID string) error {
-	const maxAttempts = 10 * 6 * 30
+	const maxAttempts = 1800
 	attempts := 0
 	printNewLineSet := false
 

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -374,7 +374,7 @@ func RunAppsCreateDeployment(c *CmdConfig) error {
 }
 
 func waitForActiveDeployment(apps do.AppsService, appID string, deploymentID string) error {
-	const maxAttempts = 1800
+	const maxAttempts = 180
 	attempts := 0
 	printNewLineSet := false
 

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -267,7 +267,7 @@ func TestRunAppsCreateDeploymentWithWait(t *testing.T) {
 			Progress: &godo.DeploymentProgress{
 				PendingSteps: 1,
 				RunningSteps: 0,
-				SuccessSteps: 0,
+				SuccessSteps: 1,
 				ErrorSteps:   0,
 				TotalSteps:   1,
 
@@ -282,7 +282,7 @@ func TestRunAppsCreateDeploymentWithWait(t *testing.T) {
 		}
 
 		tm.apps.EXPECT().CreateDeployment(appID, false).Times(1).Return(deployment, nil)
-		tm.apps.EXPECT().GetDeployment(appID, deployment.ID).Times(1).Return(activeDeployment, nil)
+		tm.apps.EXPECT().GetDeployment(appID, deployment.ID).Times(2).Return(activeDeployment, nil)
 
 		config.Args = append(config.Args, appID)
 		config.Doit.Set(config.NS, doctl.ArgCommandWait, true)

--- a/integration/apps_test.go
+++ b/integration/apps_test.go
@@ -93,10 +93,22 @@ var (
 		CreatedAt:        testAppTime,
 		UpdatedAt:        testAppTime,
 	}
+	testAppInProgress = &godo.App{
+		ID:                   testAppUUID,
+		Spec:                 &testAppSpec,
+		InProgressDeployment: testDeployment,
+		CreatedAt:            testAppTime,
+		UpdatedAt:            testAppTime,
+	}
 	testAppResponse = struct {
 		App *godo.App `json:"app"`
 	}{
 		App: testApp,
+	}
+	testAppResponseInProgress = struct {
+		App *godo.App `json:"app"`
+	}{
+		App: testAppInProgress,
 	}
 	testAppsResponse = struct {
 		Apps []*godo.App `json:"apps"`
@@ -142,8 +154,10 @@ ams       Amsterdam    Europe       [ams3]          false                       
 
 var _ = suite("apps/create", func(t *testing.T, when spec.G, it spec.S) {
 	var (
-		expect *require.Assertions
-		server *httptest.Server
+		expect          *require.Assertions
+		server          *httptest.Server
+		deploymentCount int
+		getCounter      int
 	)
 
 	it.Before(func() {
@@ -174,6 +188,38 @@ var _ = suite("apps/create", func(t *testing.T, when spec.G, it spec.S) {
 				assert.Equal(t, testAppSpec, *r.Spec)
 
 				json.NewEncoder(w).Encode(testAppResponse)
+			case "/v2/apps/" + testAppUUID:
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				if req.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				if getCounter > 0 {
+					json.NewEncoder(w).Encode(testAppResponse)
+				} else {
+					json.NewEncoder(w).Encode(testAppResponseInProgress)
+					getCounter++
+				}
+			case "/v2/apps/" + testAppUUID + "/deployments/" + testDeploymentUUID:
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				if req.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				if deploymentCount > 0 {
+					json.NewEncoder(w).Encode(testDeploymentActiveResponse)
+				} else {
+					json.NewEncoder(w).Encode(testDeploymentResponse)
+					deploymentCount++
+				}
 			default:
 				dump, err := httputil.DumpRequest(req, true)
 				if err != nil {
@@ -210,6 +256,31 @@ var _ = suite("apps/create", func(t *testing.T, when spec.G, it spec.S) {
 
 		expectedOutput := "Notice: App created\n" + testAppsOutput
 		expect.Equal(expectedOutput, strings.TrimSpace(string(output)))
+	})
+	when("the wait flag is passed", func() {
+		it("creates an app and polls for status", func() {
+			specFile, err := ioutil.TempFile("", "spec")
+			require.NoError(t, err)
+			defer func() {
+				os.Remove(specFile.Name())
+				specFile.Close()
+			}()
+			err = json.NewEncoder(specFile).Encode(&testAppSpec)
+			require.NoError(t, err)
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"apps",
+				"create",
+				"--spec",
+				specFile.Name(),
+				"--wait",
+			)
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err)
+			expectedOutput := "Notice: App creation is in progress, waiting for app to be running\n..\nNotice: App created\n" + testAppsOutput
+			expect.Equal(expectedOutput, strings.TrimSpace(string(output)))
+		})
 	})
 })
 
@@ -322,8 +393,10 @@ var _ = suite("apps/list", func(t *testing.T, when spec.G, it spec.S) {
 
 var _ = suite("apps/update", func(t *testing.T, when spec.G, it spec.S) {
 	var (
-		expect *require.Assertions
-		server *httptest.Server
+		expect          *require.Assertions
+		server          *httptest.Server
+		getAppCounter   int
+		deploymentCount int
 	)
 
 	it.Before(func() {
@@ -339,21 +412,44 @@ var _ = suite("apps/update", func(t *testing.T, when spec.G, it spec.S) {
 					w.WriteHeader(http.StatusUnauthorized)
 					return
 				}
-
-				if req.Method != http.MethodPut {
+				if req.Method != http.MethodPut && req.Method != http.MethodGet {
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
 				}
-
-				var r godo.AppUpdateRequest
-				err := json.NewDecoder(req.Body).Decode(&r)
-				if err != nil {
-					w.WriteHeader(http.StatusBadRequest)
+				if req.Method == http.MethodPut {
+					var r godo.AppUpdateRequest
+					err := json.NewDecoder(req.Body).Decode(&r)
+					if err != nil {
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+					assert.Equal(t, testAppSpec, *r.Spec)
+					json.NewEncoder(w).Encode(testAppResponse)
+				}
+				if req.Method == http.MethodGet {
+					if getAppCounter > 0 {
+						json.NewEncoder(w).Encode(testAppResponse)
+					} else {
+						json.NewEncoder(w).Encode(testAppResponseInProgress)
+						getAppCounter++
+					}
+				}
+			case "/v2/apps/" + testAppUUID + "/deployments/" + testDeploymentUUID:
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
 					return
 				}
-				assert.Equal(t, testAppSpec, *r.Spec)
-
-				json.NewEncoder(w).Encode(testAppResponse)
+				if req.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				if deploymentCount > 0 {
+					json.NewEncoder(w).Encode(testDeploymentActiveResponse)
+				} else {
+					json.NewEncoder(w).Encode(testDeploymentResponse)
+					deploymentCount++
+				}
 			default:
 				dump, err := httputil.DumpRequest(req, true)
 				if err != nil {
@@ -391,6 +487,32 @@ var _ = suite("apps/update", func(t *testing.T, when spec.G, it spec.S) {
 
 		expectedOutput := "Notice: App updated\n" + testAppsOutput
 		expect.Equal(expectedOutput, strings.TrimSpace(string(output)))
+	})
+	when("the wait flag is passed", func() {
+		it("updates an app and polls for status", func() {
+			specFile, err := ioutil.TempFile("", "spec")
+			require.NoError(t, err)
+			defer func() {
+				os.Remove(specFile.Name())
+				specFile.Close()
+			}()
+			err = json.NewEncoder(specFile).Encode(&testAppSpec)
+			require.NoError(t, err)
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"apps",
+				"update",
+				testAppUUID,
+				"--spec",
+				specFile.Name(),
+				"--wait",
+			)
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err)
+			expectedOutput := "Notice: App update is in progress, waiting for app to be running\n..\nNotice: App updated\n" + testAppsOutput
+			expect.Equal(expectedOutput, strings.TrimSpace(string(output)))
+		})
 	})
 })
 


### PR DESCRIPTION
(reopened PR to disregard 400+ vendor files committed)

per github issue #970 - adding a wait flag for doctl apps create command. The integration test is taking 30 seconds to complete. This causes a timeout error- if timeout is removed it works. Looking for a second pair of eyes to help determine why the test takes so long.

applies changes suggested from previous pr such as:
- replaced ticker with for loop (thanks @bentranter)
- clearer error messages