### PR TITLE
Use new simplified API to get sandbox namespace

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -82,14 +82,8 @@ The install operation is long-running, and a network connection is required.`,
 	CmdBuilder(cmd, RunSandboxUninstall, "uninstall", "Removes the sandbox support", `Removes sandbox support from `+"`"+`doctl`+"`",
 		Writer)
 
-	CmdBuilder(cmd, RunSandboxConnect, "connect [<token>|<namespace>]", "Connect the cloud portion of your sandbox",
-		`This command connects the cloud portion of your sandbox (needed for testing).
-There are several ways to use it.
-1. If your account has been explicitly provisioned with sandbox support, invoke with no arguments.
-2. (DO internal) If you obtained a namespace for your account using the alpha console, you may
-use either the namespace name or the generated token as the argument.  The ability to generate
-and use a token is for compatibility with the previous behavior of the command and is likely
-to be deprecated and removed`,
+	CmdBuilder(cmd, RunSandboxConnect, "connect", "Connect the cloud portion of your sandbox",
+		`This command connects the cloud portion of your sandbox (needed for testing).`,
 		Writer)
 
 	status := CmdBuilder(cmd, RunSandboxStatus, "status", "Provide information about your sandbox",
@@ -159,23 +153,13 @@ func RunSandboxUninstall(c *CmdConfig) error {
 // RunSandboxConnect implements the sandbox connect command
 func RunSandboxConnect(c *CmdConfig) error {
 	var (
-		arg   string
-		token bool
 		creds do.SandboxCredentials
 		err   error
 	)
-	if len(c.Args) > 1 {
+	if len(c.Args) > 0 {
 		return doctl.NewTooManyArgsErr(c.NS)
 	}
-	if len(c.Args) == 1 {
-		arg = c.Args[0]
-		token = isJWT(arg)
-	}
-	if token {
-		creds, err = c.Sandbox().ResolveToken(context.TODO(), arg)
-	} else {
-		creds, err = c.Sandbox().ResolveNamespace(context.TODO(), arg)
-	}
+	creds, err = c.Sandbox().GetSandboxNamespace(context.TODO())
 	if err != nil {
 		return err
 	}
@@ -187,16 +171,6 @@ func RunSandboxConnect(c *CmdConfig) error {
 	fmt.Fprintf(c.Out, "Connected to function namespace '%s' on API host '%s'\n", mapResult["namespace"], mapResult["apihost"])
 	fmt.Fprintln(c.Out)
 	return nil
-}
-
-// Determine whether an argument is a JWT or a namespace.  The heuristic is based on the length of the
-// string and whether it contains two dots (then JWT, otherwise namespace).
-func isJWT(candidate string) bool {
-	if len(candidate) < 30 {
-		return false
-	}
-	parts := strings.Split(candidate, ".")
-	return len(parts) == 3
 }
 
 // RunSandboxStatus gives a report on the status of the sandbox (installed, up to date, connected)

--- a/do/sandbox.go
+++ b/do/sandbox.go
@@ -7,50 +7,28 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/digitalocean/godo"
 )
 
-// SandboxCredentials is the type returned by the ResolveToken and ResolveNamespace functions
+// SandboxCredentials is the type returned by the GetSandboxNamespace function.
 // The values in it can be used to connect sandbox support to a specific namespace using the plugin.
 type SandboxCredentials struct {
 	Auth    string
 	APIHost string
 }
 
-// The type of the "namespace" member of POST input for API calls.
-// Only one of the fields is typically specified
-type inputNamespace struct {
-	Token     string `json:"token,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-}
-
-// The type of the "namespace" member of the response to API calls.  Only some
-// fields are relevant to each call.
+// The type of the "namespace" member of the response to /api/v2/functions/sandbox
+// Only relevant fields unmarshalled
 type outputNamespace struct {
-	APIHost   string `json:"api_host"`
-	UUID      string `json:"uuid"`
-	Key       string `json:"key"`
-	Token     string `json:"token"`
-	Label     string `json:"label"`
-	Namespace string `json:"namespace"`
+	APIHost string `json:"api_host"`
+	UUID    string `json:"uuid"`
+	Key     string `json:"key"`
 }
 
-// namespacesPostBody is the type of the request body for v2/function/namespaces/... calls that use
-// the POST verb.  Only the relevant parts of the contained inputNamespace need be specified
-type namespacesPostBody struct {
-	Namespace inputNamespace `json:"namespace"`
-}
-
-// namespacesResponseBody is the type of the response body from API calls other than "list namespaces".
+// namespacesResponseBody is the type of the response body for /api/v2/functions/sandbox
 type namespacesResponseBody struct {
 	Namespace outputNamespace `json:"namespace"`
-}
-
-// namespaceList is the type of the response body from "list namespaces"
-type namespaceList struct {
-	Namespaces []outputNamespace `json:"namespaces"`
 }
 
 // SandboxService is an interface for interacting with the sandbox plugin
