### PR TITLE
k8s/doctl: remove ha flag from update command

### DIFF
--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -322,8 +322,6 @@ This command updates the specified configuration values for the specified Kubern
 		"Boolean specifying whether to enable surge-upgrade for the cluster")
 	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgClusterUpdateKubeconfig, "",
 		true, "Boolean specifying whether to update the cluster in your kubeconfig")
-	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgHA, "", false,
-		"Boolean specifying whether to enable the highly-available control plane for the cluster")
 	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgSetCurrentContext, "", true,
 		"Boolean specifying whether to set the current kubectl context to that of the new cluster")
 	AddStringFlag(cmdKubeClusterUpdate, doctl.ArgMaintenanceWindow, "", "any=00:00",
@@ -1675,12 +1673,6 @@ func buildClusterUpdateRequestFromArgs(c *CmdConfig, r *godo.KubernetesClusterUp
 		return err
 	}
 	r.SurgeUpgrade = surgeUpgrade
-
-	ha, err := c.Doit.GetBool(c.NS, doctl.ArgHA)
-	if err != nil {
-		return err
-	}
-	r.HA = ha
 
 	return nil
 }

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -549,7 +549,6 @@ func TestKubernetesUpdate(t *testing.T) {
 				Day:       godo.KubernetesMaintenanceDayAny,
 			},
 			AutoUpgrade: boolPtr(false),
-			HA:          true,
 		}
 		tm.kubernetes.EXPECT().Update(testCluster.ID, &r).Return(&testCluster, nil)
 
@@ -558,7 +557,6 @@ func TestKubernetesUpdate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgTag, testCluster.Tags)
 		config.Doit.Set(config.NS, doctl.ArgMaintenanceWindow, "any=00:00")
 		config.Doit.Set(config.NS, doctl.ArgAutoUpgrade, false)
-		config.Doit.Set(config.NS, doctl.ArgHA, true)
 
 		err := testK8sCmdService().RunKubernetesClusterUpdate(config)
 		assert.NoError(t, err)


### PR DESCRIPTION
It's been decided that we will not support toggling the HA feature via the `update` command for the EA release. So this PR removes that the HA feature from the `update` command.

While this is technically a breaking change, it will not impact any users since it is a internal-only feature at this moment.

cc: @adamwg 