### PR TITLE
doctl/load-balancers: add flag to toggle automatic DNS record creation for certs attached to load balancers

### DIFF
--- a/args.go
+++ b/args.go
@@ -265,6 +265,8 @@ const (
 	ArgRedirectHTTPToHTTPS = "redirect-http-to-https"
 	// ArgEnableProxyProtocol is a flag that indicates whether PROXY protocol should be enabled on the load balancer.
 	ArgEnableProxyProtocol = "enable-proxy-protocol"
+	// ArgDisableLetsEncryptDNSRecords is a flag that when set will disable the creation of DNS records pointing to the load balancer IP from the apex domain in the cert.
+	ArgDisableLetsEncryptDNSRecords = "disable-lets-encrypt-dns-records"
 	// ArgEnableBackendKeepalive is a flag that indicates whether keepalive connections should be enabled to target droplets from the load balancer.
 	ArgEnableBackendKeepalive = "enable-backend-keepalive"
 	// ArgStickySessions is a list of sticky sessions settings for the load balancer.

--- a/commands/displayers/load_balancer.go
+++ b/commands/displayers/load_balancer.go
@@ -50,27 +50,29 @@ func (lb *LoadBalancer) Cols() []string {
 		"StickySessions",
 		"HealthCheck",
 		"ForwardingRules",
+		"DisableLetsEncryptDNSRecords",
 	}
 }
 
 func (lb *LoadBalancer) ColMap() map[string]string {
 	return map[string]string{
-		"ID":                  "ID",
-		"IP":                  "IP",
-		"Name":                "Name",
-		"Status":              "Status",
-		"Created":             "Created At",
-		"Algorithm":           "Algorithm",
-		"Region":              "Region",
-		"Size":                "Size",
-		"SizeUnit":            "Size Unit",
-		"VPCUUID":             "VPC UUID",
-		"Tag":                 "Tag",
-		"DropletIDs":          "Droplet IDs",
-		"RedirectHttpToHttps": "SSL",
-		"StickySessions":      "Sticky Sessions",
-		"HealthCheck":         "Health Check",
-		"ForwardingRules":     "Forwarding Rules",
+		"ID":                           "ID",
+		"IP":                           "IP",
+		"Name":                         "Name",
+		"Status":                       "Status",
+		"Created":                      "Created At",
+		"Algorithm":                    "Algorithm",
+		"Region":                       "Region",
+		"Size":                         "Size",
+		"SizeUnit":                     "Size Unit",
+		"VPCUUID":                      "VPC UUID",
+		"Tag":                          "Tag",
+		"DropletIDs":                   "Droplet IDs",
+		"RedirectHttpToHttps":          "SSL",
+		"StickySessions":               "Sticky Sessions",
+		"HealthCheck":                  "Health Check",
+		"ForwardingRules":              "Forwarding Rules",
+		"DisableLetsEncryptDNSRecords": "Disable Lets Encrypt DNS Records",
 	}
 }
 
@@ -84,20 +86,21 @@ func (lb *LoadBalancer) KV() []map[string]interface{} {
 		}
 
 		o := map[string]interface{}{
-			"ID":                  l.ID,
-			"IP":                  l.IP,
-			"Name":                l.Name,
-			"Status":              l.Status,
-			"Created":             l.Created,
-			"Algorithm":           l.Algorithm,
-			"Region":              l.Region.Slug,
-			"VPCUUID":             l.VPCUUID,
-			"Tag":                 l.Tag,
-			"DropletIDs":          strings.Trim(strings.Replace(fmt.Sprint(l.DropletIDs), " ", ",", -1), "[]"),
-			"RedirectHttpToHttps": l.RedirectHttpToHttps,
-			"StickySessions":      prettyPrintStruct(l.StickySessions),
-			"HealthCheck":         prettyPrintStruct(l.HealthCheck),
-			"ForwardingRules":     strings.Join(forwardingRules, " "),
+			"ID":                           l.ID,
+			"IP":                           l.IP,
+			"Name":                         l.Name,
+			"Status":                       l.Status,
+			"Created":                      l.Created,
+			"Algorithm":                    l.Algorithm,
+			"Region":                       l.Region.Slug,
+			"VPCUUID":                      l.VPCUUID,
+			"Tag":                          l.Tag,
+			"DropletIDs":                   strings.Trim(strings.Replace(fmt.Sprint(l.DropletIDs), " ", ",", -1), "[]"),
+			"RedirectHttpToHttps":          l.RedirectHttpToHttps,
+			"StickySessions":               prettyPrintStruct(l.StickySessions),
+			"HealthCheck":                  prettyPrintStruct(l.HealthCheck),
+			"ForwardingRules":              strings.Join(forwardingRules, " "),
+			"DisableLetsEncryptDNSRecords": toBool(l.DisableLetsEncryptDNSRecords),
 		}
 		if l.SizeSlug != "" {
 			o["Size"] = l.SizeSlug
@@ -109,6 +112,13 @@ func (lb *LoadBalancer) KV() []map[string]interface{} {
 	}
 
 	return out
+}
+
+func toBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
 }
 
 func prettyPrintStruct(obj interface{}) string {

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -87,6 +87,8 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 		"enable proxy protocol")
 	AddBoolFlag(cmdRecordCreate, doctl.ArgEnableBackendKeepalive, "", false,
 		"enable keepalive connections to backend target droplets")
