### PR TITLE
workflow/snapcraft-stable: Fetch all tags.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # fetch-depth: 0 fetches all history for all branches and tags
+          fetch-depth: 0
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1


### PR DESCRIPTION
Fixes failing Snap release https://github.com/digitalocean/doctl/runs/3284170811?check_suite_focus=true

This is the same fix used for candidate releases from https://github.com/digitalocean/doctl/pull/1011