### PR TITLE
Merge current feature/serverless contents preparatory to a release

### DIFF
--- a/commands/activations.go
+++ b/commands/activations.go
@@ -24,16 +24,16 @@ func Activations() *Command {
 		Command: &cobra.Command{
 			Use:   "activations",
 			Short: "Work with activation records",
-			Long: `The subcommands of ` + "`" + `doctl sandbox activations` + "`" + ` will list or retrieve results, logs, or complete
-"activation records" which result from invoking functions deployed to your sandbox.`,
+			Long: `The subcommands of ` + "`" + `doctl serverless activations` + "`" + ` will list or retrieve results, logs, or complete
+"activation records" which result from invoking functions deployed to your functions namespace.`,
 			Aliases: []string{"actv"},
 		},
 	}
 
 	get := CmdBuilder(cmd, RunActivationsGet, "get [<activationId>]", "Retrieves an Activation",
-		`Use `+"`"+`doctl sandbox activations get`+"`"+` to retrieve the activation record for a previously invoked function.
+		`Use `+"`"+`doctl serverless activations get`+"`"+` to retrieve the activation record for a previously invoked function.
 There are several options for specifying the activation you want.  You can limit output to the result
-or the logs.  The `+"`"+`doctl sandbox activation logs`+"`"+` command has additional advanced capabilities for retrieving
+or the logs.  The `+"`"+`doctl serverless activation logs`+"`"+` command has additional advanced capabilities for retrieving
 logs.`,
 		Writer)
 	AddBoolFlag(get, "last", "l", false, "Fetch the most recent activation (default)")
@@ -44,7 +44,7 @@ logs.`,
 	AddBoolFlag(get, "quiet", "q", false, "Suppress last activation information header")
 
 	list := CmdBuilder(cmd, RunActivationsList, "list [<activation_name>]", "Lists Activations for which records exist",
-		`Use `+"`"+`doctl sandbox activations list`+"`"+` to list the activation records that are present in the cloud for previously
+		`Use `+"`"+`doctl serverless activations list`+"`"+` to list the activation records that are present in the cloud for previously
 invoked functions.`,
 		Writer)
 	AddStringFlag(list, "limit", "l", "", "only return LIMIT number of activations (default 30, max 200)")
@@ -55,7 +55,7 @@ invoked functions.`,
 	AddBoolFlag(list, "full", "f", false, "include full activation description")
 
 	logs := CmdBuilder(cmd, RunActivationsLogs, "logs [<activationId>]", "Retrieves the Logs for an Activation",
-		`Use `+"`"+`doctl sandbox activations logs`+"`"+` to retrieve the logs portion of one or more activation records
+		`Use `+"`"+`doctl serverless activations logs`+"`"+` to retrieve the logs portion of one or more activation records
 with various options, such as selecting by package or function, and optionally watching continuously
 for new arrivals.`,
 		Writer)
@@ -67,7 +67,7 @@ for new arrivals.`,
 	AddBoolFlag(logs, "follow", "", false, "Fetch logs continuously")
 
 	result := CmdBuilder(cmd, RunActivationsResult, "result [<activationId>]", "Retrieves the Results for an Activation",
-		`Use `+"`"+`doctl sandbox activations result`+"`"+` to retrieve just the results portion
+		`Use `+"`"+`doctl serverless activations result`+"`"+` to retrieve just the results portion
 of one or more activation records.`,
 		Writer)
 	AddBoolFlag(result, "last", "l", false, "Fetch the most recent activation result (default)")

--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -130,7 +130,10 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			node := filepath.Join(sandboxDir, nodeBin)
 			sandboxJs := filepath.Join(sandboxDir, "sandbox.js")
 			nimbellaDir := getCredentialDirectory(c, sandboxDir)
-			c.Sandbox = func() do.SandboxService { return do.NewSandboxService(sandboxJs, nimbellaDir, node, godoClient) }
+			userAgent := fmt.Sprintf("doctl/%s serverless/%s", doctl.DoitVersion.String(), minSandboxVersion)
+			c.Sandbox = func() do.SandboxService {
+				return do.NewSandboxService(sandboxJs, nimbellaDir, node, userAgent, godoClient)
+			}
 
 			return nil
 		},

--- a/commands/displayers/functions.go
+++ b/commands/displayers/functions.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package displayers
+
+import (
+	"io"
+	"strings"
+	"time"
+
+	"github.com/digitalocean/doctl/do"
+)
+
+// Functions is the type of the displayer for functions list
+type Functions struct {
+	Info []do.FunctionInfo
+}
+
+var _ Displayable = &Functions{}
+
+// JSON is the displayer JSON method specialized for functions list
+func (i *Functions) JSON(out io.Writer) error {
+	return writeJSON(i.Info, out)
+}
+
+// Cols is the displayer Cols method specialized for functions list
+func (i *Functions) Cols() []string {
+	return []string{
+		"Update", "Version", "Runtime", "Function",
+	}
+}
+
+// ColMap is the displayer ColMap method specialized for functions list
+func (i *Functions) ColMap() map[string]string {
+	return map[string]string{
+		"Update":   "Latest Update",
+		"Runtime":  "Runtime Kind",
+		"Version":  "Latest Version",
+		"Function": "Function Name",
+	}
+}
+
+// KV is the displayer KV method specialized for functions list
+func (i *Functions) KV() []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(i.Info))
+	for _, ii := range i.Info {
+		x := map[string]interface{}{
+			"Update":   time.UnixMilli(ii.Updated).Format("01/02 03:04:05"),
+			"Runtime":  findRuntime(ii.Annotations),
+			"Version":  ii.Version,
+			"Function": computeFunctionName(ii.Name, ii.Namespace),
+		}
+		out = append(out, x)
+	}
+
+	return out
+}
+
+// findRuntime finds the runtime string amongst the annotations of a function
+func findRuntime(annots []do.Annotation) string {
+	for i := range annots {
+		if annots[i].Key == "exec" {
+			return annots[i].Value.(string)
+		}
+	}
+	return "<unknown>"
+}
+
+// computeFunctionName computes the effective name of a function from its simple name and the 'namespace' field
+// (which actually encodes both namespace and package).
+func computeFunctionName(simpleName string, namespace string) string {
+	nsparts := strings.Split(namespace, "/")
+	if len(nsparts) > 1 {
+		return nsparts[1] + "/" + simpleName
+	}
+	return simpleName
+}

--- a/commands/functions.go
+++ b/commands/functions.go
@@ -14,10 +14,13 @@ limitations under the License.
 package commands
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 
 	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/commands/displayers"
+	"github.com/digitalocean/doctl/do"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +60,7 @@ You can provide inputs and inspect outputs.`,
 
 	list := CmdBuilder(cmd, RunFunctionsList, "list [<packageName>]", "Lists the functions in your functions namespace",
 		`Use `+"`"+`doctl serverless functions list`+"`"+` to list the functions in your functions namespace.`,
-		Writer)
+		Writer, displayerType(&displayers.Functions{}))
 	AddStringFlag(list, "limit", "l", "", "only return LIMIT number of functions (default 30, max 200)")
 	AddStringFlag(list, "skip", "s", "", "exclude the first SKIP number of functions from the result")
 	AddBoolFlag(list, "count", "", false, "show only the total number of functions")
@@ -107,11 +110,34 @@ func RunFunctionsList(c *CmdConfig) error {
 	if argCount > 1 {
 		return doctl.NewTooManyArgsErr(c.NS)
 	}
-	output, err := RunSandboxExec(actionList, c, []string{flagCount, flagNameSort, flagNameName}, []string{flagLimit, flagSkip})
+	// Determine if '--count' is requested since we will use simple text output in that case.
+	// Count is mutually exclusive with the global format flag.
+	count, _ := c.Doit.GetBool(c.NS, flagCount)
+	if count && c.Doit.IsSet("format") {
+		return errors.New("the --count and --format flags are mutually exclusive")
+	}
+	// Add JSON flag so we can control output format
+	if !count {
+		c.Doit.Set(c.NS, flagJSON, true)
+	}
+	output, err := RunSandboxExec(actionList, c, []string{flagCount, flagNameSort, flagNameName, flagJSON}, []string{flagLimit, flagSkip})
 	if err != nil {
 		return err
 	}
-	return c.PrintSandboxTextOutput(output)
+	if count {
+		return c.PrintSandboxTextOutput(output)
+	}
+	// Reparse the output to use a more specific type, which can then be passed to the displayer
+	rawOutput, err := json.Marshal(output.Entity)
+	if err != nil {
+		return err
+	}
+	var formatted []do.FunctionInfo
+	err = json.Unmarshal(rawOutput, &formatted)
+	if err != nil {
+		return err
+	}
+	return c.Display(&displayers.Functions{Info: formatted})
 }
 
 // appendParams determines if there is a 'param' flag (value is a slice, elements

--- a/commands/functions.go
+++ b/commands/functions.go
@@ -26,17 +26,17 @@ func Functions() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
 			Use:   "functions",
-			Short: "Work with the functions of your sandbox",
-			Long: `The subcommands of ` + "`" + `doctl sandbox functions` + "`" + ` operate on the deployed (cloud-resident) functions of your sandbox.
+			Short: "Work with the functions in your namespace",
+			Long: `The subcommands of ` + "`" + `doctl serverless functions` + "`" + ` operate on your functions namespace. 
 You are able to inspect and list these functions to know what is deployed.  You can also invoke functions to test them.`,
 			Aliases: []string{"fn"},
 		},
 	}
 
 	get := CmdBuilder(cmd, RunFunctionsGet, "get <functionName>", "Retrieves the deployed copy of a function (code or metadata)",
-		`Use `+"`"+`doctl sandbox functions get`+"`"+` to obtain the code or metadata of a deployed function.
+		`Use `+"`"+`doctl serverless functions get`+"`"+` to obtain the code or metadata of a deployed function.
 This allows you to inspect the deployed copy and ascertain whether it corresponds to what
-is in your sandbox area in the local file system.`,
+is in your functions project in the local file system.`,
 		Writer)
 	AddBoolFlag(get, "url", "r", false, "get function url")
 	AddBoolFlag(get, "code", "", false, "show function code (only works if code is not a zip file)")
@@ -46,8 +46,8 @@ is in your sandbox area in the local file system.`,
 	AddStringFlag(get, "save-as", "", "", "file to save function code to")
 
 	invoke := CmdBuilder(cmd, RunFunctionsInvoke, "invoke <functionName>", "Invokes a function",
-		`Use `+"`"+`doctl sandbox functions invoke`+"`"+` to invoke a function of your sandbox that has been deployed
-to the cloud.  You can provide inputs and inspect outputs.`,
+		`Use `+"`"+`doctl serverless functions invoke`+"`"+` to invoke a function in your functions namespace.
+You can provide inputs and inspect outputs.`,
 		Writer)
 	AddBoolFlag(invoke, "web", "", false, "Invoke as a web function, show result as web page")
 	AddStringSliceFlag(invoke, "param", "p", []string{}, "parameter values in KEY:VALUE format, list allowed")
@@ -55,9 +55,8 @@ to the cloud.  You can provide inputs and inspect outputs.`,
 	AddBoolFlag(invoke, "full", "f", false, "wait for full activation record")
 	AddBoolFlag(invoke, "no-wait", "n", false, "fire and forget (asynchronous invoke, does not wait for the result)")
 
-	list := CmdBuilder(cmd, RunFunctionsList, "list [<packageName>]", "Lists all the functions",
-		`Use `+"`"+`doctl sandbox functions list`+"`"+` to list the functions of your sandbox that are deployed
-to the cloud.`,
+	list := CmdBuilder(cmd, RunFunctionsList, "list [<packageName>]", "Lists the functions in your functions namespace",
+		`Use `+"`"+`doctl serverless functions list`+"`"+` to list the functions in your functions namespace.`,
 		Writer)
 	AddStringFlag(list, "limit", "l", "", "only return LIMIT number of functions (default 30, max 200)")
 	AddStringFlag(list, "skip", "s", "", "exclude the first SKIP number of functions from the result")

--- a/commands/functions_test.go
+++ b/commands/functions_test.go
@@ -200,7 +200,7 @@ func TestFunctionsList(t *testing.T) {
 	}{
 		{
 			name:            "no flags or args",
-			expectedNimArgs: []string{},
+			expectedNimArgs: []string{"--json"},
 		},
 		{
 			name:            "count flag",
@@ -210,22 +210,22 @@ func TestFunctionsList(t *testing.T) {
 		{
 			name:            "limit flag",
 			doctlFlags:      map[string]string{"limit": "1"},
-			expectedNimArgs: []string{"--limit", "1"},
+			expectedNimArgs: []string{"--json", "--limit", "1"},
 		},
 		{
 			name:            "name flag",
 			doctlFlags:      map[string]string{"name": ""},
-			expectedNimArgs: []string{"--name"},
+			expectedNimArgs: []string{"--name", "--json"},
 		},
 		{
 			name:            "name-sort flag",
 			doctlFlags:      map[string]string{"name-sort": ""},
-			expectedNimArgs: []string{"--name-sort"},
+			expectedNimArgs: []string{"--name-sort", "--json"},
 		},
 		{
 			name:            "skip flag",
 			doctlFlags:      map[string]string{"skip": "1"},
-			expectedNimArgs: []string{"--skip", "1"},
+			expectedNimArgs: []string{"--json", "--skip", "1"},
 		},
 	}
 

--- a/commands/sandbox-extra.go
+++ b/commands/sandbox-extra.go
@@ -23,21 +23,21 @@ import (
 // oclif equivalents and subsequently modified.
 func SandboxExtras(cmd *Command) {
 
-	create := CmdBuilder(cmd, RunSandboxExtraCreate, "init <path>", "Initialize a local file system directory for the sandbox",
-		`The `+"`"+`doctl sandbox init`+"`"+` command specifies a directory in your file system which will hold functions and
-supporting artifacts while you're developing them.  When ready, you can upload these to the cloud for testing.
-Later, after the area is committed to a `+"`"+`git`+"`"+` repository, you can create an app from them.
+	create := CmdBuilder(cmd, RunSandboxExtraCreate, "init <path>", "Initialize a 'functions project' directory in your local file system",
+		`The `+"`"+`doctl serverless init`+"`"+` command specifies a directory in your file system which will hold functions and
+supporting artifacts while you're developing them.  This 'functions project' can be uploaded to your functions namespace for testing.
+Later, after the functions project is committed to a `+"`"+`git`+"`"+` repository, you can create an app, or an app component, from it.
 
-Type `+"`"+`doctl sandbox status --languages`+"`"+` for a list of supported languages.  Use one of the displayed keywords
-to choose your sample language for `+"`"+`doctl sandbox init`+"`"+`.`,
+Type `+"`"+`doctl serverless status --languages`+"`"+` for a list of supported languages.  Use one of the displayed keywords
+to choose your sample language for `+"`"+`doctl serverless init`+"`"+`.`,
 		Writer)
 	AddStringFlag(create, "language", "l", "javascript", "Language for the initial sample code")
 	AddBoolFlag(create, "overwrite", "", false, "Clears and reuses an existing directory")
 
-	deploy := CmdBuilder(cmd, RunSandboxExtraDeploy, "deploy <directories>", "Deploy sandbox local assets to the cloud",
-		`At any time you can use `+"`"+`doctl sandbox deploy`+"`"+` to upload the contents of a directory in your file system for
-testing in the cloud.  The area must be organized in the fashion expected by an App Platform Functions
-component.  The `+"`"+`doctl sandbox init`+"`"+` command will create a properly organized directory for you to work in.`,
+	deploy := CmdBuilder(cmd, RunSandboxExtraDeploy, "deploy <directories>", "Deploy a functions project to your functions namespace",
+		`At any time you can use `+"`"+`doctl serverless deploy`+"`"+` to upload the contents of a functions project in your file system for
+testing in your serverless namespace.  The project must be organized in the fashion expected by an App Platform Functions
+component.  The `+"`"+`doctl serverless init`+"`"+` command will create a properly organized directory for you to work in.`,
 		Writer)
 	AddStringFlag(deploy, "env", "", "", "Path to runtime environment file")
 	AddStringFlag(deploy, "build-env", "", "", "Path to build-time environment file")
@@ -52,17 +52,17 @@ component.  The `+"`"+`doctl sandbox init`+"`"+` command will create a properly 
 	AddBoolFlag(deploy, "remote-build", "", false, "Run builds remotely")
 	AddBoolFlag(deploy, "incremental", "", false, "Deploy only changes since last deploy")
 
-	getMetadata := CmdBuilder(cmd, RunSandboxExtraGetMetadata, "get-metadata <directory>", "Obtain metadata of a sandbox directory",
-		`The `+"`"+`doctl sandbox get-metadata`+"`"+` command produces a JSON structure that summarizes the contents of a directory
-you have designated for functions development.  This can be useful for feeding into other tools.`,
+	getMetadata := CmdBuilder(cmd, RunSandboxExtraGetMetadata, "get-metadata <directory>", "Obtain metadata of a functions project",
+		`The `+"`"+`doctl serverless get-metadata`+"`"+` command produces a JSON structure that summarizes the contents of a functions
+project (a directory you have designated for functions development).  This can be useful for feeding into other tools.`,
 		Writer)
 	AddStringFlag(getMetadata, "env", "", "", "Path to environment file")
 	AddStringFlag(getMetadata, "include", "", "", "Functions or packages to include")
 	AddStringFlag(getMetadata, "exclude", "", "", "Functions or packages to exclude")
 
-	watch := CmdBuilder(cmd, RunSandboxExtraWatch, "watch <directory>", "Watch a sandbox directory, deploying incrementally on change",
+	watch := CmdBuilder(cmd, RunSandboxExtraWatch, "watch <directory>", "Watch a functions project directory, deploying incrementally on change",
 		`Type `+"`"+`doctl sandbox watch <directory>`+"`"+` in a separate terminal window.  It will run until interrupted.
-It will watch the directory (which should be one you initialized for sandbox use) and will deploy
+It will watch the directory (which should be one you initialized for serverless development) and will deploy
 the contents to the cloud incrementally as it detects changes.`,
 		Writer)
 	AddStringFlag(watch, "env", "", "", "Path to runtime environment file")
@@ -98,16 +98,16 @@ func RunSandboxExtraCreate(c *CmdConfig) error {
 	// is not quite right for doctl.
 	if jsonOutput, ok := output.Entity.(map[string]interface{}); ok {
 		if created, ok := jsonOutput["project"].(string); ok {
-			fmt.Fprintf(c.Out, `A local sandbox area '%s' was created for you.
+			fmt.Fprintf(c.Out, `A local functions project directory '%s' was created for you.
 You may deploy it by running the command shown on the next line:
-  doctl sandbox deploy %s
+  doctl serverless deploy %s
 `, created, created)
 			fmt.Fprintln(c.Out)
 			return nil
 		}
 	}
 	// Fall back if output is not structured the way we expect
-	fmt.Println("Sandbox initialized successfully in the local file system")
+	fmt.Println("Functions project initialized successfully in the local file system")
 	return nil
 }
 

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -39,7 +39,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minSandboxVersion = "3.1.1-1.2.1"
+	minSandboxVersion = "4.0.0-1.2.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -39,7 +39,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minSandboxVersion = "4.0.0-1.2.1"
+	minSandboxVersion = "4.1.0-1.3.0"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"

--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -32,18 +32,10 @@ func TestSandboxConnect(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		buf := &bytes.Buffer{}
 		config.Out = buf
-		fakeCmd := &exec.Cmd{
-			Stdout: config.Out,
-		}
 
-		tm.sandbox.EXPECT().GetSandboxNamespace(context.TODO()).Return(do.SandboxCredentials{Auth: "xyzzy", APIHost: "https://api.example.com"}, nil)
-		tm.sandbox.EXPECT().Cmd("auth/login", []string{"--auth", "xyzzy", "--apihost", "https://api.example.com"}).Return(fakeCmd, nil)
-		tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{
-			Entity: map[string]interface{}{
-				"namespace": "hello",
-				"apihost":   "https://api.example.com",
-			},
-		}, nil)
+		creds := do.SandboxCredentials{Namespace: "hello", APIHost: "https://api.example.com"}
+		tm.sandbox.EXPECT().GetSandboxNamespace(context.TODO()).Return(creds, nil)
+		tm.sandbox.EXPECT().WriteCredentials(creds).Return(nil)
 
 		err := RunSandboxConnect(config)
 		require.NoError(t, err)

--- a/commands/sandbox_test.go
+++ b/commands/sandbox_test.go
@@ -47,7 +47,7 @@ func TestSandboxConnect(t *testing.T) {
 
 		err := RunSandboxConnect(config)
 		require.NoError(t, err)
-		assert.Equal(t, "Connected to function namespace 'hello' on API host 'https://api.example.com'\n\n", buf.String())
+		assert.Equal(t, "Connected to functions namespace 'hello' on API host 'https://api.example.com'\n\n", buf.String())
 	})
 }
 