+	AddBoolFlag(cmdRecordCreate, doctl.ArgDisableLetsEncryptDNSRecords, "", false,
+		"disable automatic DNS record creation for Let's Encrypt certificates that are added to the load balancer")
 	AddStringFlag(cmdRecordCreate, doctl.ArgTagName, "", "", "droplet tag name")
 	AddStringSliceFlag(cmdRecordCreate, doctl.ArgDropletIDs, "", []string{},
 		"A comma-separated list of Droplet IDs to add to the load balancer, e.g.: `12,33`")
@@ -124,12 +126,14 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 	AddStringFlag(cmdRecordUpdate, doctl.ArgHealthCheck, "", "",
 		"A comma-separated list of key-value pairs representing recent health check results, e.g.: `protocol:http, port:80, path:/index.html, check_interval_seconds:10, response_timeout_seconds:5, healthy_threshold:5, unhealthy_threshold:3`")
 	AddStringFlag(cmdRecordUpdate, doctl.ArgForwardingRules, "", "", forwardingRulesTxt)
+	AddBoolFlag(cmdRecordUpdate, doctl.ArgDisableLetsEncryptDNSRecords, "", false,
+		"disable automatic DNS record creation for Let's Encrypt certificates that are added to the load balancer")
 
 	CmdBuilder(cmd, RunLoadBalancerList, "list", "List load balancers", "Use this command to get a list of the load balancers on your account, including the following information for each:"+lbDetail, Writer,
 		aliasOpt("ls"), displayerType(&displayers.LoadBalancer{}))
 
 	cmdRunRecordDelete := CmdBuilder(cmd, RunLoadBalancerDelete, "delete <id>",
-		"Permanently delete a load balancer", `Use this command to permanently delete the speicified load balancer. This is irreversable.`, Writer, aliasOpt("d", "rm"))
+		"Permanently delete a load balancer", `Use this command to permanently delete the specified load balancer. This is irreversible.`, Writer, aliasOpt("d", "rm"))
 	AddBoolFlag(cmdRunRecordDelete, doctl.ArgForce, doctl.ArgShortForce, false,
 		"Delete the load balancer without a confirmation prompt")
 
@@ -456,6 +460,12 @@ func buildRequestFromArgs(c *CmdConfig, r *godo.LoadBalancerRequest) error {
 		return err
 	}
 	r.EnableBackendKeepalive = enableBackendKeepalive
+
+	disableLetsEncryptDNSRecords, err := c.Doit.GetBool(c.NS, doctl.ArgDisableLetsEncryptDNSRecords)
+	if err != nil {
+		return err
+	}
+	r.DisableLetsEncryptDNSRecords = &disableLetsEncryptDNSRecords
 
 	dropletIDsList, err := c.Doit.GetStringSlice(c.NS, doctl.ArgDropletIDs)
 	if err != nil {

--- a/commands/load_balancers_test.go
+++ b/commands/load_balancers_test.go
@@ -109,6 +109,8 @@ func TestLoadBalancerCreate(t *testing.T) {
 			},
 			VPCUUID: vpcUUID,
 		}
