### PR TITLE
apps: Add --tail flag to support tailing live application logs

### DIFF
--- a/args.go
+++ b/args.go
@@ -44,6 +44,8 @@ const (
 	ArgAppDeployment = "deployment"
 	// ArgAppLogFollow follow logs.
 	ArgAppLogFollow = "follow"
+	// ArgAppLogTail tail logs.
+	ArgAppLogTail = "tail"
 	// ArgAppForceRebuild forces a deployment rebuild
 	ArgAppForceRebuild = "force-rebuild"
 	// ArgClusterName is a cluster name argument.

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -170,6 +170,7 @@ Three types of logs are supported and can be configured with --`+doctl.ArgAppLog
 	AddStringFlag(logs, doctl.ArgAppDeployment, "", "", "The deployment ID. Defaults to current deployment.")
 	AddStringFlag(logs, doctl.ArgAppLogType, "", strings.ToLower(string(godo.AppLogTypeRun)), "The type of logs.")
 	AddBoolFlag(logs, doctl.ArgAppLogFollow, "f", false, "Follow logs as they are emitted.")
+	AddIntFlag(logs, doctl.ArgAppLogTail, "", -1, "Number of lines to show from the end of the log.")
 
 	CmdBuilder(
 		cmd,
@@ -496,8 +497,12 @@ func RunAppsGetLogs(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
+	logTail, err := c.Doit.GetInt(c.NS, doctl.ArgAppLogTail)
+	if err != nil {
+		return err
+	}
 
-	logs, err := c.Apps().GetLogs(appID, deploymentID, component, logType, logFollow)
+	logs, err := c.Apps().GetLogs(appID, deploymentID, component, logType, logFollow, logTail)
 	if err != nil {
 		return err
 	}

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -379,7 +379,7 @@ func TestRunAppsGetLogs(t *testing.T) {
 
 	for typeStr, logType := range types {
 		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-			tm.apps.EXPECT().GetLogs(appID, deploymentID, component, logType, true).Times(1).Return(&godo.AppLogs{LiveURL: "https://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=aa-bb-11-cc-33"}, nil)
+			tm.apps.EXPECT().GetLogs(appID, deploymentID, component, logType, true, 1).Times(1).Return(&godo.AppLogs{LiveURL: "https://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=aa-bb-11-cc-33"}, nil)
 			tm.listen.EXPECT().Start().Times(1).Return(nil)
 
 			tc := config.Doit.(*doctl.TestConfig)
@@ -393,6 +393,7 @@ func TestRunAppsGetLogs(t *testing.T) {
 			config.Doit.Set(config.NS, doctl.ArgAppDeployment, deploymentID)
 			config.Doit.Set(config.NS, doctl.ArgAppLogType, typeStr)
 			config.Doit.Set(config.NS, doctl.ArgAppLogFollow, true)
+			config.Doit.Set(config.NS, doctl.ArgAppLogTail, 1)
 
 			err := RunAppsGetLogs(config)
 			require.NoError(t, err)

--- a/do/apps.go
+++ b/do/apps.go
@@ -32,7 +32,7 @@ type AppsService interface {
 	GetDeployment(appID, deploymentID string) (*godo.Deployment, error)
 	ListDeployments(appID string) ([]*godo.Deployment, error)
 
-	GetLogs(appID, deploymentID, component string, logType godo.AppLogType, follow bool) (*godo.AppLogs, error)
+	GetLogs(appID, deploymentID, component string, logType godo.AppLogType, follow bool, tail int) (*godo.AppLogs, error)
 
 	ListRegions() ([]*godo.AppRegion, error)
 
@@ -171,8 +171,8 @@ func (s *appsService) ListDeployments(appID string) ([]*godo.Deployment, error) 
 	return list, nil
 }
 
-func (s *appsService) GetLogs(appID, deploymentID, component string, logType godo.AppLogType, follow bool) (*godo.AppLogs, error) {
-	logs, _, err := s.client.Apps.GetLogs(s.ctx, appID, deploymentID, component, logType, follow)
+func (s *appsService) GetLogs(appID, deploymentID, component string, logType godo.AppLogType, follow bool, tail int) (*godo.AppLogs, error) {
+	logs, _, err := s.client.Apps.GetLogs(s.ctx, appID, deploymentID, component, logType, follow, tail)
 	if err != nil {
 		return nil, err
 	}

--- a/do/mocks/AppsService.go
+++ b/do/mocks/AppsService.go
@@ -49,49 +49,19 @@ func (mr *MockAppsServiceMockRecorder) Create(req interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockAppsService)(nil).Create), req)
 }
 
-// Get mocks base method.
-func (m *MockAppsService) Get(appID string) (*godo.App, error) {
+// CreateDeployment mocks base method.
+func (m *MockAppsService) CreateDeployment(appID string, forceRebuild bool) (*godo.Deployment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", appID)
-	ret0, _ := ret[0].(*godo.App)
+	ret := m.ctrl.Call(m, "CreateDeployment", appID, forceRebuild)
+	ret0, _ := ret[0].(*godo.Deployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get.
-func (mr *MockAppsServiceMockRecorder) Get(appID interface{}) *gomock.Call {
+// CreateDeployment indicates an expected call of CreateDeployment.
+func (mr *MockAppsServiceMockRecorder) CreateDeployment(appID, forceRebuild interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockAppsService)(nil).Get), appID)
-}
-
-// List mocks base method.
-func (m *MockAppsService) List() ([]*godo.App, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List")
-	ret0, _ := ret[0].([]*godo.App)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// List indicates an expected call of List.
-func (mr *MockAppsServiceMockRecorder) List() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockAppsService)(nil).List))
-}
-
-// Update mocks base method.
-func (m *MockAppsService) Update(appID string, req *godo.AppUpdateRequest) (*godo.App, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", appID, req)
-	ret0, _ := ret[0].(*godo.App)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Update indicates an expected call of Update.
-func (mr *MockAppsServiceMockRecorder) Update(appID, req interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockAppsService)(nil).Update), appID, req)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDeployment", reflect.TypeOf((*MockAppsService)(nil).CreateDeployment), appID, forceRebuild)
 }
 
 // Delete mocks base method.
@@ -108,34 +78,19 @@ func (mr *MockAppsServiceMockRecorder) Delete(appID interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockAppsService)(nil).Delete), appID)
 }
 
-// Propose mocks base method.
-func (m *MockAppsService) Propose(req *godo.AppProposeRequest) (*godo.AppProposeResponse, error) {
+// Get mocks base method.
+func (m *MockAppsService) Get(appID string) (*godo.App, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Propose", req)
-	ret0, _ := ret[0].(*godo.AppProposeResponse)
+	ret := m.ctrl.Call(m, "Get", appID)
+	ret0, _ := ret[0].(*godo.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Propose indicates an expected call of Propose.
-func (mr *MockAppsServiceMockRecorder) Propose(req interface{}) *gomock.Call {
+// Get indicates an expected call of Get.
+func (mr *MockAppsServiceMockRecorder) Get(appID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Propose", reflect.TypeOf((*MockAppsService)(nil).Propose), req)
-}
-
-// CreateDeployment mocks base method.
-func (m *MockAppsService) CreateDeployment(appID string, forceRebuild bool) (*godo.Deployment, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDeployment", appID, forceRebuild)
-	ret0, _ := ret[0].(*godo.Deployment)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateDeployment indicates an expected call of CreateDeployment.
-func (mr *MockAppsServiceMockRecorder) CreateDeployment(appID, forceRebuild interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDeployment", reflect.TypeOf((*MockAppsService)(nil).CreateDeployment), appID, forceRebuild)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockAppsService)(nil).Get), appID)
 }
 
 // GetDeployment mocks base method.
@@ -153,6 +108,66 @@ func (mr *MockAppsServiceMockRecorder) GetDeployment(appID, deploymentID interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployment", reflect.TypeOf((*MockAppsService)(nil).GetDeployment), appID, deploymentID)
 }
 
+// GetInstanceSize mocks base method.
+func (m *MockAppsService) GetInstanceSize(slug string) (*godo.AppInstanceSize, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInstanceSize", slug)
+	ret0, _ := ret[0].(*godo.AppInstanceSize)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInstanceSize indicates an expected call of GetInstanceSize.
+func (mr *MockAppsServiceMockRecorder) GetInstanceSize(slug interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceSize", reflect.TypeOf((*MockAppsService)(nil).GetInstanceSize), slug)
+}
+
+// GetLogs mocks base method.
+func (m *MockAppsService) GetLogs(appID, deploymentID, component string, logType godo.AppLogType, follow bool, tail int) (*godo.AppLogs, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogs", appID, deploymentID, component, logType, follow, tail)
+	ret0, _ := ret[0].(*godo.AppLogs)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLogs indicates an expected call of GetLogs.
+func (mr *MockAppsServiceMockRecorder) GetLogs(appID, deploymentID, component, logType, follow, tail interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockAppsService)(nil).GetLogs), appID, deploymentID, component, logType, follow, tail)
+}
+
+// GetTier mocks base method.
+func (m *MockAppsService) GetTier(slug string) (*godo.AppTier, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTier", slug)
+	ret0, _ := ret[0].(*godo.AppTier)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTier indicates an expected call of GetTier.
+func (mr *MockAppsServiceMockRecorder) GetTier(slug interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTier", reflect.TypeOf((*MockAppsService)(nil).GetTier), slug)
+}
+
+// List mocks base method.
+func (m *MockAppsService) List() ([]*godo.App, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List")
+	ret0, _ := ret[0].([]*godo.App)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockAppsServiceMockRecorder) List() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockAppsService)(nil).List))
+}
+
 // ListDeployments mocks base method.
 func (m *MockAppsService) ListDeployments(appID string) ([]*godo.Deployment, error) {
 	m.ctrl.T.Helper()
@@ -168,19 +183,19 @@ func (mr *MockAppsServiceMockRecorder) ListDeployments(appID interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeployments", reflect.TypeOf((*MockAppsService)(nil).ListDeployments), appID)
 }
 
-// GetLogs mocks base method.
-func (m *MockAppsService) GetLogs(appID, deploymentID, component string, logType godo.AppLogType, follow bool) (*godo.AppLogs, error) {
+// ListInstanceSizes mocks base method.
+func (m *MockAppsService) ListInstanceSizes() ([]*godo.AppInstanceSize, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLogs", appID, deploymentID, component, logType, follow)
-	ret0, _ := ret[0].(*godo.AppLogs)
+	ret := m.ctrl.Call(m, "ListInstanceSizes")
+	ret0, _ := ret[0].([]*godo.AppInstanceSize)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLogs indicates an expected call of GetLogs.
-func (mr *MockAppsServiceMockRecorder) GetLogs(appID, deploymentID, component, logType, follow interface{}) *gomock.Call {
+// ListInstanceSizes indicates an expected call of ListInstanceSizes.
+func (mr *MockAppsServiceMockRecorder) ListInstanceSizes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockAppsService)(nil).GetLogs), appID, deploymentID, component, logType, follow)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceSizes", reflect.TypeOf((*MockAppsService)(nil).ListInstanceSizes))
 }
 
 // ListRegions mocks base method.
@@ -213,47 +228,32 @@ func (mr *MockAppsServiceMockRecorder) ListTiers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTiers", reflect.TypeOf((*MockAppsService)(nil).ListTiers))
 }
 
-// GetTier mocks base method.
-func (m *MockAppsService) GetTier(slug string) (*godo.AppTier, error) {
+// Propose mocks base method.
+func (m *MockAppsService) Propose(req *godo.AppProposeRequest) (*godo.AppProposeResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTier", slug)
-	ret0, _ := ret[0].(*godo.AppTier)
+	ret := m.ctrl.Call(m, "Propose", req)
+	ret0, _ := ret[0].(*godo.AppProposeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetTier indicates an expected call of GetTier.
-func (mr *MockAppsServiceMockRecorder) GetTier(slug interface{}) *gomock.Call {
+// Propose indicates an expected call of Propose.
+func (mr *MockAppsServiceMockRecorder) Propose(req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTier", reflect.TypeOf((*MockAppsService)(nil).GetTier), slug)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Propose", reflect.TypeOf((*MockAppsService)(nil).Propose), req)
 }
 
-// ListInstanceSizes mocks base method.
-func (m *MockAppsService) ListInstanceSizes() ([]*godo.AppInstanceSize, error) {
+// Update mocks base method.
+func (m *MockAppsService) Update(appID string, req *godo.AppUpdateRequest) (*godo.App, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListInstanceSizes")
-	ret0, _ := ret[0].([]*godo.AppInstanceSize)
+	ret := m.ctrl.Call(m, "Update", appID, req)
+	ret0, _ := ret[0].(*godo.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListInstanceSizes indicates an expected call of ListInstanceSizes.
-func (mr *MockAppsServiceMockRecorder) ListInstanceSizes() *gomock.Call {
+// Update indicates an expected call of Update.
+func (mr *MockAppsServiceMockRecorder) Update(appID, req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceSizes", reflect.TypeOf((*MockAppsService)(nil).ListInstanceSizes))
-}
-
-// GetInstanceSize mocks base method.
-func (m *MockAppsService) GetInstanceSize(slug string) (*godo.AppInstanceSize, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInstanceSize", slug)
-	ret0, _ := ret[0].(*godo.AppInstanceSize)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetInstanceSize indicates an expected call of GetInstanceSize.
-func (mr *MockAppsServiceMockRecorder) GetInstanceSize(slug interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceSize", reflect.TypeOf((*MockAppsService)(nil).GetInstanceSize), slug)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockAppsService)(nil).Update), appID, req)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.11
-	github.com/digitalocean/godo v1.61.0
+	github.com/digitalocean/godo v1.63.0
 	github.com/docker/cli v0.0.0-20200622130859-87db43814b48
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954 h1:RMLoZVzv4GliuW
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/digitalocean/godo v1.61.0 h1:PChvUn5+Ajwvl7caOJoFbcM9r+y91ssQbM0W0k3pnZU=
 github.com/digitalocean/godo v1.61.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
+github.com/digitalocean/godo v1.63.0 h1:WN/mv8M1DGKQ58VwnD9PjIyULpo1TZGYhoNhvEtBREk=
+github.com/digitalocean/godo v1.63.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48 h1:AC8qbhi/SjYf4iN2W3jSsofZGHWPjG8pjf5P143KUM8=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible h1:PmGHHCZ43l6h8aZIi+Xa+z1SWe4dFImd5EK3TNp1jlo=

--- a/integration/apps_test.go
+++ b/integration/apps_test.go
@@ -879,6 +879,7 @@ var _ = suite("apps/get-logs", func(t *testing.T, when spec.G, it spec.S) {
 			"service",
 			"--deployment="+testDeploymentUUID,
 			"--type=run",
+			"--tail=1",
 			"-f",
 		)
 

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v1.63.0] - 2021-07-06
+
+- #458 - @ZachEddy - apps: Add tail_lines query parameter to GetLogs function
+
+## [v1.62.0] - 2021-06-07
+
+- #454 - @house-lee - add with_droplet_agent option to create requests
+
 ## [v1.61.0] - 2021-05-12
 
 - #452 - @caiofilipini - Add support for DOKS clusters as peers in Firewall rules

--- a/vendor/github.com/digitalocean/godo/apps.go
+++ b/vendor/github.com/digitalocean/godo/apps.go
@@ -36,7 +36,7 @@ type AppsService interface {
 	ListDeployments(ctx context.Context, appID string, opts *ListOptions) ([]*Deployment, *Response, error)
 	CreateDeployment(ctx context.Context, appID string, create ...*DeploymentCreateRequest) (*Deployment, *Response, error)
 
-	GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool) (*AppLogs, *Response, error)
+	GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool, tailLines int) (*AppLogs, *Response, error)
 
 	ListRegions(ctx context.Context) ([]*AppRegion, *Response, error)
 
@@ -285,8 +285,8 @@ func (s *AppsServiceOp) CreateDeployment(ctx context.Context, appID string, crea
 }
 
 // GetLogs retrieves app logs.
-func (s *AppsServiceOp) GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool) (*AppLogs, *Response, error) {
-	url := fmt.Sprintf("%s/%s/deployments/%s/logs?type=%s&follow=%t", appsBasePath, appID, deploymentID, logType, follow)
+func (s *AppsServiceOp) GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool, tailLines int) (*AppLogs, *Response, error) {
+	url := fmt.Sprintf("%s/%s/deployments/%s/logs?type=%s&follow=%t&tail_lines=%d", appsBasePath, appID, deploymentID, logType, follow, tailLines)
 	if component != "" {
 		url = fmt.Sprintf("%s&component_name=%s", url, component)
 	}

--- a/vendor/github.com/digitalocean/godo/droplets.go
+++ b/vendor/github.com/digitalocean/godo/droplets.go
@@ -229,6 +229,7 @@ type DropletCreateRequest struct {
 	Volumes           []DropletCreateVolume `json:"volumes,omitempty"`
 	Tags              []string              `json:"tags"`
 	VPCUUID           string                `json:"vpc_uuid,omitempty"`
+	WithDropletAgent  *bool                 `json:"with_droplet_agent,omitempty"`
 }
 
 // DropletMultiCreateRequest is a request to create multiple Droplets.
@@ -245,6 +246,7 @@ type DropletMultiCreateRequest struct {
 	UserData          string                `json:"user_data,omitempty"`
 	Tags              []string              `json:"tags"`
 	VPCUUID           string                `json:"vpc_uuid,omitempty"`
+	WithDropletAgent  *bool                 `json:"with_droplet_agent,omitempty"`
 }
 
 func (d DropletCreateRequest) String() string {

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.61.0"
+	libraryVersion = "1.63.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.61.0
+# github.com/digitalocean/godo v1.63.0
 ## explicit
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util


### PR DESCRIPTION
This PR introduces a new flag on `apps logs` so users can specify the number of live log lines they want to fetch from an application. Currently, running `apps logs` will return all log lines.

It behaves as `docker logs` and `kubectl logs` would:

```sh
# fetch the last 10 logs
doctl apps logs <app-id> --tail 10

# fetch all the logs
doctl apps logs <app-id>
```

Note: I ran `make mocks` and most of the mock files changed, so I only committed changes to `mocks/AppsService.go` to keep the PR small. I tried using several different versions of `mockgen` but they all resulted in a large diff. Let me know if there's a specific version of `mockgen` I should use, or if I should commit all the mock changes in this PR.