### PR TITLE
tags: Support applying and removing tags from resources.

### DIFF
--- a/commands/tags_test.go
+++ b/commands/tags_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/digitalocean/doctl/do"
 	"github.com/digitalocean/godo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -46,7 +48,7 @@ var (
 func TestTTagCommand(t *testing.T) {
 	cmd := Tags()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "create", "get", "delete", "list")
+	assertCommandNames(t, cmd, "create", "get", "delete", "list", "apply", "remove")
 }
 
 func TestTagGet(t *testing.T) {
@@ -103,4 +105,152 @@ func TestTagDeleteMultiple(t *testing.T) {
 		err := RunCmdTagDelete(config)
 		assert.NoError(t, err)
 	})
+}
+
+func TestTagApply(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		req := &godo.TagResourcesRequest{
+			Resources: []godo.Resource{
+				{
+					ID:   "123456",
+					Type: "droplet",
+				},
+				{
+					ID:   "e88d9f78-a6ff-11ec-9ba0-1313675d1e43",
+					Type: "kubernetes",
+				},
+			},
+		}
+		tm.tags.EXPECT().TagResources("my-tag", req).Return(nil)
+		config.Args = append(config.Args, "my-tag")
+
+		config.Doit.Set(config.NS, doctl.ArgResourceType, []string{
+			"do:droplet:123456",
+			"do:kubernetes:e88d9f78-a6ff-11ec-9ba0-1313675d1e43",
+		})
+
+		err := RunCmdApplyTag(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestTagApplyWithDBaaS(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		req := &godo.TagResourcesRequest{
+			Resources: []godo.Resource{
+				{
+					ID:   "a02eb612-a700-11ec-9b48-27a1674e16fa",
+					Type: "database",
+				},
+				{
+					ID:   "e88d9f78-a6ff-11ec-9ba0-1313675d1e43",
+					Type: "database",
+				},
+			},
+		}
+		tm.tags.EXPECT().TagResources("my-tag", req).Return(nil)
+		config.Args = append(config.Args, "my-tag")
+
+		config.Doit.Set(config.NS, doctl.ArgResourceType, []string{
+			"do:database:a02eb612-a700-11ec-9b48-27a1674e16fa",
+			"do:dbaas:e88d9f78-a6ff-11ec-9ba0-1313675d1e43",
+		})
+
+		err := RunCmdApplyTag(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestTagApplyWithInvalidURNErrors(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		config.Args = append(config.Args, "my-tag")
+
+		config.Doit.Set(config.NS, doctl.ArgResourceType, []string{
+			"do:something:droplet:123456",
+		})
+
+		err := RunCmdApplyTag(config)
+		assert.Equal(t, `URN must be in the format "do:<resource_type>:<resource_id>": invalid urn`, err.Error())
+	})
+}
+
+func TestTagRemove(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		req := &godo.UntagResourcesRequest{
+			Resources: []godo.Resource{
+				{
+					ID:   "123456",
+					Type: "droplet",
+				},
+				{
+					ID:   "e88d9f78-a6ff-11ec-9ba0-1313675d1e43",
+					Type: "kubernetes",
+				},
+			},
+		}
+		tm.tags.EXPECT().UntagResources("my-tag", req).Return(nil)
+		config.Args = append(config.Args, "my-tag")
+
+		config.Doit.Set(config.NS, doctl.ArgResourceType, []string{
+			"do:droplet:123456",
+			"do:kubernetes:e88d9f78-a6ff-11ec-9ba0-1313675d1e43",
+		})
+
+		err := RunCmdRemoveTag(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestBuildTagResources(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          []string
+		expected    []godo.Resource
+		expectedErr error
+	}{
+		{
+			name: "happy path",
+			in:   []string{"do:droplet:123456", "do:kubernetes:ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984"},
+			expected: []godo.Resource{
+				{
+					ID:   "123456",
+					Type: "droplet",
+				},
+				{
+					ID:   "ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+					Type: "kubernetes",
+				},
+			},
+		},
+		{
+			name: "with dbaas",
+			in:   []string{"do:dbaas:e88d9f78-a6ff-11ec-9ba0-1313675d1e43", "do:database:ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984"},
+			expected: []godo.Resource{
+				{
+					ID:   "e88d9f78-a6ff-11ec-9ba0-1313675d1e43",
+					Type: "database",
+				},
+				{
+					ID:   "ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+					Type: "database",
+				},
+			},
+		},
+		{
+			name:        "with invalid urn",
+			in:          []string{"do:foo:bar:baz"},
+			expectedErr: errors.New(`URN must be in the format "do:<resource_type>:<resource_id>": invalid urn`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildTagResources(tt.in)
+			if tt.expectedErr == nil {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, got)
+
+		})
+	}
 }

--- a/integration/tags_apply_test.go
+++ b/integration/tags_apply_test.go
@@ -1,0 +1,141 @@
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite("compute/tags/apply", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+		expectedJSONSingle := `{
+  "resources": [
+    {
+      "resource_id": "123456",
+      "resource_type": "droplet"
+    }
+  ]
+}`
+		expectedJSONMulti := `{
+  "resources": [
+    {
+      "resource_id": "123456",
+      "resource_type": "droplet"
+    },
+    {
+      "resource_id": "64f051b2-a702-11ec-bae8-6b11363a9137",
+      "resource_type": "kubernetes"
+    }
+  ]
+}`
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/tags/foo/resources":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				reqBody, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+
+				request := godo.TagResourcesRequest{}
+				err = json.Unmarshal(reqBody, &request)
+				expect.NoError(err)
+				expect.JSONEq(expectedJSONSingle, string(reqBody))
+
+				w.WriteHeader(http.StatusNoContent)
+
+			case "/v2/tags/bar/resources":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				reqBody, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+
+				request := godo.TagResourcesRequest{}
+				err = json.Unmarshal(reqBody, &request)
+				expect.NoError(err)
+				expect.JSONEq(expectedJSONMulti, string(reqBody))
+
+				w.WriteHeader(http.StatusNoContent)
+
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	when("all required flags are passed", func() {
+		it("applies the right tag", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"tag",
+				"apply",
+				"foo",
+				"--resource", "do:droplet:123456",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Empty(output)
+		})
+	})
+
+	when("multiple resources are provided and all required flags are passed", func() {
+		it("applies the right tag", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"tag",
+				"apply",
+				"bar",
+				"--resource", "do:droplet:123456",
+				"--resource", "do:kubernetes:64f051b2-a702-11ec-bae8-6b11363a9137",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Empty(output)
+		})
+	})
+
+})

