### PR TITLE
Fix auth key mangling when switching contexts

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -217,6 +217,13 @@ func RunAuthSwitch(c *CmdConfig) error {
 		context = viper.GetString("context")
 	}
 
+	// The two lines below aren't required for doctl specific functionality,
+	// but somehow magically fixes an issue
+	// (https://github.com/digitalocean/doctl/issues/996) where auth-contexts
+	// are mangled when running this command.
+	contexts := viper.GetStringMapString("auth-contexts")
+	viper.Set("auth-contexts", contexts)
+
 	viper.Set("context", context)
 
 	fmt.Printf("Now using context [%s] by default\n", context)

--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -213,6 +213,37 @@ context: default
 		})
 	})
 
+	when("switching contexts containing a period", func() {
+		it("does not mangle that context", func() {
+			var testConfigBytes = []byte(`access-token: first-token
+auth-contexts:
+  test@example.com: second-token
+context: default
+`)
+
+			tmpDir, err := ioutil.TempDir("", "")
+			expect.NoError(err)
+			testConfig := filepath.Join(tmpDir, "test-config.yml")
+			expect.NoError(ioutil.WriteFile(testConfig, testConfigBytes, 0644))
+
+			cmd := exec.Command(builtBinaryPath,
+				"-u", server.URL,
+				"auth",
+				"switch",
+				"--config", testConfig,
+			)
+			_, err = cmd.CombinedOutput()
+			expect.NoError(err)
+
+			fileBytes, err := ioutil.ReadFile(testConfig)
+			expect.NoError(err)
+			expect.Contains(string(fileBytes), "test@example.com: second-token")
+
+			err = os.Remove(testConfig)
+			expect.NoError(err)
+		})
+	})
+
 	when("the DIGITALOCEAN_CONTEXT variable is set", func() {
 		it("uses that context for commands", func() {
 			var testConfigBytes = []byte(`access-token: first-token


### PR DESCRIPTION
"Fixes" a bizarre issue where running `doctl auth switch` mangles all auth contexts that contain a `.` character.

Prior to this change, when the command was run, it appears that Viper decides that anything containing a `.` indicates that the value should be split at the `.`, and then anything after it should become the key of a nested entry in a map in the config YAML file.

I have no idea why this fix works, but it does. I'm still looking into the root cause, but I figure that we might as well get this change out.