### PR TITLE
Update scripts/version.sh to output desired snap version.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         id: build
         run: |
           make _build_snap && \
-          find doctl_*.snap -print -exec echo ::set-output name=snap::{} \;
+          find doctl_v*.snap -print -exec echo ::set-output name=snap::{} \;
 
       - uses: snapcore/action-publish@v1
         with:

--- a/.github/workflows/snapcraft-candidate.yml
+++ b/.github/workflows/snapcraft-candidate.yml
@@ -26,7 +26,7 @@ jobs:
         id: build
         run: |
           make _build_snap && \
-          find doctl_*.snap -print -exec echo ::set-output name=snap::{} \;
+          find doctl_v*.snap -print -exec echo ::set-output name=snap::{} \;
 
       - uses: snapcore/action-publish@v1
         with:

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -18,6 +18,7 @@ Options:
   -i, --image  snap image version
   -b, --branch branch only
   -c, --commit commit only
+  --snap, returns the version formated for a snap release
 "
 
 semver() {
@@ -42,6 +43,16 @@ image() {
   echo "$(semver)-$(commit)-pre"
 }
 
+snap() {
+  version=$(semver)
+  if [[ $(git tag --points-at) != "" ]]; then
+    echo "v$version"
+  else
+    local_commit=$(git rev-parse --short HEAD)
+    echo "v$version+git$local_commit"
+  fi
+}
+
 ORIGIN=${ORIGIN:-origin}
 set +e
 git fetch --tags "${ORIGIN}" &>/dev/null
@@ -61,12 +72,12 @@ if [[ "$#" -eq 0 ]]; then
   if [[ -n "$br" ]]; then
     version="${version}-${br}"
   fi
-  
+
   cm=$(commit)
   if [[ -n "$cm" ]]; then
     version="${version}-${cm}"
   fi
-    
+
   echo "$version"
   exit 0
 fi
@@ -86,6 +97,10 @@ case "$1" in
 
   "-i"|"--image")
     version=$(image)
+    ;;
+
+  "--snap")
+    version=$(snap)
     ;;
 
   *)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,7 +32,7 @@ parts:
     override-pull: |
       git clone https://github.com/digitalocean/doctl.git .
     override-build: |
-      version=$(scripts/version.sh)
+      version=$(scripts/version.sh --snap)
       snapcraftctl set-version ${version}
 
       short=${version%+*}


### PR DESCRIPTION
This adds a new `--snap` flag to `scripts/version.sh` that is aware if it is being run from a tag and outputs desired snap version. I've added this as a new function to ensure that I don't unintentionally change any other usages of this script.

From a non-tagged version, `+git${SHA}` should be appended to the version. Eg.

```
 ./scripts/version.sh --snap
v1.70.0+git2cdebf6f
```
From a tagged version, it should print tag:

```
 ./scripts/version.sh --snap
v1.70.0
```