### PR TITLE
Ensure Snap name is "doctl"

### DIFF
--- a/doit.go
+++ b/doit.go
@@ -502,7 +502,7 @@ func emptyStringSlice(s []string) bool {
 // CommandName returns the name by which doctl was invoked
 func CommandName() string {
 	name, ok := os.LookupEnv("SNAP_NAME")
-	if !ok {
+	if !ok || name != "doctl" {
 		return os.Args[0]
 	}
 	return name

--- a/doit_test.go
+++ b/doit_test.go
@@ -117,3 +117,39 @@ type stubLatestRelease struct {
 func (slr stubLatestRelease) LatestVersion() (string, error) {
 	return slr.version, nil
 }
+
+func TestCommandName(t *testing.T) {
+	t.Run("snap name set to goland", func(t *testing.T) {
+		const snapName = "goland"
+
+		if err := os.Setenv("SNAP_NAME", snapName); err != nil {
+			t.Errorf("failed to set environment variable: %#v", err)
+		}
+
+		// When run under `go test`, os.Args[0] will be different every time,
+		// so only check that the Snap name is not "goland".
+		if actual := CommandName(); actual == snapName {
+			t.Errorf("expected name not to equal %s, got %s", snapName, actual)
+		}
+
+		if err := os.Unsetenv("SNAP_NAME"); err != nil {
+			t.Errorf("failed to unset environment variable: %#v", err)
+		}
+	})
+
+	t.Run("snap name set to doctl", func(t *testing.T) {
+		const expected = "doctl"
+
+		if err := os.Setenv("SNAP_NAME", "doctl"); err != nil {
+			t.Errorf("failed to set environment variable: %#v", err)
+		}
+
+		if actual := CommandName(); actual != expected {
+			t.Errorf("got %s, want %s", actual, expected)
+		}
+
+		if err := os.Unsetenv("SNAP_NAME"); err != nil {
+			t.Errorf("failed to unset environment variable: %#v", err)
+		}
+	})
+}


### PR DESCRIPTION
Updates the logic for determining the doctl command name to ensure that if `SNAP_NAME` is set, we only use "doctl".

Resolves #1042