### PR TITLE
Versioning and update for 'doctl sandbox'

### DIFF
--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -35,7 +35,7 @@ type CmdConfig struct {
 	getContextAccessToken func() string
 	setContextAccessToken func(string)
 	removeContext         func(string) error
-	sandboxInstalled      func() bool
+	checkSandboxStatus    func() error
 
 	// services
 	Keys              func() do.KeysService
@@ -186,8 +186,8 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			return nil
 		},
 
-		sandboxInstalled: func() bool {
-			return IsSandboxInstalled()
+		checkSandboxStatus: func() error {
+			return CheckSandboxStatus()
 		},
 	}
 

--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -120,7 +120,7 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			c.Apps = func() do.AppsService { return do.NewAppsService(godoClient) }
 			c.Monitoring = func() do.MonitoringService { return do.NewMonitoringService(godoClient) }
 
-			sandboxDir, _ := getSandboxDirectory()
+			sandboxDir, _, _ := getSandboxDirectory()
 			node := filepath.Join(sandboxDir, "node")
 			sandboxJs := filepath.Join(sandboxDir, "sandbox.js")
 			nimbellaDir := filepath.Join(sandboxDir, ".nimbella")

--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -36,6 +36,7 @@ type CmdConfig struct {
 	setContextAccessToken func(string)
 	removeContext         func(string) error
 	checkSandboxStatus    func() error
+	installSandbox        func(string, bool) error
 
 	// services
 	Keys              func() do.KeysService
@@ -120,7 +121,7 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			c.Apps = func() do.AppsService { return do.NewAppsService(godoClient) }
 			c.Monitoring = func() do.MonitoringService { return do.NewMonitoringService(godoClient) }
 
-			sandboxDir, _, _ := getSandboxDirectory()
+			sandboxDir, _ := getSandboxDirectory()
 			node := filepath.Join(sandboxDir, "node")
 			sandboxJs := filepath.Join(sandboxDir, "sandbox.js")
 			nimbellaDir := filepath.Join(sandboxDir, ".nimbella")
@@ -188,6 +189,10 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 
 		checkSandboxStatus: func() error {
 			return CheckSandboxStatus()
+		},
+
+		installSandbox: func(dir string, upgrading bool) error {
+			return InstallSandbox(dir, upgrading)
 		},
 	}
 

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -237,8 +237,8 @@ func withTestClient(t *testing.T, tFn testFn) {
 
 		setContextAccessToken: func(token string) {},
 
-		sandboxInstalled: func() bool {
-			return true
+		checkSandboxStatus: func() error {
+			return nil
 		},
 
 		Keys:              func() do.KeysService { return tm.keys },

--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -81,20 +81,33 @@ func TestSandboxStatusWhenNotConnected(t *testing.T) {
 
 		err := RunSandboxStatus(config)
 		require.Error(t, err)
-		assert.EqualError(t, err, "A sandbox is installed but not connected to a function namespace (see 'doctl sandbox connect')")
+		assert.ErrorIs(t, err, SandboxNotConnectedErr)
 	})
 }
 
 func TestSandboxStatusWhenNotInstalled(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		config.sandboxInstalled = func() bool {
-			return false
+		config.checkSandboxStatus = func() error {
+			return SandboxNotInstalledErr
 		}
 
 		err := RunSandboxStatus(config)
 
 		require.Error(t, err)
-		assert.EqualError(t, err, SandboxNotInstalledErr.Error())
+		assert.ErrorIs(t, err, SandboxNotInstalledErr)
+	})
+}
+
+func TestSandboxStatusWhenNotUpToDate(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		config.checkSandboxStatus = func() error {
+			return SandboxNeedsUpgradeErr
+		}
+
+		err := RunSandboxStatus(config)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, SandboxNeedsUpgradeErr)
 	})
 }
 


### PR DESCRIPTION
This change works in conjunction with a change to the sandbox plugin.  

The sandbox plugin build has been changed to
1.  Include a `version` file in the download.  This file becomes part of the installed sandbox support.
2. Label downloads by encoding the version in the name of the tarball to download.

By convention, version strings encode the Nimbella CLI version followed by the sandbox plugin "shim" version. 

There is an exemplar of this change already out there that can be use to test the present change.   It is at version 2.3.1-1.0.0.

The present change

1.  Adds a constant in `sandbox.go` representing the minimum version of the plugin that this `doctl sandbox` can run with.
2. Generalizes functions that determined if the sandbox is installed, so that they also detect if the sandbox is not up to date.
3. Provides a new error return and a new status in `doctl sandbox status` that expresses that the sandbox is installed but is not up to date.
4. Implements a new subcommand `doctl sandbox upgrade` which installs the "matching" sandbox version.   It shares code with `doctl sandbox install` but takes care to preserve existing credential information and also will preserve `node` if it is at the right version, to avoid using too much download bandwidth.

I have added unit tests for some of the user facing logic in `doctl sandbox [ install | upgrade ]` but these tests don't cover the core operations, which are file-system intensive.   My testing of the actual behavior, thus, was mostly manual.

I would like to merge this and leave. two follow-on items for later.
1.  Adding unit tests for the core install/upgrade operations.   I think some of this will become easier once we re-do some of that logic to stop using `tar` and start using go-native packages instead (definitely not in scope for this PR).   The refactoring to eliminate `tar` can also shift some of the internal interfaces so that more of them can use streams instead of file names and be capable of mocking.
2. Considering whether `doctl sandbox upgrade` should have an option to search for and use the latest version of the sandbox plugin instead of just one that is adequate for the current `doctl`.