### PR TITLE
Update domain record without changing TTL (#1020)

### DIFF
--- a/commands/domains.go
+++ b/commands/domains.go
@@ -84,7 +84,7 @@ func Domain() *Command {
 	AddStringFlag(cmdRecordUpdate, doctl.ArgRecordData, "", "", "Record data; varies depending on record type")
 	AddIntFlag(cmdRecordUpdate, doctl.ArgRecordPriority, "", 0, "Record priority")
 	AddIntFlag(cmdRecordUpdate, doctl.ArgRecordPort, "", 0, "The port value for an SRV record")
-	AddIntFlag(cmdRecordUpdate, doctl.ArgRecordTTL, "", 1800, "The record's Time To Live value, in seconds")
+	AddIntFlag(cmdRecordUpdate, doctl.ArgRecordTTL, "", 0, "The record's Time To Live value, in seconds")
 	AddIntFlag(cmdRecordUpdate, doctl.ArgRecordWeight, "", 0, "The weight value for an SRV record")
 	AddIntFlag(cmdRecordUpdate, doctl.ArgRecordFlags, "", 0, "An unsigned integer between 0-255 used for CAA records")
 	AddStringFlag(cmdRecordUpdate, doctl.ArgRecordTag, "", "", "The parameter tag for CAA records. Valid values are `issue`, `issuewild`, or `iodef`")


### PR DESCRIPTION
Given an existing domain record with an non-default TTL, a user can not
update a field on the record without TTL changing to 1800 unless the
user remembers to specify the desired TTL on each update.  This patch
changes the default value of the TTL argument from 1800 to 0 for domain
record updates which preserves the current TTL of the record.