+		disableLetsEncryptDNSRecords := true
+		r.DisableLetsEncryptDNSRecords = &disableLetsEncryptDNSRecords
 		tm.loadBalancers.EXPECT().Create(&r).Return(&testLoadBalancer, nil)
 
 		config.Doit.Set(config.NS, doctl.ArgRegionSlug, "nyc1")
@@ -119,6 +121,7 @@ func TestLoadBalancerCreate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgStickySessions, "type:none")
 		config.Doit.Set(config.NS, doctl.ArgHealthCheck, "protocol:http,port:80,check_interval_seconds:4,response_timeout_seconds:23,healthy_threshold:5,unhealthy_threshold:10")
 		config.Doit.Set(config.NS, doctl.ArgForwardingRules, "entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306,tls_passthrough:true")
+		config.Doit.Set(config.NS, doctl.ArgDisableLetsEncryptDNSRecords, true)
 
 		err := RunLoadBalancerCreate(config)
 		assert.NoError(t, err)
@@ -155,7 +158,8 @@ func TestLoadBalancerUpdate(t *testing.T) {
 				},
 			},
 		}
-
+		disableLetsEncryptDNSRecords := true
+		r.DisableLetsEncryptDNSRecords = &disableLetsEncryptDNSRecords
 		tm.loadBalancers.EXPECT().Update(lbID, &r).Return(&testLoadBalancer, nil)
 
 		config.Args = append(config.Args, lbID)
@@ -167,6 +171,7 @@ func TestLoadBalancerUpdate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgStickySessions, "type:cookies,cookie_name:DO-LB,cookie_ttl_seconds:5")
 		config.Doit.Set(config.NS, doctl.ArgHealthCheck, "protocol:http,port:80,check_interval_seconds:4,response_timeout_seconds:23,healthy_threshold:5,unhealthy_threshold:10")
 		config.Doit.Set(config.NS, doctl.ArgForwardingRules, "entry_protocol:http,entry_port:80,target_protocol:http,target_port:80")
+		config.Doit.Set(config.NS, doctl.ArgDisableLetsEncryptDNSRecords, true)
 
 		err := RunLoadBalancerUpdate(config)
 		assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/creack/pty v1.1.11
-	github.com/digitalocean/godo v1.68.0
+	github.com/digitalocean/godo v1.69.0
 	github.com/docker/cli v0.0.0-20200622130859-87db43814b48
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/digitalocean/godo v1.68.0 h1:s5vRGY4OQiMXztMwIweAojSyY2R1mCiTPmvNxkFRrfc=
-github.com/digitalocean/godo v1.68.0/go.mod h1:epPuOzTOOJujNo0nduDj2D5O1zu8cSpp9R+DdN0W9I0=
+github.com/digitalocean/godo v1.69.0 h1:d+CXI7s3g7zAbCYqscRrq46XPMrlv+A5doOdPYn7Pss=
+github.com/digitalocean/godo v1.69.0/go.mod h1:epPuOzTOOJujNo0nduDj2D5O1zu8cSpp9R+DdN0W9I0=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48 h1:AC8qbhi/SjYf4iN2W3jSsofZGHWPjG8pjf5P143KUM8=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible h1:PmGHHCZ43l6h8aZIi+Xa+z1SWe4dFImd5EK3TNp1jlo=

--- a/integration/lb_create_test.go
+++ b/integration/lb_create_test.go
@@ -72,6 +72,7 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 			"--enable-backend-keepalive",
 			"--tag-name", "magic-lb",
 			"--vpc-uuid", "00000000-0000-4000-8000-000000000000",
+			"--disable-lets-encrypt-dns-records",
 		}
 	})
 
