### PR TITLE
Add version info to 'sandbox status'

### DIFF
--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -69,7 +69,7 @@ func TestSandboxStatusWhenConnected(t *testing.T) {
 
 		err := RunSandboxStatus(config)
 		require.NoError(t, err)
-		assert.Equal(t, "Connected to function namespace 'hello' on API host 'https://api.example.com'\n\n", buf.String())
+		assert.Contains(t, buf.String(), "Connected to function namespace 'hello' on API host 'https://api.example.com'\nSandbox version is")
 	})
 }
 


### PR DESCRIPTION
This change allows the developer to know the version of the sandbox support, which is distinct from the doctl version.

Because `doctl sandbox status` relies on error returns for common cases (not installed, not at the right version, not connected) I decided on the following.

If you issue `doctl sandbox status` and the status is connected, you get all the information, including version:

``` 
> doctl sbx status
Connected to function namespace 'fn-5a...' on API host 'https://faas-....doserverless.co'
Sandbox version is 3.0.10-1.2.1
```

If the status is other than connected, you just get the error as before.

However, as long as sandbox support is installed, you can always get version information by specifying a flag.  The output differs according to whether your sandbox support is up to date.

```
> doctl sbx status --version
3.0.10-1.2.1
```
if up-to-date or

```
> doctl sbx status --version
Current: 3.0.9-1.2.1, required: 3.0.10-1.2.1
```
if an upgrade is required.