### PR TITLE
Refactor sandbox service for better encapsulation

### DIFF
--- a/commands/activations_test.go
+++ b/commands/activations_test.go
@@ -95,6 +95,7 @@ func TestActivationsGet(t *testing.T) {
 					}
 				}
 
+				tm.sandbox.EXPECT().CheckSandboxStatus(hashAccessToken(config)).MinTimes(1).Return(nil)
 				tm.sandbox.EXPECT().Cmd("activation/get", tt.expectedNimArgs).Return(fakeCmd, nil)
 				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
 
@@ -174,6 +175,7 @@ func TestActivationsList(t *testing.T) {
 					}
 				}
 
+				tm.sandbox.EXPECT().CheckSandboxStatus(hashAccessToken(config)).MinTimes(1).Return(nil)
 				tm.sandbox.EXPECT().Cmd("activation/list", tt.expectedNimArgs).Return(fakeCmd, nil)
 				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
 
@@ -255,6 +257,7 @@ func TestActivationsLogs(t *testing.T) {
 					}
 				}
 
+				tm.sandbox.EXPECT().CheckSandboxStatus(hashAccessToken(config)).MinTimes(1).Return(nil)
 				if tt.expectStream {
 					expectedArgs := append([]string{"activation/logs"}, tt.expectedNimArgs...)
 					tm.sandbox.EXPECT().Cmd("nocapture", expectedArgs).Return(fakeCmd, nil)
@@ -330,6 +333,7 @@ func TestActivationsResult(t *testing.T) {
 					}
 				}
 
+				tm.sandbox.EXPECT().CheckSandboxStatus(hashAccessToken(config)).MinTimes(1).Return(nil)
 				tm.sandbox.EXPECT().Cmd("activation/result", tt.expectedNimArgs).Return(fakeCmd, nil)
 				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
 

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -237,10 +237,6 @@ func withTestClient(t *testing.T, tFn testFn) {
 
 		setContextAccessToken: func(token string) {},
 
-		checkSandboxStatus: func(c *CmdConfig) error {
-			return nil
-		},
-
 		Keys:              func() do.KeysService { return tm.keys },
 		Sizes:             func() do.SizesService { return tm.sizes },
 		Regions:           func() do.RegionsService { return tm.regions },

--- a/commands/functions_test.go
+++ b/commands/functions_test.go
@@ -107,6 +107,7 @@ func TestFunctionsGet(t *testing.T) {
 					}
 				}
 
+				tm.sandbox.EXPECT().CheckSandboxStatus(hashAccessToken(config)).MinTimes(1).Return(nil)
 				tm.sandbox.EXPECT().Cmd("action/get", tt.expectedNimArgs).Return(fakeCmd, nil)
 				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
 
@@ -175,6 +176,7 @@ func TestFunctionsInvoke(t *testing.T) {
 					}
 				}
 
+				tm.sandbox.EXPECT().CheckSandboxStatus(hashAccessToken(config)).MinTimes(1).Return(nil)
 				tm.sandbox.EXPECT().Cmd("action/invoke", tt.expectedNimArgs).Return(fakeCmd, nil)
 				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{
 					Entity: map[string]interface{}{"body": "Hello world!"},
@@ -250,6 +252,7 @@ func TestFunctionsList(t *testing.T) {
 					}
 				}
 
+				tm.sandbox.EXPECT().CheckSandboxStatus(hashAccessToken(config)).MinTimes(1).Return(nil)
 				tm.sandbox.EXPECT().Cmd("action/list", tt.expectedNimArgs).Return(fakeCmd, nil)
 				tm.sandbox.EXPECT().Exec(fakeCmd).Return(do.SandboxOutput{}, nil)
 

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -15,53 +15,20 @@ package commands
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/do"
-	"github.com/digitalocean/doctl/pkg/extract"
 	"github.com/spf13/cobra"
 )
 
-const (
-	// Minimum required version of the sandbox plugin code.  The first part is
-	// the version of the incorporated Nimbella CLI and the second part is the
-	// version of the bridge code in the sandbox plugin repository.
-	minSandboxVersion = "4.1.0-1.3.0"
-
-	// The version of nodejs to download alongsize the plugin download.
-	nodeVersion = "v16.13.0"
-
-	// noCapture is the string constant recognized by the plugin.  It suppresses output
-	// capture when in the initial (command) position.
-	noCapture = "nocapture"
-
-	// credsDir is the directory under the sandbox where all credentials are stored.
-	// It in turn has a subdirectory for each access token employed (formed as a prefix of the token).
-	credsDir = "creds"
-)
-
 var (
-	// ErrSandboxNotInstalled is the error returned to users when the sandbox is not installed.
-	ErrSandboxNotInstalled = errors.New("Serverless support is not installed (use `doctl serverless install`)")
-	// ErrSandboxNeedsUpgrade is the error returned to users when the sandbox is at too low a version
-	ErrSandboxNeedsUpgrade = errors.New("Serverless support needs to be upgraded (use `doctl serverless upgrade`)")
-	// ErrSandboxNotConnected is the error returned to users when the sandbox is not connected to a namespace
-	ErrSandboxNotConnected = errors.New("Serverless support is installed but not connected to a functions namespace (use `doctl serverless connect`)")
 	// errUndeployAllAndArgs is the error returned when the --all flag is used along with args on undeploy
 	errUndeployAllAndArgs = errors.New("command line arguments and the `--all` flag are mutually exclusive")
+
 	// errUndeployTooFewArgs is the error returned when neither --all nor args are specified on undeploy
 	errUndeployTooFewArgs = errors.New("either command line arguments or `--all` must be specified")
 
@@ -98,10 +65,10 @@ Other ` + "`" + `doctl serverless` + "`" + ` commands are used to develop and te
 		},
 	}
 