@@ -69,7 +69,7 @@ func TestSandboxStatusWhenConnected(t *testing.T) {
 
 		err := RunSandboxStatus(config)
 		require.NoError(t, err)
-		assert.Contains(t, buf.String(), "Connected to function namespace 'hello' on API host 'https://api.example.com'\nSandbox version is")
+		assert.Contains(t, buf.String(), "Connected to functions namespace 'hello' on API host 'https://api.example.com'\nServerless software version is")
 	})
 }
 
@@ -201,7 +201,7 @@ func TestSandboxInstallWhenInstalledNotCurrent(t *testing.T) {
 
 		err := RunSandboxInstall(config)
 		require.NoError(t, err)
-		assert.Equal(t, "Sandbox support is already installed, but needs an upgrade for this version of `doctl`.\nUse `doctl sandbox upgrade` to upgrade the support.\n", buf.String())
+		assert.Equal(t, "Serverless support is already installed, but needs an upgrade for this version of `doctl`.\nUse `doctl serverless upgrade` to upgrade the support.\n", buf.String())
 	})
 }
 
@@ -220,7 +220,7 @@ func TestSandboxInstallWhenInstalledAndCurrent(t *testing.T) {
 
 		err := RunSandboxInstall(config)
 		require.NoError(t, err)
-		assert.Equal(t, "Sandbox support is already installed at an appropriate version.  No action needed.\n", buf.String())
+		assert.Equal(t, "Serverless support is already installed at an appropriate version.  No action needed.\n", buf.String())
 	})
 }
 