@@ -100,8 +101,8 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 
 const (
 	lbCreateOutput = `
-ID                                      IP    Name             Status    Created At              Algorithm      Region    Size        Size Unit    VPC UUID                                Tag    Droplet IDs        SSL     Sticky Sessions                                Health Check                                                                                                            Forwarding Rules
-4de7ac8b-495b-4884-9a69-1050c6793cd6          example-lb-01    new       2017-02-01T22:22:58Z    round_robin    nyc3      lb-small    <nil>        00000000-0000-4000-8000-000000000000           3164444,3164445    true    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:,port:0,path:,check_interval_seconds:0,response_timeout_seconds:0,healthy_threshold:0,unhealthy_threshold:0
+ID                                      IP    Name             Status    Created At              Algorithm      Region    Size        Size Unit    VPC UUID                                Tag    Droplet IDs        SSL     Sticky Sessions                                Health Check                                                                                                            Forwarding Rules    Disable Lets Encrypt DNS Records
+4de7ac8b-495b-4884-9a69-1050c6793cd6          example-lb-01    new       2017-02-01T22:22:58Z    round_robin    nyc3      lb-small    <nil>        00000000-0000-4000-8000-000000000000           3164444,3164445    true    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:,port:0,path:,check_interval_seconds:0,response_timeout_seconds:0,healthy_threshold:0,unhealthy_threshold:0                        true
 `
 	lbCreateResponse = `
 {
@@ -137,6 +138,7 @@ ID                                      IP    Name             Status    Created
     ],
     "redirect_http_to_https": true,
     "enable_proxy_protocol": true,
+	"disable_lets_encrypt_dns_records": true,
     "enable_backend_keepalive": true
   }
 }`
@@ -153,6 +155,7 @@ ID                                      IP    Name             Status    Created
   "redirect_http_to_https":true,
   "enable_proxy_protocol":true,
   "enable_backend_keepalive":true,
+  "disable_lets_encrypt_dns_records": true,
   "vpc_uuid": "00000000-0000-4000-8000-000000000000"
 }`
 )

--- a/integration/lb_get_test.go
+++ b/integration/lb_get_test.go
@@ -86,8 +86,8 @@ var _ = suite("compute/load-balancer/get", func(t *testing.T, when spec.G, it sp
 
 const (
 	lbGetOutput = `
