### PR TITLE
Change 'actions' to 'functions' in externals where feasible

### DIFF
--- a/commands/displayers/functions.go
+++ b/commands/displayers/functions.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package displayers
+
+import (
+	"io"
+	"strings"
+	"time"
+
+	"github.com/digitalocean/doctl/do"
+)
+
+// Functions is the type of the displayer for functions list
+type Functions struct {
+	Info []do.FunctionInfo
+}
+
+var _ Displayable = &Functions{}
+
+// JSON is the displayer JSON method specialized for functions list
+func (i *Functions) JSON(out io.Writer) error {
+	return writeJSON(i.Info, out)
+}
+
+// Cols is the displayer Cols method specialized for functions list
+func (i *Functions) Cols() []string {
+	return []string{
+		"Update", "Version", "Runtime", "Function",
+	}
+}
+
+// ColMap is the displayer ColMap method specialized for functions list
+func (i *Functions) ColMap() map[string]string {
+	return map[string]string{
+		"Update":   "Latest Update",
+		"Runtime":  "Runtime Kind",
+		"Version":  "Latest Version",
+		"Function": "Function Name",
+	}
+}
+
+// KV is the displayer KV method specialized for functions list
+func (i *Functions) KV() []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(i.Info))
+	for _, ii := range i.Info {
+		x := map[string]interface{}{
+			"Update":   time.UnixMilli(ii.Updated).Format("01/02 03:04:05"),
+			"Runtime":  findRuntime(ii.Annotations),
+			"Version":  ii.Version,
+			"Function": computeFunctionName(ii.Name, ii.Namespace),
+		}
+		out = append(out, x)
+	}
+
+	return out
+}
+
+// findRuntime finds the runtime string amongst the annotations of a function
+func findRuntime(annots []do.Annotation) string {
+	for i := range annots {
+		if annots[i].Key == "exec" {
+			return annots[i].Value.(string)
+		}
+	}
+	return "<unknown>"
+}
+
+// computeFunctionName computes the effective name of a function from its simple name and the 'namespace' field
+// (which actually encodes both namespace and package).
+func computeFunctionName(simpleName string, namespace string) string {
+	nsparts := strings.Split(namespace, "/")
+	if len(nsparts) > 1 {
+		return nsparts[1] + "/" + simpleName
+	}
+	return simpleName
+}

--- a/commands/functions.go
+++ b/commands/functions.go
@@ -60,7 +60,7 @@ You can provide inputs and inspect outputs.`,
 
 	list := CmdBuilder(cmd, RunFunctionsList, "list [<packageName>]", "Lists the functions in your functions namespace",
 		`Use `+"`"+`doctl serverless functions list`+"`"+` to list the functions in your functions namespace.`,
-		Writer)
+		Writer, displayerType(&displayers.Functions{}))
 	AddStringFlag(list, "limit", "l", "", "only return LIMIT number of functions (default 30, max 200)")
 	AddStringFlag(list, "skip", "s", "", "exclude the first SKIP number of functions from the result")
 	AddBoolFlag(list, "count", "", false, "show only the total number of functions")
@@ -111,7 +111,11 @@ func RunFunctionsList(c *CmdConfig) error {
 		return doctl.NewTooManyArgsErr(c.NS)
 	}
 	// Determine if '--count' is requested since we will use simple text output in that case.
+	// Count is mutually exclusive with the global format flag.
 	count, _ := c.Doit.GetBool(c.NS, flagCount)
+	if count && c.Doit.IsSet("format") {
+		return errors.New("the --count and --format flags are mutually exclusive")
+	}
 	// Add JSON flag so we can control output format
 	if !count {
 		c.Doit.Set(c.NS, flagJSON, true)

--- a/commands/functions_test.go
+++ b/commands/functions_test.go
@@ -200,7 +200,7 @@ func TestFunctionsList(t *testing.T) {
 	}{
 		{
 			name:            "no flags or args",
-			expectedNimArgs: []string{},
+			expectedNimArgs: []string{"--json"},
 		},
 		{
 			name:            "count flag",
@@ -210,22 +210,22 @@ func TestFunctionsList(t *testing.T) {
 		{
 			name:            "limit flag",
 			doctlFlags:      map[string]string{"limit": "1"},
-			expectedNimArgs: []string{"--limit", "1"},
+			expectedNimArgs: []string{"--json", "--limit", "1"},
 		},
 		{
 			name:            "name flag",
 			doctlFlags:      map[string]string{"name": ""},
-			expectedNimArgs: []string{"--name"},
+			expectedNimArgs: []string{"--name", "--json"},
 		},
 		{
 			name:            "name-sort flag",
 			doctlFlags:      map[string]string{"name-sort": ""},
-			expectedNimArgs: []string{"--name-sort"},
+			expectedNimArgs: []string{"--name-sort", "--json"},
 		},
 		{
 			name:            "skip flag",
 			doctlFlags:      map[string]string{"skip": "1"},
-			expectedNimArgs: []string{"--skip", "1"},
+			expectedNimArgs: []string{"--json", "--skip", "1"},
 		},
 	}
 

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -39,7 +39,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minSandboxVersion = "3.1.1-1.2.1"
+	minSandboxVersion = "4.0.0-1.2.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"

--- a/do/sandbox.go
+++ b/do/sandbox.go
@@ -63,6 +63,25 @@ type ServerlessHostInfo struct {
 	Runtimes map[string][]ServerlessRuntime `json:"runtimes"`
 }
 
+// FunctionInfo is the type of an individual function in the output
+// of doctl sls fn list.  Only relevant fields are unmarshaled.
+// Note: when we start replacing the sandbox plugin path with direct calls
+// to backend controller operations, this will be replaced by declarations
+// in the golang openwhisk client.
+type FunctionInfo struct {
+	Name        string       `json:"name"`
+	Namespace   string       `json:"namespace"`
+	Updated     int64        `json:"updated"`
+	Version     string       `json:"version"`
+	Annotations []Annotation `json:"annotations"`
+}
+
+// Annotation is a key/value type suitable for individual annotations
+type Annotation struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
 // SandboxService is an interface for interacting with the sandbox plugin,
 // with the namespaces service, and with the serverless cluster controller.
 type SandboxService interface {


### PR DESCRIPTION
This change substitutes the word `functions` for the word `actions` in several places commonly visited while using `doctl serverless`.

1.  The output of `doctl serverless functions list` has been redone using a `doctl` displayer so it no longer depends on the formatting done by the `aio` component of `nim`.
2.  Version 4.0 of `nim` is incorporated.   This brings several changes.
      a.  In deploy operations, a `functions` object is accepted in lieu of an `actions` object (but `actions` is still accepted for backward compatibility).
      b.  When `project.yml` is generated in `doctl serverless init`, the `functions` syntax is used rather than `actions`.   While this is not intended to be a breaking change (the deploy operation will accept the new syntax), it makes the public exposure of this change sensitive since App Platform must also be using the latest `nim` by the time a `doctl` release is made with the change.
      c.  The `doctl serverless get-metadata` command will return a JSON structure in which `functions` is now used in lieu of `actions`.   This _could_ be a breaking change for any tools the depend on parsing this JSON structure.   I don't know of any, but it is impossible to know if any have been coded by customers since `doctl serverless` was released.

This PR targets the feature branch, not main, since product documentation will probably need some attention when this change is released.