### PR TITLE
account: Display team name.

### DIFF
--- a/commands/account_test.go
+++ b/commands/account_test.go
@@ -28,6 +28,10 @@ var testAccount = &do.Account{
 		Email:         "user@example.com",
 		UUID:          "1234",
 		EmailVerified: true,
+		Team: &godo.TeamInfo{
+			Name: "Test Team",
+			UUID: "aaa-bbb-ccc",
+		},
 	},
 }
 

--- a/commands/displayers/account.go
+++ b/commands/displayers/account.go
@@ -31,14 +31,14 @@ func (a *Account) JSON(out io.Writer) error {
 
 func (a *Account) Cols() []string {
 	return []string{
-		"Email", "DropletLimit", "EmailVerified", "UUID", "Status",
+		"Email", "Team", "DropletLimit", "EmailVerified", "UUID", "Status",
 	}
 }
 
 func (a *Account) ColMap() map[string]string {
 	return map[string]string{
-		"Email": "Email", "DropletLimit": "Droplet Limit", "EmailVerified": "Email Verified",
-		"UUID": "UUID", "Status": "Status",
+		"Email": "User Email", "DropletLimit": "Droplet Limit", "EmailVerified": "Email Verified",
+		"UUID": "User UUID", "Status": "Status", "Team": "Team", "TeamUUID": "Team UUID",
 	}
 }
 
@@ -46,7 +46,7 @@ func (a *Account) KV() []map[string]interface{} {
 	x := map[string]interface{}{
 		"Email": a.Email, "DropletLimit": a.DropletLimit,
 		"EmailVerified": a.EmailVerified, "UUID": a.UUID,
-		"Status": a.Status,
+		"Status": a.Status, "Team": a.Team.Name, "TeamUUID": a.Team.UUID,
 	}
 
 	return []map[string]interface{}{x}

--- a/integration/account_test.go
+++ b/integration/account_test.go
@@ -64,6 +64,23 @@ var _ = suite("account/get", func(t *testing.T, when spec.G, it spec.S) {
 
 		expect.Equal(strings.TrimSpace(accountOutput), strings.TrimSpace(string(output)))
 	})
+
+	when("format flags are passed", func() {
+		it("only displays the correct fields", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"account",
+				"get",
+				"--format", "Email,UUID,TeamUUID",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, string(output))
+
+			expect.Equal(strings.TrimSpace(formattedAccountOutput), strings.TrimSpace(string(output)))
+		})
+	})
 })
 
 var _ = suite("account/ratelimit", func(t *testing.T, when spec.G, it spec.S) {
@@ -159,12 +176,21 @@ const (
     "uuid": "b6fr89dbf6d9156cace5f3c78dc9851d957381ef",
     "email_verified": true,
     "status": "active",
-    "status_message": ""
+    "status_message": "",
+    "team": {
+      "uuid": "e8566708-f6fd-11ec-aac1-7f9bcd99de41",
+      "name": "My Team"
+    }
   }
 }`
 	accountOutput = `
-Email                     Droplet Limit    Email Verified    UUID                                        Status
-sammy@digitalocean.com    25               true              b6fr89dbf6d9156cace5f3c78dc9851d957381ef    active
+User Email                Team       Droplet Limit    Email Verified    User UUID                                   Status
+sammy@digitalocean.com    My Team    25               true              b6fr89dbf6d9156cace5f3c78dc9851d957381ef    active
+`
+
+	formattedAccountOutput = `
+User Email                User UUID                                   Team UUID
+sammy@digitalocean.com    b6fr89dbf6d9156cace5f3c78dc9851d957381ef    e8566708-f6fd-11ec-aac1-7f9bcd99de41
 `
 
 	ratelimitOutput = `


### PR DESCRIPTION
Now that the API returns team info, we can can display it in the output here. Additionally I've updated the existing headers to clarify that the email and UUID displayed are for the user.  I've retained the existing arguments to the `--format` flag for them to prevent breaking any existing scripting. e.g. `doctl account get --format Email,UUID`