### PR TITLE
account: ratelimit command should not error when limit exhausted.

### DIFF
--- a/commands/account_test.go
+++ b/commands/account_test.go
@@ -15,6 +15,7 @@ package commands
 
 import (
 	"testing"
+	"time"
 
 	"github.com/digitalocean/doctl/do"
 	"github.com/digitalocean/godo"
@@ -30,6 +31,13 @@ var testAccount = &do.Account{
 	},
 }
 
+var testRateLimit = &do.RateLimit{
+	Rate: &godo.Rate{
+		Limit:     200,
+		Remaining: 199,
+	},
+}
+
 func TestAccountCommand(t *testing.T) {
 	acctCmd := Account()
 	assert.NotNil(t, acctCmd)
@@ -41,6 +49,17 @@ func TestAccountGet(t *testing.T) {
 		tm.account.EXPECT().Get().Return(testAccount, nil)
 
 		err := RunAccountGet(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestAccountGetRateLimit(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		now := time.Now()
+		testRateLimit.Reset = godo.Timestamp{Time: now}
+		tm.account.EXPECT().RateLimit().Return(testRateLimit, nil)
+
+		err := RunAccountRateLimit(config)
 		assert.NoError(t, err)
 	})
 }

--- a/do/account.go
+++ b/do/account.go
@@ -15,6 +15,8 @@ package do
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/digitalocean/godo"
 )
 
@@ -60,7 +62,9 @@ func (as *accountService) Get() (*Account, error) {
 func (as *accountService) RateLimit() (*RateLimit, error) {
 	_, resp, err := as.client.Account.Get(context.TODO())
 	if err != nil {
-		return nil, err
+		if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
+			return nil, err
+		}
 	}
 
 	rateLimit := &RateLimit{Rate: &resp.Rate}


### PR DESCRIPTION
When calling `doctl account ratelimit`, we return an error if we receive a 429 from the API. This isn't helpful. The rate limit info is in the response headers. We should return them despite the 429 error so the user knows when their limit resets. 