### PR TITLE
Correct behavior for 'sandbox actv logs --poll'

### DIFF
--- a/commands/activations.go
+++ b/commands/activations.go
@@ -64,9 +64,7 @@ for new arrivals.`,
 	AddBoolFlag(logs, "last", "l", false, "Fetch the most recent activation logs (default)")
 	AddIntFlag(logs, "limit", "n", 1, "Fetch the last LIMIT activation logs (up to 200)")
 	AddBoolFlag(logs, "strip", "r", false, "strip timestamp information and output first line only")
-	AddBoolFlag(logs, "tail", "", false, "Fetch logs continuously")
-	AddBoolFlag(logs, "watch", "w", false, "Fetch logs continuously")
-	AddBoolFlag(logs, "poll", "", false, "Fetch logs continuously")
+	AddBoolFlag(logs, "follow", "", false, "Fetch logs continuously")
 
 	result := CmdBuilder(cmd, RunActivationsResult, "result [<activationId>]", "Retrieves the Results for an Activation",
 		`Use `+"`"+`doctl sandbox activations result`+"`"+` to retrieve just the results portion
@@ -114,9 +112,9 @@ func RunActivationsLogs(c *CmdConfig) error {
 		return doctl.NewTooManyArgsErr(c.NS)
 	}
 	if isWatching(c) {
-		return RunSandboxExecStreaming("activation/logs", c, []string{"last", "strip", "tail", "watch", "poll"}, []string{"function", "package", "limit"})
+		return RunSandboxExecStreaming("activation/logs", c, []string{"last", "strip", "follow"}, []string{"function", "package", "limit"})
 	}
-	output, err := RunSandboxExec("activation/logs", c, []string{"last", "strip", "tail", "watch", "poll"}, []string{"function", "package", "limit"})
+	output, err := RunSandboxExec("activation/logs", c, []string{"last", "strip", "follow"}, []string{"function", "package", "limit"})
 	if err != nil {
 		return err
 	}
@@ -124,15 +122,10 @@ func RunActivationsLogs(c *CmdConfig) error {
 }
 
 // isWatching decides whether the flags of an 'activation logs' command are implementing the watching
-// feature.  The possible flags are --tail, --watch, and --poll (they are equivalent).
+// feature.  Currently, this is indicated by the --follow flag.
 func isWatching(c *CmdConfig) bool {
-	for _, flag := range []string{"tail", "watch", "poll"} {
-		yes, err := c.Doit.GetBool(c.NS, flag)
-		if yes && err == nil {
-			return true
-		}
-	}
-	return false
+	yes, err := c.Doit.GetBool(c.NS, "follow")
+	return yes && err == nil
 }
 
 // RunActivationsResult supports the 'activations result' command

--- a/commands/activations_test.go
+++ b/commands/activations_test.go
@@ -222,27 +222,15 @@ func TestActivationsLogs(t *testing.T) {
 			expectedNimArgs: []string{"--deployed", "--package", "sample"},
 		},
 		{
-			name:            "poll flag",
-			doctlFlags:      map[string]string{"poll": ""},
-			expectedNimArgs: []string{"--poll"},
+			name:            "follow flag",
+			doctlFlags:      map[string]string{"follow": ""},
+			expectedNimArgs: []string{"--follow"},
 			expectStream:    true,
 		},
 		{
 			name:            "strip flag",
 			doctlFlags:      map[string]string{"strip": ""},
 			expectedNimArgs: []string{"--strip"},
-		},
-		{
-			name:            "tail flag",
-			doctlFlags:      map[string]string{"tail": ""},
-			expectedNimArgs: []string{"--tail"},
-			expectStream:    true,
-		},
-		{
-			name:            "watch flag",
-			doctlFlags:      map[string]string{"watch": ""},
-			expectedNimArgs: []string{"--watch"},
-			expectStream:    true,
 		},
 	}
 

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -33,7 +33,11 @@ import (
 )
 
 const nodeVersion = "v14.16.0"
-const minSandboxVersion = "2.3.1-1.0.0"
+const minSandboxVersion = "2.3.6-1.1.0"
+
+// noCapture is the string constant recognized by the plugin.  It suppresses output
+// capture when in the initial (command) position.
+const noCapture = "nocapture"
 
 // ErrSandboxNotInstalled is the error returned to users when the sandbox is not installed.
 var ErrSandboxNotInstalled = errors.New("The sandbox is not installed (use `doctl sandbox install`)")
@@ -250,7 +254,9 @@ func RunSandboxExecStreaming(command string, c *CmdConfig, booleanFlags []string
 	sandbox := c.Sandbox()
 
 	args := getFlatArgsArray(c, booleanFlags, stringFlags)
-	cmd, err := sandbox.Cmd(command, args)
+	args = append([]string{command}, args...)
+
+	cmd, err := sandbox.Cmd(noCapture, args)
 	if err != nil {
 		return err
 	}
@@ -505,8 +511,7 @@ func getFlatArgsArray(c *CmdConfig, booleanFlags []string, stringFlags []string)
 		value, err := c.Doit.GetString(c.NS, flag)
 		if err == nil && len(value) > 0 {
 			if flag == "function" {
-				flag = "action"
-				// TODO: Should this be added to the args?
+				args = append(args, "--action", value)
 			} else if flag == "exclude" {
 				// --exclude non-empty, add web
 				args = append(args, "--exclude", value+",web")

--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -377,7 +377,7 @@ func TestSandboxWatch(t *testing.T) {
 		{
 			name:            "no flags with path",
 			doctlArgs:       "path/to/project",
-			expectedNimArgs: []string{"path/to/project", "--exclude", "web"},
+			expectedNimArgs: []string{"project/watch", "path/to/project", "--exclude", "web"},
 		},
 		// TODO: Add additional scenarios for other flags, etc.
 	}
@@ -403,7 +403,7 @@ func TestSandboxWatch(t *testing.T) {
 					}
 				}
 
-				tm.sandbox.EXPECT().Cmd("project/watch", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.sandbox.EXPECT().Cmd("nocapture", tt.expectedNimArgs).Return(fakeCmd, nil)
 				tm.sandbox.EXPECT().Stream(fakeCmd).Return(nil)
 
 				err := RunSandboxExtraWatch(config)


### PR DESCRIPTION
This change eliminates a bug in `doctl sandbox activation logs`.   The command was not behaving correctly when one of the flags `--poll`, `--tail`, or `--watch` was specified (these are actually equivalent). 

With these flags set, the command will now keep running, streaming its output to the console, making it appropriate to run in a separate window as designed.

To make this change, I changed the protocol between `doctl` and the sandbox plugin so that the plugin doesn't independently decide when the capture of output should be suppressed.   Rather, `doctl` directs this behavior with a prefixed command.

This in turn required incrementing the minimum required version of the sandbox.  The required version has been staged and will be available to `doctl sandbox upgrade`.