### PR TITLE
Add an 'undeploy' command

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -89,7 +89,8 @@ to be deprecated and removed`,
 		`This command reports the status of your sandbox and some details
 concerning its connected cloud portion`, Writer)
 
-	undeploy := CmdBuilder(cmd, RunSandboxUndeploy, "undeploy", "Removes resources from the cloud portion of your sandbox",
+	undeploy := CmdBuilder(cmd, RunSandboxUndeploy, "undeploy [<package|function>...]",
+		"Removes resources from the cloud portion of your sandbox",
 		`This command removes functions, entire packages, or all functions and packages, from the cloud portion
 of your sandbox.  In general, deploying new content does not remove old content although it may overwrite it.
 Use `+"`"+`doctl sandbox undeploy`+"`"+` to effect removal.  The command accepts a list of functions or packages.

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -48,6 +48,12 @@ var ErrSandboxNeedsUpgrade = errors.New("The sandbox support needs to be upgrade
 // ErrSandboxNotConnected is the error returned to users when the sandbox is not connected to a namespace
 var ErrSandboxNotConnected = errors.New("A sandbox is installed but not connected to a function namespace (use `doctl sandbox connect`)")
 
+// ErrUndeployAllAndArgs is the error returned when the --all flag is used along with args on undeploy
+var errUndeployAllAndArgs = errors.New("command line arguments and the `--all` flag are mutually exclusive")
+
+// ErrUndeployTooFewArgs is the error returned when neither --all nor args are specified on undeploy
+var errUndeployTooFewArgs = errors.New("either command line arguments or `--all` must be specified")
+
 // Sandbox contains support for 'sandbox' commands provided by a hidden install of the Nimbella CLI
 func Sandbox() *Command {
 	cmd := &Command{
@@ -218,10 +224,10 @@ func RunSandboxUndeploy(c *CmdConfig) error {
 	pkgFlag, _ := c.Doit.GetBool(c.NS, "packages")
 	all, _ := c.Doit.GetBool(c.NS, "all")
 	if haveArgs && all {
-		return fmt.Errorf("command line arguments and the `--all` flag are mutually exclusive")
+		return errUndeployAllAndArgs
 	}
 	if !haveArgs && !all {
-		return fmt.Errorf("either command line arguments or `--all` must be specified")
+		return errUndeployTooFewArgs
 	}
 	if all {
 		return cleanNamespace(c)


### PR DESCRIPTION
We deliberately omitted CRUD operations in the `functions` subtree and omitted the `packages` subtree entirely.  This was to avoid confusion between the portion of the sandbox in the local filesystem and the portion in the cloud, and maintain the idea that you push the former to the latter with `deploy`.   As this leaves developers with no way to delete resources from the namespace, we need an `undeploy`.   Given that this is a destructive operation, I made an `--all` flag obligatory when you wish to undeploy everything, and allowed specific resources to be listed on the command line.

```
Usage:
  doctl sandbox undeploy [<package|function>...] [flags]

Flags:
      --all        remove all packages and functions
```
This PR will remain a draft until I have added supporting unit tests.