### PR TITLE
Fix project.yml templating of multi-line variables

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -39,7 +39,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minSandboxVersion = "3.0.10-1.2.1"
+	minSandboxVersion = "3.1.0-1.2.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -39,7 +39,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minSandboxVersion = "3.1.0-1.2.1"
+	minSandboxVersion = "3.1.1-1.2.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"


### PR DESCRIPTION
A problem was identified when a variable with a multi-line value (string containing newlines) is substituted into `project.yml` via the symbolic substitution mechanism.   The newlines come in "raw" which results in multiple lines of YAML and (usually) a parsing error.   This is fixed in `nim` 3.1.1, which now
- escapes newlines (turns them into `\\n` values) by default (release 3.1.0)
- also updates the `dotenv` parser dependency to support the documented syntax for putting multi-line values in `.env` file (release 3.1.1).  Using the previous release, a multi-line value could only be specified in the process environment.  In typical use cases you will want these in the `.env` file along with other substitutions.

This PR increments the `minSandboxVersion` number to incorporate the change.