### PR TITLE
snap: Update build env to use go 1.18

### DIFF
--- a/dockerfiles/Dockerfile.snap
+++ b/dockerfiles/Dockerfile.snap
@@ -4,7 +4,7 @@
 #
 # For help with the technical aspects of this Dockerfile, see
 #   https://snapcraft.io/docs/t/creating-docker-images-for-snapcraft/11739
-#   https://raw.githubusercontent.com/snapcore/snapcraft/master/docker/stable.Dockerfile
+#   https://github.com/snapcore/snapcraft/blob/main/docker/Dockerfile
 # and https://forum.snapcraft.io/. Note that the snapcraft forum does not appear to be indexed
 # effectively (at all?) by google.
 #
@@ -37,30 +37,42 @@ RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/sna
         mkdir -p /snap/snapcraft && \
         unsquashfs -d /snap/snapcraft/current snapcraft.snap
 
+# Fix Python3 installation: Make sure we use the interpreter from
+# the snapcraft snap:
+RUN unlink /snap/snapcraft/current/usr/bin/python3
+RUN ln -s /snap/snapcraft/current/usr/bin/python3.* /snap/snapcraft/current/usr/bin/python3
+RUN echo /snap/snapcraft/current/lib/python3.*/site-packages >> /snap/snapcraft/current/usr/lib/python3/dist-packages/site-packages.pth
+
 # Create a snapcraft runner (TODO: move version detection to the core of snapcraft)
 RUN mkdir -p /snap/bin && \
         echo "#!/bin/sh" > /snap/bin/snapcraft && \
-        snap_version="$(awk '/^version:/{print $2}' /snap/snapcraft/current/meta/snap.yaml)" && \
+        snap_version="$(awk '/^version:/{print $2}' /snap/snapcraft/current/meta/snap.yaml | tr -d \')" && \
         echo "export SNAP_VERSION=\"$snap_version\"" >> /snap/bin/snapcraft && \
         echo 'exec "$SNAP/usr/bin/python3" "$SNAP/bin/snapcraft" "$@"' >> /snap/bin/snapcraft && \
         chmod +x /snap/bin/snapcraft
 
 # Grab the golang snap from the stable channel, unpack it in the proper place, and create a runner for it
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/go?channel=1.17/stable' | jq '.download_url' -r) --output go.snap && \
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/go?channel=1.18/stable' | jq '.download_url' -r) --output go.snap && \
         mkdir -p /snap/go && \
         unsquashfs -d /snap/go/current go.snap && \
         cd /snap/bin && \
         ln -s /snap/go/current/bin/go
 
+# Multi-stage build, only need the snaps from the builder. Copy them one at a
+# time so they can be cached.
 FROM ubuntu:focal
-COPY --from=builder /snap /snap
+COPY --from=builder /snap/core /snap/core
+COPY --from=builder /snap/core18 /snap/core18
+COPY --from=builder /snap/core20 /snap/core20
+COPY --from=builder /snap/snapcraft /snap/snapcraft
+COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
+COPY --from=builder /snap/go /snap/go
+COPY --from=builder /snap/bin/go /snap/bin/go
 
 # Install Snap build-time dependencies & generate locale
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get clean && apt-get update && apt-get install --yes \
-	build-essential \
-	golang-go \
-	git \
+	sudo \
 	locales \
 	snapd && \
 	locale-gen en_US.UTF-8 && \
@@ -70,7 +82,7 @@ RUN apt-get clean && apt-get update && apt-get install --yes \
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-ENV PATH "/snap/bin:$PATH"
+ENV PATH "/snap/bin:/snap/snapcraft/current/usr/bin:$PATH"
 ENV SNAP /snap/snapcraft/current
 ENV SNAP_NAME snapcraft
 ENV SNAP_ARCH amd64

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,6 +40,8 @@ parts:
       version=$(scripts/version.sh --snap)
       snapcraftctl set-version ${version}
 
+      echo "==> Building doctl ${version} using $(go version)"
+
       short=${version#v}
       short=${short%+*}
       short=${short%-*}


### PR DESCRIPTION
When cutting the last release, I happened to notice that the Snap builds were still on Go 1.17. Of course things did not end up as straight forward as simply bumping the version string. Rebuilding the image using the Dockerfile in currently in main now creates an unusable image:

```
$ docker run sammytheshark/doctl-snap-base:latest
Traceback (most recent call last):
  File "/snap/snapcraft/current/bin/snapcraft", line 5, in <module>
    from snapcraft.cli import run
ModuleNotFoundError: No module named 'snapcraft'
```

So I've brought in a fix from the upstream Dockerfile this is based on. I also brought in a few small improvements that make the image smaller and the layers more cachable. 