### PR TITLE
Fail early and cleanly when the sandbox was never connected

### DIFF
--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -36,7 +36,7 @@ type CmdConfig struct {
 	getContextAccessToken func() string
 	setContextAccessToken func(string)
 	removeContext         func(string) error
-	checkSandboxStatus    func() error
+	checkSandboxStatus    func(*CmdConfig) error
 	installSandbox        func(*CmdConfig, string, bool) error
 
 	// services
@@ -192,8 +192,8 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			return nil
 		},
 
-		checkSandboxStatus: func() error {
-			return CheckSandboxStatus()
+		checkSandboxStatus: func(c *CmdConfig) error {
+			return CheckSandboxStatus(c)
 		},
 
 		installSandbox: func(c *CmdConfig, dir string, upgrading bool) error {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -237,7 +237,7 @@ func withTestClient(t *testing.T, tFn testFn) {
 
 		setContextAccessToken: func(token string) {},
 
-		checkSandboxStatus: func() error {
+		checkSandboxStatus: func(c *CmdConfig) error {
 			return nil
 		},
 

--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -92,7 +92,7 @@ func TestSandboxStatusWhenNotConnected(t *testing.T) {
 
 func TestSandboxStatusWhenNotInstalled(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		config.checkSandboxStatus = func() error {
+		config.checkSandboxStatus = func(*CmdConfig) error {
 			return ErrSandboxNotInstalled
 		}
 
@@ -105,7 +105,7 @@ func TestSandboxStatusWhenNotInstalled(t *testing.T) {
 
 func TestSandboxStatusWhenNotUpToDate(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		config.checkSandboxStatus = func() error {
+		config.checkSandboxStatus = func(*CmdConfig) error {
 			return ErrSandboxNeedsUpgrade
 		}
 
@@ -125,7 +125,7 @@ func TestSandboxInstallFromScratch(t *testing.T) {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}
-		config.checkSandboxStatus = func() error {
+		config.checkSandboxStatus = func(*CmdConfig) error {
 			return ErrSandboxNotInstalled
 		}
 
@@ -144,7 +144,7 @@ func TestSandboxInstallWhenInstalledNotCurrent(t *testing.T) {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}
-		config.checkSandboxStatus = func() error {
+		config.checkSandboxStatus = func(*CmdConfig) error {
 			return ErrSandboxNeedsUpgrade
 		}
 
@@ -163,7 +163,7 @@ func TestSandboxInstallWhenInstalledAndCurrent(t *testing.T) {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}
-		config.checkSandboxStatus = func() error {
+		config.checkSandboxStatus = func(*CmdConfig) error {
 			return nil
 		}
 
@@ -182,7 +182,7 @@ func TestSandboxUpgradeWhenNotInstalled(t *testing.T) {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}
-		config.checkSandboxStatus = func() error {
+		config.checkSandboxStatus = func(*CmdConfig) error {
 			return ErrSandboxNotInstalled
 		}
 
@@ -201,7 +201,7 @@ func TestSandboxUpgradeWhenInstalledAndCurrent(t *testing.T) {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}
-		config.checkSandboxStatus = func() error {
+		config.checkSandboxStatus = func(*CmdConfig) error {
 			return nil
 		}
 
@@ -220,7 +220,7 @@ func TestSandboxUpgradeWhenInstalledAndNotCurrent(t *testing.T) {
 			fmt.Fprintf(config.Out, "Installed with upgrade %v\n", upgrade)
 			return nil
 		}
-		config.checkSandboxStatus = func() error {
+		config.checkSandboxStatus = func(*CmdConfig) error {
 			return ErrSandboxNeedsUpgrade
 		}
 

--- a/do/sandbox.go
+++ b/do/sandbox.go
@@ -88,7 +88,11 @@ func (n *sandboxService) Cmd(command string, args []string) (*exec.Cmd, error) {
 	args = append([]string{n.sandboxJs, command}, args...)
 	cmd := exec.Command(n.node, args...)
 	cmd.Env = append(os.Environ(), "NIMBELLA_DIR="+n.sandboxDir)
-
+	// If DEBUG is specified, we need to open up stderr for that stream.  The stdout stream
+	// will continue to work for returning structured results.
+	if os.Getenv("DEBUG") != "" {
+		cmd.Stderr = os.Stderr
+	}
 	return cmd, nil
 }
 


### PR DESCRIPTION
Beta users of `doctl sandbox` have reported that a common user error is handled in a confusing way.   If the user has done `doctl sandbox install` but not `doctl sandbox connect`, and then tries other sandbox commands, the errors that come back are arbitrary and confusing because they are attempting to invoke various APIs on the serverless backend.   This change inserts a pre-check for being connected, prior to calling out to the sandbox plugin, meaning that the user always gets the informative message saying that the sandbox needs to be connected.

It is important that the pre-check not double the overhead of most calls, which is what would happen if we invoked the plugin to do the credential check.   So, the check uses a simple file existence check, which is slightly weaker since it doesn't  check for possible corruption of the credentials (etc).  The deeper check is done when `sandbox status` is called.

This PR also includes a small change to sandbox plugin DEBUG support.  It had become incomplete due to an earlier refactoring.