### PR TITLE
Increment nim version (improves error reporting)

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -39,7 +39,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minSandboxVersion = "3.0.8-1.2.1"
+	minSandboxVersion = "3.0.10-1.2.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"


### PR DESCRIPTION
This change increments the included `nim` version from 3.0.8 to 3.0.10.   Benefits:

- a more comprehensible error message when a function build for `nodejs` includes an invalid `package.json` file
- the ability to see more information about remote build errors when debugging is enabled