### PR TITLE
fixed the instructions for auto-completions on zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,12 @@ The most common way to use the `completion` command is by adding a line to your 
 source <(doctl completion your_shell_here)
 ```
 
+for zsh, also add this:
+
+```
+compdef _doctl doctl
+```
+
 Then refresh your profile.
 
 ```

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ The most common way to use the `completion` command is by adding a line to your 
 source <(doctl completion your_shell_here)
 ```
 
-for zsh, also add this:
+If you are using ZSH, add this line to your `~/.zshrc` file:
 
 ```
 compdef _doctl doctl


### PR DESCRIPTION
The README instructions for auto-completions on Linux for zsh don't currently work.

Cobra handles zsh completion generations differently so sourcing them is not enough to activate the completions: https://github.com/spf13/cobra/blob/master/shell_completions.md#zsh-completions

Either `compdef _doctl doctl` needs to be added after sourcing, or the generated completions need to be added to a file on the $fpath.

The help message for doctl completion zsh actually has the correct instructions:

```
❯ doctl completion zsh --help

Generate the autocompletion script for the zsh shell.

If shell completion is not already enabled in your environment you will need
to enable it.  You can execute the following once:

$ echo "autoload -U compinit; compinit" >> ~/.zshrc

To load completions for every new session, execute once:
# Linux:
$ doctl completion zsh > "${fpath[1]}/_doctl"
# macOS:
$ doctl completion zsh > /usr/local/share/zsh/site-functions/_doctl

You will need to start a new shell for this setup to take effect.
```