### PR TITLE
sandbox: Support Windows node downloads.

### DIFF
--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"runtime"
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/commands/displayers"
@@ -122,7 +123,11 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			c.Monitoring = func() do.MonitoringService { return do.NewMonitoringService(godoClient) }
 
 			sandboxDir, _ := getSandboxDirectory()
-			node := filepath.Join(sandboxDir, "node")
+			nodeBin := "node"
+			if runtime.GOOS == "windows" {
+				nodeBin = "node.exe"
+			}
+			node := filepath.Join(sandboxDir, nodeBin)
 			sandboxJs := filepath.Join(sandboxDir, "sandbox.js")
 			nimbellaDir := filepath.Join(sandboxDir, ".nimbella")
 			c.Sandbox = func() do.SandboxService { return do.NewSandboxService(sandboxJs, nimbellaDir, node, godoClient) }

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -408,27 +408,42 @@ func InstallSandbox(sandboxDir string, upgrading bool) error {
 	if err != nil {
 		return err
 	}
+
 	// Download the nodejs tarball for this os and architecture
+	fmt.Print("Downloading...")
+
 	goos := runtime.GOOS
 	arch := runtime.GOARCH
 	if arch == "amd64" {
 		arch = "x64"
-	} else if arch == "windows" {
-		arch = "win"
 	}
-	fmt.Print("Downloading...")
-	var nodeFileName string
-	var nodeDir string
+	if goos == "windows" {
+		goos = "win"
+	}
+
+	var (
+		nodeURL      string
+		nodeFileName string
+		nodeDir      string
+	)
+
 	// Download nodejs only if necessary
 	if !upgrading || !canReuseNode(sandboxDir) {
 		nodeDir = fmt.Sprintf("node-%s-%s-%s", nodeVersion, goos, arch)
-		URL := fmt.Sprintf("https://nodejs.org/dist/%s/%s.tar.gz", nodeVersion, nodeDir)
+		nodeURL = fmt.Sprintf("https://nodejs.org/dist/%s/%s.tar.gz", nodeVersion, nodeDir)
 		nodeFileName = filepath.Join(tmp, "node-install.tar.gz")
-		err = download(URL, nodeFileName)
+
+		if goos == "win" {
+			nodeURL = fmt.Sprintf("https://nodejs.org/dist/%s/%s.zip", nodeVersion, nodeDir)
+			nodeFileName = filepath.Join(tmp, "node-install.zip")
+		}
+
+		err = download(nodeURL, nodeFileName)
 		if err != nil {
 			return err
 		}
 	}
+
 	// Download the fat tarball with the nim CLI, deployer, and sandbox bridge
 	// TODO do these need to be arch-specific?  Currently assuming not.
 	URL := fmt.Sprintf("https://do-serverless-tools.nyc3.digitaloceanspaces.com/doctl-sandbox-%s.tar.gz", minSandboxVersion)
@@ -437,6 +452,7 @@ func InstallSandbox(sandboxDir string, upgrading bool) error {
 	if err != nil {
 		return err
 	}
+
 	// Exec the tar binary at least once to unpack the fat tarball and possibly a second time if
 	// node was downloaded.  If node was not download, just move the existing binary into place.
 	fmt.Print("Unpacking...")
@@ -444,12 +460,14 @@ func InstallSandbox(sandboxDir string, upgrading bool) error {
 	if err != nil {
 		return err
 	}
+
 	if nodeFileName != "" {
 		err = extract.Extract(nodeFileName, tmp)
 		if err != nil {
 			return err
 		}
 	}
+
 	// Move artifacts to final location
 	fmt.Print("Installing...")
 	srcPath := filepath.Join(tmp, "sandbox")
@@ -481,6 +499,9 @@ func InstallSandbox(sandboxDir string, upgrading bool) error {
 	}
 	if nodeFileName != "" {
 		srcPath = filepath.Join(tmp, nodeDir, "bin", "node")
+		if goos == "win" {
+			srcPath = filepath.Join(tmp, nodeDir, "node.exe")
+		}
 		destPath := filepath.Join(sandboxDir, "node")
 		err = os.Rename(srcPath, destPath)
 		if err != nil {

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -499,10 +499,11 @@ func InstallSandbox(sandboxDir string, upgrading bool) error {
 	}
 	if nodeFileName != "" {
 		srcPath = filepath.Join(tmp, nodeDir, "bin", "node")
+		destPath := filepath.Join(sandboxDir, "node")
 		if goos == "win" {
 			srcPath = filepath.Join(tmp, nodeDir, "node.exe")
+			destPath = filepath.Join(sandboxDir, "node.exe")
 		}
-		destPath := filepath.Join(sandboxDir, "node")
 		err = os.Rename(srcPath, destPath)
 		if err != nil {
 			return err


### PR DESCRIPTION
As mentioned in https://github.com/digitalocean/doctl/pull/1122, the Node download for Windows only comes as a zip. Additionally, I found that Windows (or at least the version of PowerShell I was testing in) will not run it without the `exe` file extension. So this required special casing Windows in a few places.