### PR TITLE
Fix two small bugs (1) handling of arch=386, (2) sbx init adds unsupported config

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -39,7 +39,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minSandboxVersion = "3.0.7-1.2.1"
+	minSandboxVersion = "3.0.8-1.2.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"
@@ -415,6 +415,12 @@ func InstallSandbox(c *CmdConfig, sandboxDir string, upgrading bool) error {
 	nodeBin := "node"
 	if arch == "amd64" {
 		arch = "x64"
+	}
+	if arch == "386" {
+		if goos == "linux" {
+			return errors.New("sandbox is not supported on 32-bit linux")
+		}
+		arch = "x86"
 	}
 	if goos == "windows" {
 		goos = "win"


### PR DESCRIPTION
This change fixes two small bugs.

1.  If the GOARCH in the `doctl` instance is 386, it is used unmodified when downloading `nodejs`.   But, `nodejs.org` uses `x86` not `386`.   Furthermore, the combination of that arch with GOOS=linux can't be supported because `nodejs` does not provide a download for that combination.  This now results in an error.
2. The command `doctl sbx init` creates a `project.yml` in which there are fields that App Platform detection for a functions component will reject.   The fix for this is in `nim` 3.0.8` which is incorporated by incrementing the `minSandboxVersion` field.