@@ -59,8 +37,7 @@ type SandboxService interface {
 	Cmd(string, []string) (*exec.Cmd, error)
 	Exec(*exec.Cmd) (SandboxOutput, error)
 	Stream(*exec.Cmd) error
-	ResolveToken(context.Context, string) (SandboxCredentials, error)
-	ResolveNamespace(context.Context, string) (SandboxCredentials, error)
+	GetSandboxNamespace(context.Context) (SandboxCredentials, error)
 }
 
 type sandboxService struct {
@@ -131,90 +108,22 @@ func (n *sandboxService) Stream(cmd *exec.Cmd) error {
 	return cmd.Run()
 }
 
-// ResolveToken resolves a JWT issued by the UI into a set of credentials for the sandbox
-// Note: the use of JWTs may eventually go away in favor of going straight from namespace
-// name to the actual tokens.
-func (n *sandboxService) ResolveToken(ctx context.Context, token string) (SandboxCredentials, error) {
-	path := "v2/function/namespaces/namespace"
-	body := namespacesPostBody{Namespace: inputNamespace{Token: token}}
-	req, err := n.client.NewRequest(ctx, http.MethodPost, path, body)
+// GetSandboxNamespace returns the credentials of the one sandbox namespace assigned to
+// the invoking doctl context.
+func (n *sandboxService) GetSandboxNamespace(ctx context.Context) (SandboxCredentials, error) {
+	path := "v2/functions/sandbox"
+	req, err := n.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return SandboxCredentials{}, err
 	}
-	tokenDecoded := new(namespacesResponseBody)
-	_, err = n.client.Do(ctx, req, tokenDecoded)
+	decoded := new(namespacesResponseBody)
+	_, err = n.client.Do(ctx, req, decoded)
 	if err != nil {
 		return SandboxCredentials{}, err
 	}
 	ans := SandboxCredentials{
-		APIHost: tokenDecoded.Namespace.APIHost,
-		Auth:    tokenDecoded.Namespace.UUID + ":" + tokenDecoded.Namespace.Key,
+		APIHost: decoded.Namespace.APIHost,
+		Auth:    decoded.Namespace.UUID + ":" + decoded.Namespace.Key,
 	}
 	return ans, nil
-}
-
-// ResolveNamespace resolves a namespace name into a set of credentials for the sandbox.
-// If "" is given as the namespace name, the available namespaces are retrieved and the
-// function attempts to identify one of them as the sandbox namespace.
-// Note: at present, the "" option only works when the customer has exactly one namespace
-// whose 'label' field contains the substring 'sandbox'.   This is subject to change.
-// Note: at present, two remote calls are needed to go from a namespace name to the needed
-// credentials.  First, a JWT token is remotely generated, then ResolveToken call is used
-// to resolve it.  This will be streamlined in the future.
-func (n *sandboxService) ResolveNamespace(ctx context.Context, namespace string) (SandboxCredentials, error) {
-	var err error
-	if namespace == "" {
-		namespace, err = findSandboxNamespace(ctx, n.client)
-		if err != nil {
-			return SandboxCredentials{}, err
-		}
-	}
-	token, err := getTokenForNamespace(ctx, n.client, namespace)
-	if err != nil {
-		return SandboxCredentials{}, err
-	}
-	return n.ResolveToken(ctx, token)
-}
-
-// getTokenForNamespace is a subroutine of ResolveNamespace wrapping the call to
-// obtain a JWT.  This step should eventually be eliminated in favor of an API
-// that goes directly from namespace to credentials.
-func getTokenForNamespace(ctx context.Context, client *godo.Client, namespace string) (string, error) {
-	path := "v2/function/namespaces/login_token"
-	body := namespacesPostBody{Namespace: inputNamespace{Namespace: namespace}}
-	req, err := client.NewRequest(ctx, http.MethodPost, path, body)
-	if err != nil {
-		return "", err
-	}
-	tokenResponse := new(namespacesResponseBody)
-	_, err = client.Do(ctx, req, tokenResponse)
-	if err != nil {
-		return "", err
-	}
-	return tokenResponse.Namespace.Token, nil
-}
-
-// findSandboxNamespace is a subroutine of ResolveNamespace implementing the search for
-// a sandbox namespace.
-func findSandboxNamespace(ctx context.Context, client *godo.Client) (string, error) {
-	path := "v2/function/namespaces"
-	req, err := client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return "", err
-	}
-	namespaces := new(namespaceList)
-	_, err = client.Do(ctx, req, namespaces)
-	if err != nil {
-		return "", err
-	}
-	sandboxes := []string{}
-	for _, ns := range namespaces.Namespaces {
-		if strings.Contains(ns.Label, "sandbox") {
-			sandboxes = append(sandboxes, ns.Namespace)
-		}
-	}
-	if len(sandboxes) == 1 {
-		return sandboxes[0], nil
-	}
-	return "", errors.New("could not find a sandbox namespace in the cloud for this account")
 }


### PR DESCRIPTION
This removes the need for the namespace to be added via the cloud console or administratively prior to connecting.  The new API creates the sandbox namespace if it doesn't already exist and doesn't require you to know anything about it a priori.

_Still a draft until I fix the tests_.