--- a/integration/tags_remove_test.go
+++ b/integration/tags_remove_test.go
@@ -1,0 +1,141 @@
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite("compute/tags/remove", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+		expectedJSONSingle := `{
+  "resources": [
+    {
+      "resource_id": "123456",
+      "resource_type": "droplet"
+    }
+  ]
+}`
+		expectedJSONMulti := `{
+  "resources": [
+    {
+      "resource_id": "123456",
+      "resource_type": "droplet"
+    },
+    {
+      "resource_id": "64f051b2-a702-11ec-bae8-6b11363a9137",
+      "resource_type": "kubernetes"
+    }
+  ]
+}`
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/tags/foo/resources":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodDelete {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				reqBody, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+
+				request := godo.UntagResourcesRequest{}
+				err = json.Unmarshal(reqBody, &request)
+				expect.NoError(err)
+				expect.JSONEq(expectedJSONSingle, string(reqBody))
+
+				w.WriteHeader(http.StatusNoContent)
+
+			case "/v2/tags/bar/resources":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodDelete {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				reqBody, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+
+				request := godo.UntagResourcesRequest{}
+				err = json.Unmarshal(reqBody, &request)
+				expect.NoError(err)
+				expect.JSONEq(expectedJSONMulti, string(reqBody))
+
+				w.WriteHeader(http.StatusNoContent)
+
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	when("all required flags are passed", func() {
+		it("removes the right tag", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"tag",
+				"remove",
+				"foo",
+				"--resource", "do:droplet:123456",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Empty(output)
+		})
+	})
+
+	when("multiple resources are provided and all required flags are passed", func() {
+		it("removes the right tag", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"compute",
+				"tag",
+				"remove",
+				"bar",
+				"--resource", "do:droplet:123456",
+				"--resource", "do:kubernetes:64f051b2-a702-11ec-bae8-6b11363a9137",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Empty(output)
+		})
+	})
+
+})

--- a/pkg/urn/urn.go
+++ b/pkg/urn/urn.go
@@ -1,0 +1,65 @@
+package urn
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	// DefaultNamespace is the default URN namespace for DigitalOcean resources.
+	DefaultNamespace = "do"
+)
+
+var (
+	segmentFormat = `[a-zA-Z0-9-_~\.]{1,256}`
+	urnRegexp     = regexp.MustCompile(`^(` + segmentFormat + `):(` + segmentFormat + `):(` + segmentFormat + `)$`)
+)
+
+// URN is a unique, uniform identifier for a resource. This structure holds an
+// URN parse into its three segments: a namespace, a collection and an identifier.
+type URN struct {
+	namespace  string
+	collection string
+	identifier string
+}
+
+// ParseURN parses a string representation of an URN and returns its structured representation (*URN).
+func ParseURN(s string) (*URN, error) {
+	segments := urnRegexp.FindStringSubmatch(s)
+	if len(segments) < 4 {
+		return nil, errors.New("invalid urn")
+	}
+
+	return NewURN(segments[1], segments[2], segments[3]), nil
+}
+
+// NewURN constructs an *URN from a namespace, resource type, and identifier.
+func NewURN(namespace string, collection string, id interface{}) *URN {
+	return &URN{
+		namespace:  strings.ToLower(namespace),
+		collection: strings.ToLower(collection),
+		identifier: fmt.Sprintf("%v", id),
+	}
+}
+
+// Namespace returns the namespace segment of the URN.
+func (u *URN) Namespace() string {
+	return u.namespace
+}
+
+// Collection returns the collection segment of the URN.
+func (u *URN) Collection() string {
+	return u.collection
+}
+
+// Identifier returns the identifier segment of the URN.
+func (u *URN) Identifier() string {
+	return u.identifier
+}
+
+// String returns a string representation of the URN.
+func (u *URN) String() string {
+	return fmt.Sprintf("%s:%s:%s", u.namespace, u.collection, u.identifier)
+}

