### PR TITLE
Rename sandbox to serverless

### DIFF
--- a/commands/activations.go
+++ b/commands/activations.go
@@ -24,16 +24,16 @@ func Activations() *Command {
 		Command: &cobra.Command{
 			Use:   "activations",
 			Short: "Work with activation records",
-			Long: `The subcommands of ` + "`" + `doctl sandbox activations` + "`" + ` will list or retrieve results, logs, or complete
-"activation records" which result from invoking functions deployed to your sandbox.`,
+			Long: `The subcommands of ` + "`" + `doctl serverless activations` + "`" + ` will list or retrieve results, logs, or complete
+"activation records" which result from invoking functions deployed to your functions namespace.`,
 			Aliases: []string{"actv"},
 		},
 	}
 
 	get := CmdBuilder(cmd, RunActivationsGet, "get [<activationId>]", "Retrieves an Activation",
-		`Use `+"`"+`doctl sandbox activations get`+"`"+` to retrieve the activation record for a previously invoked function.
+		`Use `+"`"+`doctl serverless activations get`+"`"+` to retrieve the activation record for a previously invoked function.
 There are several options for specifying the activation you want.  You can limit output to the result
-or the logs.  The `+"`"+`doctl sandbox activation logs`+"`"+` command has additional advanced capabilities for retrieving
+or the logs.  The `+"`"+`doctl serverless activation logs`+"`"+` command has additional advanced capabilities for retrieving
 logs.`,
 		Writer)
 	AddBoolFlag(get, "last", "l", false, "Fetch the most recent activation (default)")
@@ -44,7 +44,7 @@ logs.`,
 	AddBoolFlag(get, "quiet", "q", false, "Suppress last activation information header")
 
 	list := CmdBuilder(cmd, RunActivationsList, "list [<activation_name>]", "Lists Activations for which records exist",
-		`Use `+"`"+`doctl sandbox activations list`+"`"+` to list the activation records that are present in the cloud for previously
+		`Use `+"`"+`doctl serverless activations list`+"`"+` to list the activation records that are present in the cloud for previously
 invoked functions.`,
 		Writer)
 	AddStringFlag(list, "limit", "l", "", "only return LIMIT number of activations (default 30, max 200)")
@@ -55,7 +55,7 @@ invoked functions.`,
 	AddBoolFlag(list, "full", "f", false, "include full activation description")
 
 	logs := CmdBuilder(cmd, RunActivationsLogs, "logs [<activationId>]", "Retrieves the Logs for an Activation",
-		`Use `+"`"+`doctl sandbox activations logs`+"`"+` to retrieve the logs portion of one or more activation records
+		`Use `+"`"+`doctl serverless activations logs`+"`"+` to retrieve the logs portion of one or more activation records
 with various options, such as selecting by package or function, and optionally watching continuously
 for new arrivals.`,
 		Writer)
@@ -67,7 +67,7 @@ for new arrivals.`,
 	AddBoolFlag(logs, "follow", "", false, "Fetch logs continuously")
 
 	result := CmdBuilder(cmd, RunActivationsResult, "result [<activationId>]", "Retrieves the Results for an Activation",
-		`Use `+"`"+`doctl sandbox activations result`+"`"+` to retrieve just the results portion
+		`Use `+"`"+`doctl serverless activations result`+"`"+` to retrieve just the results portion
 of one or more activation records.`,
 		Writer)
 	AddBoolFlag(result, "last", "l", false, "Fetch the most recent activation result (default)")

--- a/commands/functions.go
+++ b/commands/functions.go
@@ -26,17 +26,17 @@ func Functions() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
 			Use:   "functions",
-			Short: "Work with the functions of your sandbox",
-			Long: `The subcommands of ` + "`" + `doctl sandbox functions` + "`" + ` operate on the deployed (cloud-resident) functions of your sandbox.
+			Short: "Work with the functions in your namespace",
+			Long: `The subcommands of ` + "`" + `doctl serverless functions` + "`" + ` operate on your functions namespace. 
 You are able to inspect and list these functions to know what is deployed.  You can also invoke functions to test them.`,
 			Aliases: []string{"fn"},
 		},
 	}
 
 	get := CmdBuilder(cmd, RunFunctionsGet, "get <functionName>", "Retrieves the deployed copy of a function (code or metadata)",
-		`Use `+"`"+`doctl sandbox functions get`+"`"+` to obtain the code or metadata of a deployed function.
+		`Use `+"`"+`doctl serverless functions get`+"`"+` to obtain the code or metadata of a deployed function.
 This allows you to inspect the deployed copy and ascertain whether it corresponds to what
-is in your sandbox area in the local file system.`,
+is in your functions project in the local file system.`,
 		Writer)
 	AddBoolFlag(get, "url", "r", false, "get function url")
 	AddBoolFlag(get, "code", "", false, "show function code (only works if code is not a zip file)")
@@ -46,8 +46,8 @@ is in your sandbox area in the local file system.`,
 	AddStringFlag(get, "save-as", "", "", "file to save function code to")
 
 	invoke := CmdBuilder(cmd, RunFunctionsInvoke, "invoke <functionName>", "Invokes a function",
-		`Use `+"`"+`doctl sandbox functions invoke`+"`"+` to invoke a function of your sandbox that has been deployed
-to the cloud.  You can provide inputs and inspect outputs.`,
+		`Use `+"`"+`doctl serverless functions invoke`+"`"+` to invoke a function in your functions namespace.
+You can provide inputs and inspect outputs.`,
 		Writer)
 	AddBoolFlag(invoke, "web", "", false, "Invoke as a web function, show result as web page")
 	AddStringSliceFlag(invoke, "param", "p", []string{}, "parameter values in KEY:VALUE format, list allowed")
@@ -55,9 +55,8 @@ to the cloud.  You can provide inputs and inspect outputs.`,
 	AddBoolFlag(invoke, "full", "f", false, "wait for full activation record")
 	AddBoolFlag(invoke, "no-wait", "n", false, "fire and forget (asynchronous invoke, does not wait for the result)")
 
-	list := CmdBuilder(cmd, RunFunctionsList, "list [<packageName>]", "Lists all the functions",
-		`Use `+"`"+`doctl sandbox functions list`+"`"+` to list the functions of your sandbox that are deployed
-to the cloud.`,
+	list := CmdBuilder(cmd, RunFunctionsList, "list [<packageName>]", "Lists the functions in your functions namespace",
+		`Use `+"`"+`doctl serverless functions list`+"`"+` to list the functions in your functions namespace.`,
 		Writer)
 	AddStringFlag(list, "limit", "l", "", "only return LIMIT number of functions (default 30, max 200)")
 	AddStringFlag(list, "skip", "s", "", "exclude the first SKIP number of functions from the result")

--- a/commands/sandbox-extra.go
+++ b/commands/sandbox-extra.go
@@ -23,21 +23,21 @@ import (
 // oclif equivalents and subsequently modified.
 func SandboxExtras(cmd *Command) {
 
-	create := CmdBuilder(cmd, RunSandboxExtraCreate, "init <path>", "Initialize a local file system directory for the sandbox",
-		`The `+"`"+`doctl sandbox init`+"`"+` command specifies a directory in your file system which will hold functions and
-supporting artifacts while you're developing them.  When ready, you can upload these to the cloud for testing.
-Later, after the area is committed to a `+"`"+`git`+"`"+` repository, you can create an app from them.
+	create := CmdBuilder(cmd, RunSandboxExtraCreate, "init <path>", "Initialize a 'functions project' directory in your local file system",
+		`The `+"`"+`doctl serverless init`+"`"+` command specifies a directory in your file system which will hold functions and
+supporting artifacts while you're developing them.  This 'functions project' can be uploaded to your functions namespace for testing.
+Later, after the functions project is committed to a `+"`"+`git`+"`"+` repository, you can create an app, or an app component, from it.
 
-Type `+"`"+`doctl sandbox status --languages`+"`"+` for a list of supported languages.  Use one of the displayed keywords
-to choose your sample language for `+"`"+`doctl sandbox init`+"`"+`.`,
+Type `+"`"+`doctl serverless status --languages`+"`"+` for a list of supported languages.  Use one of the displayed keywords
+to choose your sample language for `+"`"+`doctl serverless init`+"`"+`.`,
 		Writer)
 	AddStringFlag(create, "language", "l", "javascript", "Language for the initial sample code")
 	AddBoolFlag(create, "overwrite", "", false, "Clears and reuses an existing directory")
 
-	deploy := CmdBuilder(cmd, RunSandboxExtraDeploy, "deploy <directories>", "Deploy sandbox local assets to the cloud",
-		`At any time you can use `+"`"+`doctl sandbox deploy`+"`"+` to upload the contents of a directory in your file system for
-testing in the cloud.  The area must be organized in the fashion expected by an App Platform Functions
-component.  The `+"`"+`doctl sandbox init`+"`"+` command will create a properly organized directory for you to work in.`,
+	deploy := CmdBuilder(cmd, RunSandboxExtraDeploy, "deploy <directories>", "Deploy a functions project to your functions namespace",
+		`At any time you can use `+"`"+`doctl serverless deploy`+"`"+` to upload the contents of a functions project in your file system for
+testing in your serverless namespace.  The project must be organized in the fashion expected by an App Platform Functions
+component.  The `+"`"+`doctl serverless init`+"`"+` command will create a properly organized directory for you to work in.`,
 		Writer)
 	AddStringFlag(deploy, "env", "", "", "Path to runtime environment file")
 	AddStringFlag(deploy, "build-env", "", "", "Path to build-time environment file")
@@ -52,17 +52,17 @@ component.  The `+"`"+`doctl sandbox init`+"`"+` command will create a properly 
 	AddBoolFlag(deploy, "remote-build", "", false, "Run builds remotely")
 	AddBoolFlag(deploy, "incremental", "", false, "Deploy only changes since last deploy")
 
-	getMetadata := CmdBuilder(cmd, RunSandboxExtraGetMetadata, "get-metadata <directory>", "Obtain metadata of a sandbox directory",
-		`The `+"`"+`doctl sandbox get-metadata`+"`"+` command produces a JSON structure that summarizes the contents of a directory
-you have designated for functions development.  This can be useful for feeding into other tools.`,
+	getMetadata := CmdBuilder(cmd, RunSandboxExtraGetMetadata, "get-metadata <directory>", "Obtain metadata of a functions project",
+		`The `+"`"+`doctl serverless get-metadata`+"`"+` command produces a JSON structure that summarizes the contents of a functions
+project (a directory you have designated for functions development).  This can be useful for feeding into other tools.`,
 		Writer)
 	AddStringFlag(getMetadata, "env", "", "", "Path to environment file")
 	AddStringFlag(getMetadata, "include", "", "", "Functions or packages to include")
 	AddStringFlag(getMetadata, "exclude", "", "", "Functions or packages to exclude")
 
-	watch := CmdBuilder(cmd, RunSandboxExtraWatch, "watch <directory>", "Watch a sandbox directory, deploying incrementally on change",
+	watch := CmdBuilder(cmd, RunSandboxExtraWatch, "watch <directory>", "Watch a functions project directory, deploying incrementally on change",
 		`Type `+"`"+`doctl sandbox watch <directory>`+"`"+` in a separate terminal window.  It will run until interrupted.
-It will watch the directory (which should be one you initialized for sandbox use) and will deploy
+It will watch the directory (which should be one you initialized for serverless development) and will deploy
 the contents to the cloud incrementally as it detects changes.`,
 		Writer)
 	AddStringFlag(watch, "env", "", "", "Path to runtime environment file")
@@ -98,16 +98,16 @@ func RunSandboxExtraCreate(c *CmdConfig) error {
 	// is not quite right for doctl.
 	if jsonOutput, ok := output.Entity.(map[string]interface{}); ok {
 		if created, ok := jsonOutput["project"].(string); ok {
-			fmt.Fprintf(c.Out, `A local sandbox area '%s' was created for you.
+			fmt.Fprintf(c.Out, `A local functions project directory '%s' was created for you.
 You may deploy it by running the command shown on the next line:
-  doctl sandbox deploy %s
+  doctl serverless deploy %s
 `, created, created)
 			fmt.Fprintln(c.Out)
 			return nil
 		}
 	}
 	// Fall back if output is not structured the way we expect
-	fmt.Println("Sandbox initialized successfully in the local file system")
+	fmt.Println("Functions project initialized successfully in the local file system")
 	return nil
 }
 

--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -47,7 +47,7 @@ func TestSandboxConnect(t *testing.T) {
 
 		err := RunSandboxConnect(config)
 		require.NoError(t, err)
-		assert.Equal(t, "Connected to function namespace 'hello' on API host 'https://api.example.com'\n\n", buf.String())
+		assert.Equal(t, "Connected to functions namespace 'hello' on API host 'https://api.example.com'\n\n", buf.String())
 	})
 }
 
@@ -69,7 +69,7 @@ func TestSandboxStatusWhenConnected(t *testing.T) {
 
 		err := RunSandboxStatus(config)
 		require.NoError(t, err)
-		assert.Contains(t, buf.String(), "Connected to function namespace 'hello' on API host 'https://api.example.com'\nSandbox version is")
+		assert.Contains(t, buf.String(), "Connected to functions namespace 'hello' on API host 'https://api.example.com'\nServerless software version is")
 	})
 }
 
@@ -201,7 +201,7 @@ func TestSandboxInstallWhenInstalledNotCurrent(t *testing.T) {
 
 		err := RunSandboxInstall(config)
 		require.NoError(t, err)
-		assert.Equal(t, "Sandbox support is already installed, but needs an upgrade for this version of `doctl`.\nUse `doctl sandbox upgrade` to upgrade the support.\n", buf.String())
+		assert.Equal(t, "Serverless support is already installed, but needs an upgrade for this version of `doctl`.\nUse `doctl serverless upgrade` to upgrade the support.\n", buf.String())
 	})
 }
 
@@ -220,7 +220,7 @@ func TestSandboxInstallWhenInstalledAndCurrent(t *testing.T) {
 
 		err := RunSandboxInstall(config)
 		require.NoError(t, err)
-		assert.Equal(t, "Sandbox support is already installed at an appropriate version.  No action needed.\n", buf.String())
+		assert.Equal(t, "Serverless support is already installed at an appropriate version.  No action needed.\n", buf.String())
 	})
 }
 
@@ -239,7 +239,7 @@ func TestSandboxUpgradeWhenNotInstalled(t *testing.T) {
 
 		err := RunSandboxUpgrade(config)
 		require.NoError(t, err)
-		assert.Equal(t, "Sandbox support was never installed.  Use `doctl sandbox install`.\n", buf.String())
+		assert.Equal(t, "Serverless support was never installed.  Use `doctl serverless install`.\n", buf.String())
 	})
 }
 
@@ -258,7 +258,7 @@ func TestSandboxUpgradeWhenInstalledAndCurrent(t *testing.T) {
 
 		err := RunSandboxUpgrade(config)
 		require.NoError(t, err)
-		assert.Equal(t, "Sandbox support is already installed at an appropriate version.  No action needed.\n", buf.String())
+		assert.Equal(t, "Serverless support is already installed at an appropriate version.  No action needed.\n", buf.String())
 	})
 }
 
@@ -341,9 +341,9 @@ func TestSandboxInit(t *testing.T) {
 
 				err := RunSandboxExtraCreate(config)
 				require.NoError(t, err)
-				assert.Equal(t, `A local sandbox area 'foo' was created for you.
+				assert.Equal(t, `A local functions project directory 'foo' was created for you.
 You may deploy it by running the command shown on the next line:
-  doctl sandbox deploy foo`+"\n\n", buf.String())
+  doctl serverless deploy foo`+"\n\n", buf.String())
 			})
 		})
 	}


### PR DESCRIPTION
The `doctl` command for developing and testing functions has historically been called `sandbox` but has the aliases `serverless` and `sls` as well as `sbx`.

This change inverts the primary command and full-word alias so that the command is now called `serverless` and `sandbox` becomes an alias.   The shorter aliases `sls` and `sbx` are retained.

The change also adjusts all of the help texts and error texts (all texts made visible at runtime) to avoid the term "sandbox" altogether.    This was not accompanied by a wholesale editing of purely internal uses (e.g. function names, variable names, comments): the term sandbox is still used there, and also for the directory name of the "hidden" area where the software is installed.

By avoiding the word "sandbox" certain concepts had to be given alternative names.   The visible texts now use the "functions namespace" for what used to be called the cloud portion of the sandbox, and "functions project" for what used to be called the local disk areas of the sandbox.
 
This change targets the feature branch since it will require updates of product docs at release time.