### PR TITLE
sandbox: Use Go native libs to extract archives.

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -29,30 +29,31 @@ import (
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/do"
+	"github.com/digitalocean/doctl/pkg/extract"
 	"github.com/spf13/cobra"
 )
 
-const nodeVersion = "v16.13.0"
-const minSandboxVersion = "2.3.9-1.1.0"
+const (
+	nodeVersion       = "v16.13.0"
+	minSandboxVersion = "2.3.9-1.1.0"
 
-// noCapture is the string constant recognized by the plugin.  It suppresses output
-// capture when in the initial (command) position.
-const noCapture = "nocapture"
+	// noCapture is the string constant recognized by the plugin.  It suppresses output
+	// capture when in the initial (command) position.
+	noCapture = "nocapture"
+)
 
-// ErrSandboxNotInstalled is the error returned to users when the sandbox is not installed.
-var ErrSandboxNotInstalled = errors.New("The sandbox is not installed (use `doctl sandbox install`)")
-
-// ErrSandboxNeedsUpgrade is the error returned to users when the sandbox is at too low a version
-var ErrSandboxNeedsUpgrade = errors.New("The sandbox support needs to be upgraded (use `doctl sandbox upgrade`)")
-
-// ErrSandboxNotConnected is the error returned to users when the sandbox is not connected to a namespace
-var ErrSandboxNotConnected = errors.New("A sandbox is installed but not connected to a function namespace (use `doctl sandbox connect`)")
-
-// ErrUndeployAllAndArgs is the error returned when the --all flag is used along with args on undeploy
-var errUndeployAllAndArgs = errors.New("command line arguments and the `--all` flag are mutually exclusive")
-
-// ErrUndeployTooFewArgs is the error returned when neither --all nor args are specified on undeploy
-var errUndeployTooFewArgs = errors.New("either command line arguments or `--all` must be specified")
+var (
+	// ErrSandboxNotInstalled is the error returned to users when the sandbox is not installed.
+	ErrSandboxNotInstalled = errors.New("The sandbox is not installed (use `doctl sandbox install`)")
+	// ErrSandboxNeedsUpgrade is the error returned to users when the sandbox is at too low a version
+	ErrSandboxNeedsUpgrade = errors.New("The sandbox support needs to be upgraded (use `doctl sandbox upgrade`)")
+	// ErrSandboxNotConnected is the error returned to users when the sandbox is not connected to a namespace
+	ErrSandboxNotConnected = errors.New("A sandbox is installed but not connected to a function namespace (use `doctl sandbox connect`)")
+	// ErrUndeployAllAndArgs is the error returned when the --all flag is used along with args on undeploy
+	errUndeployAllAndArgs = errors.New("command line arguments and the `--all` flag are mutually exclusive")
+	// ErrUndeployTooFewArgs is the error returned when neither --all nor args are specified on undeploy
+	errUndeployTooFewArgs = errors.New("either command line arguments or `--all` must be specified")
+)
 
 // Sandbox contains support for 'sandbox' commands provided by a hidden install of the Nimbella CLI
 func Sandbox() *Command {
@@ -438,19 +439,14 @@ func InstallSandbox(sandboxDir string, upgrading bool) error {
 	}
 	// Exec the tar binary at least once to unpack the fat tarball and possibly a second time if
 	// node was downloaded.  If node was not download, just move the existing binary into place.
-	// TODO eliminate use of separate tar binary so we can support windows install with pure go code
 	fmt.Print("Unpacking...")
-	cmd := exec.Command("tar", "-C", tmp, "-xzf", sandboxFileName)
-	output, err := cmd.CombinedOutput()
+	err = extract.Extract(sandboxFileName, tmp)
 	if err != nil {
-		fmt.Printf("%s", output)
 		return err
 	}
 	if nodeFileName != "" {
-		cmd := exec.Command("tar", "-C", tmp, "-xzf", nodeFileName)
-		output, err := cmd.CombinedOutput()
+		err = extract.Extract(nodeFileName, tmp)
 		if err != nil {
-			fmt.Printf("%s", output)
 			return err
 		}
 	}

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -1,0 +1,164 @@
+package extract
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Extract extracts files from an archive to the specified location. It supports
+// .tar.gz and .zip archives.
+func Extract(source, target string) error {
+	if _, err := os.Stat(target); os.IsNotExist(err) {
+		return errors.New("target directory does not exist")
+	}
+	if _, err := os.Stat(source); os.IsNotExist(err) {
+		return errors.New("source archive does not exist")
+	}
+
+	switch filepath.Ext(source) {
+	case ".gz":
+		err := extractTarGz(source, target)
+		if err != nil {
+			return err
+		}
+
+	case ".zip":
+		err := extractZip(source, target)
+		if err != nil {
+			return err
+		}
+
+	default:
+		return errors.New("unexpected file type")
+	}
+
+	return nil
+}
+
+func extractTarGz(source, target string) error {
+	s, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	gzReader, err := gzip.NewReader(s)
+	if err != nil {
+		return err
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		info := header.FileInfo()
+		path := filepath.Join(target, header.Name)
+		if !strings.HasPrefix(path, filepath.Clean(target)+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal file path: %s", path)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			err := os.MkdirAll(path, info.Mode())
+			if err != nil {
+				return err
+			}
+
+		case tar.TypeReg:
+			if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+				os.MkdirAll(filepath.Dir(path), 0700)
+			}
+
+			f, err := os.Create(path)
+			if err != nil {
+				return err
+			}
+
+			f.Chmod(info.Mode())
+			if err != nil {
+				return err
+			}
+
+			_, err = io.Copy(f, tarReader)
+			if err != nil {
+				return err
+			}
+			f.Close()
+
+		case tar.TypeLink:
+			os.Link(header.Linkname, path)
+
+		case tar.TypeSymlink:
+			os.Symlink(header.Linkname, path)
+
+		default:
+			return fmt.Errorf("unknown type %s in %s", string(header.Typeflag), header.Name)
+		}
+	}
+
+	return nil
+}
+
+func extractZip(source, target string) error {
+	zReader, err := zip.OpenReader(source)
+	if err != nil {
+		return err
+	}
+	defer zReader.Close()
+
+	for _, zf := range zReader.File {
+		path := filepath.Join(target, zf.Name)
+		if !strings.HasPrefix(path, filepath.Clean(target)+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal file path: %s", path)
+		}
+
+		if zf.FileInfo().IsDir() {
+			if err := os.MkdirAll(path, zf.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+			os.MkdirAll(filepath.Dir(path), 0700)
+		}
+
+		f, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+
+		f.Chmod(zf.Mode())
+		if err != nil {
+			return err
+		}
+
+		zippedFile, err := zf.Open()
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(f, zippedFile)
+		if err != nil {
+			return err
+		}
+		f.Close()
+		zippedFile.Close()
+	}
+
+	return nil
+}

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -1,0 +1,144 @@
+package extract
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractTarGz(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "test-materials")
+	require.NoError(t, err, "error creating tmp dir")
+	out, err := ioutil.TempDir("", "output")
+	require.NoError(t, err, "error creating out dir")
+	defer func() {
+		err := os.RemoveAll(tmp)
+		require.NoError(t, err, "error cleaning tmp dir")
+		err = os.RemoveAll(out)
+		require.NoError(t, err, "error cleaning out dir")
+	}()
+
+	files := []string{"test.txt", "test/test.txt"}
+	testTarGz := setUpTarGz(t, tmp, files)
+	err = Extract(testTarGz, out)
+	require.NoError(t, err, "error extracting archive")
+
+	for _, f := range files {
+		path := filepath.Join(out, f)
+		_, err := os.Stat(path)
+		require.NoError(t, err, "expected files not found")
+	}
+}
+
+func TestExtractZip(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "test-materials")
+	require.NoError(t, err, "error creating tmp dir")
+	out, err := ioutil.TempDir("", "output")
+	require.NoError(t, err, "error creating out dir")
+	defer func() {
+		err := os.RemoveAll(tmp)
+		require.NoError(t, err, "error cleaning tmp dir")
+		err = os.RemoveAll(out)
+		require.NoError(t, err, "error cleaning out dir")
+	}()
+
+	files := []string{"test.txt", "test/test.txt"}
+	testZip := setUpZip(t, tmp, files)
+	err = Extract(testZip, out)
+	require.NoError(t, err, "error extracting archive")
+
+	for _, f := range files {
+		path := filepath.Join(out, f)
+		_, err := os.Stat(path)
+		require.NoError(t, err, "expected files not found")
+	}
+}
+
+func setUpTarGz(t *testing.T, tmpDir string, files []string) string {
+	tarballName := fmt.Sprintf("%s.tar.gz", uuid.New())
+	tarballPath := filepath.Join(tmpDir, tarballName)
+	tarball, err := os.Create(tarballPath)
+	require.NoError(t, err, "error creating tar file")
+	defer tarball.Close()
+
+	gzipWriter := gzip.NewWriter(tarball)
+	defer gzipWriter.Close()
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	for _, f := range files {
+		path := filepath.Join(tmpDir, f)
+		if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+			os.MkdirAll(filepath.Dir(path), 0700)
+		}
+
+		file, err := os.Create(path)
+		require.NoError(t, err, "error creating test file")
+		defer file.Close()
+
+		info, err := file.Stat()
+		require.NoError(t, err, "error getting file info")
+
+		header := &tar.Header{
+			Name:    f,
+			Size:    info.Size(),
+			Mode:    int64(info.Mode()),
+			ModTime: info.ModTime(),
+		}
+		err = tarWriter.WriteHeader(header)
+		require.NoError(t, err, "error writting header")
+
+		_, err = io.Copy(tarWriter, file)
+		require.NoError(t, err, "error writting tar")
+	}
+
+	return tarballPath
+}
+
+func setUpZip(t *testing.T, tmpDir string, files []string) string {
+	zipName := fmt.Sprintf("%s.zip", uuid.New())
+	zipPath := filepath.Join(tmpDir, zipName)
+	zipFile, err := os.Create(zipPath)
+	require.NoError(t, err, "error creating tar file")
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+	defer zipWriter.Close()
+
+	for _, f := range files {
+		path := filepath.Join(tmpDir, f)
+		if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+			os.MkdirAll(filepath.Dir(path), 0700)
+		}
+
+		file, err := os.Create(path)
+		require.NoError(t, err, "error creating test file")
+		defer file.Close()
+
+		info, err := file.Stat()
+		require.NoError(t, err)
+
+		header, err := zip.FileInfoHeader(info)
+		require.NoError(t, err)
+
+		header.Name = f
+
+		writer, err := zipWriter.CreateHeader(header)
+		require.NoError(t, err, "error writting zip")
+
+		_, err = io.Copy(writer, file)
+
+		require.NoError(t, err, "error writting file to zip")
+	}
+
+	return zipPath
+}


### PR DESCRIPTION
This replaces shelling out to `tar` with a new utility package. It is the first step to getting sandbox support working for Windows. The Node download for Windows only comes as a zip, hence the support for extracting zips in the utility package.