--- a/pkg/urn/urn_test.go
+++ b/pkg/urn/urn_test.go
@@ -1,0 +1,141 @@
+package urn
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURN(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		in          string
+		expected    *URN
+		expectedErr error
+	}{
+		{
+			name: "urn with int id",
+			in:   "do:droplet:123456",
+			expected: &URN{
+				namespace:  DefaultNamespace,
+				collection: "droplet",
+				identifier: "123456",
+			},
+		},
+		{
+			name: "urn with string id",
+			in:   "do:kubernetes:ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+			expected: &URN{
+				namespace:  DefaultNamespace,
+				collection: "kubernetes",
+				identifier: "ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+			},
+		},
+		{
+			name: "urn with capitalized input",
+			in:   "DO:Kubernetes:ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+			expected: &URN{
+				namespace:  DefaultNamespace,
+				collection: "kubernetes",
+				identifier: "ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+			},
+		},
+		{
+			name:        "invalid urn with too many segments",
+			in:          "DO:Kubernetes:123:abc",
+			expectedErr: errors.New("invalid urn"),
+		},
+		{
+			name:        "not an urn",
+			in:          "9adfd91e-a6f8-11ec-970d-dfc761e0603d",
+			expectedErr: errors.New("invalid urn"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseURN(tt.in)
+			if tt.expectedErr == nil {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, got)
+
+		})
+	}
+}
+
+func TestNewURN(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespace  string
+		collection string
+		identifier interface{}
+		expected   *URN
+		asString   string
+	}{
+		{
+			name:       "urn with int id",
+			namespace:  DefaultNamespace,
+			collection: "droplet",
+			identifier: 123456,
+			asString:   "do:droplet:123456",
+			expected: &URN{
+				namespace:  DefaultNamespace,
+				collection: "droplet",
+				identifier: "123456",
+			},
+		},
+		{
+			name:       "urn with string id",
+			namespace:  DefaultNamespace,
+			collection: "droplet",
+			identifier: 123456,
+			asString:   "do:droplet:123456",
+			expected: &URN{
+				namespace:  DefaultNamespace,
+				collection: "droplet",
+				identifier: "123456",
+			},
+		},
+		{
+			name:       "urn with string uuid",
+			namespace:  DefaultNamespace,
+			collection: "kubernetes",
+			identifier: "ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+			asString:   "do:kubernetes:ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+			expected: &URN{
+				namespace:  DefaultNamespace,
+				collection: "kubernetes",
+				identifier: "ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+			},
+		},
+		{
+			name:       "urn with capitalized input",
+			namespace:  DefaultNamespace,
+			collection: "Kubernetes",
+			identifier: "ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+			asString:   "do:kubernetes:ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+			expected: &URN{
+				namespace:  DefaultNamespace,
+				collection: "kubernetes",
+				identifier: "ca0cc702-a6f7-11ec-a8fc-6bcc60f7e984",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewURN(tt.namespace, tt.collection, tt.identifier)
+			assert.Equal(t, tt.expected, got)
+			assert.Equal(t, tt.namespace, got.Namespace())
+			assert.Equal(t, strings.ToLower(tt.collection), got.Collection())
+			assert.Equal(t, strings.ToLower(fmt.Sprintf("%v", tt.identifier)), got.Identifier())
+			assert.Equal(t, tt.asString, got.String())
+		})
+	}
+}


### PR DESCRIPTION
Somehow we've never added support for tagging arbitrary resources. There is a `doctl compute droplet tag` command that allows you to tag a single Droplet, but there is no wider support for other resources or tagging multiple in one request. The PR adds new `doctl compute tag apply` and `doctl compute tag remove` commands. 

These can tag multiple resources using their URNs (e.g. `--resource do:droplet:123456 --resource do:kubernets:aaa-bbb-ccc`). The API itself does not use URNs, but it seemed like an natural approach here as we already use this pattern for other commands like assigning resources to project. So this also adds a small utility package for working with URNs. 