### PR TITLE
Incorporate a newer Nimbella CLI version with a bug fix

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	nodeVersion       = "v16.13.0"
-	minSandboxVersion = "2.3.9-1.1.0"
+	minSandboxVersion = "2.3.10-1.1.0"
 
 	// noCapture is the string constant recognized by the plugin.  It suppresses output
 	// capture when in the initial (command) position.


### PR DESCRIPTION
The fix in Nimbella CLI 2.3.10 addresses a problem with remote build when using the default package.