### PR TITLE
Fix Snap publishing in workflows.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,9 @@ jobs:
           make _build_snap && \
           find doctl_v*.snap -print -exec echo ::set-output name=snap::{} \;
 
-      - uses: snapcore/action-publish@v1
+      - uses: snapcore/action-publish@master
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_TOKEN }}
         with:
-          store_login: ${{ secrets.SNAP_TOKEN }}
           snap: ${{ steps.build.outputs.snap }}
           release: stable

--- a/.github/workflows/snapcraft-candidate.yml
+++ b/.github/workflows/snapcraft-candidate.yml
@@ -28,8 +28,9 @@ jobs:
           make _build_snap && \
           find doctl_v*.snap -print -exec echo ::set-output name=snap::{} \;
 
-      - uses: snapcore/action-publish@v1
+      - uses: snapcore/action-publish@master
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_TOKEN }}
         with:
-          store_login: ${{ secrets.SNAP_TOKEN }}
           snap: ${{ steps.build.outputs.snap }}
           release: candidate


### PR DESCRIPTION
Our workflows publishing snap packages seem to have stopped working 7 days ago.  It looks like it now installs a newer version of the `snapcraft` binary even though we are pinned to a specific release of the action.

```
Installing Snapcraft...
/usr/bin/sudo snap install --classic snapcraft
snapcraft 7.0.4 from Canonical* installed
```

The version of the action we are using is incompatible with the version of snapcraft it installs, leading to this failure:

```
--with is no longer supported, export the auth to the environment variable 'SNAPCRAFT_STORE_CREDENTIALS' instead                                               
Login successful                                                               
/snap/bin/snapcraft upload doctl_v1.76.2+git0e3d4cb9_amd64.snap --release candidate
This login method is not longer supported                                      Traceback (most recent call last):
  File "/snap/snapcraft/7664/bin/snapcraft", line 8, in <module>
    sys.exit(run())
  File "/snap/snapcraft/7664/lib/python3.8/site-packages/snapcraft/cli.py", line 179, in run
    dispatcher.run()
  File "/snap/snapcraft/7664/lib/python3.8/site-packages/craft_cli/dispatcher.py", line 406, in run
    return self._loaded_command.run(self._parsed_command_args)
  File "/snap/snapcraft/7664/lib/python3.8/site-packages/snapcraft/commands/upload.py", line 89, in run
    client.verify_upload(snap_name=snap_name)
  File "/snap/snapcraft/7664/lib/python3.8/site-packages/snapcraft/commands/store/client.py", line 344, in verify_upload
    self.request(
  File "/snap/snapcraft/7664/lib/python3.8/site-packages/snapcraft/commands/store/client.py", line 217, in request
    return self.store_client.request(*args, **kwargs)
  File "/snap/snapcraft/7664/lib/python3.8/site-packages/craft_store/ubuntu_one_store_client.py", line [13](https://github.com/digitalocean/doctl/runs/6907765825?check_suite_focus=true#step:5:14)7, in request
    self._refresh_token()
  File "/snap/snapcraft/7664/lib/python3.8/site-packages/craft_store/ubuntu_one_store_client.py", line 70, in _refresh_token
    macaroons = json.loads(self._auth.get_credentials())
  File "/snap/snapcraft/7664/usr/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/snap/snapcraft/7664/usr/lib/python3.8/json/decoder.py", line [33](https://github.com/digitalocean/doctl/runs/6907765825?check_suite_focus=true#step:5:34)7, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/snap/snapcraft/7664/usr/lib/python3.8/json/decoder.py", line [35](https://github.com/digitalocean/doctl/runs/6907765825?check_suite_focus=true#step:5:36)5, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

See: https://github.com/snapcore/action-publish/issues/28