### PR TITLE
sizes: Output the description field.

### DIFF
--- a/commands/displayers/size.go
+++ b/commands/displayers/size.go
@@ -32,13 +32,14 @@ func (si *Size) JSON(out io.Writer) error {
 
 func (si *Size) Cols() []string {
 	return []string{
-		"Slug", "Memory", "VCPUs", "Disk", "PriceMonthly", "PriceHourly",
+		"Slug", "Description", "Memory", "VCPUs", "Disk", "PriceMonthly", "PriceHourly",
 	}
 }
 
 func (si *Size) ColMap() map[string]string {
 	return map[string]string{
-		"Slug": "Slug", "Memory": "Memory", "VCPUs": "VCPUs",
+		"Slug": "Slug", "Description": "Description",
+		"Memory": "Memory", "VCPUs": "VCPUs",
 		"Disk": "Disk", "PriceMonthly": "Price Monthly",
 		"PriceHourly": "Price Hourly",
 	}
@@ -49,7 +50,8 @@ func (si *Size) KV() []map[string]interface{} {
 
 	for _, s := range si.Sizes {
 		o := map[string]interface{}{
-			"Slug": s.Slug, "Memory": s.Memory, "VCPUs": s.Vcpus,
+			"Slug": s.Slug, "Description": s.Description,
+			"Memory": s.Memory, "VCPUs": s.Vcpus,
 			"Disk": s.Disk, "PriceMonthly": fmt.Sprintf("%0.2f", s.PriceMonthly),
 			"PriceHourly": s.PriceHourly,
 		}

--- a/integration/size_list_test.go
+++ b/integration/size_list_test.go
@@ -106,6 +106,7 @@ const (
     {
       "slug": "512mb",
       "memory": 512,
+	  "description": "Basic",
       "vcpus": 1,
       "disk": 20,
       "transfer": 1,
@@ -119,6 +120,7 @@ const (
     {
       "slug": "s-1vcpu-1gb",
       "memory": 1024,
+	  "description": "Basic",
       "vcpus": 1,
       "disk": 25,
       "transfer": 1,
@@ -137,9 +139,9 @@ const (
 }
 `
 	sizeListOutput = `
-Slug           Memory    VCPUs    Disk    Price Monthly    Price Hourly
-512mb          512       1        20      5.00             0.007440
-s-1vcpu-1gb    1024      1        25      5.00             0.007440
+Slug           Description    Memory    VCPUs    Disk    Price Monthly    Price Hourly
+512mb          Basic          512       1        20      5.00             0.007440
+s-1vcpu-1gb    Basic          1024      1        25      5.00             0.007440
 `
 	sizeListFormatOutput = `
 Slug           Price Monthly
@@ -148,7 +150,7 @@ s-1vcpu-1gb    5.00
 
 `
 	sizeListNoHeaderOutput = `
-512mb          512     1    20    5.00    0.007440
-s-1vcpu-1gb    1024    1    25    5.00    0.007440
+512mb          Basic    512     1    20    5.00    0.007440
+s-1vcpu-1gb    Basic    1024    1    25    5.00    0.007440
 `
 )


### PR DESCRIPTION
The `/v2/sizes` response grew a description field awhile back. It would be useful to output that in doctl's list. 