### PR TITLE
Adopt nim 2.3.9, which fixes two bugs

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -33,7 +33,7 @@ import (
 )
 
 const nodeVersion = "v16.13.0"
-const minSandboxVersion = "2.3.8-1.1.0"
+const minSandboxVersion = "2.3.9-1.1.0"
 
 // noCapture is the string constant recognized by the plugin.  It suppresses output
 // capture when in the initial (command) position.


### PR DESCRIPTION
The Nimbella CLI version 2.3.9 contains two fixes relevant to doctl sbx commands.

1.  The use of initial './' sequences in .include file entries was causing incorrect behavior. Although unnecessary, these sequences should be harmless.
2.  Incremental deploy (used by 'doctl sbx watch') was not detecting environment changes. If the change was made to project.yml or to a contained .env file the watcher would "fire" as per the spec. However, when calculating whether actions had changed it failed to include the environment clause and the affected actions would be unchanged.