### PR TITLE
Snap Version Fix

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: doctl
-version: git
+adopt-info: doctl
 summary: The official DigitalOcean command line interface
 description: |
   doctl allows you to interact with the DigitalOcean API via the command line.


### PR DESCRIPTION
The version was taken by running `version: git` which is a short hand for `version: $(git describe)` which can at times add the commit hash to the end of the version. This change forces the version to be set by the script in the `override-build` section lower in `snapcraft.yml` .