### PR TITLE
Switch from GET to POST when connecting to sandbox

### DIFF
--- a/do/sandbox.go
+++ b/do/sandbox.go
@@ -134,7 +134,7 @@ func (n *sandboxService) Stream(cmd *exec.Cmd) error {
 // the invoking doctl context.
 func (n *sandboxService) GetSandboxNamespace(ctx context.Context) (SandboxCredentials, error) {
 	path := "v2/functions/sandbox"
-	req, err := n.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := n.client.NewRequest(ctx, http.MethodPost, path, nil)
 	if err != nil {
 		return SandboxCredentials{}, err
 	}


### PR DESCRIPTION
It has been requested by security to switch from GET to POST when connecting to the sandbox.

The portal API has already been amended to accept both for the time being so we can cut over.

This PR accomplishes the switch.   Once this is approved and merged, a new `doctl` release will be needed before support for GET can be removed from the portal API.

