### PR TITLE
remove v from snap name:

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         id: build
         run: |
           make _build_snap && \
-          find doctl_v*.snap -print -exec echo ::set-output name=snap::{} \;
+          find doctl_*.snap -print -exec echo ::set-output name=snap::{} \;
 
       - uses: snapcore/action-publish@v1
         with:

--- a/.github/workflows/snapcraft-candidate.yml
+++ b/.github/workflows/snapcraft-candidate.yml
@@ -26,7 +26,7 @@ jobs:
         id: build
         run: |
           make _build_snap && \
-          find doctl_v*.snap -print -exec echo ::set-output name=snap::{} \;
+          find doctl_*.snap -print -exec echo ::set-output name=snap::{} \;
 
       - uses: snapcore/action-publish@v1
         with:


### PR DESCRIPTION
The extra `v` is no longer set on the snap name. it was originally set by `version: git`. The new version name will be `doctl_1.70.0_amd64.snap`