### PR TITLE
Upgrade node version to 16.13.0

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -32,8 +32,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const nodeVersion = "v14.16.0"
-const minSandboxVersion = "2.3.6-1.1.0"
+const nodeVersion = "v16.13.0"
+const minSandboxVersion = "2.3.7-1.1.0"
 
 // noCapture is the string constant recognized by the plugin.  It suppresses output
 // capture when in the initial (command) position.


### PR DESCRIPTION
Also changes the minimum required nim release to 2.3.7, since that is the point at which we officially started bundling node 16.x rather than 14.x.

Older versions of nim and hence the sandbox would almost certainly work with node 16 but were not explicitly tested with it.