@@ -239,7 +239,7 @@ func TestSandboxUpgradeWhenNotInstalled(t *testing.T) {
 
 		err := RunSandboxUpgrade(config)
 		require.NoError(t, err)
-		assert.Equal(t, "Sandbox support was never installed.  Use `doctl sandbox install`.\n", buf.String())
+		assert.Equal(t, "Serverless support was never installed.  Use `doctl serverless install`.\n", buf.String())
 	})
 }
 
@@ -258,7 +258,7 @@ func TestSandboxUpgradeWhenInstalledAndCurrent(t *testing.T) {
 
 		err := RunSandboxUpgrade(config)
 		require.NoError(t, err)
-		assert.Equal(t, "Sandbox support is already installed at an appropriate version.  No action needed.\n", buf.String())
+		assert.Equal(t, "Serverless support is already installed at an appropriate version.  No action needed.\n", buf.String())
 	})
 }
 
@@ -341,9 +341,9 @@ func TestSandboxInit(t *testing.T) {
 
 				err := RunSandboxExtraCreate(config)
 				require.NoError(t, err)
-				assert.Equal(t, `A local sandbox area 'foo' was created for you.
+				assert.Equal(t, `A local functions project directory 'foo' was created for you.
 You may deploy it by running the command shown on the next line:
-  doctl sandbox deploy foo`+"\n\n", buf.String())
+  doctl serverless deploy foo`+"\n\n", buf.String())
 			})
 		})
 	}

