### PR TITLE
Grammar and typo fixes in comments and tests

### DIFF
--- a/args.go
+++ b/args.go
@@ -82,7 +82,7 @@ const (
 	ArgHA = "ha"
 	// ArgSurgeUpgrade is a cluster's surge-upgrade argument.
 	ArgSurgeUpgrade = "surge-upgrade"
-	// ArgCommandUpsert is a upsert for a resource to be created or updated argument.
+	// ArgCommandUpsert is an upsert for a resource to be created or updated argument.
 	ArgCommandUpsert = "upsert"
 	// ArgCommandWait is a wait for a resource to be created argument.
 	ArgCommandWait = "wait"
@@ -92,7 +92,7 @@ const (
 	ArgDropletID = "droplet-id"
 	// ArgDropletIDs is a list of droplet IDs.
 	ArgDropletIDs = "droplet-ids"
-	// ArgKernelID is a ekrnel id argument.
+	// ArgKernelID is a kernel id argument.
 	ArgKernelID = "kernel-id"
 	// ArgKubernetesLabel is a Kubernetes label argument.
 	ArgKubernetesLabel = "label"
@@ -106,7 +106,7 @@ const (
 	ArgImageID = "image-id"
 	// ArgImagePublic is a public image argument.
 	ArgImagePublic = "public"
-	// ArgImageSlug is an image slug argment.
+	// ArgImageSlug is an image slug argument.
 	ArgImageSlug = "image-slug"
 	// ArgIPAddress is an IP address argument.
 	ArgIPAddress = "ip-address"
@@ -128,7 +128,7 @@ const (
 	ArgPrivateNetworking = "enable-private-networking"
 	// ArgMonitoring is an enable monitoring argument.
 	ArgMonitoring = "enable-monitoring"
-	// ArgDropletAgent is an argument for enabling/disbling the Droplet agent.
+	// ArgDropletAgent is an argument for enabling/disabling the Droplet agent.
 	ArgDropletAgent = "droplet-agent"
 	// ArgRecordData is a record data argument.
 	ArgRecordData = "record-data"
@@ -192,7 +192,7 @@ const (
 	ArgKeyPublicKeyFile = "public-key-file"
 	// ArgSSHUser is a SSH user argument.
 	ArgSSHUser = "ssh-user"
-	// ArgFormat is columns to include in output argment.
+	// ArgFormat is columns to include in output argument.
 	ArgFormat = "format"
 	// ArgNoHeader hides the output header.
 	ArgNoHeader = "no-header"
@@ -396,9 +396,9 @@ const (
 	// ArgAlertPolicyEmails are the emails to send alerts to.
 	ArgAlertPolicyEmails = "emails"
 
-	// ArgAlertPolicySlackChannels are the slack channels to send alerts to.
+	// ArgAlertPolicySlackChannels are the Slack channels to send alerts to.
 	ArgAlertPolicySlackChannels = "slack-channels"
 
-	// ArgAlertPolicySlackURLs are the slack URLs to send alerts to.
+	// ArgAlertPolicySlackURLs are the Slack URLs to send alerts to.
 	ArgAlertPolicySlackURLs = "slack-urls"
 )

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -112,7 +112,7 @@ func Test_displayAuthContexts(t *testing.T) {
 			Expected: "default (current)\ntest\n",
 		},
 		{
-			Name:    "default context and additional context set to addditional context",
+			Name:    "default context and additional context set to additional context",
 			Out:     &bytes.Buffer{},
 			Context: "test",
 			Contexts: map[string]interface{}{

--- a/commands/certificates_test.go
+++ b/commands/certificates_test.go
@@ -78,7 +78,7 @@ func TestCertificatesCreate(t *testing.T) {
 		},
 
 		{
-			desc:           "creates custom cerftificate without specifying chain",
+			desc:           "creates custom certificate without specifying chain",
 			certName:       "cert-without-chain",
 			privateKeyPath: filepath.Join(os.TempDir(), "cer-key.crt"),
 			certLeafPath:   filepath.Join(os.TempDir(), "leaf-cer.crt"),
@@ -90,7 +90,7 @@ func TestCertificatesCreate(t *testing.T) {
 			},
 		},
 		{
-			desc:     "creates lets_encrypt cerftificate",
+			desc:     "creates lets_encrypt certificate",
 			certName: "lets-encrypt-cert",
 			DNSNames: []string{"sampledomain.org", "api.sampledomain.org"},
 			certType: "lets_encrypt",

--- a/commands/completion.go
+++ b/commands/completion.go
@@ -462,7 +462,7 @@ func RunCompletionZsh(c *CmdConfig) error {
 	// zshHead is the header required to declare zsh completion
 	zshHead := "#compdef doctl\n"
 
-	// zshInit represents intialization code needed to convert bash completion
+	// zshInit represents initialization code needed to convert bash completion
 	// code to zsh completion.
 	zshInit := `
 __doctl_bash_source() {

--- a/commands/confirmation.go
+++ b/commands/confirmation.go
@@ -44,7 +44,7 @@ func AskForConfirm(message string) error {
 	return nil
 }
 
-// AskForConfirmDelete builds a message to ask the user to confirm deleteing
+// AskForConfirmDelete builds a message to ask the user to confirm deleting
 // one or multiple resources and then sends it through to AskForConfirm to
 // parses and verifies user input.
 func AskForConfirmDelete(resourceType string, count int) error {

--- a/commands/displayers/1_click.go
+++ b/commands/displayers/1_click.go
@@ -31,7 +31,7 @@ func (oc *OneClick) JSON(out io.Writer) error {
 	return writeJSON(oc.OneClicks, out)
 }
 
-// Cols are the colums returned in the json
+// Cols are the columns returned in the json
 func (oc *OneClick) Cols() []string {
 	return []string{
 		"SLUG",

--- a/commands/displayers/output.go
+++ b/commands/displayers/output.go
@@ -23,7 +23,7 @@ import (
 	"text/tabwriter"
 )
 
-// Displayable is a displable entity. These are used for printing results.
+// Displayable is a displayable entity. These are used for printing results.
 type Displayable interface {
 	Cols() []string
 	ColMap() map[string]string

--- a/commands/droplet_actions.go
+++ b/commands/droplet_actions.go
@@ -410,7 +410,7 @@ func RunDropletActionRestore(c *CmdConfig) error {
 	return performAction(c, fn)
 }
 
-// RunDropletActionResize resizesx a droplet giving a size slug and
+// RunDropletActionResize resizes a droplet giving a size slug and
 // optionally expands the disk.
 func RunDropletActionResize(c *CmdConfig) error {
 	fn := func(das do.DropletActionsService) (*do.Action, error) {

--- a/commands/images.go
+++ b/commands/images.go
@@ -137,7 +137,7 @@ func RunImagesListDistribution(c *CmdConfig) error {
 
 }
 
-// RunImagesListApplication lists application iamges.
+// RunImagesListApplication lists application images.
 func RunImagesListApplication(c *CmdConfig) error {
 	is := c.Images()
 

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -153,7 +153,7 @@ func (p *kubeconfigProvider) Local() (*clientcmdapi.Config, error) {
 			for _, err := range a.Errors() {
 				// this should NOT be a contains check but they are formatting the
 				// error without implementing an unwrap (so the original permission
-				// error type is lost.
+				// error type is lost).
 				if strings.Contains(err.Error(), "permission denied") && isSnap {
 					warn("Using the doctl Snap? Grant access to the doctl:kube-config plug to use this command with: sudo snap connect doctl:kube-config")
 					return nil, err
@@ -1691,7 +1691,7 @@ func buildNodePoolRecycleRequestFromArgs(c *CmdConfig, clusterID, poolID string,
 	if allUUIDs {
 		r.Nodes = nodeIDorNames
 	} else {
-		// at least some of the args weren't UUIDs, so assume that they're all names
+		// at least some args weren't UUIDs, so assume that they're all names
 		nodes, err := nodesByNames(c.Kubernetes(), clusterID, poolID, nodeIDorNames)
 		if err != nil {
 			return err
@@ -2414,7 +2414,7 @@ func versionMaxBy(versions []do.KubernetesVersion, selector func(do.KubernetesVe
 	if err != nil {
 		return max, err
 	}
-	// NOTE: We have to iterate over all of versions here even though we know
+	// NOTE: We have to iterate over all versions here even though we know
 	// versions[0] won't be greater than maxSV so that the index i will be a
 	// valid index into versions rather than into versions[1:].
 	for i, v := range versions {

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -651,7 +651,7 @@ func TestKubernetesUpgrade(t *testing.T) {
 
 func TestKubernetesDelete(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		// should'nt call `DeleteNodePool` so we don't set any expectations
+		// shouldn't call `DeleteNodePool` so we don't set any expectations
 		config.Doit.Set(config.NS, doctl.ArgForce, "false")
 		config.Args = append(config.Args, testCluster.ID)
 
@@ -710,7 +710,7 @@ func TestKubernetesDelete(t *testing.T) {
 
 func TestKubernetesDeleteSelective(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		// should'nt call `DeleteNodePool` so we don't set any expectations
+		// shouldn't call `DeleteNodePool` so we don't set any expectations
 		config.Doit.Set(config.NS, doctl.ArgForce, "false")
 		config.Args = append(config.Args, testCluster.ID)
 
@@ -1180,7 +1180,7 @@ func TestKubernetesNodePool_Recycle(t *testing.T) {
 
 func TestKubernetesNodePool_Delete(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		// should'nt call `DeleteNodePool` so we don't set any expectations
+		// shouldn't call `DeleteNodePool` so we don't set any expectations
 		config.Doit.Set(config.NS, doctl.ArgForce, "false")
 		config.Args = append(config.Args, testCluster.ID, testNodePool.ID)
 

--- a/do/account_test.go
+++ b/do/account_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// MockAccountService is a mock of AccountService interface
+// MockAccountService is a mock for AccountService interface
 type MockAccountService struct {
 	ctrl     *gomock.Controller
 	recorder *MockAccountServiceMockRecorder

--- a/do/balance_test.go
+++ b/do/balance_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// MockBalanceService is a mock of BalanceService interface
+// MockBalanceService is a mock for BalanceService interface
 type MockBalanceService struct {
 	ctrl     *gomock.Controller
 	recorder *MockBalanceServiceMockRecorder

--- a/do/domains.go
+++ b/do/domains.go
@@ -57,7 +57,7 @@ type DomainRecordEditRequest struct {
 // DomainRecords is a slice of DomainRecord.
 type DomainRecords []DomainRecord
 
-// DomainsService is the godo DOmainsService interface.
+// DomainsService is the godo DomainsService interface.
 type DomainsService interface {
 	List() (Domains, error)
 	Get(string) (*Domain, error)

--- a/do/droplets.go
+++ b/do/droplets.go
@@ -23,7 +23,7 @@ import (
 // DropletIPTable is a table of interface IPS.
 type DropletIPTable map[InterfaceType]string
 
-// InterfaceType is a an interface type.
+// InterfaceType is an interface type.
 type InterfaceType string
 
 const (

--- a/do/images.go
+++ b/do/images.go
@@ -19,7 +19,7 @@ import (
 	"github.com/digitalocean/godo"
 )
 
-// Image is a werapper for godo.Image
+// Image is a wrapper for godo.Image
 type Image struct {
 	*godo.Image
 }

--- a/do/invoices.go
+++ b/do/invoices.go
@@ -34,7 +34,7 @@ type InvoiceSummary struct {
 	*godo.InvoiceSummary
 }
 
-// InvoiceList is a the results when listing invoices
+// InvoiceList is the results when listing invoices
 type InvoiceList struct {
 	*godo.InvoiceList
 }

--- a/doit.go
+++ b/doit.go
@@ -140,7 +140,7 @@ type LatestVersioner interface {
 	LatestVersion() (string, error)
 }
 
-// GithubLatestVersioner retrieves the latest version from Github.
+// GithubLatestVersioner retrieves the latest version from GitHub.
 type GithubLatestVersioner struct{}
 
 var _ LatestVersioner = &GithubLatestVersioner{}

--- a/integration/domain_records_delete_test.go
+++ b/integration/domain_records_delete_test.go
@@ -114,7 +114,7 @@ var _ = suite("compute/domain/records/delete", func(t *testing.T, when spec.G, i
 	})
 
 	when("deleting one domain record without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,
@@ -133,7 +133,7 @@ var _ = suite("compute/domain/records/delete", func(t *testing.T, when spec.G, i
 	})
 
 	when("deleting two domain records without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,

--- a/integration/droplet_delete_test.go
+++ b/integration/droplet_delete_test.go
@@ -136,7 +136,7 @@ var _ = suite("compute/droplet/delete", func(t *testing.T, when spec.G, it spec.
 	})
 
 	when("deleting one Droplet without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,
@@ -153,7 +153,7 @@ var _ = suite("compute/droplet/delete", func(t *testing.T, when spec.G, it spec.
 	})
 
 	when("deleting two Droplet without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,
@@ -171,7 +171,7 @@ var _ = suite("compute/droplet/delete", func(t *testing.T, when spec.G, it spec.
 	})
 
 	when("deleting one Droplet by tag without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,
@@ -188,7 +188,7 @@ var _ = suite("compute/droplet/delete", func(t *testing.T, when spec.G, it spec.
 	})
 
 	when("deleting two Droplet by tag without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,

--- a/integration/firewall_delete_test.go
+++ b/integration/firewall_delete_test.go
@@ -98,7 +98,7 @@ var _ = suite("compute/firewall/delete", func(t *testing.T, when spec.G, it spec
 	})
 
 	when("deleting one firewall without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,
@@ -115,7 +115,7 @@ var _ = suite("compute/firewall/delete", func(t *testing.T, when spec.G, it spec
 	})
 
 	when("deleting two firewalls without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,

--- a/integration/image_delete_test.go
+++ b/integration/image_delete_test.go
@@ -98,7 +98,7 @@ var _ = suite("compute/image/delete", func(t *testing.T, when spec.G, it spec.S)
 	})
 
 	when("deleting one image without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,
@@ -115,7 +115,7 @@ var _ = suite("compute/image/delete", func(t *testing.T, when spec.G, it spec.S)
 	})
 
 	when("deleting two images without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic("failed to create temp dir")
 	}
-	defer os.RemoveAll(tmpDir) // yes, this is best effort only
+	defer os.RemoveAll(tmpDir) // yes, this is the best effort only
 
 	builtBinaryPath = filepath.Join(tmpDir, path.Base(packagePath))
 	if runtime.GOOS == "windows" {

--- a/integration/projects_resources_assign_test.go
+++ b/integration/projects_resources_assign_test.go
@@ -63,7 +63,7 @@ var _ = suite("projects/resources/assign", func(t *testing.T, when spec.G, it sp
 	})
 
 	when("all required flags are passed", func() {
-		it("assigns resources to the proejct", func() {
+		it("assigns resources to the project", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,

--- a/integration/projects_resources_list_test.go
+++ b/integration/projects_resources_list_test.go
@@ -49,7 +49,7 @@ var _ = suite("projects/resources/list", func(t *testing.T, when spec.G, it spec
 	})
 
 	when("all required flags are passed", func() {
-		it("list resources for the proejct", func() {
+		it("list resources for the project", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,

--- a/integration/registry_docker_config_test.go
+++ b/integration/registry_docker_config_test.go
@@ -113,7 +113,7 @@ var _ = suite("registry/docker-config", func(t *testing.T, when spec.G, it spec.
 	})
 
 	when("expiry-seconds flag is passed", func() {
-		it("add the correct query paramater", func() {
+		it("add the correct query parameter", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,

--- a/integration/registry_login_test.go
+++ b/integration/registry_login_test.go
@@ -100,7 +100,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("expiry-seconds flag is passed", func() {
-		it("add the correct query paramater", func() {
+		it("add the correct query parameter", func() {
 			tmpDir, err := ioutil.TempDir("", "")
 			expect.NoError(err)
 

--- a/integration/snapshot_delete_test.go
+++ b/integration/snapshot_delete_test.go
@@ -110,7 +110,7 @@ var _ = suite("compute/snapshot/delete", func(t *testing.T, when spec.G, it spec
 	})
 
 	when("deleting one snapshot without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,
@@ -127,7 +127,7 @@ var _ = suite("compute/snapshot/delete", func(t *testing.T, when spec.G, it spec
 	})
 
 	when("deleting two snapshots without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,

--- a/integration/tags_delete_test.go
+++ b/integration/tags_delete_test.go
@@ -110,7 +110,7 @@ var _ = suite("compute/tags/delete", func(t *testing.T, when spec.G, it spec.S) 
 	})
 
 	when("deleting one tag without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,
@@ -127,7 +127,7 @@ var _ = suite("compute/tags/delete", func(t *testing.T, when spec.G, it spec.S) 
 	})
 
 	when("deleting two tags without force flag", func() {
-		it("correctly promts for confirmation", func() {
+		it("correctly prompts for confirmation", func() {
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
 				"-u", server.URL,

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -18,10 +18,10 @@ type Listener struct {
 	// URL is the url for the websocket. The schema should be "wss" or "ws"
 	URL *url.URL
 	// Token is used for authenticating with the websocket. It will be passed
-	// using the "token" query paramater.
+	// using the "token" query parameter.
 	Token string
 	// SchemaFunc is a function allowing you to customize the output. For example,
-	// this can be useful for unmarshal a JSON message and formating the output.
+	// this can be useful for unmarshal a JSON message and formatting the output.
 	// It should return an io.Reader. If set to nil, the raw message will be outputted.
 	SchemaFunc SchemaFunc
 	// Out is an io.Writer to output to.
@@ -104,7 +104,7 @@ func (l *Listener) Start() error {
 	}
 }
 
-// Stop signels the Listener to close the websocket connetion
+// Stop signals the Listener to close the websocket connection
 func (l *Listener) Stop() {
 	select {
 	case <-l.done:

--- a/util.go
+++ b/util.go
@@ -18,7 +18,7 @@ import (
 	"github.com/digitalocean/doctl/pkg/runner"
 )
 
-// MockRunner is an implemenation of Runner for mocking.
+// MockRunner is an implementation of Runner for mocking.
 type MockRunner struct {
 	Err error
 }


### PR DESCRIPTION
Fix grammar errors and typos in comments or tests. Production code is not affected.