### PR TITLE
Strip leading 'v' before setting ldflags.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,7 +35,8 @@ parts:
       version=$(scripts/version.sh --snap)
       snapcraftctl set-version ${version}
 
-      short=${version%+*}
+      short=${version#v}
+      short=${short%+*}
       short=${short%-*}
       baseFlag="-X github.com/digitalocean/doctl"
       ldFlags="${baseFlag}.Label=release ${baseFlag}.Build=$(git rev-parse --short HEAD)"


### PR DESCRIPTION
Following up on https://github.com/digitalocean/doctl/pull/1100, the leading `v` needs to be stripped before setting setting the ldflags to make sure `doctl version` is correct. We convert the string to an int. `v1` will fail and lead to `0` being set as the major version.

https://github.com/digitalocean/doctl/blob/455a4e5d1c2b8aa1ef5f65954aa3562eaf8ae56e/doit.go#L84-L87