### PR TITLE
workflow/github-release: Build with Go 1.16.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
 
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
       - name: Restore cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This should build Darwin ARM64 releases again. 

https://github.com/digitalocean/doctl/runs/3284170730?check_suite_focus=true#step:6:29