### PR TITLE
Add AppPlatformApp to Projects documentation

### DIFF
--- a/commands/projects.go
+++ b/commands/projects.go
@@ -111,13 +111,14 @@ A valid URN has the format: ` + "`" + `do:resource_type:resource_id` + "`" + `. 
 
   - ` + "`" + `do:droplet:4126873` + "`" + `
   - ` + "`" + `do:volume:6fc4c277-ea5c-448a-93cd-dd496cfef71f` + "`" + `
+  - ` + "`" + `do:app:be5aab85-851b-4cab-b2ed-98d5a63ba4e8` + "`" + `
 `
 
 	CmdBuilder(cmd, RunProjectResourcesList, "list <project-id>", "List resources assigned to a project",
 		"List all of the resources assigned to the specified project displaying their uniform resource names (\"URNs\").",
 		Writer, aliasOpt("ls"), displayerType(&displayers.ProjectResource{}))
 	CmdBuilder(cmd, RunProjectResourcesGet, "get <urn>", "Retrieve a resource by its URN",
-		"Retrieve information about a resource by specifying its uniform resource name (\"URN\"). Currently, ony Droplets, floating IPs, load balancers, domains, and volumes are supported."+urnDesc,
+		"Retrieve information about a resource by specifying its uniform resource name (\"URN\"). Currently, ony Droplets, floating IPs, load balancers, domains, volumes, and App Platform apps are supported."+urnDesc,
 		Writer, aliasOpt("g"), displayerType(&displayers.ProjectResource{}))
 
 	cmdProjectResourcesAssign := CmdBuilder(cmd, RunProjectResourcesAssign,

--- a/commands/projects_test.go
+++ b/commands/projects_test.go
@@ -29,6 +29,9 @@ var (
 		{
 			ProjectResource: &godo.ProjectResource{URN: "do:floatingip:1.2.3.4"},
 		},
+		{
+			ProjectResource: &godo.ProjectResource{URN: "do:app:6f30f890-d2f7-11ec-b23c-bf05f13731ef"},
+		},
 	}
 	testProjectResourcesListSingle = do.ProjectResources{
 		{
@@ -215,12 +218,14 @@ func TestProjectResourcesAssignOneResource(t *testing.T) {
 func TestProjectResourcesAssignMultipleResources(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		projectUUID := "ab06e011-6dd1-4034-9293-201f71aba299"
-		urn := "do:droplet:1234"
-		otherURN := "do:floatingip:1.2.3.4"
-		tm.projects.EXPECT().AssignResources(projectUUID, []string{urn, otherURN}).Return(testProjectResourcesList, nil)
+		dropletURN := "do:droplet:1234"
+		flipURN := "do:floatingip:1.2.3.4"
+		appURN := "do:app:6f30f890-d2f7-11ec-b23c-bf05f13731ef"
+
+		tm.projects.EXPECT().AssignResources(projectUUID, []string{dropletURN, flipURN, appURN}).Return(testProjectResourcesList, nil)
 
 		config.Args = append(config.Args, projectUUID)
-		config.Doit.Set(config.NS, doctl.ArgProjectResource, []string{urn, otherURN})
+		config.Doit.Set(config.NS, doctl.ArgProjectResource, []string{dropletURN, flipURN, appURN})
 
 		err := RunProjectResourcesAssign(config)
 		assert.NoError(t, err)


### PR DESCRIPTION
This PR adds App Platform apps to the documented list of resources
supported by projects and adds an example URN for an app.