### PR TITLE
Set a distinct user agent header for doctl serverless

### DIFF
--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -130,7 +130,10 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			node := filepath.Join(sandboxDir, nodeBin)
 			sandboxJs := filepath.Join(sandboxDir, "sandbox.js")
 			nimbellaDir := getCredentialDirectory(c, sandboxDir)
-			c.Sandbox = func() do.SandboxService { return do.NewSandboxService(sandboxJs, nimbellaDir, node, godoClient) }
+			userAgent := fmt.Sprintf("doctl/%s serverless/%s", doctl.DoitVersion.String(), minSandboxVersion)
+			c.Sandbox = func() do.SandboxService {
+				return do.NewSandboxService(sandboxJs, nimbellaDir, node, userAgent, godoClient)
+			}
 
 			return nil
 		},

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -39,7 +39,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minSandboxVersion = "4.0.0-1.2.1"
+	minSandboxVersion = "4.1.0-1.3.0"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"

--- a/do/sandbox.go
+++ b/do/sandbox.go
@@ -96,6 +96,7 @@ type sandboxService struct {
 	sandboxJs  string
 	sandboxDir string
 	node       string
+	userAgent  string
 	client     *godo.Client
 }
 
@@ -111,11 +112,12 @@ type SandboxOutput struct {
 }
 
 // NewSandboxService returns a configured SandboxService.
-func NewSandboxService(sandboxJs string, sandboxDir string, node string, client *godo.Client) SandboxService {
+func NewSandboxService(sandboxJs string, sandboxDir string, node string, userAgent string, client *godo.Client) SandboxService {
 	return &sandboxService{
 		sandboxJs:  sandboxJs,
 		sandboxDir: sandboxDir,
 		node:       node,
+		userAgent:  userAgent,
 		client:     client,
 	}
 }
@@ -124,7 +126,7 @@ func NewSandboxService(sandboxJs string, sandboxDir string, node string, client 
 func (n *sandboxService) Cmd(command string, args []string) (*exec.Cmd, error) {
 	args = append([]string{n.sandboxJs, command}, args...)
 	cmd := exec.Command(n.node, args...)
-	cmd.Env = append(os.Environ(), "NIMBELLA_DIR="+n.sandboxDir)
+	cmd.Env = append(os.Environ(), "NIMBELLA_DIR="+n.sandboxDir, "NIM_USER_AGENT="+n.userAgent)
 	// If DEBUG is specified, we need to open up stderr for that stream.  The stdout stream
 	// will continue to work for returning structured results.
 	if os.Getenv("DEBUG") != "" {


### PR DESCRIPTION
Previously, when `doctl serverless` drove `nim` via the sandbox plugin, requests arriving at the serverless cluster endpoint could not be distinguished from ones generated by direct uses of `nim`.   This change ensures that requests originating via `doctl sls` will present a distinct and informative user agent header.

Version 4.1.0 of `nim` and version 1.3 of the sandbox plugin are needed to cooperate in this change, so changing to those versions is part of this change.

Note that `doctl` also sets a user header for use via `godo`.    Requests with that user agent header go to the main DigitalOcean API endpoint.   I don't believe there is a conflict here because the endpoints are different and the overall traffic to them is different and their needs to discriminate between different sources of requests are different.