### PR TITLE
Update godo to support new app component type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/creack/pty v1.1.11
-	github.com/digitalocean/godo v1.73.0
+	github.com/digitalocean/godo v1.74.0
 	github.com/docker/cli v0.0.0-20200622130859-87db43814b48
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/digitalocean/godo v1.73.0 h1:VEPb2YIgvbG5WP9+2Yin6ty+1s01mTUrSEW4CO6alVc=
 github.com/digitalocean/godo v1.73.0/go.mod h1:GBmu8MkjZmNARE7IXRPmkbbnocNN8+uBm0xbEVw2LCs=
+github.com/digitalocean/godo v1.74.0 h1:K2C4N5xZzs0MALofSQHuONbRDlTIYo+Vqg80nf/qZXc=
+github.com/digitalocean/godo v1.74.0/go.mod h1:GBmu8MkjZmNARE7IXRPmkbbnocNN8+uBm0xbEVw2LCs=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48 h1:AC8qbhi/SjYf4iN2W3jSsofZGHWPjG8pjf5P143KUM8=
 github.com/docker/cli v0.0.0-20200622130859-87db43814b48/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible h1:PmGHHCZ43l6h8aZIi+Xa+z1SWe4dFImd5EK3TNp1jlo=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.74.0] - 2022-01-20
+
+- #506 - @ZachEddy - Add new component type to apps-related structs
+
 ## [v1.73.0] - 2021-12-03
 
 - #501 - @CollinShoop - Add support for Registry ListManifests and ListRepositoriesV2

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -327,7 +327,8 @@ type AppSpec struct {
 	// Workloads which do not expose publicly-accessible HTTP services.
 	Workers []*AppWorkerSpec `json:"workers,omitempty"`
 	// Pre and post deployment workloads which do not expose publicly-accessible HTTP routes.
-	Jobs []*AppJobSpec `json:"jobs,omitempty"`
+	Jobs      []*AppJobSpec       `json:"jobs,omitempty"`
+	Functions []*AppFunctionsSpec `json:"functions,omitempty"`
 	// Database instances which can provide persistence to workloads within the application.
 	Databases []*AppDatabaseSpec `json:"databases,omitempty"`
 	// A set of hostnames where the application will be available.
@@ -404,6 +405,22 @@ type AppWorkerSpec struct {
 	LogDestinations  []*AppLogDestinationSpec `json:"log_destinations,omitempty"`
 }
 
+// AppFunctionsSpec struct for AppFunctionsSpec
+type AppFunctionsSpec struct {
+	// The name. Must be unique across all components within the same app.
+	Name   string            `json:"name"`
+	Git    *GitSourceSpec    `json:"git,omitempty"`
+	GitHub *GitHubSourceSpec `json:"github,omitempty"`
+	GitLab *GitLabSourceSpec `json:"gitlab,omitempty"`
+	// An optional path to the working directory to use for the build. Must be relative to the root of the repo.
+	SourceDir string `json:"source_dir,omitempty"`
+	// A list of environment variables made available to the component.
+	Envs []*AppVariableDefinition `json:"envs,omitempty"`
+	// A list of HTTP routes that should be routed to this component.
+	Routes []*AppRouteSpec `json:"routes,omitempty"`
+	CORS   *AppCORSPolicy  `json:"cors,omitempty"`
+}
+
 // DeploymentCauseDetailsDigitalOceanUser struct for DeploymentCauseDetailsDigitalOceanUser
 type DeploymentCauseDetailsDigitalOceanUser struct {
 	UUID     string `json:"uuid,omitempty"`
@@ -455,6 +472,7 @@ type Deployment struct {
 	StaticSites          []*DeploymentStaticSite `json:"static_sites,omitempty"`
 	Workers              []*DeploymentWorker     `json:"workers,omitempty"`
 	Jobs                 []*DeploymentJob        `json:"jobs,omitempty"`
+	Functions            []*DeploymentFunctions  `json:"functions,omitempty"`
 	PhaseLastUpdatedAt   time.Time               `json:"phase_last_updated_at,omitempty"`
 	CreatedAt            time.Time               `json:"created_at,omitempty"`
 	UpdatedAt            time.Time               `json:"updated_at,omitempty"`
@@ -565,6 +583,12 @@ type DeploymentStaticSite struct {
 
 // DeploymentWorker struct for DeploymentWorker
 type DeploymentWorker struct {
+	Name             string `json:"name,omitempty"`
+	SourceCommitHash string `json:"source_commit_hash,omitempty"`
+}
+
+// DeploymentFunctions struct for DeploymentFunctions
+type DeploymentFunctions struct {
 	Name             string `json:"name,omitempty"`
 	SourceCommitHash string `json:"source_commit_hash,omitempty"`
 }

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.73.0"
+	libraryVersion = "1.74.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -20,7 +20,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.73.0
+# github.com/digitalocean/godo v1.74.0
 ## explicit; go 1.16
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
This PR bumps `godo` to incorporate digitalocean/godo#506 changes (released [here](https://github.com/digitalocean/godo/pull/507)), allowing `doctl` users to create and manage apps that have `functions` components.

I verified locally that commands like `apps create` and `apps spec get` work as expected with the new component type.