### PR TITLE
Reject 'doctl sbx init --language' value if the backend has no runtime for it.

### DIFF
--- a/commands/sandbox-extra.go
+++ b/commands/sandbox-extra.go
@@ -29,9 +29,9 @@ func SandboxExtras(cmd *Command) {
 		`The `+"`"+`doctl sandbox init`+"`"+` command specifies a directory in your file system which will hold functions and
 supporting artifacts while you're developing them.  When ready, you can upload these to the cloud for
 testing.  Later, after the area is committed to a `+"`"+`git`+"`"+` repository, you can create an app from them.
-`,
+Type `+"`"+`doctl sandbox status --languages`+"`"+` for a list of supported languages.`,
 		Writer)
-	AddStringFlag(create, "language", "l", "js", "Language for the initial sample code")
+	AddStringFlag(create, "language", "l", "javascript", "Language for the initial sample code")
 	AddBoolFlag(create, "overwrite", "", false, "Clears and reuses an existing directory")
 
 	deploy := CmdBuilder(cmd, RunSandboxExtraDeploy, "deploy <directories>", "Deploy sandbox local assets to the cloud",

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -33,7 +33,7 @@ import (
 )
 
 const nodeVersion = "v16.13.0"
-const minSandboxVersion = "2.3.7-1.1.0"
+const minSandboxVersion = "2.3.8-1.1.0"
 
 // noCapture is the string constant recognized by the plugin.  It suppresses output
 // capture when in the initial (command) position.
@@ -91,9 +91,10 @@ and use a token is for compatibility with the previous behavior of the command a
 to be deprecated and removed`,
 		Writer)
 
-	CmdBuilder(cmd, RunSandboxStatus, "status", "Provide information about your sandbox",
-		`This command reports the status of your sandbox and some details
-concerning its connected cloud portion`, Writer)
+	status := CmdBuilder(cmd, RunSandboxStatus, "status", "Provide information about your sandbox",
+		`This command reports the status of your sandbox and some details concerning its connected cloud portion.
+With the `+"`"+`--languages flag, it will report the supported languages.`, Writer)
+	AddBoolFlag(status, "languages", "l", false, "show available languages (if connected to the cloud)")
 
 	undeploy := CmdBuilder(cmd, RunSandboxUndeploy, "undeploy [<package|function>...]",
 		"Removes resources from the cloud portion of your sandbox",
@@ -215,6 +216,14 @@ func RunSandboxStatus(c *CmdConfig) error {
 	}
 	mapResult := result.Entity.(map[string]interface{})
 	fmt.Fprintf(c.Out, "Connected to function namespace '%s' on API host '%s'\n\n", mapResult["name"], mapResult["apihost"])
+	displayRuntimes, _ := c.Doit.GetBool(c.NS, "languages")
+	if displayRuntimes {
+		result, err = SandboxExec(c, "info", "--runtimes")
+		if result.Error == "" && err == nil {
+			fmt.Fprintf(c.Out, "Available runtimes:\n")
+			c.PrintSandboxTextOutput(result)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Previously, a language would be accepted if it was in a static list of languages for which we know how to generate samples.  But, not all languages in that list necessarily have runtimes in the backend, which was leading to a situation where the developer could initialize a local sandbox area that could not be deployed.

Most of the change is in `nim`, hence the required minimum version of the sandbox is incremented.

But, help texts had to change because we can no longer enumerate the supported languages in the usage help for the `--language` flag.   Contacting the controller is an asynchronous operation, and we don't want to unduly delay or hang usage help (also a bit unclear how to shoe-horn such an operation into `cobra`).    The `nim` solution refers the developer to the separate `nim info --runtimes` command.   We did not have an import of that into `doctl` so I added it but called it `doctl sbx status --languages`.   The `doctl sbx init` help is then augmented appropriately.

The check for. a runtime is omitted if you issue `doctl sbx init` before `doctl sbx connect` because, in that case, we don't have an API host to interrogate.   The language selection is just accepted as before.   Arguably, we should refuse to perform `init` until after `connect`.   But, once the namespace APIs settle down into their final configuration and we are able to do the connect operation by default at install time, the unconnected state should rarely arise and the special rule would no longer be needed.