### PR TITLE
Store serverless credentials directly instead of invoking the plugin with auth/login

### DIFF
--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -237,7 +237,7 @@ func RunSandboxConnect(c *CmdConfig) error {
 
 	// Write the credentials
 	credsPath := filepath.Join(credsDir, credentialsFile)
-	err = os.WriteFile(credsPath, bytes, 0644)
+	err = os.WriteFile(credsPath, bytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -32,18 +32,8 @@ func TestSandboxConnect(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		buf := &bytes.Buffer{}
 		config.Out = buf
-		fakeCmd := &exec.Cmd{
-			Stdout: config.Out,
-		}
 
-		tm.sandbox.EXPECT().GetSandboxNamespace(context.TODO()).Return(do.SandboxCredentials{Auth: "xyzzy", APIHost: "https://api.example.com"}, nil)
-		tm.sandbox.EXPECT().Cmd("auth/login", []string{"--auth", "xyzzy", "--apihost", "https://api.example.com"}).Return(fakeCmd, nil)
-		tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{
-			Entity: map[string]interface{}{
-				"namespace": "hello",
-				"apihost":   "https://api.example.com",
-			},
-		}, nil)
+		tm.sandbox.EXPECT().GetSandboxNamespace(context.TODO()).Return(do.SandboxCredentials{Namespace: "hello", APIHost: "https://api.example.com"}, nil)
 
 		err := RunSandboxConnect(config)
 		require.NoError(t, err)


### PR DESCRIPTION
This change eliminates the call to `SandboxExec...(auth/login...)` in favor of directly storing the credentials returned from the DigitalOcean endpoint.   The format for the credential storage remains the same since the plugin will continue to be the main consumer in the immediate future.

The change serves two goals.

1.  It is a first small step in the direction of eliminating dependence on the plugin and better aligning the serverless functionality with how `doctl` supports other DigitalOcean services.
2. It is an enabler for a likely future extension in the direction of supporting multiple serverless namespaces per customer/team.   If we left the plugin in charge of populating the credential store in that extension, we would be perpetuating the Nimbella CLI model whereby the local credential store is treated as an initial source of truth.   Of course, the effective "final" source of truth is the serverless backend (which will reject revoked or stale credentials), but, by letting credentials of unknown validity accumulate, we are complicating recovery in those situations.   With this change, we can treat the DigitalOcean API endpoint as the initial source of truth and only store ("cache") the serverless credentials for the namespace actively being used.

Because achieving the first goal is a distant objective, it is important that the format of the stored credentials not change immediately.   But, the credential store will now be used in a more degenerate way (where it is not expected there will ever be more than one namespace's worth of information stored in it at a time).

One thing that the plugin's `auth/login` call did which this change is temporarily dropping is an interrogation of the serverless controller to check whether the credentials are valid.   This is only useful in catching unusual cases (probably bugs, actually) where the information returned from the DO API endpoint does not match the information in the serverless controller's cache of that information.    In contrast, when developer issues `doctl serverless status`, the check is important because time will have elapsed during which previously valid credentials may have become invalid.    Thus, there will be two follow-on changes (expect new PRs for them):

1.  There will be a re-factoring of the internal `CmdConfig` and `SandboxService` abstractions to move some material from the former to the latter.   This will allow the `SandboxService` to more accurately reflect what must be encapsulated for independent change and mocked for testing.    It is a prudent initial step before embarking on the next series of changes.
2. The use of the plugin's `auth/current` call in the implementation of `doctl serverless status` will be dropped and the controller will be contacted more directly to achieve the same end (validating the credentials).   This can then also be done for `doctl serverless connect`