### PR TITLE
Add ability to get 'app' project resources

### DIFF
--- a/commands/projects.go
+++ b/commands/projects.go
@@ -265,6 +265,8 @@ func RunProjectResourcesGet(c *CmdConfig) error {
 		return RunDomainGet(c)
 	case "volume":
 		return RunVolumeGet(c)
+	case "app":
+		return RunAppsGet(c)
 	default:
 		return fmt.Errorf("%q is an invalid resource type, consult the documentation", parts[1])
 	}


### PR DESCRIPTION
Apps can be assigned to projects.  This patch adds support for getting an project resource that is an app by running 'doctl resources get do:app:APP_UUID'.