### PR TITLE
Fix bug in sandbox activations logs --follow

### DIFF
--- a/commands/activations.go
+++ b/commands/activations.go
@@ -115,20 +115,25 @@ func RunActivationsLogs(c *CmdConfig) error {
 	replaceFunctionWithAction(c)
 	augmentPackageWithDeployed(c)
 	if isWatching(c) {
-		return RunSandboxExecStreaming(activationLogs, c, []string{flagLast, flagStrip, flagFollow, flagDeployed}, []string{flagAction, flagPackage, flagLimit})
+		return RunSandboxExecStreaming(activationLogs, c, []string{flagLast, flagStrip, flagWatch, flagDeployed}, []string{flagAction, flagPackage, flagLimit})
 	}
-	output, err := RunSandboxExec(activationLogs, c, []string{flagLast, flagStrip, flagFollow, flagDeployed}, []string{flagAction, flagPackage, flagLimit})
+	output, err := RunSandboxExec(activationLogs, c, []string{flagLast, flagStrip, flagWatch, flagDeployed}, []string{flagAction, flagPackage, flagLimit})
 	if err != nil {
 		return err
 	}
 	return c.PrintSandboxTextOutput(output)
 }
 
-// isWatching decides whether the flags of an 'activation logs' command are implementing the watching
-// feature.  Currently, this is indicated by the --follow flag.
+// isWatching (1) modifies the config replacing the "follow" flag (significant to doctl) with the
+// "watch" flag (significant to nim)  (2) Returns whether the command should be run in streaming mode
+// (will be true iff follow/watch is true).
 func isWatching(c *CmdConfig) bool {
 	yes, err := c.Doit.GetBool(c.NS, flagFollow)
-	return yes && err == nil
+	if yes && err == nil {
+		c.Doit.Set(c.NS, flagWatch, true)
+		return true
+	}
+	return false
 }
 
 // RunActivationsResult supports the 'activations result' command

--- a/commands/activations_test.go
+++ b/commands/activations_test.go
@@ -224,7 +224,7 @@ func TestActivationsLogs(t *testing.T) {
 		{
 			name:            "follow flag",
 			doctlFlags:      map[string]string{"follow": ""},
-			expectedNimArgs: []string{"--follow"},
+			expectedNimArgs: []string{"--watch"},
 			expectStream:    true,
 		},
 		{

--- a/commands/const.go
+++ b/commands/const.go
@@ -48,6 +48,7 @@ const (
 	activationLogs     = "activation/logs"
 	flagStrip          = "strip"
 	flagFollow         = "follow"
+	flagWatch          = "watch"
 	flagDeployed       = "deployed"
 	flagPackage        = "package"
 	activationResult   = "activation/result"


### PR DESCRIPTION
An earlier change broke the functionality of `activations logs --follow`.   It is necessary to translate the `--follow` flag to one of the flags actually recognized by `nim` (`--watch`, `--poll`, or `--tail`) before invoking `nim`.