--- a/do/mocks/SandboxService.go
+++ b/do/mocks/SandboxService.go
@@ -109,3 +109,17 @@ func (mr *MockSandboxServiceMockRecorder) Stream(arg0 interface{}) *gomock.Call 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stream", reflect.TypeOf((*MockSandboxService)(nil).Stream), arg0)
 }
+
+// WriteCredentials mocks base method.
+func (m *MockSandboxService) WriteCredentials(arg0 do.SandboxCredentials) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteCredentials", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteCredentials indicates an expected call of WriteCredentials.
+func (mr *MockSandboxServiceMockRecorder) WriteCredentials(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCredentials", reflect.TypeOf((*MockSandboxService)(nil).WriteCredentials), arg0)
+}

--- a/do/sandbox.go
+++ b/do/sandbox.go
@@ -96,6 +96,7 @@ type sandboxService struct {
 	sandboxJs  string
 	sandboxDir string
 	node       string
+	userAgent  string
 	client     *godo.Client
 }
 
@@ -111,11 +112,12 @@ type SandboxOutput struct {
 }
 
 // NewSandboxService returns a configured SandboxService.
-func NewSandboxService(sandboxJs string, sandboxDir string, node string, client *godo.Client) SandboxService {
+func NewSandboxService(sandboxJs string, sandboxDir string, node string, userAgent string, client *godo.Client) SandboxService {
 	return &sandboxService{
 		sandboxJs:  sandboxJs,
 		sandboxDir: sandboxDir,
 		node:       node,
+		userAgent:  userAgent,
 		client:     client,
 	}
 }
@@ -124,7 +126,7 @@ func NewSandboxService(sandboxJs string, sandboxDir string, node string, client 
 func (n *sandboxService) Cmd(command string, args []string) (*exec.Cmd, error) {
 	args = append([]string{n.sandboxJs, command}, args...)
 	cmd := exec.Command(n.node, args...)
-	cmd.Env = append(os.Environ(), "NIMBELLA_DIR="+n.sandboxDir)
+	cmd.Env = append(os.Environ(), "NIMBELLA_DIR="+n.sandboxDir, "NIM_USER_AGENT="+n.userAgent)
 	// If DEBUG is specified, we need to open up stderr for that stream.  The stdout stream
 	// will continue to work for returning structured results.
 	if os.Getenv("DEBUG") != "" {

--- a/do/sandbox.go
+++ b/do/sandbox.go
@@ -21,16 +21,23 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/digitalocean/godo"
 )
 
-// SandboxCredentials is the type returned by the GetSandboxNamespace function.
-// The values in it can be used to connect sandbox support to a specific namespace using the plugin.
+// SandboxCredentials models what is stored in credentials.json for use by the plugin and nim.
+// It is also the type returned by the GetSandboxNamespace function.
 type SandboxCredentials struct {
-	Auth    string
-	APIHost string
+	APIHost     string                                  `json:"currentHost"`
+	Namespace   string                                  `json:"currentNamespace"`
+	Credentials map[string]map[string]SandboxCredential `json:"credentials"`
+}
+
+// SandboxCredential is the type of an individual entry in SandboxCredentials
+type SandboxCredential struct {
+	Auth string `json:"api_key"`
 }
 
 // The type of the "namespace" member of the response to /api/v2/functions/sandbox
@@ -89,16 +96,20 @@ type SandboxService interface {
 	Exec(*exec.Cmd) (SandboxOutput, error)
 	Stream(*exec.Cmd) error
 	GetSandboxNamespace(context.Context) (SandboxCredentials, error)
+	WriteCredentials(SandboxCredentials) error
 	GetHostInfo(string) (ServerlessHostInfo, error)
 }
 
 type sandboxService struct {
-	sandboxJs  string
-	sandboxDir string
-	node       string
-	userAgent  string
-	client     *godo.Client
+	sandboxJs string
+	credsDir  string // note: this was misleadingly named sandboxDir previously
+	node      string
+	userAgent string
+	client    *godo.Client
 }
+
+// CredentialsFile is the name of the file where the sandbox plugin stores OpenWhisk credentials.
+const CredentialsFile = "credentials.json"
 
 var _ SandboxService = &sandboxService{}
 
@@ -112,13 +123,13 @@ type SandboxOutput struct {
 }
 
 // NewSandboxService returns a configured SandboxService.
-func NewSandboxService(sandboxJs string, sandboxDir string, node string, userAgent string, client *godo.Client) SandboxService {
+func NewSandboxService(sandboxJs string, credsDir string, node string, userAgent string, client *godo.Client) SandboxService {
 	return &sandboxService{
-		sandboxJs:  sandboxJs,
-		sandboxDir: sandboxDir,
-		node:       node,
-		userAgent:  userAgent,
-		client:     client,
+		sandboxJs: sandboxJs,
+		credsDir:  credsDir,
+		node:      node,
+		userAgent: userAgent,
+		client:    client,
 	}
 }
 
@@ -126,7 +137,7 @@ func NewSandboxService(sandboxJs string, sandboxDir string, node string, userAge
 func (n *sandboxService) Cmd(command string, args []string) (*exec.Cmd, error) {
 	args = append([]string{n.sandboxJs, command}, args...)
 	cmd := exec.Command(n.node, args...)
-	cmd.Env = append(os.Environ(), "NIMBELLA_DIR="+n.sandboxDir, "NIM_USER_AGENT="+n.userAgent)
+	cmd.Env = append(os.Environ(), "NIMBELLA_DIR="+n.credsDir, "NIM_USER_AGENT="+n.userAgent)
 	// If DEBUG is specified, we need to open up stderr for that stream.  The stdout stream
 	// will continue to work for returning structured results.
 	if os.Getenv("DEBUG") != "" {
@@ -182,9 +193,13 @@ func (n *sandboxService) GetSandboxNamespace(ctx context.Context) (SandboxCreden
 	if err != nil {
 		return SandboxCredentials{}, err
 	}
+	host := assignAPIHost(decoded.Namespace.APIHost, decoded.Namespace.Namespace)
+	credential := SandboxCredential{Auth: decoded.Namespace.UUID + ":" + decoded.Namespace.Key}
+	namespace := decoded.Namespace.Namespace
 	ans := SandboxCredentials{
-		APIHost: assignAPIHost(decoded.Namespace.APIHost, decoded.Namespace.Namespace),
-		Auth:    decoded.Namespace.UUID + ":" + decoded.Namespace.Key,
+		APIHost:     host,
+		Namespace:   namespace,
+		Credentials: map[string]map[string]SandboxCredential{host: {namespace: credential}},
 	}
 	return ans, nil
 }
@@ -219,4 +234,20 @@ func assignAPIHost(origAPIHost string, namespace string) string {
 		return sansSuffix + ".co"
 	}
 	return origAPIHost
+}
+
+// WriteCredentials writes a set of serverless credentials to the appropriate 'creds' directory
+func (n *sandboxService) WriteCredentials(creds SandboxCredentials) error {
+	// Create the directory into which the file will be written.
+	err := os.MkdirAll(n.credsDir, 0700)
+	if err != nil {
+		return err
+	}
+	// Write the credentials
+	credsPath := filepath.Join(n.credsDir, CredentialsFile)
+	bytes, err := json.MarshalIndent(&creds, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(credsPath, bytes, 0600)
 }

--- a/do/sandbox.go
+++ b/do/sandbox.go
@@ -63,6 +63,25 @@ type ServerlessHostInfo struct {
 	Runtimes map[string][]ServerlessRuntime `json:"runtimes"`
 }
 
+// FunctionInfo is the type of an individual function in the output
+// of doctl sls fn list.  Only relevant fields are unmarshaled.
+// Note: when we start replacing the sandbox plugin path with direct calls
+// to backend controller operations, this will be replaced by declarations
+// in the golang openwhisk client.
+type FunctionInfo struct {
+	Name        string       `json:"name"`
+	Namespace   string       `json:"namespace"`
+	Updated     int64        `json:"updated"`
+	Version     string       `json:"version"`
+	Annotations []Annotation `json:"annotations"`
+}
+
+// Annotation is a key/value type suitable for individual annotations
+type Annotation struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
 // SandboxService is an interface for interacting with the sandbox plugin,
 // with the namespaces service, and with the serverless cluster controller.
 type SandboxService interface {


### PR DESCRIPTION
The accumulated changes on feature/serverless are ready to be in a release, assuming the co-requisite docs changes become ready.   The changes are

1.  change cobra and help texts to de-emphasize ‘sandbox’ as a command and eliminate it as a concept
2. change 'actions' to 'functions' where feasible, including an improved  output format for `doctl sls fn list`
3.  interactions with the serverless backend now use a distinguished user agent string
4.  the mechanism for storing credentials now no longer goes through the sandbox plugin