### PR TITLE
Improve friendliness of the languages table

### DIFF
--- a/commands/sandbox-extra.go
+++ b/commands/sandbox-extra.go
@@ -25,9 +25,11 @@ func SandboxExtras(cmd *Command) {
 
 	create := CmdBuilder(cmd, RunSandboxExtraCreate, "init <path>", "Initialize a local file system directory for the sandbox",
 		`The `+"`"+`doctl sandbox init`+"`"+` command specifies a directory in your file system which will hold functions and
-supporting artifacts while you're developing them.  When ready, you can upload these to the cloud for
-testing.  Later, after the area is committed to a `+"`"+`git`+"`"+` repository, you can create an app from them.
-Type `+"`"+`doctl sandbox status --languages`+"`"+` for a list of supported languages.`,
+supporting artifacts while you're developing them.  When ready, you can upload these to the cloud for testing.
+Later, after the area is committed to a `+"`"+`git`+"`"+` repository, you can create an app from them.
+
+Type `+"`"+`doctl sandbox status --languages`+"`"+` for a list of supported languages.  Use one of the displayed keywords
+to choose your sample language for `+"`"+`doctl sandbox init`+"`"+`.`,
 		Writer)
 	AddStringFlag(create, "language", "l", "javascript", "Language for the initial sample code")
 	AddBoolFlag(create, "overwrite", "", false, "Clears and reuses an existing directory")

--- a/do/mocks/SandboxService.go
+++ b/do/mocks/SandboxService.go
@@ -66,6 +66,21 @@ func (mr *MockSandboxServiceMockRecorder) Exec(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockSandboxService)(nil).Exec), arg0)
 }
 
+// GetHostInfo mocks base method.
+func (m *MockSandboxService) GetHostInfo(arg0 string) (do.ServerlessHostInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHostInfo", arg0)
+	ret0, _ := ret[0].(do.ServerlessHostInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHostInfo indicates an expected call of GetHostInfo.
+func (mr *MockSandboxServiceMockRecorder) GetHostInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostInfo", reflect.TypeOf((*MockSandboxService)(nil).GetHostInfo), arg0)
+}
+
 // GetSandboxNamespace mocks base method.
 func (m *MockSandboxService) GetSandboxNamespace(arg0 context.Context) (do.SandboxCredentials, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
The current output of `doctl sbx status --languages` is not helpful in telling the user what keywords will actually be accepted on `doctl sbx init <path> --language <?>`.   It conflates "runtime categories" like `nodejs` with real languages (like `JavaScript`) and might also imply to some users that they need to (or even can) specify the exact release of a language runtime in the `doctl sbx init` command.

This change attempts to be clearer about the terminology and give a more helpful display.  It is designed so that the static table of languages compiled into `doctl` is inclusive of all languages for which `nim` had samples, but the actual table that is displayed is responsive to the backend reporting which runtimes are currently available.   This means that changes to the `doctl` code will not be required when (1) a new runtime is deployed for a language in the list, (2) a runtime is deprecated, (3) the default version of a runtime changes.