### PR TITLE
Make serverless and sls aliases of sandbox

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -78,7 +78,7 @@ func Sandbox() *Command {
 			Long: `The ` + "`" + `doctl sandbox` + "`" + ` commands provide a development sandbox for functions.  A sandbox has a local file system component and a cloud component.
 A one-time install of the sandbox software is needed (use ` + "`" + `doctl sandbox install` + "`" + ` to install the software, then ` + "`" + `doctl sandbox connect` + "`" + ` to
 connect to the cloud component of the sandbox provided with your account).  Other ` + "`" + `doctl sandbox` + "`" + ` commands are used to develop and test.`,
-			Aliases: []string{"sbx"},
+			Aliases: []string{"sbx", "serverless", "sls"},
 			Hidden:  !isSandboxInstalled(),
 		},
 	}


### PR DESCRIPTION
The sole purpose of this PR is to establish serverless (and the shorter sls) as additional aliases of sandbox (and sbx).