### PR TITLE
goreleaser: Release stable source tarball (fixes: #1001).

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,10 @@ archives:
   files: [a-workaround-to-include-only-the-binary*]
   wrap_in_directory: false
 
+source:
+  enabled: true
+  name_template: 'doctl-{{ .Version }}-source'
+
 checksum:
   name_template: "doctl-{{ .Version }}-checksums.sha256"
 


### PR DESCRIPTION
When GitHub generates source tarballs on the fly, there is no guarantee of byte-for-byte equivalence. This can cause issues for distribution packagers and others that wish to verify their downloads. 

This can be tested locally using: `goreleaser --snapshot ` The resulting `dist/` directory should include a tarball with the project source and the resulting SHA256 file should have the checksum of that file.