### PR TITLE
pagination: updated pagination to give deterministic and natural ordering

### DIFF
--- a/do/pagination.go
+++ b/do/pagination.go
@@ -29,15 +29,16 @@ var perPage = 200
 var fetchFn = fetchPage
 
 type paginatedList struct {
-	list []interface{}
-	mu   sync.Mutex
+	list  [][]interface{}
+	total int
+	mu    sync.Mutex
 }
 
-func (pl *paginatedList) append(items ...interface{}) {
+func (pl *paginatedList) set(page int, items []interface{}) {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
-
-	pl.list = append(pl.list, items...)
+	pl.total += len(items)
+	pl.list[page-1] = items
 }
 
 // Generator is a function that generates the list to be paginated.
@@ -47,7 +48,24 @@ type Generator func(*godo.ListOptions) ([]interface{}, *godo.Response, error)
 func PaginateResp(gen Generator) ([]interface{}, error) {
 	opt := &godo.ListOptions{Page: 1, PerPage: perPage}
 
-	l := paginatedList{}
+	// fetch first page to get page count (x)
+	firstPage, resp, err := gen(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	// find last page
+	lp, err := lastPage(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	l := paginatedList{
+		list: make([][]interface{}, lp),
+	}
+
+	// set results from the first page
+	l.set(1, firstPage)
 
 	fetchChan := make(chan int, maxFetchPages)
 
@@ -58,25 +76,11 @@ func PaginateResp(gen Generator) ([]interface{}, error) {
 			for page := range fetchChan {
 				items, err := fetchFn(gen, page)
 				if err == nil {
-					l.append(items...)
+					l.set(page, items)
 				}
 			}
 			wg.Done()
 		}()
-	}
-
-	// fetch first page to get page count (x)
-	items, resp, err := gen(opt)
-	if err != nil {
-		return nil, err
-	}
-
-	l.append(items...)
-
-	// find last page
-	lp, err := lastPage(resp)
-	if err != nil {
-		return nil, err
 	}
 
 	// start with second page
@@ -88,7 +92,19 @@ func PaginateResp(gen Generator) ([]interface{}, error) {
 
 	wg.Wait()
 
-	return l.list, nil
+	// flatten paginated list
+	items := make([]interface{}, l.total)[:0]
+	for _, page := range l.list {
+		if page == nil {
+			// must have been an error getting page results
+			continue
+		}
+		for _, item := range page {
+			items = append(items, item)
+		}
+	}
+
+	return items, nil
 }
 
 func fetchPage(gen Generator, page int) ([]interface{}, error) {


### PR DESCRIPTION
The motivation for these changes is to ensure that results are ordered as they were intended to be by the endpoint being called. Currently, pages may be inconsistently ordered after the first, depending on the order in which the async page loads are completed.  This likely hasn't been an issue since there would need to be 3+ pages (at least 401 results) to be observed. 

Out-of-order results can be observed by temporarily updating pagination `perPage` to some small value like `5` and running a command with more than a handfull of pages of results. 

### Comparing with `perPage=1` to magnify the effect

**current pagination**
```
$ builds/doctl registry repository list
Name       Latest Tag    Tag Count    Updated At
1            2021-12-08 17:02:20 +0000 UTC
bulk_05    bulk_01       1            2021-12-08 17:02:49 +0000 UTC
bulk_02    bulk_01       1            2021-12-08 17:02:45 +0000 UTC
bulk_03    bulk_01       1            2021-12-08 17:02:47 +0000 UTC
bulk_04    bulk_01       1            2021-12-08 17:02:47 +0000 UTC
bulk_06    bulk_01       1            2021-12-08 17:02:49 +0000 UTC
bulk_07    bulk_01       1            2021-12-08 17:02:50 +0000 UTC
bulk_08    bulk_01       1            2021-12-08 17:02:51 +0000 UTC
bulk_09    bulk_01       1            2021-12-08 17:02:52 +0000 UTC
bulk_10    bulk_01       1            2021-12-08 17:02:54 +0000 UTC
bulk_13    bulk_01       1            2021-12-08 17:02:56 +0000 UTC
bulk_12    bulk_01       1            2021-12-08 17:02:55 +0000 UTC
bulk_14    bulk_01       1            2021-12-08 17:02:58 +0000 UTC
bulk_15    bulk_01       1            2021-12-08 17:02:58 +0000 UTC
bulk_11    bulk_01       1            2021-12-08 17:02:54 +0000 UTC
bulk_16    bulk_01       1            2021-12-08 17:02:59 +0000 UTC
bulk_17    bulk_01       1            2021-12-08 17:03:00 +0000 UTC
bulk_19    bulk_01       1            2021-12-08 17:03:02 +0000 UTC
bulk_18    bulk_01       1            2021-12-08 17:03:01 +0000 UTC
bulk_20    bulk_01       1            2021-12-08 17:03:04 +0000 UTC

$ builds/doctl registry repository list
Name       Latest Tag    Tag Count    Updated At
bulk_01    bulk_01       1            2021-12-08 17:02:20 +0000 UTC
bulk_05    bulk_01       1            2021-12-08 17:02:49 +0000 UTC
bulk_03    bulk_01       1            2021-12-08 17:02:47 +0000 UTC
bulk_04    bulk_01       1            2021-12-08 17:02:47 +0000 UTC
bulk_06    bulk_01       1            2021-12-08 17:02:49 +0000 UTC
bulk_02    bulk_01       1            2021-12-08 17:02:45 +0000 UTC
bulk_07    bulk_01       1            2021-12-08 17:02:50 +0000 UTC
bulk_10    bulk_01       1            2021-12-08 17:02:54 +0000 UTC
bulk_08    bulk_01       1            2021-12-08 17:02:51 +0000 UTC
bulk_09    bulk_01       1            2021-12-08 17:02:52 +0000 UTC
bulk_11    bulk_01       1            2021-12-08 17:02:54 +0000 UTC
bulk_12    bulk_01       1            2021-12-08 17:02:55 +0000 UTC
bulk_13    bulk_01       1            2021-12-08 17:02:56 +0000 UTC
bulk_14    bulk_01       1            2021-12-08 17:02:58 +0000 UTC
bulk_15    bulk_01       1            2021-12-08 17:02:58 +0000 UTC
bulk_17    bulk_01       1            2021-12-08 17:03:00 +0000 UTC
bulk_16    bulk_01       1            2021-12-08 17:02:59 +0000 UTC
bulk_18    bulk_01       1            2021-12-08 17:03:01 +0000 UTC
bulk_20    bulk_01       1            2021-12-08 17:03:04 +0000 UTC
bulk_19    bulk_01       1            2021-12-08 17:03:02 +0000 UTC

```

**updated pagination**
```
$ time builds/doctl registry repository list
Name       Latest Tag    Tag Count    Updated At
bulk_01    bulk_01       1            2021-12-08 17:02:20 +0000 UTC
bulk_02    bulk_01       1            2021-12-08 17:02:45 +0000 UTC
bulk_03    bulk_01       1            2021-12-08 17:02:47 +0000 UTC
bulk_04    bulk_01       1            2021-12-08 17:02:47 +0000 UTC
bulk_05    bulk_01       1            2021-12-08 17:02:49 +0000 UTC
bulk_06    bulk_01       1            2021-12-08 17:02:49 +0000 UTC
bulk_07    bulk_01       1            2021-12-08 17:02:50 +0000 UTC
bulk_08    bulk_01       1            2021-12-08 17:02:51 +0000 UTC
bulk_09    bulk_01       1            2021-12-08 17:02:52 +0000 UTC
bulk_10    bulk_01       1            2021-12-08 17:02:54 +0000 UTC
bulk_11    bulk_01       1            2021-12-08 17:02:54 +0000 UTC
bulk_12    bulk_01       1            2021-12-08 17:02:55 +0000 UTC
bulk_13    bulk_01       1            2021-12-08 17:02:56 +0000 UTC
bulk_14    bulk_01       1            2021-12-08 17:02:58 +0000 UTC
bulk_15    bulk_01       1            2021-12-08 17:02:58 +0000 UTC
bulk_16    bulk_01       1            2021-12-08 17:02:59 +0000 UTC
bulk_17    bulk_01       1            2021-12-08 17:03:00 +0000 UTC
bulk_18    bulk_01       1            2021-12-08 17:03:01 +0000 UTC
bulk_19    bulk_01       1            2021-12-08 17:03:02 +0000 UTC
bulk_20    bulk_01       1            2021-12-08 17:03:04 +0000 UTC
```