### PR TITLE
Maintain sandbox credentials on per-DO-token basis

### DIFF
--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -37,7 +37,7 @@ type CmdConfig struct {
 	setContextAccessToken func(string)
 	removeContext         func(string) error
 	checkSandboxStatus    func() error
-	installSandbox        func(string, bool) error
+	installSandbox        func(*CmdConfig, string, bool) error
 
 	// services
 	Keys              func() do.KeysService
@@ -129,7 +129,7 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			}
 			node := filepath.Join(sandboxDir, nodeBin)
 			sandboxJs := filepath.Join(sandboxDir, "sandbox.js")
-			nimbellaDir := filepath.Join(sandboxDir, ".nimbella")
+			nimbellaDir := getCredentialDirectory(c, sandboxDir)
 			c.Sandbox = func() do.SandboxService { return do.NewSandboxService(sandboxJs, nimbellaDir, node, godoClient) }
 
 			return nil
@@ -196,8 +196,8 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			return CheckSandboxStatus()
 		},
 
-		installSandbox: func(dir string, upgrading bool) error {
-			return InstallSandbox(dir, upgrading)
+		installSandbox: func(c *CmdConfig, dir string, upgrading bool) error {
+			return InstallSandbox(c, dir, upgrading)
 		},
 	}
 

--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -118,7 +118,7 @@ func TestSandboxInstallFromScratch(t *testing.T) {
 		buf := &bytes.Buffer{}
 		config.Out = buf
 
-		config.installSandbox = func(dir string, upgrade bool) error {
+		config.installSandbox = func(c *CmdConfig, dir string, upgrade bool) error {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}
@@ -137,7 +137,7 @@ func TestSandboxInstallWhenInstalledNotCurrent(t *testing.T) {
 		buf := &bytes.Buffer{}
 		config.Out = buf
 
-		config.installSandbox = func(dir string, upgrade bool) error {
+		config.installSandbox = func(c *CmdConfig, dir string, upgrade bool) error {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}
@@ -156,7 +156,7 @@ func TestSandboxInstallWhenInstalledAndCurrent(t *testing.T) {
 		buf := &bytes.Buffer{}
 		config.Out = buf
 
-		config.installSandbox = func(dir string, upgrade bool) error {
+		config.installSandbox = func(c *CmdConfig, dir string, upgrade bool) error {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}
@@ -175,7 +175,7 @@ func TestSandboxUpgradeWhenNotInstalled(t *testing.T) {
 		buf := &bytes.Buffer{}
 		config.Out = buf
 
-		config.installSandbox = func(dir string, upgrade bool) error {
+		config.installSandbox = func(c *CmdConfig, dir string, upgrade bool) error {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}
@@ -194,7 +194,7 @@ func TestSandboxUpgradeWhenInstalledAndCurrent(t *testing.T) {
 		buf := &bytes.Buffer{}
 		config.Out = buf
 
-		config.installSandbox = func(dir string, upgrade bool) error {
+		config.installSandbox = func(c *CmdConfig, dir string, upgrade bool) error {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}
@@ -213,7 +213,7 @@ func TestSandboxUpgradeWhenInstalledAndNotCurrent(t *testing.T) {
 		buf := &bytes.Buffer{}
 		config.Out = buf
 
-		config.installSandbox = func(dir string, upgrade bool) error {
+		config.installSandbox = func(c *CmdConfig, dir string, upgrade bool) error {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}


### PR DESCRIPTION
When `doctl sandbox connect` is executed, the sandbox credentials are returned and stored for a specific account or team identified by the DO API token used for the call.   But, `doctl` anticipates the use of multiple DO API tokens on a given machine, generally stored in the form of (locally) named "contexts" but also directly specifiable on the command line.  The previous practice of storing the returned sandbox credentials in a single place is thus inappropriate.   This change allows for multiple credential sets to be stored, identified by a short prefix of the token that is in use at the time of connection.   This change then allows for correct semantics when `doctl auth switch` is used or any of the `--context`, `--config` or `--access-token` flags appear on a sandbox command, altering the effective identity of the requestor.

When the sandbox was connected under one identity and the user switches to another identity for which the sandbox was not previously connected, the sandbox becomes disconnected.   This is by design.  It allows the user to do a fresh connect under the new identity.   In general this will connect to a different sandbox.

Note that the underlying Nimbella CLI is capable of storing credentials for multiple namespaces.   I did not want to load the present requirement onto that capability because in the future we are likely to allow multiple namespaces to be used within a single "sandbox."   The current change is simply maintaining the invariant that different tokens imply different identities and hence different resource sets.