-	cmdBuilderWithInit(cmd, RunSandboxInstall, "install", "Installs the serverless support",
+	CmdBuilder(cmd, RunSandboxInstall, "install", "Installs the serverless support",
 		`This command installs additional software under `+"`"+`doctl`+"`"+` needed to make the other serverless commands work.
 The install operation is long-running, and a network connection is required.`,
-		Writer, false)
+		Writer)
 
 	CmdBuilder(cmd, RunSandboxUpgrade, "upgrade", "Upgrades serverless support to match this version of doctl",
 		`This command upgrades the serverless support software under `+"`"+`doctl`+"`"+` by installing over the existing version.
@@ -141,54 +108,52 @@ the entire packages are removed.`, Writer)
 
 // RunSandboxInstall performs the network installation of the 'nim' adjunct to support sandbox development
 func RunSandboxInstall(c *CmdConfig) error {
-	status := c.checkSandboxStatus(c)
+	credsLeafDir := hashAccessToken(c)
+	sandbox := c.Sandbox()
+	status := sandbox.CheckSandboxStatus(credsLeafDir)
 	switch status {
 	case nil:
 		fmt.Fprintln(c.Out, "Serverless support is already installed at an appropriate version.  No action needed.")
 		return nil
-	case ErrSandboxNeedsUpgrade:
+	case do.ErrSandboxNeedsUpgrade:
 		fmt.Fprintln(c.Out, "Serverless support is already installed, but needs an upgrade for this version of `doctl`.")
 		fmt.Fprintln(c.Out, "Use `doctl serverless upgrade` to upgrade the support.")
 		return nil
-	case ErrSandboxNotConnected:
+	case do.ErrSandboxNotConnected:
 		fmt.Fprintln(c.Out, "Serverless support is already installed at an appropriate version, but not connected to a functions namespace.  Use `doctl serverless connect`.")
 		return nil
 	}
-
-	sandboxDir, _ := getSandboxDirectory()
-
-	return c.installSandbox(c, sandboxDir, false)
+	return sandbox.InstallSandbox(credsLeafDir, false)
 }
 
 // RunSandboxUpgrade is a variant on RunSandboxInstall for installing over an existing version when
 // the existing version is inadequate as detected by checkSandboxStatus()
 func RunSandboxUpgrade(c *CmdConfig) error {
-	status := c.checkSandboxStatus(c)
+	credsLeafDir := hashAccessToken(c)
+	sandbox := c.Sandbox()
+	status := sandbox.CheckSandboxStatus(credsLeafDir)
 	switch status {
 	case nil:
 		fmt.Fprintln(c.Out, "Serverless support is already installed at an appropriate version.  No action needed.")
 		// TODO should there be an option to upgrade beyond the minimum needed?
 		return nil
-	case ErrSandboxNotInstalled:
+	case do.ErrSandboxNotInstalled:
 		fmt.Fprintln(c.Out, "Serverless support was never installed.  Use `doctl serverless install`.")
 		return nil
-	case ErrSandboxNotConnected:
+	case do.ErrSandboxNotConnected:
 		fmt.Fprintln(c.Out, "Serverless support is already installed at an appropriate version, but not connected to a functions namespace.  Use `doctl serverless connect`.")
 		return nil
 	}
-
-	sandboxDir, _ := getSandboxDirectory()
-
-	return c.installSandbox(c, sandboxDir, true)
+	return sandbox.InstallSandbox(credsLeafDir, true)
 }
 
 // RunSandboxUninstall removes the sandbox support and any stored credentials
 func RunSandboxUninstall(c *CmdConfig) error {
-	sandboxDir, exists := getSandboxDirectory()
-	if !exists {
+	err := c.Sandbox().CheckSandboxStatus(hashAccessToken(c))
+	if err == do.ErrSandboxNotInstalled {
 		return errors.New("Nothing to uninstall: no serverless support was found")
 	}
-	return os.RemoveAll(sandboxDir)
+	return os.RemoveAll(getSandboxDirectory())
 }
 
 // RunSandboxConnect implements the sandbox connect command
@@ -202,14 +167,15 @@ func RunSandboxConnect(c *CmdConfig) error {
 		return doctl.NewTooManyArgsErr(c.NS)
 	}
 
+	sandbox := c.Sandbox()
+
 	// Non-standard check for the connect command (only): it's ok to not be connected.
-	err = c.checkSandboxStatus(c)
-	if err != nil && err != ErrSandboxNotConnected {
+	err = sandbox.CheckSandboxStatus(hashAccessToken(c))
+	if err != nil && err != do.ErrSandboxNotConnected {
 		return err
 	}
 
 	// Get the credentials for the sandbox namespace
-	sandbox := c.Sandbox()
 	creds, err = sandbox.GetSandboxNamespace(context.TODO())
 	if err != nil {
 		return err
@@ -228,22 +194,22 @@ func RunSandboxConnect(c *CmdConfig) error {
 
 // RunSandboxStatus gives a report on the status of the sandbox (installed, up to date, connected)
 func RunSandboxStatus(c *CmdConfig) error {
-	status := c.checkSandboxStatus(c)
-	if status == ErrSandboxNotInstalled {
+	status := c.Sandbox().CheckSandboxStatus(hashAccessToken(c))
+	if status == do.ErrSandboxNotInstalled {
 		return status
 	}
 	version, _ := c.Doit.GetBool(c.NS, "version")
 	if version {
-		if status == ErrSandboxNeedsUpgrade {
-			sandboxDir, _ := getSandboxDirectory() // we know it exists
-			currentVersion := getCurrentSandboxVersion(sandboxDir)
-			fmt.Fprintf(c.Out, "Current: %s, required: %s\n", currentVersion, getMinSandboxVersion())
+		if status == do.ErrSandboxNeedsUpgrade {
+			sandboxDir := getSandboxDirectory() // we know it exists
+			currentVersion := do.GetCurrentSandboxVersion(sandboxDir)
+			fmt.Fprintf(c.Out, "Current: %s, required: %s\n", currentVersion, do.GetMinSandboxVersion())
 			return nil
 		}
-		fmt.Fprintln(c.Out, getMinSandboxVersion())
+		fmt.Fprintln(c.Out, do.GetMinSandboxVersion())
 		return nil
 	}
-	if status == ErrSandboxNeedsUpgrade || status == ErrSandboxNotConnected {
+	if status == do.ErrSandboxNeedsUpgrade || status == do.ErrSandboxNotConnected {
 		return status
 	}
 	if status != nil {
@@ -253,7 +219,7 @@ func RunSandboxStatus(c *CmdConfig) error {
 	// be more accurate; the connected check in checkSandboxStatus is lightweight and heuristic).
 	result, err := SandboxExec(c, "auth/current", "--apihost", "--name")
 	if err != nil || len(result.Error) > 0 {
-		return ErrSandboxNotConnected
+		return do.ErrSandboxNotConnected
 	}
 	if result.Entity == nil {
 		return errors.New("Could not retrieve information about the connected namespace")
@@ -369,420 +335,4 @@ func deletePackage(c *CmdConfig, pkg string) error {
 		return fmt.Errorf(result.Error)
 	}
 	return nil
-}
-
-// "Public" functions
-
-// SandboxExec executes a sandbox command
-func SandboxExec(c *CmdConfig, command string, args ...string) (do.SandboxOutput, error) {
-	err := c.checkSandboxStatus(c)
-	if err != nil {
-		return do.SandboxOutput{}, err
-	}
-	return sandboxExecNoCheck(c, command, args)
-}
-
-func sandboxExecNoCheck(c *CmdConfig, command string, args []string) (do.SandboxOutput, error) {
-	sandbox := c.Sandbox()
-	cmd, err := sandbox.Cmd(command, args)
-	if err != nil {
-		return do.SandboxOutput{}, err
-	}
-	return sandbox.Exec(cmd)
-}
-
-// RunSandboxExec is a variant of SandboxExec convenient for calling from stylized command runners
-// Sets up the arguments and (especially) the flags for the actual call
-func RunSandboxExec(command string, c *CmdConfig, booleanFlags []string, stringFlags []string) (do.SandboxOutput, error) {
-	err := c.checkSandboxStatus(c)
-	if err != nil {
-		return do.SandboxOutput{}, err
-	}
-
-	sandbox := c.Sandbox()
-	args := getFlatArgsArray(c, booleanFlags, stringFlags)
-	cmd, err := sandbox.Cmd(command, args)
-	if err != nil {
-		return do.SandboxOutput{}, err
-	}
-
-	return sandbox.Exec(cmd)
-}
-
-// RunSandboxExecStreaming is like RunSandboxExec but assumes that output will not be captured and can be streamed.
-func RunSandboxExecStreaming(command string, c *CmdConfig, booleanFlags []string, stringFlags []string) error {
-	err := c.checkSandboxStatus(c)
-	if err != nil {
-		return err
-	}
-	sandbox := c.Sandbox()
-
-	args := getFlatArgsArray(c, booleanFlags, stringFlags)
-	args = append([]string{command}, args...)
-
-	cmd, err := sandbox.Cmd(noCapture, args)
-	if err != nil {
-		return err
-	}
-	// TODO the following does not filter output.  We might want output filtering as part of
-	// this function.
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return sandbox.Stream(cmd)
-}
-
-// PrintSandboxTextOutput prints the output of a sandbox command execution in a
-// textual form (often, this can be improved upon).
-// Prints Formatted if present.
-// Else, prints Captured if present.
-// Else, prints Table or Entity using generic JSON formatting.
-// We don't expect both Table and Entity to be present and have no
-// special handling for that.
-func (c *CmdConfig) PrintSandboxTextOutput(output do.SandboxOutput) error {
-	var err error
-	if len(output.Formatted) > 0 {
-		_, err = fmt.Fprintln(c.Out, strings.Join(output.Formatted, "\n"))
-	} else if len(output.Captured) > 0 {
-		_, err = fmt.Fprintln(c.Out, strings.Join(output.Captured, "\n"))
-	} else if len(output.Table) > 0 {
-		_, err = fmt.Fprintln(c.Out, genericJSON(output.Table))
-	} else if output.Entity != nil {
-		_, err = fmt.Fprintln(c.Out, genericJSON(output.Entity))
-	} // else no output (unusual but not impossible)
-
-	return err
-}
-
-// CheckSandboxStatus checks install status and returns an appropriate error for common issues
-// such as not installed or needs upgrade.  Returns nil when no error.
-func CheckSandboxStatus(c *CmdConfig) error {
-	sandboxDir, exists := getSandboxDirectory()
-	if !exists {
-		return ErrSandboxNotInstalled
-	}
-	if !sandboxUptodate(sandboxDir) {
-		return ErrSandboxNeedsUpgrade
-	}
-	if !isSandboxConnected(c, sandboxDir) {
-		return ErrSandboxNotConnected
-	}
-	return nil
-}
-
-// InstallSandbox is the working subroutine for 'install' and 'upgrade'
-func InstallSandbox(c *CmdConfig, sandboxDir string, upgrading bool) error {
-	// Make a temporary directory for use during the install.
-	// Note: we don't let this be allocated in the system temporaries area because
-	// that might be on a separate file system, meaning that the final install step
-	// will require an additional copy rather than a simple rename.
-	tmp, err := ioutil.TempDir(configHome(), "sbx-install")
-	if err != nil {
-		return err
-	}
-
-	// Download the nodejs tarball for this os and architecture
-	fmt.Print("Downloading...")
-
-	goos := runtime.GOOS
-	arch := runtime.GOARCH
-	nodeBin := "node"
-	if arch == "amd64" {
-		arch = "x64"
-	}
-	if arch == "386" {
-		if goos == "linux" {
-			return errors.New("serverless support is not available for 32-bit linux")
-		}
-		arch = "x86"
-	}
-	if goos == "windows" {
-		goos = "win"
-		nodeBin = "node.exe"
-	}
-
-	var (
-		nodeURL      string
-		nodeFileName string
-		nodeDir      string
-	)
-
-	// Download nodejs only if necessary
-	if !upgrading || !canReuseNode(sandboxDir, nodeBin) {
-		nodeDir = fmt.Sprintf("node-%s-%s-%s", nodeVersion, goos, arch)
-		nodeURL = fmt.Sprintf("https://nodejs.org/dist/%s/%s.tar.gz", nodeVersion, nodeDir)
-		nodeFileName = filepath.Join(tmp, "node-install.tar.gz")
-
-		if goos == "win" {
-			nodeURL = fmt.Sprintf("https://nodejs.org/dist/%s/%s.zip", nodeVersion, nodeDir)
-			nodeFileName = filepath.Join(tmp, "node-install.zip")
-		}
-
-		err = download(nodeURL, nodeFileName)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Download the fat tarball with the nim CLI, deployer, and sandbox bridge
-	// TODO do these need to be arch-specific?  Currently assuming not.
-	URL := fmt.Sprintf("https://do-serverless-tools.nyc3.digitaloceanspaces.com/doctl-sandbox-%s.tar.gz",
-		getMinSandboxVersion())
-	sandboxFileName := filepath.Join(tmp, "doctl-sandbox.tar.gz")
-	err = download(URL, sandboxFileName)
-	if err != nil {
-		return err
-	}
-
-	// Exec the Extract utility at least once to unpack the fat tarball and possibly a second time if
-	// node was downloaded.  If node was not downloaded, just move the existing binary into place.
-	fmt.Print("Unpacking...")
-	err = extract.Extract(sandboxFileName, tmp)
-	if err != nil {
-		return err
-	}
-
-	if nodeFileName != "" {
-		err = extract.Extract(nodeFileName, tmp)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Move artifacts to final location
-	fmt.Print("Installing...")
-	srcPath := filepath.Join(tmp, "sandbox")
-	if upgrading {
-		// Preserve credentials by moving them from target (which will be replaced) to source.
-		err = preserveCreds(c, srcPath, sandboxDir)
-		if err != nil {
-			return err
-		}
-		// Preserve existing node if necessary
-		if nodeFileName == "" {
-			// Node was not downloaded
-			err = moveExistingNode(sandboxDir, srcPath, nodeBin)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		// Make new empty credentials directory
-		emptyCreds := filepath.Join(srcPath, credsDir)
-		err = os.MkdirAll(emptyCreds, 0700)
-		if err != nil {
-			return nil
-		}
-
-		// Create the sandbox directory if necessary.
-		err := os.MkdirAll(sandboxDir, 0755)
-		if err != nil {
-			return err
-		}
-	}
-	// Remove former sandboxDir before moving in the new one
-	err = os.RemoveAll(sandboxDir)
-	if err != nil {
-		return err
-	}
-	err = os.Rename(srcPath, sandboxDir)
-	if err != nil {
-		return err
-	}
-
-	if nodeFileName != "" {
-		if goos == "win" {
-			srcPath = filepath.Join(tmp, nodeDir, nodeBin)
-		} else {
-			// Additional nesting in non-windows case
-			srcPath = filepath.Join(tmp, nodeDir, "bin", nodeBin)
-		}
-		destPath := filepath.Join(sandboxDir, nodeBin)
-		err = os.Rename(srcPath, destPath)
-		if err != nil {
-			return err
-		}
-	}
-	// Clean up temp directory
-	fmt.Print("Cleaning up...")
-	os.RemoveAll(tmp) // Best effort, ignore error
-	fmt.Println("\nDone")
-	return nil
-}
-
-// preserveCreds preserves existing credentials in a sandbox directory
-// that is about to be replaced by moving them to the staging directory
-// containing the replacement.
-func preserveCreds(c *CmdConfig, stagingDir string, sandboxDir string) error {
-	credPath := filepath.Join(sandboxDir, credsDir)
-	relocPath := filepath.Join(stagingDir, credsDir)
-	err := os.Rename(credPath, relocPath)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	// There was no creds directory.  Check for legacy form and convert as part
-	// of preserving.
-	legacyCredPath := filepath.Join(sandboxDir, ".nimbella")
-	err = os.MkdirAll(relocPath, 0700)
-	if err != nil {
-		return err
-	}
-	moveLegacyTo := getCredentialDirectory(c, stagingDir)
-	return os.Rename(legacyCredPath, moveLegacyTo)
-}
-
-// "Private" utility functions
-
-// getCurrentSandboxVersion gets the version of the current sandbox.
-// To be called only when sandbox is known to exist.
-// Returns "0" if the installed sandbox pre-dates the versioning system
-// Otherwise, returns the version string stored in the sandbox directory.
-func getCurrentSandboxVersion(sandboxDir string) string {
-	versionFile := filepath.Join(sandboxDir, "version")
-	contents, err := ioutil.ReadFile(versionFile)
-	if err != nil {
-		return "0"
-	}
-	return string(contents)
-}
-
-// Gets the version of the node binary in the sandbox.  Determine if it is
-// usable or whether it has to be upgraded.
-func canReuseNode(sandboxDir string, nodeBin string) bool {
-	fullNodeBin := filepath.Join(sandboxDir, nodeBin)
-	cmd := exec.Command(fullNodeBin, "--version")
-	result, err := cmd.Output()
-	if err == nil {
-		installed := strings.TrimSpace(string(result))
-		return installed == nodeVersion
-	}
-	return false
-}
-
-// Moves the existing node binary from the sandbox that contains it to the new sandbox being
-// staged during an upgrade.  This preserves it for reuse and avoids the need to download.
-func moveExistingNode(existing string, staging string, nodeBin string) error {
-	srcPath := filepath.Join(existing, nodeBin)
-	destPath := filepath.Join(staging, nodeBin)
-	return os.Rename(srcPath, destPath)
-}
-
-// Download a network file to a local file
-func download(URL, targetFile string) error {
-	response, err := http.Get(URL)
-	if err != nil {
-		return err
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != 200 {
-		return fmt.Errorf("Received status code %d attempting to download from %s",
-			response.StatusCode, URL)
-	}
-	file, err := os.Create(targetFile)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	_, err = io.Copy(file, response.Body)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// getSandboxDirectory returns the "sandbox" directory in which the artifacts for sandbox support
-// are stored.  Returns the name of the directory and whether it exists.  The standard location
-// (and the only one that customers are expected to use) is relative to the defaultConfigHome.
-// For testing purposes, an override can be provided via an environment variable.
-func getSandboxDirectory() (string, bool) {
-	sandboxDir, shouldOverride := os.LookupEnv("OVERRIDE_SANDBOX_DIR")
-	if !shouldOverride {
-		sandboxDir = filepath.Join(defaultConfigHome(), "sandbox")
-	}
-	_, err := os.Stat(sandboxDir)
-	exists := !os.IsNotExist(err)
-
-	return sandboxDir, exists
-}
-
-// getCredentialDirectory returns the directory in which credentials should be stored for a given
-// CmdConfig.  The actual leaf directory is a function of the access token being used.  This ties
-// sandbox credentials to DO credentials
-func getCredentialDirectory(c *CmdConfig, sandboxDir string) string {
-	token := c.getContextAccessToken()
-	hasher := sha1.New()
-	hasher.Write([]byte(token))
-	sha := hasher.Sum(nil)
-	leafDir := hex.EncodeToString(sha[:4])
-
-	// When running as a snap, the credential are stored separately from the
-	// actual sandbox install. So we ignore any override of the sandboxDir here.
-	_, isSnap := os.LookupEnv("SNAP")
-	if isSnap {
-		sandboxDir = filepath.Join(configHome(), "sandbox")
-	}
-
-	return filepath.Join(sandboxDir, credsDir, leafDir)
-}
-
-// sandboxUpToDate answers whether the installed version of the sandbox is at least
-// what is required by doctl
-func sandboxUptodate(sandboxDir string) bool {
-	return getCurrentSandboxVersion(sandboxDir) >= getMinSandboxVersion()
-}
-
-// Determines whether the sandbox appears to be connected.  The purpose is
-// to fail fast (when feasible) on sandboxes that are clearly not connected.
-// However, it is important not to add excessive overhead on each call (e.g.
-// asking the plugin to validate credentials), so the test is not foolproof.
-// It merely tests whether a credentials directory has been created for the
-// current doctl access token and appears to have a credentials.json in it.
-func isSandboxConnected(c *CmdConfig, sandboxDir string) bool {
-	creds := getCredentialDirectory(c, sandboxDir)
-	credsFile := filepath.Join(creds, do.CredentialsFile)
-	_, err := os.Stat(credsFile)
-	return !os.IsNotExist(err)
-}
-
-// Converts something "object-like" but untyped to generic JSON
-// Designed for human eyes; does not provide an explicit error
-// result
-func genericJSON(toFormat interface{}) string {
-	bytes, err := json.MarshalIndent(&toFormat, "", "  ")
-	if err != nil {
-		return "<not representable as JSON>"
-	}
-	return string(bytes)
-}
-
-// Convert the actual args, the boolean flags, and the string flags for a command
-// into a flat array which are passed to the plugin as 'args'.
-func getFlatArgsArray(c *CmdConfig, booleanFlags []string, stringFlags []string) []string {
-	args := append([]string{}, c.Args...)
-	for _, flag := range booleanFlags {
-		truth, err := c.Doit.GetBool(c.NS, flag)
-		if truth && err == nil {
-			args = append(args, "--"+flag)
-		}
-	}
-	for _, flag := range stringFlags {
-		value, err := c.Doit.GetString(c.NS, flag)
-		if err == nil && len(value) > 0 {
-			args = append(args, "--"+flag, value)
-		}
-	}
-
-	return args
-}
-
-// Return the minSandboxVersion (allows the constant to be overridden via an environment variable)
-func getMinSandboxVersion() string {
-	fromEnv := os.Getenv("minSandboxVersion")
-	if fromEnv != "" {
-		return fromEnv
-	}
-	return minSandboxVersion
 }

--- a/commands/sandbox.go
+++ b/commands/sandbox.go
@@ -227,7 +227,7 @@ func RunSandboxStatus(c *CmdConfig) error {
 	mapResult := result.Entity.(map[string]interface{})
 	apiHost := mapResult["apihost"].(string)
 	fmt.Fprintf(c.Out, "Connected to functions namespace '%s' on API host '%s'\n", mapResult["name"], apiHost)
-	fmt.Fprintf(c.Out, "Serverless software version is %s\n\n", minSandboxVersion)
+	fmt.Fprintf(c.Out, "Serverless software version is %s\n\n", do.GetMinSandboxVersion())
 	languages, _ := c.Doit.GetBool(c.NS, "languages")
 	if languages {
 		return showLanguageInfo(c, apiHost)

--- a/commands/sandbox_util.go
+++ b/commands/sandbox_util.go
@@ -26,21 +26,9 @@ import (
 )
 
 const (
-	// Minimum required version of the sandbox plugin code.  The first part is
-	// the version of the incorporated Nimbella CLI and the second part is the
-	// version of the bridge code in the sandbox plugin repository.
-	minSandboxVersion = "4.1.0-1.3.0"
-
-	// The version of nodejs to download alongsize the plugin download.
-	nodeVersion = "v16.13.0"
-
 	// noCapture is the string constant recognized by the plugin.  It suppresses output
 	// capture when in the initial (command) position.
 	noCapture = "nocapture"
-
-	// credsDir is the directory under the sandbox where all credentials are stored.
-	// It in turn has a subdirectory for each access token employed (formed as a prefix of the token).
-	credsDir = "creds"
 )
 
 // SandboxExec executes a sandbox command

--- a/commands/sandbox_util.go
+++ b/commands/sandbox_util.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/digitalocean/doctl/do"
+)
+
+const (
+	// Minimum required version of the sandbox plugin code.  The first part is
+	// the version of the incorporated Nimbella CLI and the second part is the
+	// version of the bridge code in the sandbox plugin repository.
+	minSandboxVersion = "4.1.0-1.3.0"
+
+	// The version of nodejs to download alongsize the plugin download.
+	nodeVersion = "v16.13.0"
+
+	// noCapture is the string constant recognized by the plugin.  It suppresses output
+	// capture when in the initial (command) position.
+	noCapture = "nocapture"
+
+	// credsDir is the directory under the sandbox where all credentials are stored.
+	// It in turn has a subdirectory for each access token employed (formed as a prefix of the token).
+	credsDir = "creds"
+)
+
+// SandboxExec executes a sandbox command
+func SandboxExec(c *CmdConfig, command string, args ...string) (do.SandboxOutput, error) {
+	sandbox := c.Sandbox()
+	err := sandbox.CheckSandboxStatus(hashAccessToken(c))
+	if err != nil {
+		return do.SandboxOutput{}, err
+	}
+	return sandboxExecNoCheck(sandbox, command, args)
+}
+
+func sandboxExecNoCheck(sandbox do.SandboxService, command string, args []string) (do.SandboxOutput, error) {
+	cmd, err := sandbox.Cmd(command, args)
+	if err != nil {
+		return do.SandboxOutput{}, err
+	}
+	return sandbox.Exec(cmd)
+}
+
+// RunSandboxExec is a variant of SandboxExec convenient for calling from stylized command runners
+// Sets up the arguments and (especially) the flags for the actual call
+func RunSandboxExec(command string, c *CmdConfig, booleanFlags []string, stringFlags []string) (do.SandboxOutput, error) {
+	sandbox := c.Sandbox()
+	err := sandbox.CheckSandboxStatus(hashAccessToken(c))
+	if err != nil {
+		return do.SandboxOutput{}, err
+	}
+
+	args := getFlatArgsArray(c, booleanFlags, stringFlags)
+	cmd, err := sandbox.Cmd(command, args)
+	if err != nil {
+		return do.SandboxOutput{}, err
+	}
+
+	return sandbox.Exec(cmd)
+}
+
+// RunSandboxExecStreaming is like RunSandboxExec but assumes that output will not be captured and can be streamed.
+func RunSandboxExecStreaming(command string, c *CmdConfig, booleanFlags []string, stringFlags []string) error {
+	sandbox := c.Sandbox()
+	err := sandbox.CheckSandboxStatus(hashAccessToken(c))
+	if err != nil {
+		return err
+	}
+
+	args := getFlatArgsArray(c, booleanFlags, stringFlags)
+	args = append([]string{command}, args...)
+
+	cmd, err := sandbox.Cmd(noCapture, args)
+	if err != nil {
+		return err
+	}
+	// TODO the following does not filter output.  We might want output filtering as part of
+	// this function.
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return sandbox.Stream(cmd)
+}
+
+// PrintSandboxTextOutput prints the output of a sandbox command execution in a
+// textual form (often, this can be improved upon).
+// Prints Formatted if present.
+// Else, prints Captured if present.
+// Else, prints Table or Entity using generic JSON formatting.
+// We don't expect both Table and Entity to be present and have no
+// special handling for that.
+func (c *CmdConfig) PrintSandboxTextOutput(output do.SandboxOutput) error {
+	var err error
+	if len(output.Formatted) > 0 {
+		_, err = fmt.Fprintln(c.Out, strings.Join(output.Formatted, "\n"))
+	} else if len(output.Captured) > 0 {
+		_, err = fmt.Fprintln(c.Out, strings.Join(output.Captured, "\n"))
+	} else if len(output.Table) > 0 {
+		_, err = fmt.Fprintln(c.Out, genericJSON(output.Table))
+	} else if output.Entity != nil {
+		_, err = fmt.Fprintln(c.Out, genericJSON(output.Entity))
+	} // else no output (unusual but not impossible)
+
+	return err
+}
+
+func hashAccessToken(c *CmdConfig) string {
+	token := c.getContextAccessToken()
+	hasher := sha1.New()
+	hasher.Write([]byte(token))
+	sha := hasher.Sum(nil)
+	return hex.EncodeToString(sha[:4])
+}
+
+// Determines whether the sandbox appears to be connected.  The purpose is
+// to fail fast (when feasible) on sandboxes that are clearly not connected.
+// However, it is important not to add excessive overhead on each call (e.g.
+// asking the plugin to validate credentials), so the test is not foolproof.
+// It merely tests whether a credentials directory has been created for the
+// current doctl access token and appears to have a credentials.json in it.
+func isSandboxConnected(leafCredsDir string, sandboxDir string) bool {
+	creds := do.GetCredentialDirectory(leafCredsDir, sandboxDir)
+	credsFile := filepath.Join(creds, do.CredentialsFile)
+	_, err := os.Stat(credsFile)
+	return !os.IsNotExist(err)
+}
+
+// Converts something "object-like" but untyped to generic JSON
+// Designed for human eyes; does not provide an explicit error
+// result
+func genericJSON(toFormat interface{}) string {
+	bytes, err := json.MarshalIndent(&toFormat, "", "  ")
+	if err != nil {
+		return "<not representable as JSON>"
+	}
+	return string(bytes)
+}
+
+// Convert the actual args, the boolean flags, and the string flags for a command
+// into a flat array which are passed to the plugin as 'args'.
+func getFlatArgsArray(c *CmdConfig, booleanFlags []string, stringFlags []string) []string {
+	args := append([]string{}, c.Args...)
+	for _, flag := range booleanFlags {
+		truth, err := c.Doit.GetBool(c.NS, flag)
+		if truth && err == nil {
+			args = append(args, "--"+flag)
+		}
+	}
+	for _, flag := range stringFlags {
+		value, err := c.Doit.GetString(c.NS, flag)
+		if err == nil && len(value) > 0 {
+			args = append(args, "--"+flag, value)
+		}
+	}
+
+	return args
+}
+
+// getSandboxDirectory returns the "sandbox" directory in which the artifacts for sandbox support
+// are stored.  Returns the name of the directory whether or not it exists.  The standard location
+// (and the only one that customers are expected to use) is relative to the defaultConfigHome.
+func getSandboxDirectory() string {
+	return filepath.Join(defaultConfigHome(), "sandbox")
+}

--- a/do/mocks/SandboxService.go
+++ b/do/mocks/SandboxService.go
@@ -36,6 +36,20 @@ func (m *MockSandboxService) EXPECT() *MockSandboxServiceMockRecorder {
 	return m.recorder
 }
 
+// CheckSandboxStatus mocks base method.
+func (m *MockSandboxService) CheckSandboxStatus(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckSandboxStatus", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckSandboxStatus indicates an expected call of CheckSandboxStatus.
+func (mr *MockSandboxServiceMockRecorder) CheckSandboxStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckSandboxStatus", reflect.TypeOf((*MockSandboxService)(nil).CheckSandboxStatus), arg0)
+}
+
 // Cmd mocks base method.
 func (m *MockSandboxService) Cmd(arg0 string, arg1 []string) (*exec.Cmd, error) {
 	m.ctrl.T.Helper()
@@ -94,6 +108,20 @@ func (m *MockSandboxService) GetSandboxNamespace(arg0 context.Context) (do.Sandb
 func (mr *MockSandboxServiceMockRecorder) GetSandboxNamespace(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSandboxNamespace", reflect.TypeOf((*MockSandboxService)(nil).GetSandboxNamespace), arg0)
+}
+
+// InstallSandbox mocks base method.
+func (m *MockSandboxService) InstallSandbox(arg0 string, arg1 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallSandbox", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallSandbox indicates an expected call of InstallSandbox.
+func (mr *MockSandboxServiceMockRecorder) InstallSandbox(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallSandbox", reflect.TypeOf((*MockSandboxService)(nil).InstallSandbox), arg0, arg1)
 }
 
 // Stream mocks base method.

--- a/do/sandbox.go
+++ b/do/sandbox.go
@@ -17,13 +17,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
+	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/pkg/extract"
 	"github.com/digitalocean/godo"
 )
 
@@ -98,20 +103,48 @@ type SandboxService interface {
 	GetSandboxNamespace(context.Context) (SandboxCredentials, error)
 	WriteCredentials(SandboxCredentials) error
 	GetHostInfo(string) (ServerlessHostInfo, error)
+	CheckSandboxStatus(string) error
+	InstallSandbox(string, bool) error
 }
 
 type sandboxService struct {
-	sandboxJs string
-	credsDir  string // note: this was misleadingly named sandboxDir previously
-	node      string
-	userAgent string
-	client    *godo.Client
+	sandboxJs  string
+	sandboxDir string
+	credsDir   string
+	node       string
+	userAgent  string
+	client     *godo.Client
 }
 
-// CredentialsFile is the name of the file where the sandbox plugin stores OpenWhisk credentials.
-const CredentialsFile = "credentials.json"
+const (
+	// Minimum required version of the sandbox plugin code.  The first part is
+	// the version of the incorporated Nimbella CLI and the second part is the
+	// version of the bridge code in the sandbox plugin repository.
+	minSandboxVersion = "4.1.0-1.3.0"
+
+	// The version of nodejs to download alongsize the plugin download.
+	nodeVersion = "v16.13.0"
+
+	// credsDir is the directory under the sandbox where all credentials are stored.
+	// It in turn has a subdirectory for each access token employed (formed as a prefix of the token).
+	credsDir = "creds"
+
+	// CredentialsFile is the name of the file where the sandbox plugin stores OpenWhisk credentials.
+	CredentialsFile = "credentials.json"
+)
 
 var _ SandboxService = &sandboxService{}
+
+var (
+	// ErrSandboxNotInstalled is the error returned to users when the sandbox is not installed.
+	ErrSandboxNotInstalled = errors.New("Serverless support is not installed (use `doctl serverless install`)")
+
+	// ErrSandboxNeedsUpgrade is the error returned to users when the sandbox is at too low a version
+	ErrSandboxNeedsUpgrade = errors.New("Serverless support needs to be upgraded (use `doctl serverless upgrade`)")
+
+	// ErrSandboxNotConnected is the error returned to users when the sandbox is not connected to a namespace
+	ErrSandboxNotConnected = errors.New("Serverless support is installed but not connected to a functions namespace (use `doctl serverless connect`)")
+)
 
 // SandboxOutput contains the output returned from calls to the sandbox plugin.
 type SandboxOutput struct {
@@ -123,21 +156,183 @@ type SandboxOutput struct {
 }
 
 // NewSandboxService returns a configured SandboxService.
-func NewSandboxService(sandboxJs string, credsDir string, node string, userAgent string, client *godo.Client) SandboxService {
+func NewSandboxService(client *godo.Client, sandboxDir string, credsToken string) SandboxService {
+	nodeBin := "node"
+	if runtime.GOOS == "windows" {
+		nodeBin = "node.exe"
+	}
 	return &sandboxService{
-		sandboxJs: sandboxJs,
-		credsDir:  credsDir,
-		node:      node,
-		userAgent: userAgent,
-		client:    client,
+		sandboxJs:  filepath.Join(sandboxDir, "sandbox.js"),
+		sandboxDir: sandboxDir,
+		credsDir:   GetCredentialDirectory(credsToken, sandboxDir),
+		node:       filepath.Join(sandboxDir, nodeBin),
+		userAgent:  fmt.Sprintf("doctl/%s serverless/%s", doctl.DoitVersion.String(), minSandboxVersion),
+		client:     client,
 	}
 }
 
+func (s *sandboxService) CheckSandboxStatus(leafCredsDir string) error {
+	_, err := os.Stat(s.sandboxDir)
+	if os.IsNotExist(err) {
+		return ErrSandboxNotInstalled
+	}
+	if !sandboxUptodate(s.sandboxDir) {
+		return ErrSandboxNeedsUpgrade
+	}
+	if !isSandboxConnected(leafCredsDir, s.sandboxDir) {
+		return ErrSandboxNotConnected
+	}
+	return nil
+}
+
+// InstallSandbox is the common subroutine for both serverless install and serverless upgrade
+func (s *sandboxService) InstallSandbox(leafCredsDir string, upgrading bool) error {
+	sandboxDir := s.sandboxDir
+
+	// Make a temporary directory for use during the install.
+	// Note: we don't let this be allocated in the system temporaries area because
+	// that might be on a separate file system, meaning that the final install step
+	// will require an additional copy rather than a simple rename.
+
+	tmp, err := ioutil.TempDir(filepath.Dir(sandboxDir), "sbx-install")
+	if err != nil {
+		return err
+	}
+
+	// Download the nodejs tarball for this os and architecture
+	fmt.Print("Downloading...")
+
+	goos := runtime.GOOS
+	arch := runtime.GOARCH
+	nodeBin := "node"
+	if arch == "amd64" {
+		arch = "x64"
+	}
+	if arch == "386" {
+		if goos == "linux" {
+			return errors.New("serverless support is not available for 32-bit linux")
+		}
+		arch = "x86"
+	}
+	if goos == "windows" {
+		goos = "win"
+		nodeBin = "node.exe"
+	}
+
+	var (
+		nodeURL      string
+		nodeFileName string
+		nodeDir      string
+	)
+
+	// Download nodejs only if necessary
+	if !upgrading || !canReuseNode(sandboxDir, nodeBin) {
+		nodeDir = fmt.Sprintf("node-%s-%s-%s", nodeVersion, goos, arch)
+		nodeURL = fmt.Sprintf("https://nodejs.org/dist/%s/%s.tar.gz", nodeVersion, nodeDir)
+		nodeFileName = filepath.Join(tmp, "node-install.tar.gz")
+
+		if goos == "win" {
+			nodeURL = fmt.Sprintf("https://nodejs.org/dist/%s/%s.zip", nodeVersion, nodeDir)
+			nodeFileName = filepath.Join(tmp, "node-install.zip")
+		}
+
+		err = download(nodeURL, nodeFileName)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Download the fat tarball with the nim CLI, deployer, and sandbox bridge
+	// TODO do these need to be arch-specific?  Currently assuming not.
+	URL := fmt.Sprintf("https://do-serverless-tools.nyc3.digitaloceanspaces.com/doctl-sandbox-%s.tar.gz",
+		GetMinSandboxVersion())
+	sandboxFileName := filepath.Join(tmp, "doctl-sandbox.tar.gz")
+	err = download(URL, sandboxFileName)
+	if err != nil {
+		return err
+	}
+
+	// Exec the Extract utility at least once to unpack the fat tarball and possibly a second time if
+	// node was downloaded.  If node was not downloaded, just move the existing binary into place.
+	fmt.Print("Unpacking...")
+	err = extract.Extract(sandboxFileName, tmp)
+	if err != nil {
+		return err
+	}
+
+	if nodeFileName != "" {
+		err = extract.Extract(nodeFileName, tmp)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Move artifacts to final location
+	fmt.Print("Installing...")
+	srcPath := filepath.Join(tmp, "sandbox")
+	if upgrading {
+		// Preserve credentials by moving them from target (which will be replaced) to source.
+		err = PreserveCreds(leafCredsDir, srcPath, sandboxDir)
+		if err != nil {
+			return err
+		}
+		// Preserve existing node if necessary
+		if nodeFileName == "" {
+			// Node was not downloaded
+			err = moveExistingNode(sandboxDir, srcPath, nodeBin)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		// Make new empty credentials directory
+		emptyCreds := filepath.Join(srcPath, credsDir)
+		err = os.MkdirAll(emptyCreds, 0700)
+		if err != nil {
+			return nil
+		}
+
+		// Create the sandbox directory if necessary.
+		err := os.MkdirAll(sandboxDir, 0755)
+		if err != nil {
+			return err
+		}
+	}
+	// Remove former sandboxDir before moving in the new one
+	err = os.RemoveAll(sandboxDir)
+	if err != nil {
+		return err
+	}
+	err = os.Rename(srcPath, sandboxDir)
+	if err != nil {
+		return err
+	}
+
+	if nodeFileName != "" {
+		if goos == "win" {
+			srcPath = filepath.Join(tmp, nodeDir, nodeBin)
+		} else {
+			// Additional nesting in non-windows case
+			srcPath = filepath.Join(tmp, nodeDir, "bin", nodeBin)
+		}
+		destPath := filepath.Join(sandboxDir, nodeBin)
+		err = os.Rename(srcPath, destPath)
+		if err != nil {
+			return err
+		}
+	}
+	// Clean up temp directory
+	fmt.Print("Cleaning up...")
+	os.RemoveAll(tmp) // Best effort, ignore error
+	fmt.Println("\nDone")
+	return nil
+}
+
 // Cmd builds an *exec.Cmd for calling into the sandbox plugin.
-func (n *sandboxService) Cmd(command string, args []string) (*exec.Cmd, error) {
-	args = append([]string{n.sandboxJs, command}, args...)
-	cmd := exec.Command(n.node, args...)
-	cmd.Env = append(os.Environ(), "NIMBELLA_DIR="+n.credsDir, "NIM_USER_AGENT="+n.userAgent)
+func (s *sandboxService) Cmd(command string, args []string) (*exec.Cmd, error) {
+	args = append([]string{s.sandboxJs, command}, args...)
+	cmd := exec.Command(s.node, args...)
+	cmd.Env = append(os.Environ(), "NIMBELLA_DIR="+s.credsDir, "NIM_USER_AGENT="+s.userAgent)
 	// If DEBUG is specified, we need to open up stderr for that stream.  The stdout stream
 	// will continue to work for returning structured results.
 	if os.Getenv("DEBUG") != "" {
@@ -147,7 +342,7 @@ func (n *sandboxService) Cmd(command string, args []string) (*exec.Cmd, error) {
 }
 
 // Exec executes an *exec.Cmd and captures its output in a SandboxOutput.
-func (n *sandboxService) Exec(cmd *exec.Cmd) (SandboxOutput, error) {
+func (s *sandboxService) Exec(cmd *exec.Cmd) (SandboxOutput, error) {
 	output, err := cmd.Output()
 	if err != nil {
 		// Ignore "errors" that are just non-zero exit.  The
@@ -175,21 +370,21 @@ func (n *sandboxService) Exec(cmd *exec.Cmd) (SandboxOutput, error) {
 }
 
 // Stream is like Exec but assumes that output will not be captured and can be streamed.
-func (n *sandboxService) Stream(cmd *exec.Cmd) error {
+func (s *sandboxService) Stream(cmd *exec.Cmd) error {
 
 	return cmd.Run()
 }
 
 // GetSandboxNamespace returns the credentials of the one sandbox namespace assigned to
 // the invoking doctl context.
-func (n *sandboxService) GetSandboxNamespace(ctx context.Context) (SandboxCredentials, error) {
+func (s *sandboxService) GetSandboxNamespace(ctx context.Context) (SandboxCredentials, error) {
 	path := "v2/functions/sandbox"
-	req, err := n.client.NewRequest(ctx, http.MethodPost, path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
 	if err != nil {
 		return SandboxCredentials{}, err
 	}
 	decoded := new(namespacesResponseBody)
-	_, err = n.client.Do(ctx, req, decoded)
+	_, err = s.client.Do(ctx, req, decoded)
 	if err != nil {
 		return SandboxCredentials{}, err
 	}
@@ -205,7 +400,7 @@ func (n *sandboxService) GetSandboxNamespace(ctx context.Context) (SandboxCreden
 }
 
 // GetHostInfo returns the HostInfo structure of the provided API host
-func (n *sandboxService) GetHostInfo(APIHost string) (ServerlessHostInfo, error) {
+func (s *sandboxService) GetHostInfo(APIHost string) (ServerlessHostInfo, error) {
 	endpoint := APIHost + "/api/v1"
 	resp, err := http.Get(endpoint)
 	if err != nil {
@@ -237,17 +432,134 @@ func assignAPIHost(origAPIHost string, namespace string) string {
 }
 
 // WriteCredentials writes a set of serverless credentials to the appropriate 'creds' directory
-func (n *sandboxService) WriteCredentials(creds SandboxCredentials) error {
+func (s *sandboxService) WriteCredentials(creds SandboxCredentials) error {
 	// Create the directory into which the file will be written.
-	err := os.MkdirAll(n.credsDir, 0700)
+	err := os.MkdirAll(s.credsDir, 0700)
 	if err != nil {
 		return err
 	}
 	// Write the credentials
-	credsPath := filepath.Join(n.credsDir, CredentialsFile)
+	credsPath := filepath.Join(s.credsDir, CredentialsFile)
 	bytes, err := json.MarshalIndent(&creds, "", "  ")
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(credsPath, bytes, 0600)
+}
+
+// Determines whether the sandbox appears to be connected.  The purpose is
+// to fail fast (when feasible) on sandboxes that are clearly not connected.
+// However, it is important not to add excessive overhead on each call (e.g.
+// asking the plugin to validate credentials), so the test is not foolproof.
+// It merely tests whether a credentials directory has been created for the
+// current doctl access token and appears to have a credentials.json in it.
+func isSandboxConnected(leafCredsDir string, sandboxDir string) bool {
+	creds := GetCredentialDirectory(leafCredsDir, sandboxDir)
+	credsFile := filepath.Join(creds, CredentialsFile)
+	_, err := os.Stat(credsFile)
+	return !os.IsNotExist(err)
+}
+
+// sandboxUpToDate answers whether the installed version of the sandbox is at least
+// what is required by doctl
+func sandboxUptodate(sandboxDir string) bool {
+	return GetCurrentSandboxVersion(sandboxDir) >= GetMinSandboxVersion()
+}
+
+// GetCurrentSandboxVersion gets the version of the current sandbox.
+// To be called only when sandbox is known to exist.
+// Returns "0" if the installed sandbox pre-dates the versioning system
+// Otherwise, returns the version string stored in the sandbox directory.
+func GetCurrentSandboxVersion(sandboxDir string) string {
+	versionFile := filepath.Join(sandboxDir, "version")
+	contents, err := ioutil.ReadFile(versionFile)
+	if err != nil {
+		return "0"
+	}
+	return string(contents)
+}
+
+// GetMinSandboxVersion returns the minSandboxVersion (allows the constant to be overridden via an environment variable)
+func GetMinSandboxVersion() string {
+	fromEnv := os.Getenv("minSandboxVersion")
+	if fromEnv != "" {
+		return fromEnv
+	}
+	return minSandboxVersion
+}
+
+// GetCredentialDirectory returns the directory in which credentials should be stored for a given
+// CmdConfig.  The actual leaf directory is a function of the access token being used.  This ties
+// sandbox credentials to DO credentials
+func GetCredentialDirectory(leafDir string, sandboxDir string) string {
+	return filepath.Join(sandboxDir, credsDir, leafDir)
+}
+
+// Gets the version of the node binary in the sandbox.  Determine if it is
+// usable or whether it has to be upgraded.
+func canReuseNode(sandboxDir string, nodeBin string) bool {
+	fullNodeBin := filepath.Join(sandboxDir, nodeBin)
+	cmd := exec.Command(fullNodeBin, "--version")
+	result, err := cmd.Output()
+	if err == nil {
+		installed := strings.TrimSpace(string(result))
+		return installed == nodeVersion
+	}
+	return false
+}
+
+// Moves the existing node binary from the sandbox that contains it to the new sandbox being
+// staged during an upgrade.  This preserves it for reuse and avoids the need to download.
+func moveExistingNode(existing string, staging string, nodeBin string) error {
+	srcPath := filepath.Join(existing, nodeBin)
+	destPath := filepath.Join(staging, nodeBin)
+	return os.Rename(srcPath, destPath)
+}
+
+// Download a network file to a local file
+func download(URL, targetFile string) error {
+	response, err := http.Get(URL)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		return fmt.Errorf("Received status code %d attempting to download from %s",
+			response.StatusCode, URL)
+	}
+	file, err := os.Create(targetFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = io.Copy(file, response.Body)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// PreserveCreds preserves existing credentials in a sandbox directory
+// that is about to be replaced by moving them to the staging directory
+// containing the replacement.
+func PreserveCreds(leafDir string, stagingDir string, sandboxDir string) error {
+	credPath := filepath.Join(sandboxDir, credsDir)
+	relocPath := filepath.Join(stagingDir, credsDir)
+	err := os.Rename(credPath, relocPath)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	// There was no creds directory.  Check for legacy form and convert as part
+	// of preserving.
+	legacyCredPath := filepath.Join(sandboxDir, ".nimbella")
+	err = os.MkdirAll(relocPath, 0700)
+	if err != nil {
+		return err
+	}
+	moveLegacyTo := GetCredentialDirectory(leafDir, stagingDir)
+	return os.Rename(legacyCredPath, moveLegacyTo)
 }


### PR DESCRIPTION
The `SandboxService` is our abstraction of the serverless capabilities for mocking and testing purposes.  

The original version of this abstraction left out status checking and installation, leaving some serverless code paths to be abstracted directly in `CmdConfig`, outside the abstraction boundary.   We worked around this deviation for testing purposes, but it creates a conflict going forward because the service itself only partly separates serverless concerns from other concerns. 

Specifically, we are about to temporarily complicate the service, giving it a direct path to the functions backend cluster, as part of an effort to reduce dependence on the plugin for serverless capabilities (ultimately, it should get simplified again as serverless APIs are regularized, but this will take time).

I did not want to continue the practice of complicating `CmdConfig` as the serverless path goes through a series of non-trivial changes.   So, this change attempts to move installation and status checking from the `commands` package to the `do` package where they become part of `SandboxService`.   

There is a fair amount of code relocation in this PR but it is conceptually simple.   I did make an orthogonal split of `commands/sandbox.go` to put its utility functions (those that were not relocated to `do`) in a separate source file.  I did not make the corresponding split in `do/sandbox.go`.

Small warts are left: `do` cannot depend on `commands` because that creates a circularity, but `commands` is where the current access token is kept as well as the conventions for finding the config directory.   This is dealt with in the initialization of the service and in the signatures of some functions.

In this change I dropped support for the `OVERRIDE_SANDBOX_DIR` environment variable because it unduly complicated the coding and has never actually been used in testing.  The installation and upgrade tests in `doctl-sandbox-plugin` run under a github action in a clean container.   Even for manual testing during development, since the sandbox area contains no mutable state other than the latest connected namespace, it is no problem in practice to delete and recreate it.