### PR TITLE
Fix `doctl auth list` command’s help

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -108,7 +108,7 @@ For details on creating an authentication context, see the help for `+"`"+`doctl
 
 	cmdAuthList := cmdBuilderWithInit(cmd, RunAuthList, "list", "List available authentication contexts", `List named authentication contexts that you created with `+"`"+`doctl auth init`+"`"+`.
 
-To switch between the contexts use `+"`"+`doctl switch <name>`+"`"+`, where `+"`"+`<name>`+"`"+` is one of the contexts listed.
+To switch between the contexts use `+"`"+`doctl auth switch --context <name>`+"`"+`, where `+"`"+`<name>`+"`"+` is one of the contexts listed.
 
 To create new contexts, see the help for `+"`"+`doctl auth init`+"`"+`.`, Writer, false, aliasOpt("ls"))
 	// The command runner expects that any command named "list" accepts a


### PR DESCRIPTION
I think that the help instructions in the `doctl auth list` command are (no longer?) valid, and that switching auth context must be done using the `doctl auth switch --context <name>` command.

This PR fixed the help text.

(I’m sorry if I’m mistaken – I just started using `doctl` today and run into this when trying to switch between contexts.)