### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/integration/auth_remove_context_test.go
+++ b/integration/auth_remove_context_test.go
@@ -23,9 +23,7 @@ var _ = suite("auth/remove", func(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		expect = require.New(t)
 
-		var err error
-		tmpDir, err = ioutil.TempDir("", "")
-		expect.NoError(err)
+		tmpDir = t.TempDir()
 
 		testConfig = filepath.Join(tmpDir, "test-config.yml")
 		var testConfigBytes = []byte(`access-token: first-token

--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -64,8 +64,7 @@ var _ = suite("auth/init", func(t *testing.T, when spec.G, it spec.S) {
 
 	when("a custom config is provided", func() {
 		it("validates and saves the provided auth token", func() {
-			tmpDir, err := ioutil.TempDir("", "")
-			expect.NoError(err)
+			tmpDir := t.TempDir()
 
 			testConfig := filepath.Join(tmpDir, "test-config.yml")
 
@@ -136,8 +135,7 @@ var _ = suite("auth/init", func(t *testing.T, when spec.G, it spec.S) {
 
 	when("a token cannot be validated", func() {
 		it("exits non-zero with an error", func() {
-			tmpDir, err := ioutil.TempDir("", "")
-			expect.NoError(err)
+			tmpDir := t.TempDir()
 
 			testConfig := filepath.Join(tmpDir, "test-config.yml")
 
@@ -176,8 +174,7 @@ auth-contexts:
 context: default
 `)
 
-			tmpDir, err := ioutil.TempDir("", "")
-			expect.NoError(err)
+			tmpDir := t.TempDir()
 			testConfig := filepath.Join(tmpDir, "test-config.yml")
 			expect.NoError(ioutil.WriteFile(testConfig, testConfigBytes, 0644))
 
@@ -189,7 +186,7 @@ context: default
 				"--context",
 				nextContext,
 			)
-			_, err = cmd.CombinedOutput()
+			_, err := cmd.CombinedOutput()
 			expect.NoError(err)
 
 			fileBytes, err := ioutil.ReadFile(testConfig)
@@ -222,8 +219,7 @@ auth-contexts:
 context: default
 `)
 
-			tmpDir, err := ioutil.TempDir("", "")
-			expect.NoError(err)
+			tmpDir := t.TempDir()
 			testConfig := filepath.Join(tmpDir, "test-config.yml")
 			expect.NoError(ioutil.WriteFile(testConfig, testConfigBytes, 0644))
 
@@ -233,7 +229,7 @@ context: default
 				"switch",
 				"--config", testConfig,
 			)
-			_, err = cmd.CombinedOutput()
+			_, err := cmd.CombinedOutput()
 			expect.NoError(err)
 
 			fileBytes, err := ioutil.ReadFile(testConfig)
@@ -253,8 +249,7 @@ auth-contexts:
 context: default
 `)
 
-			tmpDir, err := ioutil.TempDir("", "")
-			expect.NoError(err)
+			tmpDir := t.TempDir()
 			testConfig := filepath.Join(tmpDir, "test-config.yml")
 			expect.NoError(ioutil.WriteFile(testConfig, testConfigBytes, 0644))
 

--- a/integration/certificate_create_test.go
+++ b/integration/certificate_create_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -83,9 +82,7 @@ var _ = suite("compute/certificate/create", func(t *testing.T, when spec.G, it s
 	when("asking for a custom cert", func() {
 		it("creates the certificate", func() {
 			testFiles := []string{"test-private.key", "test-cert.chain", "test-leaf.cert"}
-			dir, err := ioutil.TempDir("", "doctl-tests-cert")
-			expect.NoError(err)
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			for _, f := range testFiles {
 				err := ioutil.WriteFile(filepath.Join(dir, f), []byte(f), 0600)

--- a/integration/droplet_get_test.go
+++ b/integration/droplet_get_test.go
@@ -26,12 +26,11 @@ var _ = suite("compute/droplet/get", func(t *testing.T, when spec.G, it spec.S) 
 	it.Before(func() {
 		expect = require.New(t)
 
-		dir, err := ioutil.TempDir("", "doct-integratio-tests")
-		expect.NoError(err)
+		dir := t.TempDir()
 
 		configPath = filepath.Join(dir, "config.yaml")
 
-		err = ioutil.WriteFile(configPath, []byte(dropletGetConfig), 0644)
+		err := ioutil.WriteFile(configPath, []byte(dropletGetConfig), 0644)
 		expect.NoError(err)
 
 		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/integration/droplet_neighbors_test.go
+++ b/integration/droplet_neighbors_test.go
@@ -26,12 +26,11 @@ var _ = suite("compute/droplet/neighbors", func(t *testing.T, when spec.G, it sp
 	it.Before(func() {
 		expect = require.New(t)
 
-		dir, err := ioutil.TempDir("", "doct-integration-tests")
-		expect.NoError(err)
+		dir := t.TempDir()
 
 		configPath = filepath.Join(dir, "config.yaml")
 
-		err = ioutil.WriteFile(configPath, []byte(dropletNeighborsConfig), 0644)
+		err := ioutil.WriteFile(configPath, []byte(dropletNeighborsConfig), 0644)
 		expect.NoError(err)
 
 		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/integration/registry_login_test.go
+++ b/integration/registry_login_test.go
@@ -68,8 +68,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 
 	when("all required flags are passed", func() {
 		it("writes a docker config.json file", func() {
-			tmpDir, err := ioutil.TempDir("", "")
-			expect.NoError(err)
+			tmpDir := t.TempDir()
 
 			config := filepath.Join(tmpDir, "config.json")
 
@@ -101,8 +100,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 
 	when("expiry-seconds flag is passed", func() {
 		it("add the correct query parameter", func() {
-			tmpDir, err := ioutil.TempDir("", "")
-			expect.NoError(err)
+			tmpDir := t.TempDir()
 
 			config := filepath.Join(tmpDir, "config.json")
 

--- a/integration/registry_logout_test.go
+++ b/integration/registry_logout_test.go
@@ -61,11 +61,10 @@ var _ = suite("registry/logout", func(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it("removes the registry from the docker config.json file", func() {
-		tmpDir, err := ioutil.TempDir("", "")
-		expect.NoError(err)
+		tmpDir := t.TempDir()
 
 		config := filepath.Join(tmpDir, "config.json")
-		err = ioutil.WriteFile(config, []byte(registryDockerCredentialsResponse), 0600)
+		err := ioutil.WriteFile(config, []byte(registryDockerCredentialsResponse), 0600)
 		expect.NoError(err)
 
 		cmd := exec.Command(builtBinaryPath,


### PR DESCRIPTION
Use `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir