### PR TITLE
Fix doctl sandbox connect and support additional options

### DIFF
--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -125,7 +125,7 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			node := filepath.Join(sandboxDir, "node")
 			sandboxJs := filepath.Join(sandboxDir, "sandbox.js")
 			nimbellaDir := filepath.Join(sandboxDir, ".nimbella")
-			c.Sandbox = func() do.SandboxService { return do.NewSandboxService(sandboxJs, nimbellaDir, node) }
+			c.Sandbox = func() do.SandboxService { return do.NewSandboxService(sandboxJs, nimbellaDir, node, godoClient) }
 
 			return nil
 		},

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -14,6 +14,7 @@ limitations under the License.
 package commands
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -137,7 +138,11 @@ func RunSandboxConnect(c *CmdConfig) error {
 		return err
 	}
 	token := c.Args[0]
-	result, err := SandboxExec(c, "auth/login", token)
+	creds, err := c.Sandbox().ResolveToken(context.TODO(), token)
+	if err != nil {
+		return err
+	}
+	result, err := SandboxExec(c, "auth/login", "--auth", creds.Auth, "--apihost", creds.ApiHost)
 	if err != nil {
 		return err
 	}

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -139,10 +139,12 @@ func RunSandboxUninstall(c *CmdConfig) error {
 
 // The connect command
 func RunSandboxConnect(c *CmdConfig) error {
-	var arg string
-	var token bool
-	var creds do.SandboxCredentials
-	var err error
+	var (
+		arg   string
+		token bool
+		creds do.SandboxCredentials
+		err   error
+	)
 	if len(c.Args) > 1 {
 		return doctl.NewTooManyArgsErr(c.NS)
 	}

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -27,6 +27,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/do"
 	"github.com/spf13/cobra"
 )
@@ -74,9 +75,14 @@ The install operation is long-running, and a network connection is required.`,
 	CmdBuilder(cmd, RunSandboxUninstall, "uninstall", "Removes the sandbox support", `Removes sandbox support from `+"`"+`doctl`+"`",
 		Writer)
 
-	CmdBuilder(cmd, RunSandboxConnect, "connect <token>", "Connect the cloud portion of your sandbox",
-		`This command connects the cloud portion of your sandbox (needed for testing) by using a provided token.
-You obtain the token from the cloud console (details TBD)`,
+	CmdBuilder(cmd, RunSandboxConnect, "connect [<token>|<namespace>]", "Connect the cloud portion of your sandbox",
+		`This command connects the cloud portion of your sandbox (needed for testing).
+There are several ways to use it.
+1. If your account has been explicitly provisioned with sandbox support, invoke with no arguments.
+2. (DO internal) If you obtained a namespace for your account using the alpha console, you may
+use either the namespace name or the generated token as the argument.  The ability to generate
+and use a token is for compatibility with the previous behavior of the command and is likely
+to be deprecated and removed`,
 		Writer)
 
 	CmdBuilder(cmd, RunSandboxStatus, "status", "Provide information about your sandbox",
@@ -133,12 +139,22 @@ func RunSandboxUninstall(c *CmdConfig) error {
 
 // The connect command
 func RunSandboxConnect(c *CmdConfig) error {
-	err := ensureOneArg(c)
-	if err != nil {
-		return err
+	var arg string
+	var token bool
+	var creds do.SandboxCredentials
+	var err error
+	if len(c.Args) > 1 {
+		return doctl.NewTooManyArgsErr(c.NS)
 	}
-	token := c.Args[0]
-	creds, err := c.Sandbox().ResolveToken(context.TODO(), token)
+	if len(c.Args) == 1 {
+		arg = c.Args[0]
+		token = isJWT(arg)
+	}
+	if token {
+		creds, err = c.Sandbox().ResolveToken(context.TODO(), arg)
+	} else {
+		creds, err = c.Sandbox().ResolveNamespace(context.TODO(), arg)
+	}
 	if err != nil {
 		return err
 	}
@@ -150,6 +166,16 @@ func RunSandboxConnect(c *CmdConfig) error {
 	fmt.Fprintf(c.Out, "Connected to function namespace '%s' on API host '%s'\n", mapResult["namespace"], mapResult["apihost"])
 	fmt.Fprintln(c.Out)
 	return nil
+}
+
+// Determine whether an argument is a JWT or a namespace.  The heuristic is based on the length of the
+// string and whether it contains two dots (then JWT, otherwise namespace).
+func isJWT(candidate string) bool {
+	if len(candidate) < 30 {
+		return false
+	}
+	parts := strings.Split(candidate, ".")
+	return len(parts) == 3
 }
 
 // The status command

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -160,7 +160,7 @@ func RunSandboxConnect(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	result, err := SandboxExec(c, "auth/login", "--auth", creds.Auth, "--apihost", creds.ApiHost)
+	result, err := SandboxExec(c, "auth/login", "--auth", creds.Auth, "--apihost", creds.APIHost)
 	if err != nil {
 		return err
 	}

--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -34,7 +34,7 @@ func TestSandboxConnectNamespace(t *testing.T) {
 		}
 
 		config.Args = append(config.Args, "hello")
-		tm.sandbox.EXPECT().ResolveNamespace(context.TODO(), "hello").Return(do.SandboxCredentials{Auth: "xyzzy", ApiHost: "https://api.example.com"}, nil)
+		tm.sandbox.EXPECT().ResolveNamespace(context.TODO(), "hello").Return(do.SandboxCredentials{Auth: "xyzzy", APIHost: "https://api.example.com"}, nil)
 		tm.sandbox.EXPECT().Cmd("auth/login", []string{"--auth", "xyzzy", "--apihost", "https://api.example.com"}).Return(fakeCmd, nil)
 		tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{
 			Entity: map[string]interface{}{
@@ -59,7 +59,7 @@ func TestSandboxConnectToken(t *testing.T) {
 
 		fakeJWT := "a-very-fake-JWT.a-very-fake-JWT.a-very-fake-JWT" // very unimaginative also, but this is enough to trigger JWT recognition
 		config.Args = append(config.Args, fakeJWT)
-		tm.sandbox.EXPECT().ResolveToken(context.TODO(), fakeJWT).Return(do.SandboxCredentials{Auth: "xyzzy", ApiHost: "https://api.example.com"}, nil)
+		tm.sandbox.EXPECT().ResolveToken(context.TODO(), fakeJWT).Return(do.SandboxCredentials{Auth: "xyzzy", APIHost: "https://api.example.com"}, nil)
 		tm.sandbox.EXPECT().Cmd("auth/login", []string{"--auth", "xyzzy", "--apihost", "https://api.example.com"}).Return(fakeCmd, nil)
 		tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{
 			Entity: map[string]interface{}{

--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -15,6 +15,7 @@ package commands
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"testing"
@@ -32,8 +33,9 @@ func TestSandboxConnect(t *testing.T) {
 			Stdout: config.Out,
 		}
 
-		config.Args = append(config.Args, "token")
-		tm.sandbox.EXPECT().Cmd("auth/login", []string{"token"}).Return(fakeCmd, nil)
+		config.Args = append(config.Args, "hello")
+		tm.sandbox.EXPECT().ResolveNamespace(context.TODO(), "hello").Return(do.SandboxCredentials{Auth: "xyzzy", ApiHost: "https://api.example.com"}, nil)
+		tm.sandbox.EXPECT().Cmd("auth/login", []string{"--auth", "xyzzy", "--apihost", "https://api.example.com"}).Return(fakeCmd, nil)
 		tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{
 			Entity: map[string]interface{}{
 				"namespace": "hello",

--- a/do/mocks/SandboxService.go
+++ b/do/mocks/SandboxService.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	exec "os/exec"
 	reflect "reflect"
 
@@ -63,6 +64,36 @@ func (m *MockSandboxService) Exec(arg0 *exec.Cmd) (do.SandboxOutput, error) {
 func (mr *MockSandboxServiceMockRecorder) Exec(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockSandboxService)(nil).Exec), arg0)
+}
+
+// ResolveNamespace mocks base method.
+func (m *MockSandboxService) ResolveNamespace(arg0 context.Context, arg1 string) (do.SandboxCredentials, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveNamespace", arg0, arg1)
+	ret0, _ := ret[0].(do.SandboxCredentials)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveNamespace indicates an expected call of ResolveNamespace.
+func (mr *MockSandboxServiceMockRecorder) ResolveNamespace(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveNamespace", reflect.TypeOf((*MockSandboxService)(nil).ResolveNamespace), arg0, arg1)
+}
+
+// ResolveToken mocks base method.
+func (m *MockSandboxService) ResolveToken(arg0 context.Context, arg1 string) (do.SandboxCredentials, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveToken", arg0, arg1)
+	ret0, _ := ret[0].(do.SandboxCredentials)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveToken indicates an expected call of ResolveToken.
+func (mr *MockSandboxServiceMockRecorder) ResolveToken(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveToken", reflect.TypeOf((*MockSandboxService)(nil).ResolveToken), arg0, arg1)
 }
 
 // Stream mocks base method.


### PR DESCRIPTION
This change restores functionality to `doctl sandbox connect` that was lost due to changes in the functions cloud.   It uses DigitalOcean APIs to retrieve the necessary information that used to be retrieved by invoking administrative functions.   It also expands the functionality of the command as follows.
```
Usage:
  doctl sandbox connect [<token>|<namespace>] [flags]
```
The argument is now optional.  If it is omitted, the function namespaces of the account are searched to find an eligible sandbox namespace.  If it is provided, it can now be either a namespace name, or a JWT issued by the UI for the namespace (previously only a JWT was accepted). 