### PR TITLE
Add warning language when installing under snap

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -152,6 +152,13 @@ func RunSandboxInstall(c *CmdConfig) error {
 		return nil
 	}
 	sandboxDir, _ := getSandboxDirectory()
+	_, isSnap := os.LookupEnv("SNAP")
+	if isSnap {
+		warn(`Using the doctl Snap? You may have to relax its confinement in order to use the sandbox support.
+Use 'snap remove doctl', then 'snap install doctl --devmode'.
+You should not have to repeat 'doctl sandbox install' after doing that.
+`)
+	}
 	return c.installSandbox(c, sandboxDir, false)
 }
 


### PR DESCRIPTION
The normal snap confinement for `doctl` won't allow it to exec anything outside its install area.   So, the sandbox will not work.

The circumvention is to use the `--devmode` flag on `snap install doctl` to disable the confinement.

This PR simply adds language to the output of `doctl sbx install` to give the user a clue that this will be necessary.   A proper fix will take more time.