### PR TITLE
APICLI-528: adding option to pick context name in 'kubeconfig save'

### DIFF
--- a/args.go
+++ b/args.go
@@ -98,6 +98,8 @@ const (
 	ArgKubernetesLabel = "label"
 	// ArgKubernetesTaint is a Kubernetes taint argument.
 	ArgKubernetesTaint = "taint"
+	// 	ArgKubernetesAlias is a Kubernetes alias argument that saves authentication information under the specified context.
+	ArgKubernetesAlias = "alias"
 	// ArgKubeConfigExpirySeconds indicates the length of time the token in a kubeconfig will be valid in seconds.
 	ArgKubeConfigExpirySeconds = "expiry-seconds"
 	// ArgImage is an image argument.

--- a/args.go
+++ b/args.go
@@ -98,7 +98,7 @@ const (
 	ArgKubernetesLabel = "label"
 	// ArgKubernetesTaint is a Kubernetes taint argument.
 	ArgKubernetesTaint = "taint"
-	// 	ArgKubernetesAlias is a Kubernetes alias argument that saves authentication information under the specified context.
+	// ArgKubernetesAlias is a Kubernetes alias argument that saves authentication information under the specified context.
 	ArgKubernetesAlias = "alias"
 	// ArgKubeConfigExpirySeconds indicates the length of time the token in a kubeconfig will be valid in seconds.
 	ArgKubeConfigExpirySeconds = "expiry-seconds"

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -399,7 +399,7 @@ This command adds the credentials for the specified cluster to your local kubeco
 	AddBoolFlag(cmdSaveConfig, doctl.ArgSetCurrentContext, "", true, "Boolean indicating whether to set the current kubectl context to that of the new cluster")
 	AddIntFlag(cmdSaveConfig, doctl.ArgKubeConfigExpirySeconds, "", 0,
 		"The length of time the cluster credentials will be valid for in seconds. By default, the credentials are automatically renewed as needed.")
-	AddStringFlag(cmdSaveConfig, doctl.ArgKubernetesAlias, "", "", "The context to save authentication information.")
+	AddStringFlag(cmdSaveConfig, doctl.ArgKubernetesAlias, "", "", "An alias for the cluster context name. Defaults to 'do-<region>-<cluster-name>'.")
 
 	CmdBuilder(cmd, k8sCmdService.RunKubernetesKubeconfigRemove, "remove <cluster-id|cluster-name>", "Remove a cluster's credentials from your local kubeconfig", `
 This command removes the specified cluster's credentials from your local kubeconfig. After running this command, you will not be able to use `+"`"+`kubectl`+"`"+` to interact with your cluster.

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -399,6 +399,7 @@ This command adds the credentials for the specified cluster to your local kubeco
 	AddBoolFlag(cmdSaveConfig, doctl.ArgSetCurrentContext, "", true, "Boolean indicating whether to set the current kubectl context to that of the new cluster")
 	AddIntFlag(cmdSaveConfig, doctl.ArgKubeConfigExpirySeconds, "", 0,
 		"The length of time the cluster credentials will be valid for in seconds. By default, the credentials are automatically renewed as needed.")
+	AddStringFlag(cmdSaveConfig, doctl.ArgKubernetesAlias, "", "", "The context to save authentication information.")
 
 	CmdBuilder(cmd, k8sCmdService.RunKubernetesKubeconfigRemove, "remove <cluster-id|cluster-name>", "Remove a cluster's credentials from your local kubeconfig", `
 This command removes the specified cluster's credentials from your local kubeconfig. After running this command, you will not be able to use `+"`"+`kubectl`+"`"+` to interact with your cluster.
@@ -1258,6 +1259,17 @@ func (s *KubernetesCommandService) RunKubernetesKubeconfigSave(c *CmdConfig) err
 	remoteKubeconfig, err := s.KubeconfigProvider.Remote(kube, clusterID, expirySeconds)
 	if err != nil {
 		return err
+	}
+
+	alias, err := c.Doit.GetString(c.NS, doctl.ArgKubernetesAlias)
+	if err != nil {
+		return err
+	}
+
+	if alias != "" {
+		remoteKubeconfig.Contexts[alias] = remoteKubeconfig.Contexts[remoteKubeconfig.CurrentContext]
+		delete(remoteKubeconfig.Contexts, remoteKubeconfig.CurrentContext)
+		remoteKubeconfig.CurrentContext = alias
 	}
 
 	setCurrentContext, err := c.Doit.GetBool(c.NS, doctl.ArgSetCurrentContext)

--- a/integration/kubernetes_clusters_kubeconfig_save_test.go
+++ b/integration/kubernetes_clusters_kubeconfig_save_test.go
@@ -149,6 +149,7 @@ var _ = suite("kubernetes/clusters/kubeconfig/save", func(t *testing.T, when spe
 			err = f.Close()
 			expect.NoError(err)
 			expect.Contains(string(fileBytes), fmt.Sprintf("current-context: %s", "newalias_test"))
+			expect.Contains(string(fileBytes), fmt.Sprintf("name: %s", "newalias_test"))
 		})
 	})
 })

--- a/integration/kubernetes_clusters_kubeconfig_save_test.go
+++ b/integration/kubernetes_clusters_kubeconfig_save_test.go
@@ -142,6 +142,7 @@ var _ = suite("kubernetes/clusters/kubeconfig/save", func(t *testing.T, when spe
 			)
 
 			output, err := cmd.CombinedOutput()
+
 			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
 
 			fileBytes, err := ioutil.ReadAll(f)

--- a/integration/kubernetes_clusters_kubeconfig_save_test.go
+++ b/integration/kubernetes_clusters_kubeconfig_save_test.go
@@ -119,6 +119,38 @@ var _ = suite("kubernetes/clusters/kubeconfig/save", func(t *testing.T, when spe
 			expect.Contains(string(fileBytes), "token: some-token")
 		})
 	})
+	when("passing alias", func() {
+		it("creates an alias for a config", func() {
+			f, err := ioutil.TempFile("", "fake-kube-config")
+			expect.NoError(err)
+
+			defer os.Remove(f.Name())
+
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"kubernetes",
+				"clusters",
+				"kubeconfig",
+				"save",
+				"--alias", "newalias_test",
+				"some-cluster-name",
+			)
+
+			cmd.Env = append(os.Environ(),
+				fmt.Sprintf("KUBECONFIG=%s", f.Name()),
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+
+			fileBytes, err := ioutil.ReadAll(f)
+			expect.NoError(err)
+			err = f.Close()
+			expect.NoError(err)
+			expect.Contains(string(fileBytes), fmt.Sprintf("current-context: %s", "newalias_test"))
+		})
+	})
 })
 
 const (


### PR DESCRIPTION
per #856- adding the option to add an alias for a kubernetes context, as such:
`go run cmd/doctl/main.go kubernetes cluster kubeconfig save k8ds-test --alias=newalias_k8ds`