### PR TITLE
Adds release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: tagged-release
+
+on:
+  push:
+    tags:
+      - 'v[1-9].[0-9]+.[0-9]+'
+
+jobs:
+  github-release:
+    name: 'GitHub Release'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          # https://github.com/marketplace/actions/goreleaser-action#usage
+          # note the fetch-depth: 0 input in Checkout step. It is required for
+          # the changelog to work correctly
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+      - name: Restore cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  snapcraft-stable:
+    name: 'Snapcraft: Stable Release'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Buld snap
+        id: build
+        run: |
+          make _build_snap && \
+          find doctl_v*.snap -print -exec echo ::set-output name=snap::{} \;
+
+      - uses: snapcore/action-publish@v1
+        with:
+          store_login: ${{ secrets.SNAP_TOKEN }}
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable

--- a/.github/workflows/snapcraft-candidate.yml
+++ b/.github/workflows/snapcraft-candidate.yml
@@ -1,0 +1,32 @@
+name: snapcraft-candidate
+# Builds and publishes the package to the candidate channel on merge to main.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-publish:
+    name: 'Snapcraft: Candidate Release'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Buld snap
+        id: build
+        run: |
+          make _build_snap && \
+          find doctl_v*.snap -print -exec echo ::set-output name=snap::{} \;
+
+      - uses: snapcore/action-publish@v1
+        with:
+          store_login: ${{ secrets.SNAP_TOKEN }}
+          snap: ${{ steps.build.outputs.snap }}
+          release: candidate

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,4 +50,4 @@ release:
     name: doctl
 
 changelog:
-  skip: true
+  skip: false


### PR DESCRIPTION
Migrates workflows from travis-ci.org to GitHub Actions.

- migrates changelog generator to use goreleaser
- adds workflow to build and publish a snap release candidate on push to main
- adds job to the release.yml workflow to build a publish a snap stable release on push of a tag

For APICLI-490