-ID            IP                 Name             Status    Created At              Algorithm      Region    Size        Size Unit    VPC UUID                                Tag    Droplet IDs    SSL      Sticky Sessions                                Health Check                                                                                                            Forwarding Rules
-find-lb-id    104.131.186.241    example-lb-01    new       2017-02-01T22:22:58Z    round_robin    nyc3      lb-small    <nil>        00000000-0000-4000-8000-000000000000           3164445        false    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:,port:0,path:,check_interval_seconds:0,response_timeout_seconds:0,healthy_threshold:0,unhealthy_threshold:0
+ID            IP                 Name             Status    Created At              Algorithm      Region    Size        Size Unit    VPC UUID                                Tag    Droplet IDs    SSL      Sticky Sessions                                Health Check                                                                                                            Forwarding Rules    Disable Lets Encrypt DNS Records
+find-lb-id    104.131.186.241    example-lb-01    new       2017-02-01T22:22:58Z    round_robin    nyc3      lb-small    <nil>        00000000-0000-4000-8000-000000000000           3164445        false    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:,port:0,path:,check_interval_seconds:0,response_timeout_seconds:0,healthy_threshold:0,unhealthy_threshold:0                        false
 `
 	lbGetResponse = `
 {
@@ -100,6 +100,7 @@ find-lb-id    104.131.186.241    example-lb-01    new       2017-02-01T22:22:58Z
     "created_at": "2017-02-01T22:22:58Z",
     "forwarding_rules": [],
     "health_check": {},
+	"disable_lets_encrypt_dns_records": false,
     "sticky_sessions": {
       "type": "none"
 	},

--- a/integration/lb_list_test.go
+++ b/integration/lb_list_test.go
@@ -80,9 +80,9 @@ var _ = suite("compute/load-balancer/list", func(t *testing.T, when spec.G, it s
 
 const (
 	lbListOutput = `
-ID        IP                 Name             Status    Created At              Algorithm      Region    Size         Size Unit    VPC UUID                                Tag    Droplet IDs    SSL      Sticky Sessions                                Health Check                                                                                                                   Forwarding Rules
-lb-one    104.131.186.241    example-lb-01    new       2017-02-01T22:22:58Z    round_robin    venus3    lb-small     <nil>        00000000-0000-4000-8000-000000000000           3164444        false    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:http,port:80,path:/,check_interval_seconds:10,response_timeout_seconds:5,healthy_threshold:5,unhealthy_threshold:3    entry_protocol:http,entry_port:80,target_protocol:http,target_port:80,certificate_id:,tls_passthrough:false
-lb-two    104.131.188.204    example-lb-02    new       2017-02-01T20:44:58Z    round_robin    mars1     lb-medium    <nil>        00000000-0000-4000-8000-000000000000           3164445        false    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:http,port:80,path:/,check_interval_seconds:10,response_timeout_seconds:5,healthy_threshold:5,unhealthy_threshold:3    entry_protocol:http,entry_port:80,target_protocol:http,target_port:80,certificate_id:,tls_passthrough:false
+ID        IP                 Name             Status    Created At              Algorithm      Region    Size         Size Unit    VPC UUID                                Tag    Droplet IDs    SSL      Sticky Sessions                                Health Check                                                                                                                   Forwarding Rules                                                                                               Disable Lets Encrypt DNS Records
+lb-one    104.131.186.241    example-lb-01    new       2017-02-01T22:22:58Z    round_robin    venus3    lb-small     <nil>        00000000-0000-4000-8000-000000000000           3164444        false    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:http,port:80,path:/,check_interval_seconds:10,response_timeout_seconds:5,healthy_threshold:5,unhealthy_threshold:3    entry_protocol:http,entry_port:80,target_protocol:http,target_port:80,certificate_id:,tls_passthrough:false    true
+lb-two    104.131.188.204    example-lb-02    new       2017-02-01T20:44:58Z    round_robin    mars1     lb-medium    <nil>        00000000-0000-4000-8000-000000000000           3164445        false    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:http,port:80,path:/,check_interval_seconds:10,response_timeout_seconds:5,healthy_threshold:5,unhealthy_threshold:3    entry_protocol:http,entry_port:80,target_protocol:http,target_port:80,certificate_id:,tls_passthrough:false    false
 `
 	lbListResponse = `
 {
@@ -128,6 +128,7 @@ lb-two    104.131.188.204    example-lb-02    new       2017-02-01T20:44:58Z    
       "tag": "",
       "droplet_ids": [3164444],
       "redirect_http_to_https": false,
+      "disable_lets_encrypt_dns_records": true,
       "enable_proxy_protocol": false
     },
     {
@@ -171,6 +172,7 @@ lb-two    104.131.188.204    example-lb-02    new       2017-02-01T20:44:58Z    
       "tag": "",
       "droplet_ids": [3164445],
       "redirect_http_to_https": false,
+      "disable_lets_encrypt_dns_records": false,
       "enable_proxy_protocol": false
     }
   ],

--- a/integration/lb_update_test.go
+++ b/integration/lb_update_test.go
@@ -97,7 +97,7 @@ var _ = suite("compute/load-balancer/update", func(t *testing.T, when spec.G, it
 })
 
 // Formatting of responses from server looks very similar
-// easier for us to reuse said resonses from get request.
+// easier for us to reuse said responses from get request.
 // If / when they materially differ we should feel free
 // to make these custom.
 const (
@@ -113,6 +113,7 @@ const (
     "sticky_sessions":{},
     "droplet_ids":[1,2,3,4],
     "tag":"some-tag",
+    "disable_lets_encrypt_dns_records": false,
     "vpc_uuid": "00000000-0000-4000-8000-000000000000"
 }`
 )

--- a/integration/projects_resources_get_test.go
+++ b/integration/projects_resources_get_test.go
@@ -212,8 +212,8 @@ IP             Region    Droplet ID    Droplet Name
 }
 `
 	projectsResourcesGetLoadbalancerOutput = `
-ID                                      IP                 Name             Status    Created At              Algorithm      Region    Size        Size Unit    VPC UUID                                Tag    Droplet IDs    SSL      Sticky Sessions                                Health Check                                                                                                            Forwarding Rules
-4de7ac8b-495b-4884-9a69-1050c6793cd6    104.131.186.241    example-lb-01    new       2017-02-01T22:22:58Z    round_robin    nyc3      lb-small    <nil>        00000000-0000-4000-8000-000000000000           3164445        false    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:,port:0,path:,check_interval_seconds:0,response_timeout_seconds:0,healthy_threshold:0,unhealthy_threshold:0    entry_protocol:https,entry_port:444,target_protocol:https,target_port:443,certificate_id:,tls_passthrough:true
+ID                                      IP                 Name             Status    Created At              Algorithm      Region    Size        Size Unit    VPC UUID                                Tag    Droplet IDs    SSL      Sticky Sessions                                Health Check                                                                                                            Forwarding Rules                                                                                                  Disable Lets Encrypt DNS Records
+4de7ac8b-495b-4884-9a69-1050c6793cd6    104.131.186.241    example-lb-01    new       2017-02-01T22:22:58Z    round_robin    nyc3      lb-small    <nil>        00000000-0000-4000-8000-000000000000           3164445        false    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:,port:0,path:,check_interval_seconds:0,response_timeout_seconds:0,healthy_threshold:0,unhealthy_threshold:0    entry_protocol:https,entry_port:444,target_protocol:https,target_port:443,certificate_id:,tls_passthrough:true    false
 `
 	projectsResourcesGetLoadbalancerResponse = `
 {
@@ -251,7 +251,8 @@ ID                                      IP                 Name             Stat
     "vpc_uuid": "00000000-0000-4000-8000-000000000000",
     "droplet_ids": [ 3164445 ],
     "redirect_http_to_https": false,
-    "enable_proxy_protocol": false
+    "enable_proxy_protocol": false,
+    "disable_lets_encrypt_dns_records": false
   }
 }
 `

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change Log
 
+## [v1.69.0] - 2021-10-04
+
+- #482 - @dikshant - godo/load-balancers: add DisableLetsEncryptDNSRecords field for LBaaS
+
 ## [v1.68.0] - 2021-09-29
 
-- #480 - @sunny-b - kubernetes: add support for HA control plane 
+- #480 - @sunny-b - kubernetes: add support for HA control plane
 
 ## [v1.67.0] - 2021-09-22
 

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.68.0"
+	libraryVersion = "1.69.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/load_balancers.go
+++ b/vendor/github.com/digitalocean/godo/load_balancers.go
@@ -34,21 +34,22 @@ type LoadBalancer struct {
 	// SizeSlug is mutually exclusive with SizeUnit. Only one should be specified
 	SizeSlug string `json:"size,omitempty"`
 	// SizeUnit is mutually exclusive with SizeSlug. Only one should be specified
-	SizeUnit               uint32           `json:"size_unit,omitempty"`
-	Algorithm              string           `json:"algorithm,omitempty"`
-	Status                 string           `json:"status,omitempty"`
-	Created                string           `json:"created_at,omitempty"`
-	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
-	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`
-	StickySessions         *StickySessions  `json:"sticky_sessions,omitempty"`
-	Region                 *Region          `json:"region,omitempty"`
-	DropletIDs             []int            `json:"droplet_ids,omitempty"`
-	Tag                    string           `json:"tag,omitempty"`
-	Tags                   []string         `json:"tags,omitempty"`
-	RedirectHttpToHttps    bool             `json:"redirect_http_to_https,omitempty"`
-	EnableProxyProtocol    bool             `json:"enable_proxy_protocol,omitempty"`
-	EnableBackendKeepalive bool             `json:"enable_backend_keepalive,omitempty"`
-	VPCUUID                string           `json:"vpc_uuid,omitempty"`
+	SizeUnit                     uint32           `json:"size_unit,omitempty"`
+	Algorithm                    string           `json:"algorithm,omitempty"`
+	Status                       string           `json:"status,omitempty"`
+	Created                      string           `json:"created_at,omitempty"`
+	ForwardingRules              []ForwardingRule `json:"forwarding_rules,omitempty"`
+	HealthCheck                  *HealthCheck     `json:"health_check,omitempty"`
+	StickySessions               *StickySessions  `json:"sticky_sessions,omitempty"`
+	Region                       *Region          `json:"region,omitempty"`
+	DropletIDs                   []int            `json:"droplet_ids,omitempty"`
+	Tag                          string           `json:"tag,omitempty"`
+	Tags                         []string         `json:"tags,omitempty"`
+	RedirectHttpToHttps          bool             `json:"redirect_http_to_https,omitempty"`
+	EnableProxyProtocol          bool             `json:"enable_proxy_protocol,omitempty"`
+	EnableBackendKeepalive       bool             `json:"enable_backend_keepalive,omitempty"`
+	VPCUUID                      string           `json:"vpc_uuid,omitempty"`
+	DisableLetsEncryptDNSRecords *bool            `json:"disable_lets_encrypt_dns_records,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancer.
@@ -65,18 +66,23 @@ func (l LoadBalancer) URN() string {
 // Modifying the returned LoadBalancerRequest will not modify the original LoadBalancer.
 func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 	r := LoadBalancerRequest{
-		Name:                   l.Name,
-		Algorithm:              l.Algorithm,
-		SizeSlug:               l.SizeSlug,
-		SizeUnit:               l.SizeUnit,
-		ForwardingRules:        append([]ForwardingRule(nil), l.ForwardingRules...),
-		DropletIDs:             append([]int(nil), l.DropletIDs...),
-		Tag:                    l.Tag,
-		RedirectHttpToHttps:    l.RedirectHttpToHttps,
-		EnableProxyProtocol:    l.EnableProxyProtocol,
-		EnableBackendKeepalive: l.EnableBackendKeepalive,
-		HealthCheck:            l.HealthCheck,
-		VPCUUID:                l.VPCUUID,
+		Name:                         l.Name,
+		Algorithm:                    l.Algorithm,
+		SizeSlug:                     l.SizeSlug,
+		SizeUnit:                     l.SizeUnit,
+		ForwardingRules:              append([]ForwardingRule(nil), l.ForwardingRules...),
+		DropletIDs:                   append([]int(nil), l.DropletIDs...),
+		Tag:                          l.Tag,
+		RedirectHttpToHttps:          l.RedirectHttpToHttps,
+		EnableProxyProtocol:          l.EnableProxyProtocol,
+		EnableBackendKeepalive:       l.EnableBackendKeepalive,
+		HealthCheck:                  l.HealthCheck,
+		VPCUUID:                      l.VPCUUID,
+		DisableLetsEncryptDNSRecords: l.DisableLetsEncryptDNSRecords,
+	}
+
+	if l.DisableLetsEncryptDNSRecords != nil {
+		*r.DisableLetsEncryptDNSRecords = *l.DisableLetsEncryptDNSRecords
 	}
 
 	if l.HealthCheck != nil {
@@ -144,17 +150,18 @@ type LoadBalancerRequest struct {
 	// SizeSlug is mutually exclusive with SizeUnit. Only one should be specified
 	SizeSlug string `json:"size,omitempty"`
 	// SizeUnit is mutually exclusive with SizeSlug. Only one should be specified
-	SizeUnit               uint32           `json:"size_unit,omitempty"`
-	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
-	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`
-	StickySessions         *StickySessions  `json:"sticky_sessions,omitempty"`
-	DropletIDs             []int            `json:"droplet_ids,omitempty"`
-	Tag                    string           `json:"tag,omitempty"`
-	Tags                   []string         `json:"tags,omitempty"`
-	RedirectHttpToHttps    bool             `json:"redirect_http_to_https,omitempty"`
-	EnableProxyProtocol    bool             `json:"enable_proxy_protocol,omitempty"`
-	EnableBackendKeepalive bool             `json:"enable_backend_keepalive,omitempty"`
-	VPCUUID                string           `json:"vpc_uuid,omitempty"`
+	SizeUnit                     uint32           `json:"size_unit,omitempty"`
+	ForwardingRules              []ForwardingRule `json:"forwarding_rules,omitempty"`
+	HealthCheck                  *HealthCheck     `json:"health_check,omitempty"`
+	StickySessions               *StickySessions  `json:"sticky_sessions,omitempty"`
+	DropletIDs                   []int            `json:"droplet_ids,omitempty"`
+	Tag                          string           `json:"tag,omitempty"`
+	Tags                         []string         `json:"tags,omitempty"`
+	RedirectHttpToHttps          bool             `json:"redirect_http_to_https,omitempty"`
+	EnableProxyProtocol          bool             `json:"enable_proxy_protocol,omitempty"`
+	EnableBackendKeepalive       bool             `json:"enable_backend_keepalive,omitempty"`
+	VPCUUID                      string           `json:"vpc_uuid,omitempty"`
+	DisableLetsEncryptDNSRecords *bool            `json:"disable_lets_encrypt_dns_records,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancerRequest.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.68.0
+# github.com/digitalocean/godo v1.69.0
 ## explicit
 github.com/digitalocean/godo
 github.com/digitalocean/godo/util


### PR DESCRIPTION
This brings in the change from godo: https://github.com/digitalocean/godo/pull/482 to doctl. We may need a new version release for godo before this can go in. This will probably also require some updates to doctl from DOKS side.