### PR TITLE
Fix bug in handling --param values with colons

### DIFF
--- a/commands/functions.go
+++ b/commands/functions.go
@@ -127,10 +127,11 @@ func appendParams(c *CmdConfig, args []string) ([]string, error) {
 	}
 	for _, param := range params {
 		parts := strings.Split(param, ":")
-		if len(parts) != 2 {
+		if len(parts) < 2 {
 			return args, errors.New("values for --params must have KEY:VALUE form")
 		}
-		args = append(args, dashdashParam, parts[0], parts[1])
+		parts1 := strings.Join(parts[1:], ":")
+		args = append(args, dashdashParam, parts[0], parts1)
 	}
 	return args, nil
 }

--- a/commands/functions_test.go
+++ b/commands/functions_test.go
@@ -147,6 +147,12 @@ func TestFunctionsInvoke(t *testing.T) {
 			doctlFlags:      map[string]interface{}{"param": []string{"name:world", "address:everywhere"}},
 			expectedNimArgs: []string{"hello", "--param", "name", "world", "--param", "address", "everywhere"},
 		},
+		{
+			name:            "param flag colon-value",
+			doctlArgs:       "hello",
+			doctlFlags:      map[string]interface{}{"param": []string{"url:https://example.com"}},
+			expectedNimArgs: []string{"hello", "--param", "url", "https://example.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
In `doctl sls fn invoke` the syntax `--param  key:value` is mandated for passing parameters.   Because the code is currently handing off to the sandbox plugin, where the syntax is `--param key value`, there is a translation between the two in the code.   This change fixes a flaw in the translation:  it was not taking into account that the value might contain a colon.   So, for example, `--param url:https://example.com` was failing with a spurious and confusing error message.