### PR TITLE
sandbox: Add additional tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches:
+    - main
+    - feature/**
 
 jobs:
   test:

--- a/commands/activations.go
+++ b/commands/activations.go
@@ -88,8 +88,7 @@ func RunActivationsGet(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	PrintSandboxTextOutput(output)
-	return nil
+	return c.PrintSandboxTextOutput(output)
 }
 
 func RunActivationsList(c *CmdConfig) error {
@@ -101,8 +100,7 @@ func RunActivationsList(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	PrintSandboxTextOutput(output)
-	return nil
+	return c.PrintSandboxTextOutput(output)
 }
 
 func RunActivationsLogs(c *CmdConfig) error {
@@ -117,8 +115,7 @@ func RunActivationsLogs(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	PrintSandboxTextOutput(output)
-	return nil
+	return c.PrintSandboxTextOutput(output)
 }
 
 func RunActivationsResult(c *CmdConfig) error {
@@ -130,6 +127,5 @@ func RunActivationsResult(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	PrintSandboxTextOutput(output)
-	return nil
+	return c.PrintSandboxTextOutput(output)
 }

--- a/commands/activations_test.go
+++ b/commands/activations_test.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"os/exec"
+	"sort"
+	"testing"
+
+	"github.com/digitalocean/doctl/do"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActivationsCommand(t *testing.T) {
+	cmd := Activations()
+	assert.NotNil(t, cmd)
+	expected := []string{"get", "list", "logs", "result"}
+
+	names := []string{}
+	for _, c := range cmd.Commands() {
+		names = append(names, c.Name())
+	}
+
+	sort.Strings(expected)
+	sort.Strings(names)
+	assert.Equal(t, expected, names)
+}
+
+func TestActivationsGet(t *testing.T) {
+	tests := []struct {
+		name            string
+		doctlArgs       string
+		doctlFlags      map[string]string
+		expectedNimArgs []string
+	}{
+		{
+			name:            "no flags with ID",
+			doctlArgs:       "activationid",
+			expectedNimArgs: []string{"activationid"},
+		},
+		{
+			name:            "no flags or args",
+			expectedNimArgs: []string{},
+		},
+		{
+			name:            "last flag",
+			doctlArgs:       "activationid",
+			doctlFlags:      map[string]string{"last": ""},
+			expectedNimArgs: []string{"activationid", "--last"},
+		},
+		{
+			name:            "logs flag",
+			doctlArgs:       "activationid",
+			doctlFlags:      map[string]string{"logs": ""},
+			expectedNimArgs: []string{"activationid", "--logs"},
+		},
+		{
+			name:            "skip flag",
+			doctlArgs:       "activationid",
+			doctlFlags:      map[string]string{"skip": "10"},
+			expectedNimArgs: []string{"activationid", "--skip", "10"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				fakeCmd := &exec.Cmd{
+					Stdout: config.Out,
+				}
+
+				if tt.doctlArgs != "" {
+					config.Args = append(config.Args, tt.doctlArgs)
+				}
+
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
+
+				tm.sandbox.EXPECT().Cmd("activation/get", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
+
+				err := RunActivationsGet(config)
+				require.NoError(t, err)
+			})
+		})
+	}
+}
+
+func TestActivationsList(t *testing.T) {
+	tests := []struct {
+		name            string
+		doctlArgs       string
+		doctlFlags      map[string]string
+		expectedNimArgs []string
+	}{
+		{
+			name:            "no flags or args",
+			expectedNimArgs: []string{},
+		},
+		{
+			name:            "full flag",
+			doctlFlags:      map[string]string{"full": ""},
+			expectedNimArgs: []string{"--full"},
+		},
+		{
+			name:            "count flag",
+			doctlFlags:      map[string]string{"count": ""},
+			expectedNimArgs: []string{"--count"},
+		},
+		{
+			name:            "limit flag",
+			doctlFlags:      map[string]string{"limit": "10"},
+			expectedNimArgs: []string{"--limit", "10"},
+		},
+		{
+			name:            "since flag",
+			doctlFlags:      map[string]string{"since": "1644866670085"},
+			expectedNimArgs: []string{"--since", "1644866670085"},
+		},
+		{
+			name:            "skip flag",
+			doctlFlags:      map[string]string{"skip": "1"},
+			expectedNimArgs: []string{"--skip", "1"},
+		},
+		{
+			name:            "upto flag",
+			doctlFlags:      map[string]string{"upto": "1644866670085"},
+			expectedNimArgs: []string{"--upto", "1644866670085"},
+		},
+		{
+			name:            "multiple flags",
+			doctlFlags:      map[string]string{"limit": "10", "count": ""},
+			expectedNimArgs: []string{"--count", "--limit", "10"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				fakeCmd := &exec.Cmd{
+					Stdout: config.Out,
+				}
+
+				if tt.doctlArgs != "" {
+					config.Args = append(config.Args, tt.doctlArgs)
+				}
+
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
+
+				tm.sandbox.EXPECT().Cmd("activation/list", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
+
+				err := RunActivationsList(config)
+				require.NoError(t, err)
+			})
+		})
+	}
+}
+
+func TestActivationsLogs(t *testing.T) {
+	tests := []struct {
+		name            string
+		doctlArgs       string
+		doctlFlags      map[string]string
+		expectedNimArgs []string
+	}{
+		{
+			name:            "no flags or args",
+			expectedNimArgs: []string{},
+		},
+		{
+			name:            "no flags with ID",
+			doctlArgs:       "activationid",
+			expectedNimArgs: []string{"activationid"},
+		},
+		{
+			name:            "last flag",
+			doctlFlags:      map[string]string{"last": ""},
+			expectedNimArgs: []string{"--last"},
+		},
+		{
+			name:            "limit flag",
+			doctlFlags:      map[string]string{"limit": "10"},
+			expectedNimArgs: []string{"--limit", "10"},
+		},
+		// TODO: This flag is currently ignored. Is that what we want?
+		// {
+		// 	name:            "function flag",
+		// 	doctlFlags:      map[string]string{"function": "sample"},
+		// 	expectedNimArgs: []string{"--action", "sample"},
+		// },
+		{
+			name:            "package flag",
+			doctlFlags:      map[string]string{"package": "sample"},
+			expectedNimArgs: []string{"--deployed", "--package", "sample"},
+		},
+		{
+			name:            "poll flag",
+			doctlFlags:      map[string]string{"poll": ""},
+			expectedNimArgs: []string{"--poll"},
+		},
+		{
+			name:            "strip flag",
+			doctlFlags:      map[string]string{"strip": ""},
+			expectedNimArgs: []string{"--strip"},
+		},
+		{
+			name:            "tail flag",
+			doctlFlags:      map[string]string{"tail": ""},
+			expectedNimArgs: []string{"--tail"},
+		},
+		{
+			name:            "watch flag",
+			doctlFlags:      map[string]string{"watch": ""},
+			expectedNimArgs: []string{"--watch"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				fakeCmd := &exec.Cmd{
+					Stdout: config.Out,
+				}
+
+				if tt.doctlArgs != "" {
+					config.Args = append(config.Args, tt.doctlArgs)
+				}
+
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
+
+				tm.sandbox.EXPECT().Cmd("activation/logs", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
+
+				err := RunActivationsLogs(config)
+				require.NoError(t, err)
+			})
+		})
+	}
+}
+
+func TestActivationsResult(t *testing.T) {
+	tests := []struct {
+		name            string
+		doctlArgs       string
+		doctlFlags      map[string]string
+		expectedNimArgs []string
+	}{
+		{
+			name:            "no flags or args",
+			expectedNimArgs: []string{},
+		},
+		{
+			name:            "no flags with ID",
+			doctlArgs:       "activationid",
+			expectedNimArgs: []string{"activationid"},
+		},
+		{
+			name:            "last flag",
+			doctlFlags:      map[string]string{"last": ""},
+			expectedNimArgs: []string{"--last"},
+		},
+		{
+			name:            "limit flag",
+			doctlFlags:      map[string]string{"limit": "10"},
+			expectedNimArgs: []string{"--limit", "10"},
+		},
+		{
+			name:            "quiet flag",
+			doctlFlags:      map[string]string{"quiet": ""},
+			expectedNimArgs: []string{"--quiet"},
+		},
+		{
+			name:            "skip flag",
+			doctlFlags:      map[string]string{"skip": "1"},
+			expectedNimArgs: []string{"--skip", "1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				fakeCmd := &exec.Cmd{
+					Stdout: config.Out,
+				}
+
+				if tt.doctlArgs != "" {
+					config.Args = append(config.Args, tt.doctlArgs)
+				}
+
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
+
+				tm.sandbox.EXPECT().Cmd("activation/result", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
+
+				err := RunActivationsResult(config)
+				require.NoError(t, err)
+			})
+		})
+	}
+}

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -64,7 +64,7 @@ func Databases() *Command {
 - A connection string for the database cluster
 - The date and time when the database cluster was created`+databaseListDetails, Writer, aliasOpt("g"), displayerType(&displayers.Databases{}))
 
-	nodeSizeDetails := "The size of the nodes in the database cluster, e.g. `db-s-1vcpu-1gb`` for a 1 CPU, 1GB node"
+	nodeSizeDetails := "The size of the nodes in the database cluster, e.g. `db-s-1vcpu-1gb`` for a 1 CPU, 1GB node. For a list of available size slugs, visit: https://docs.digitalocean.com/reference/api/api-reference/#tag/Databases"
 	nodeNumberDetails := "The number of nodes in the database cluster. Valid values are are 1-3. In addition to the primary node, up to two standby nodes may be added for high availability."
 	cmdDatabaseCreate := CmdBuilder(cmd, RunDatabaseCreate, "create <name>", "Create a database cluster", `This command creates a database cluster with the specified name.
 

--- a/commands/functions.go
+++ b/commands/functions.go
@@ -73,8 +73,7 @@ func RunFunctionsGet(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	PrintSandboxTextOutput(output)
-	return nil
+	return c.PrintSandboxTextOutput(output)
 }
 
 func RunFunctionsInvoke(c *CmdConfig) error {
@@ -87,8 +86,7 @@ func RunFunctionsInvoke(c *CmdConfig) error {
 		return err
 	}
 
-	PrintSandboxTextOutput(output)
-	return nil
+	return c.PrintSandboxTextOutput(output)
 }
 
 func RunFunctionsList(c *CmdConfig) error {
@@ -100,6 +98,5 @@ func RunFunctionsList(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	PrintSandboxTextOutput(output)
-	return nil
+	return c.PrintSandboxTextOutput(output)
 }

--- a/commands/functions_test.go
+++ b/commands/functions_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/digitalocean/doctl/do"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,23 +38,207 @@ func TestFunctionsCommand(t *testing.T) {
 	assert.Equal(t, expected, names)
 }
 
+func TestFunctionsGet(t *testing.T) {
+	tests := []struct {
+		name            string
+		doctlArgs       string
+		doctlFlags      map[string]string
+		expectedNimArgs []string
+	}{
+		{
+			name:            "no flags",
+			doctlArgs:       "hello",
+			expectedNimArgs: []string{"hello"},
+		},
+		{
+			name:            "code flag",
+			doctlArgs:       "hello",
+			doctlFlags:      map[string]string{"code": ""},
+			expectedNimArgs: []string{"hello", "--code"},
+		},
+		{
+			name:            "url flag",
+			doctlArgs:       "hello",
+			doctlFlags:      map[string]string{"url": ""},
+			expectedNimArgs: []string{"hello", "--url"},
+		},
+		{
+			name:            "save flag",
+			doctlArgs:       "hello",
+			doctlFlags:      map[string]string{"save": ""},
+			expectedNimArgs: []string{"hello", "--save"},
+		},
+		{
+			name:            "save-as flag",
+			doctlArgs:       "hello",
+			doctlFlags:      map[string]string{"save-as": "/path/to/code.py"},
+			expectedNimArgs: []string{"hello", "--save-as", "/path/to/code.py"},
+		},
+		{
+			name:            "save-env flag",
+			doctlArgs:       "hello",
+			doctlFlags:      map[string]string{"save-env": "/path/to/code.env"},
+			expectedNimArgs: []string{"hello", "--save-env", "/path/to/code.env"},
+		},
+		{
+			name:            "save-env-json flag",
+			doctlArgs:       "hello",
+			doctlFlags:      map[string]string{"save-env-json": "/path/to/code.json"},
+			expectedNimArgs: []string{"hello", "--save-env-json", "/path/to/code.json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				fakeCmd := &exec.Cmd{
+					Stdout: config.Out,
+				}
+
+				config.Args = append(config.Args, tt.doctlArgs)
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
+
+				tm.sandbox.EXPECT().Cmd("action/get", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
+
+				err := RunFunctionsGet(config)
+				require.NoError(t, err)
+			})
+		})
+	}
+}
+
 func TestFunctionsInvoke(t *testing.T) {
-	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		fakeCmd := &exec.Cmd{
-			Stdout: config.Out,
-		}
-		out := make(map[string]string)
-		out["body"] = "Hello world!"
-		tm.sandbox.EXPECT().Cmd("action/invoke", []string{"hello", "--param", "name", "world"}).Return(fakeCmd, nil)
-		tm.sandbox.EXPECT().Exec(gomock.Eq(fakeCmd)).Return(do.SandboxOutput{
-			Entity: out,
-		}, nil)
+	tests := []struct {
+		name            string
+		doctlArgs       string
+		doctlFlags      map[string]string
+		expectedNimArgs []string
+	}{
+		{
+			name:            "no flags",
+			doctlArgs:       "hello",
+			expectedNimArgs: []string{"hello"},
+		},
+		{
+			name:            "full flag",
+			doctlArgs:       "hello",
+			doctlFlags:      map[string]string{"full": ""},
+			expectedNimArgs: []string{"hello", "--full"},
+		},
+		{
+			name:            "param flag",
+			doctlArgs:       "hello",
+			doctlFlags:      map[string]string{"param": "name world"},
+			expectedNimArgs: []string{"hello", "--param", "name", "world"},
+		},
+	}
 
-		config.Args = append(config.Args, "hello")
-		config.Doit.Set(config.NS, "param", "name world")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				fakeCmd := &exec.Cmd{
+					Stdout: config.Out,
+				}
 
-		err := RunFunctionsInvoke(config)
-		require.NoError(t, err)
-	})
+				config.Args = append(config.Args, tt.doctlArgs)
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
 
+				out := make(map[string]string)
+				out["body"] = "Hello world!"
+				tm.sandbox.EXPECT().Cmd("action/invoke", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{
+					Entity: out,
+				}, nil)
+
+				err := RunFunctionsInvoke(config)
+				require.NoError(t, err)
+			})
+		})
+	}
+}
+
+func TestFunctionsList(t *testing.T) {
+	tests := []struct {
+		name            string
+		doctlArgs       string
+		doctlFlags      map[string]string
+		expectedNimArgs []string
+	}{
+		{
+			name:            "no flags or args",
+			expectedNimArgs: []string{},
+		},
+		{
+			name:            "count flag",
+			doctlFlags:      map[string]string{"count": ""},
+			expectedNimArgs: []string{"--count"},
+		},
+		{
+			name:            "limit flag",
+			doctlFlags:      map[string]string{"limit": "1"},
+			expectedNimArgs: []string{"--limit", "1"},
+		},
+		{
+			name:            "name flag",
+			doctlFlags:      map[string]string{"name": ""},
+			expectedNimArgs: []string{"--name"},
+		},
+		{
+			name:            "name-sort flag",
+			doctlFlags:      map[string]string{"name-sort": ""},
+			expectedNimArgs: []string{"--name-sort"},
+		},
+		{
+			name:            "skip flag",
+			doctlFlags:      map[string]string{"skip": "1"},
+			expectedNimArgs: []string{"--skip", "1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				fakeCmd := &exec.Cmd{
+					Stdout: config.Out,
+				}
+
+				if tt.doctlArgs != "" {
+					config.Args = append(config.Args, tt.doctlArgs)
+				}
+
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
+
+				tm.sandbox.EXPECT().Cmd("action/list", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
+
+				err := RunFunctionsList(config)
+				require.NoError(t, err)
+			})
+		})
+	}
 }

--- a/commands/sandbox-extra.go
+++ b/commands/sandbox-extra.go
@@ -122,8 +122,7 @@ func RunSandboxExtraDeploy(c *CmdConfig) error {
 			output.Captured[index] = "Deployed functions ('doctl sbx fn get <funcName> --url' for URL):"
 		}
 	}
-	PrintSandboxTextOutput(output)
-	return nil
+	return c.PrintSandboxTextOutput(output)
 }
 
 func RunSandboxExtraGetMetadata(c *CmdConfig) error {
@@ -135,8 +134,7 @@ func RunSandboxExtraGetMetadata(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	PrintSandboxTextOutput(output)
-	return nil
+	return c.PrintSandboxTextOutput(output)
 }
 
 // This is not the usual boiler-plate because the command is intended to be long-running in a separate window

--- a/commands/sandbox-extra.go
+++ b/commands/sandbox-extra.go
@@ -95,10 +95,11 @@ func RunSandboxExtraCreate(c *CmdConfig) error {
 	// is not quite right for doctl.
 	if jsonOutput, ok := output.Entity.(map[string]interface{}); ok {
 		if created, ok := jsonOutput["project"].(string); ok {
-			fmt.Printf(`A local sandbox area '%s' was created for you.
+			fmt.Fprintf(c.Out, `A local sandbox area '%s' was created for you.
 You may deploy it by running the command shown on the next line:
   doctl sandbox deploy %s
 `, created, created)
+			fmt.Fprintln(c.Out)
 			return nil
 		}
 	}

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -243,23 +243,27 @@ func RunSandboxExecStreaming(command string, c *CmdConfig, booleanFlags []string
 	return sandbox.Stream(cmd)
 }
 
-// Prints the output of a sandbox command execution in a
+// PrintSandboxTextOutput prints the output of a sandbox command execution in a
 // textual form (often, this can be improved upon).
 // Prints Formatted if present.
 // Else, prints Captured if present.
 // Else, prints Table or Entity using generic JSON formatting.
 // We don't expect both Table and Entity to be present and have no
 // special handling for that.
-func PrintSandboxTextOutput(output do.SandboxOutput) {
+func (c *CmdConfig) PrintSandboxTextOutput(output do.SandboxOutput) error {
 	if len(output.Formatted) > 0 {
-		fmt.Println(strings.Join(output.Formatted, "\n"))
+		fmt.Fprintf(c.Out, strings.Join(output.Formatted, "\n"))
 	} else if len(output.Captured) > 0 {
-		fmt.Println(strings.Join(output.Captured, "\n"))
+		fmt.Fprintf(c.Out, strings.Join(output.Captured, "\n"))
 	} else if len(output.Table) > 0 {
-		fmt.Println(genericJSON(output.Table))
+		fmt.Fprintf(c.Out, genericJSON(output.Table))
 	} else if output.Entity != nil {
-		fmt.Println(genericJSON(output.Entity))
+		fmt.Fprintf(c.Out, genericJSON(output.Entity))
 	} // else no output (unusual but not impossible)
+
+	_, err := fmt.Fprintln(c.Out)
+
+	return err
 }
 
 // Answers whether sandbox is installed

--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"bytes"
+	"os/exec"
+	"testing"
+
+	"github.com/digitalocean/doctl/do"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSandboxConnect(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		buf := &bytes.Buffer{}
+		config.Out = buf
+		fakeCmd := &exec.Cmd{
+			Stdout: config.Out,
+		}
+
+		config.Args = append(config.Args, "token")
+		tm.sandbox.EXPECT().Cmd("auth/login", []string{"token"}).Return(fakeCmd, nil)
+		tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{
+			Entity: map[string]interface{}{
+				"namespace": "hello",
+				"apihost":   "https://api.example.com",
+			},
+		}, nil)
+
+		err := RunSandboxConnect(config)
+		require.NoError(t, err)
+		assert.Equal(t, "Connected to function namespace 'hello' on API host 'https://api.example.com'\n\n", buf.String())
+	})
+}
+
+func TestSandboxStatusWhenConnected(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		buf := &bytes.Buffer{}
+		config.Out = buf
+		fakeCmd := &exec.Cmd{
+			Stdout: config.Out,
+		}
+
+		tm.sandbox.EXPECT().Cmd("auth/current", []string{"--apihost", "--name"}).Return(fakeCmd, nil)
+		tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{
+			Entity: map[string]interface{}{
+				"name":    "hello",
+				"apihost": "https://api.example.com",
+			},
+		}, nil)
+
+		err := RunSandboxStatus(config)
+		require.NoError(t, err)
+		assert.Equal(t, "Connected to function namespace 'hello' on API host 'https://api.example.com'\n\n", buf.String())
+	})
+}
+
+func TestSandboxStatusWhenNotConnected(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		fakeCmd := &exec.Cmd{
+			Stdout: config.Out,
+		}
+
+		tm.sandbox.EXPECT().Cmd("auth/current", []string{"--apihost", "--name"}).Return(fakeCmd, nil)
+		tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{
+			Error: "403",
+		}, nil)
+
+		err := RunSandboxStatus(config)
+		require.Error(t, err)
+		assert.EqualError(t, err, "A sandbox is installed but not connected to a function namespace (see 'doctl sandbox connect')")
+	})
+}
+
+func TestSandboxStatusWhenNotInstalled(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		config.sandboxInstalled = func() bool {
+			return false
+		}
+
+		err := RunSandboxStatus(config)
+
+		require.Error(t, err)
+		assert.EqualError(t, err, SandboxNotInstalledErr.Error())
+	})
+}
+
+func TestSandboxInit(t *testing.T) {
+	tests := []struct {
+		name            string
+		doctlArgs       string
+		doctlFlags      map[string]string
+		expectedNimArgs []string
+		out             map[string]interface{}
+	}{
+		{
+			name:            "no flags",
+			doctlArgs:       "path/to/foo",
+			expectedNimArgs: []string{"path/to/foo"},
+			out:             map[string]interface{}{"project": "foo"},
+		},
+		{
+			name:            "overwrite",
+			doctlArgs:       "path/to/project",
+			doctlFlags:      map[string]string{"overwrite": ""},
+			expectedNimArgs: []string{"path/to/project", "--overwrite"},
+			out:             map[string]interface{}{"project": "foo"},
+		},
+		{
+			name:            "language flag",
+			doctlArgs:       "path/to/project",
+			doctlFlags:      map[string]string{"language": "go"},
+			expectedNimArgs: []string{"path/to/project", "--language", "go"},
+			out:             map[string]interface{}{"project": "foo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				buf := &bytes.Buffer{}
+				config.Out = buf
+				fakeCmd := &exec.Cmd{
+					Stdout: config.Out,
+				}
+
+				if tt.doctlArgs != "" {
+					config.Args = append(config.Args, tt.doctlArgs)
+				}
+
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
+
+				tm.sandbox.EXPECT().Cmd("project/create", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{
+					Entity: tt.out,
+				}, nil)
+
+				err := RunSandboxExtraCreate(config)
+				require.NoError(t, err)
+				assert.Equal(t, `A local sandbox area 'foo' was created for you.
+You may deploy it by running the command shown on the next line:
+  doctl sandbox deploy foo`+"\n\n", buf.String())
+			})
+		})
+	}
+}
+
+func TestSandboxDeploy(t *testing.T) {
+	tests := []struct {
+		name            string
+		doctlArgs       string
+		doctlFlags      map[string]string
+		expectedNimArgs []string
+	}{
+		{
+			name:            "no flags with path",
+			doctlArgs:       "path/to/project",
+			expectedNimArgs: []string{"path/to/project", "--exclude", "web"},
+		},
+		// TODO: Add additional scenarios for other flags, etc.
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				fakeCmd := &exec.Cmd{
+					Stdout: config.Out,
+				}
+
+				if tt.doctlArgs != "" {
+					config.Args = append(config.Args, tt.doctlArgs)
+				}
+
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
+
+				tm.sandbox.EXPECT().Cmd("project/deploy", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
+
+				err := RunSandboxExtraDeploy(config)
+				require.NoError(t, err)
+			})
+		})
+	}
+}
+
+func TestSandboxWatch(t *testing.T) {
+	tests := []struct {
+		name            string
+		doctlArgs       string
+		doctlFlags      map[string]string
+		expectedNimArgs []string
+	}{
+		{
+			name:            "no flags with path",
+			doctlArgs:       "path/to/project",
+			expectedNimArgs: []string{"path/to/project", "--exclude", "web"},
+		},
+		// TODO: Add additional scenarios for other flags, etc.
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				fakeCmd := &exec.Cmd{
+					Stdout: config.Out,
+				}
+
+				if tt.doctlArgs != "" {
+					config.Args = append(config.Args, tt.doctlArgs)
+				}
+
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
+
+				tm.sandbox.EXPECT().Cmd("project/watch", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.sandbox.EXPECT().Stream(fakeCmd).Return(nil)
+
+				err := RunSandboxExtraWatch(config)
+				require.NoError(t, err)
+			})
+		})
+	}
+}

--- a/do/mocks/SandboxService.go
+++ b/do/mocks/SandboxService.go
@@ -64,3 +64,17 @@ func (mr *MockSandboxServiceMockRecorder) Exec(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockSandboxService)(nil).Exec), arg0)
 }
+
+// Stream mocks base method.
+func (m *MockSandboxService) Stream(arg0 *exec.Cmd) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stream", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Stream indicates an expected call of Stream.
+func (mr *MockSandboxServiceMockRecorder) Stream(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stream", reflect.TypeOf((*MockSandboxService)(nil).Stream), arg0)
+}

--- a/do/sandbox.go
+++ b/do/sandbox.go
@@ -23,7 +23,7 @@ type sandboxService struct {
 var _ SandboxService = &sandboxService{}
 
 // SandboxOutput contains the output returned from calls to the sandbox plugin.
-type SandboxOutput = struct {
+type SandboxOutput struct {
 	Table     []map[string]interface{} `json:"table,omitempty"`
 	Captured  []string                 `json:"captured,omitempty"`
 	Formatted []string                 `json:"formatted,omitempty"`

--- a/do/sandbox.go
+++ b/do/sandbox.go
@@ -11,6 +11,7 @@ import (
 type SandboxService interface {
 	Cmd(string, []string) (*exec.Cmd, error)
 	Exec(*exec.Cmd) (SandboxOutput, error)
+	Stream(*exec.Cmd) error
 }
 
 type sandboxService struct {
@@ -71,4 +72,10 @@ func (n *sandboxService) Exec(cmd *exec.Cmd) (SandboxOutput, error) {
 	}
 	// Result is both sound and error free
 	return result, nil
+}
+
+// Stream is like Exec but assumes that output will not be captured and can be streamed.
+func (n *sandboxService) Stream(cmd *exec.Cmd) error {
+
+	return cmd.Run()
 }


### PR DESCRIPTION
This PR adds more tests for the sandbox commands. They are mostly very basic and only test that the correct arguments are passed through to nim. Though I did make some changes to start some deeper testing. Where possible, I've moved to using `CmdConfig.Out` so that we can test the actual command output as well. There should be no functional changes.