### PR TITLE
goreleaser: Don't use release label for snapshots.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
   - -X github.com/digitalocean/doctl.Major={{ .Major }}
   - -X github.com/digitalocean/doctl.Minor={{ .Minor }}
   - -X github.com/digitalocean/doctl.Patch={{ .Patch }}
-  - -X github.com/digitalocean/doctl.Label=release
+  - -X github.com/digitalocean/doctl.Label={{ if .IsSnapshot }}snapshot{{ else }}release{{ end }}
   goos:
   - windows
   - darwin


### PR DESCRIPTION
Built a local snapshot with goreleaser and realized `doctl version` shows the `release` label. This makes it so that the `snapshot` label is used when building with `goreleaser build --snapshot`