### PR TITLE
Support multiple namespaces

### DIFF
--- a/commands/displayers/namespaces.go
+++ b/commands/displayers/namespaces.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package displayers
+
+import (
+	"io"
+
+	"github.com/digitalocean/doctl/do"
+)
+
+// Namespaces is the type of the displayer for namespaces list
+type Namespaces struct {
+	Info []do.OutputNamespace
+}
+
+var _ Displayable = &Namespaces{}
+
+// JSON is the displayer JSON method specialized for namespaces list
+func (i *Namespaces) JSON(out io.Writer) error {
+	return writeJSON(i.Info, out)
+}
+
+// Cols is the displayer Cols method specialized for namespaces list
+func (i *Namespaces) Cols() []string {
+	return []string{
+		"Label", "Region", "ID", "Host",
+	}
+}
+
+// ColMap is the displayer ColMap method specialized for namespaces list
+func (i *Namespaces) ColMap() map[string]string {
+	return map[string]string{
+		"Label":  "Label",
+		"Region": "Region",
+		"ID":     "Namespace ID",
+		"Host":   "API Host",
+	}
+}
+
+// KV is the displayer KV method specialized for namespaces list
+func (i *Namespaces) KV() []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(i.Info))
+	for _, ii := range i.Info {
+		x := map[string]interface{}{
+			"Label":  ii.Label,
+			"Region": ii.Region,
+			"ID":     ii.Namespace,
+			"Host":   ii.APIHost,
+		}
+		out = append(out, x)
+	}
+
+	return out
+}

--- a/commands/namespaces.go
+++ b/commands/namespaces.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/commands/displayers"
+	"github.com/digitalocean/doctl/do"
+	"github.com/spf13/cobra"
+)
+
+// validRegions provides the list of regions and datacenters where namespaces may be created.
+// Note that AP and Functions share the same list of regions but Functions are availble in only
+// one datacenter per region, so we're using our own static list for the moment (AP has a dynamic
+// list that can be interrogated once we have a reliable dynamic way of distinguishing which datacenters
+// actually host Functions).
+var validRegions = map[string]string{
+	"ams": "ams3", "blr": "blr1", "fra": "fra1", "lon": "lon1",
+	"nyc": "nyc1", "sfo": "sfo3", "sgp": "sgp1", "tor": "tor1",
+}
+
+// Namespaces generates the serverless 'namespaces' subtree for addition to the doctl command
+func Namespaces() *Command {
+	cmd := &Command{
+		Command: &cobra.Command{
+			Use:   "namespaces",
+			Short: "Manage your functions namespaces",
+			Long: `Functions namespaces (in the cloud) contain the result of deploying packages and functions with ` + "`" + `doctl serverless deploy` + "`" + `.
+The subcommands of ` + "`" + `doctl serverless namespaces` + "`" + ` are used to manage multiple functions namespaces within your account.
+Use ` + "`" + `doctl serverless connect` + "`" + ` with an explicit argument to connect to a specific namespace.  You are connected to one namespace at a time.`,
+			Aliases: []string{"ns"},
+			Hidden:  true, // multiple namespace support is guarded by a feature flipper
+		},
+	}
+	create := CmdBuilder(cmd, RunNamespacesCreate, "create", "Creates a namespace",
+		``+"`"+`Use `+"`"+`doctl serverless namespaces create`+"`"+` to create a new functions namespace.
+Both a region and a label must be specified.`,
+		Writer)
+	AddStringFlag(create, "region", "r", "", "the region for the namespace", requiredOpt())
+	AddStringFlag(create, "label", "l", "", "the label for the namespace", requiredOpt())
+	AddBoolFlag(create, "no-connect", "n", false, "don't immediately connect to the created namespace")
+
+	delete := CmdBuilder(cmd, RunNamespacesDelete, "delete <namespaceIdOrLabel>", "Deletes a namespace",
+		`Use `+"`"+`doctl serverless namespaces delete`+"`"+` to delete a functions namespace.
+The full label or full id of the namespace is required as an argument.
+You are prompted for confirmation unless `+"`"+`--force`+"`"+` is specified.`,
+		Writer)
+	AddBoolFlag(delete, "force", "f", false, "Just do it, omitting confirmatory prompt")
+
+	CmdBuilder(cmd, RunNamespacesList, "list", "Lists your namespaces",
+		`Use `+"`"+`doctl serverless namespaces list`+"`"+` to list your functions namespaces.`,
+		Writer, displayerType(&displayers.Namespaces{}))
+
+	CmdBuilder(cmd, RunNamespacesListRegions, "list-regions", "Lists the accepted 'region' values",
+		`Use `+"`"+`doctl serverless namespaces list-regions`+"`"+` to list the values that are accepted
+in the `+"`"+`--region`+"`"+` flag of `+"`"+`doctl serverless namespaces create`+"`"+`.`,
+		Writer)
+	return cmd
+}
+
+// RunNamespacesCreate supports the 'serverless namespaces create' command
+func RunNamespacesCreate(c *CmdConfig) error {
+	label, _ := c.Doit.GetString(c.NS, "label")
+	region, _ := c.Doit.GetString(c.NS, "region")
+	skipConnect, _ := c.Doit.GetBool(c.NS, "no-connect")
+	if label == "" || region == "" {
+		return fmt.Errorf("the '--label' and '--region' flags are both required")
+	}
+	validRegion := getValidRegion(region)
+	if validRegion == "" {
+		fmt.Fprintf(c.Out, "Valid region values are %+v\n", getValidRegions())
+		return fmt.Errorf("'%s' is not a valid region value", region)
+	}
+	ss := c.Serverless()
+	ctx := context.TODO()
+	uniq, err := isLabelUnique(ctx, ss, label)
+	if err != nil {
+		return err
+	}
+	if !uniq {
+		return fmt.Errorf("you are using  label '%s' for another namespace; labels should be unique", label)
+	}
+	if !skipConnect && ss.CheckServerlessStatus(hashAccessToken(c)) == do.ErrServerlessNotInstalled {
+		skipConnect = true
+		fmt.Fprintln(c.Out, "Warning: namespace will be created but not connected (serverless software is not installed)")
+	}
+	creds, err := ss.CreateNamespace(ctx, label, validRegion)
+	if err != nil {
+		return err
+	}
+	if skipConnect {
+		fmt.Fprintf(c.Out, "New namespace %s created, but not connected.\n", creds.Namespace)
+		return nil
+	}
+	err = ss.WriteCredentials(creds)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(c.Out, "Connected to functions namespace '%s' on API host '%s'\n", creds.Namespace, creds.APIHost)
+	return nil
+}
+
+// RunNamespacesDelete supports the 'serverless namespaces delete' command
+func RunNamespacesDelete(c *CmdConfig) error {
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
+	}
+	arg := c.Args[0]
+	ss := c.Serverless()
+	ctx := context.TODO()
+	// Since arg may be either a label or an id, match against existing namespaces
+	var (
+		id    string
+		label string
+	)
+	matches, err := getMatchingNamespaces(ctx, ss, arg)
+	if err != nil {
+		return err
+	}
+	if len(matches) > 0 {
+		id = matches[0].Namespace
+		label = matches[0].Label
+	}
+	// Must be an exact match though (avoids errors).
+	if len(matches) != 1 || (arg != label && arg != id) {
+		return fmt.Errorf("'%s' does not correspond to any of your namespaces", arg)
+	}
+	force, _ := c.Doit.GetBool(c.NS, "force")
+	if !force {
+		fmt.Fprintf(c.Out, "Deleting namespace '%s' with label '%s'.\n", id, label)
+		if AskForConfirmDelete("namespace", 1) != nil {
+			return fmt.Errorf("deletion of '%s' not confirmed, doing nothing", id)
+		}
+	}
+	err = ss.DeleteNamespace(ctx, id)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(c.Out, "Namespace successfully deleted")
+	return nil
+}
+
+// RunNamespacesList supports the 'serverless namespaces list' command
+func RunNamespacesList(c *CmdConfig) error {
+	if len(c.Args) > 0 {
+		return doctl.NewTooManyArgsErr(c.NS)
+	}
+	list, err := c.Serverless().ListNamespaces(context.TODO())
+	if err != nil {
+		return err
+	}
+	return c.Display(&displayers.Namespaces{Info: list.Namespaces})
+}
+
+// RunNamespacesListRegions supports the 'serverless namespaces list-regions' command
+func RunNamespacesListRegions(c *CmdConfig) error {
+	if len(c.Args) > 0 {
+		return doctl.NewTooManyArgsErr(c.NS)
+	}
+	fmt.Fprintf(c.Out, "%+v\n", getValidRegions())
+	return nil
+}
+
+// getValidRegions returns all the region values that are accepted (region slugs and datacanter slugs)
+func getValidRegions() []string {
+	vrs := make([]string, len(validRegions)*2)
+	i := 0
+	for k, v := range validRegions {
+		vrs[i] = k
+		vrs[i+1] = v
+		i += 2
+	}
+	return vrs
+}
+
+// isLabelUnique tests that a label value is unique (not used for any other namespace in the same
+// account).
+func isLabelUnique(ctx context.Context, ss do.ServerlessService, label string) (bool, error) {
+	resp, err := ss.ListNamespaces(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, ns := range resp.Namespaces {
+		if label == ns.Label {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// getValidRegion returns a valid region value for the API (a four-letter datacenter slug) given either
+// a datacenter slug a three-letter region slug).  Functions are offered in one data center per region.
+// The empty string is returned if the value is invalid.
+func getValidRegion(value string) string {
+	if len(value) == 3 {
+		return validRegions[value]
+	}
+	if len(value) != 4 {
+		return ""
+	}
+	for _, dc := range validRegions {
+		if value == dc {
+			return value
+		}
+	}
+	return ""
+}
+
+// get the Namespaces that match a pattern, where the "pattern" has no wildcards but can be a
+// prefix, infix, or suffix match to a namespace ID or label.
+func getMatchingNamespaces(ctx context.Context, ss do.ServerlessService, pattern string) ([]do.OutputNamespace, error) {
+	ans := []do.OutputNamespace{}
+	list, err := ss.ListNamespaces(ctx)
+	if err != nil {
+		return ans, err
+	}
+	if pattern == "" {
+		return list.Namespaces, nil
+	}
+	for _, ns := range list.Namespaces {
+		if strings.Contains(ns.Namespace, pattern) || strings.Contains(ns.Label, pattern) {
+			ans = append(ans, ns)
+		}
+	}
+	return ans, nil
+}

--- a/commands/namespaces.go
+++ b/commands/namespaces.go
@@ -16,6 +16,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/digitalocean/doctl"
@@ -25,7 +26,7 @@ import (
 )
 
 // validRegions provides the list of regions and datacenters where namespaces may be created.
-// Note that AP and Functions share the same list of regions but Functions are availble in only
+// Note that AP and Functions share the same list of regions but Functions are available in only
 // one datacenter per region, so we're using our own static list for the moment (AP has a dynamic
 // list that can be interrogated once we have a reliable dynamic way of distinguishing which datacenters
 // actually host Functions).
@@ -186,6 +187,7 @@ func getValidRegions() []string {
 		vrs[i+1] = v
 		i += 2
 	}
+	sort.Strings(vrs)
 	return vrs
 }
 
@@ -205,7 +207,7 @@ func isLabelUnique(ctx context.Context, ss do.ServerlessService, label string) (
 }
 
 // getValidRegion returns a valid region value for the API (a four-letter datacenter slug) given either
-// a datacenter slug a three-letter region slug).  Functions are offered in one data center per region.
+// a datacenter slug or a three-letter region slug.  Functions are offered in one data center per region.
 // The empty string is returned if the value is invalid.
 func getValidRegion(value string) string {
 	if len(value) == 3 {

--- a/commands/namespaces.go
+++ b/commands/namespaces.go
@@ -140,7 +140,7 @@ func RunNamespacesDelete(c *CmdConfig) error {
 	}
 	// Must be an exact match though (avoids errors).
 	if len(matches) != 1 || (arg != label && arg != id) {
-		return fmt.Errorf("'%s' does not correspond to any of your namespaces", arg)
+		return fmt.Errorf("'%s' does not exactly match the label or id of any of your namespaces", arg)
 	}
 	force, _ := c.Doit.GetBool(c.NS, "force")
 	if !force {

--- a/commands/namespaces_test.go
+++ b/commands/namespaces_test.go
@@ -139,3 +139,47 @@ func TestNamespacesCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestNamespacesListRegions(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		buf := &bytes.Buffer{}
+		config.Out = buf
+
+		expectedOutput := "[ams ams3 blr blr1 fra fra1 lon lon1 nyc nyc1 sfo sfo3 sgp sgp1 tor tor1]\n"
+
+		err := RunNamespacesListRegions(config)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedOutput, buf.String())
+	})
+}
+
+func TestNamespacesList(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		buf := &bytes.Buffer{}
+		config.Out = buf
+
+		returnedList := do.NamespaceListResponse{Namespaces: []do.OutputNamespace{
+			do.OutputNamespace{
+				Label:     "my_dog",
+				Namespace: "ns1",
+				Region:    "lon1",
+				APIHost:   "https://lon1.example.com",
+			},
+			do.OutputNamespace{
+				Label:     "something",
+				Namespace: "ns2",
+				Region:    "sgp1",
+				APIHost:   "https://sgp1.example.com",
+			},
+		}}
+		expectedOutput := "Label        Region    Namespace ID    API Host\nmy_dog       lon1      ns1             https://lon1.example.com\nsomething    sgp1      ns2             https://sgp1.example.com\n"
+
+		tm.serverless.EXPECT().ListNamespaces(context.TODO()).Return(returnedList, nil)
+
+		err := RunNamespacesList(config)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedOutput, buf.String())
+	})
+}

--- a/commands/namespaces_test.go
+++ b/commands/namespaces_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/digitalocean/doctl/do"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamespacesCommand(t *testing.T) {
+	cmd := Namespaces()
+	assert.NotNil(t, cmd)
+	expected := []string{"create", "delete", "list", "list-regions"}
+
+	names := []string{}
+	for _, c := range cmd.Commands() {
+		names = append(names, c.Name())
+	}
+
+	sort.Strings(expected)
+	sort.Strings(names)
+	assert.Equal(t, expected, names)
+}
+
+func TestNamespacesCreate(t *testing.T) {
+	tests := []struct {
+		name           string
+		doctlFlags     map[string]interface{}
+		expectedOutput string
+		expectedError  error
+		expectList     bool
+		willConnect    bool
+	}{
+		{
+			name:          "no flags",
+			expectedError: errors.New("the '--label' and '--region' flags are both required"),
+		},
+		{
+			name: "invalid region",
+			doctlFlags: map[string]interface{}{
+				"label":  "my_dog",
+				"region": "dog",
+			},
+			expectedError: errors.New("'dog' is not a valid region value"),
+		},
+		{
+			name: "legal flags, with no-connect",
+			doctlFlags: map[string]interface{}{
+				"label":      "something",
+				"region":     "lon",
+				"no-connect": true,
+			},
+			expectedOutput: "New namespace hello created, but not connected.\n",
+			expectList:     true,
+		},
+		{
+			name: "legal flags, with label conflict",
+			doctlFlags: map[string]interface{}{
+				"label":  "my_dog",
+				"region": "lon",
+			},
+			expectList:    true,
+			expectedError: errors.New("you are using  label 'my_dog' for another namespace; labels should be unique"),
+		},
+		{
+			name: "legal flags, should connect",
+			doctlFlags: map[string]interface{}{
+				"label":  "something",
+				"region": "lon",
+			},
+			expectList:     true,
+			willConnect:    true,
+			expectedOutput: "Connected to functions namespace 'hello' on API host 'https://api.example.com'\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				buf := &bytes.Buffer{}
+				config.Out = buf
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
+
+				ctx := context.TODO()
+				if tt.expectList {
+					initialList := do.NamespaceListResponse{Namespaces: []do.OutputNamespace{
+						do.OutputNamespace{Label: "my_dog"},
+					}}
+					tm.serverless.EXPECT().ListNamespaces(ctx).Return(initialList, nil)
+				}
+				if tt.willConnect {
+					tm.serverless.EXPECT().CheckServerlessStatus(hashAccessToken(config)).Return(nil)
+					creds := do.ServerlessCredentials{Namespace: "hello", APIHost: "https://api.example.com"}
+					tm.serverless.EXPECT().WriteCredentials(creds).Return(nil)
+				}
+				if tt.expectedError == nil {
+					label := tt.doctlFlags["label"]
+					tm.serverless.EXPECT().CreateNamespace(ctx, label, "lon1").Return(do.ServerlessCredentials{
+						Namespace: "hello",
+						APIHost:   "https://api.example.com",
+					}, nil)
+				}
+
+				err := RunNamespacesCreate(config)
+				if tt.expectedError != nil {
+					assert.Equal(t, err, tt.expectedError)
+				} else {
+					require.NoError(t, err)
+				}
+				if tt.expectedOutput != "" {
+					assert.Equal(t, tt.expectedOutput, buf.String())
+				}
+			})
+		})
+	}
+}

--- a/commands/namespaces_test.go
+++ b/commands/namespaces_test.go
@@ -128,7 +128,7 @@ func TestNamespacesCreate(t *testing.T) {
 
 				err := RunNamespacesCreate(config)
 				if tt.expectedError != nil {
-					assert.Equal(t, err, tt.expectedError)
+					assert.Equal(t, tt.expectedError, err)
 				} else {
 					require.NoError(t, err)
 				}
@@ -258,7 +258,7 @@ func TestNamespacesDelete(t *testing.T) {
 
 				err := RunNamespacesDelete(config)
 				if tt.expectedError != nil {
-					assert.Equal(t, err, tt.expectedError)
+					assert.Equal(t, tt.expectedError, err)
 				} else {
 					require.NoError(t, err)
 				}

--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -242,9 +242,9 @@ func connectFromList(ctx context.Context, sls do.ServerlessService, list []do.Ou
 	return finishConnecting(sls, creds, ns.Label, out)
 }
 
-// ChoiceReader is the Reader for reading the user's response to the prompt to choose
+// connectChoiceReader is the bufio.Reader for reading the user's response to the prompt to choose
 // a namespace.  It can be replaced for testing.
-var ChoiceReader = os.Stdin
+var connectChoiceReader *bufio.Reader = bufio.NewReader(os.Stdin)
 
 // chooseFromList displays a list of namespaces (label, region, id) assigning each one a number.
 // The user can than respond to a prompt that chooses from the list by number.  The response 'x' is
@@ -253,10 +253,9 @@ func chooseFromList(list []do.OutputNamespace, out io.Writer) do.OutputNamespace
 	for i, ns := range list {
 		fmt.Fprintf(out, "%d: %s in %s, label=%s\n", i, ns.Namespace, ns.Region, ns.Label)
 	}
-	reader := bufio.NewReader(ChoiceReader)
 	for {
 		fmt.Fprintln(out, "Choose a namespace by number or 'x' to exit")
-		choice, err := reader.ReadString('\n')
+		choice, err := connectChoiceReader.ReadString('\n')
 		if err != nil {
 			continue
 		}

--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -102,6 +102,7 @@ the entire packages are removed.`, Writer)
 
 	cmd.AddCommand(Activations())
 	cmd.AddCommand(Functions())
+	cmd.AddCommand(Namespaces())
 	ServerlessExtras(cmd)
 	return cmd
 }

--- a/commands/serverless_test.go
+++ b/commands/serverless_test.go
@@ -14,12 +14,15 @@ limitations under the License.
 package commands
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/digitalocean/doctl/do"
@@ -41,6 +44,100 @@ func TestServerlessConnect(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "Connected to functions namespace 'hello' on API host 'https://api.example.com'\n\n", buf.String())
 	})
+}
+
+func TestServerlessConnectBeta(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespaceList  []do.OutputNamespace
+		expectedOutput string
+		expectedError  error
+		doctlArg       string
+	}{
+		{
+			name:          "no namespaces",
+			namespaceList: []do.OutputNamespace{},
+			expectedError: errors.New("you must create a namespace with `doctl namespace create`, specifying a region and label"),
+		},
+		{
+			name: "one namespace",
+			namespaceList: []do.OutputNamespace{
+				{
+					Namespace: "ns1",
+					Region:    "nyc1",
+					Label:     "something",
+				},
+			},
+			expectedOutput: "Connected to functions namespace 'ns1' on API host 'https://api.example.com' (label=something)\n\n",
+		},
+		{
+			name: "two namespaces",
+			namespaceList: []do.OutputNamespace{
+				{
+					Namespace: "ns1",
+					Region:    "nyc1",
+					Label:     "something",
+				},
+				{
+					Namespace: "ns2",
+					Region:    "lon1",
+					Label:     "another",
+				},
+			},
+			expectedOutput: "0: ns1 in nyc1, label=something\n1: ns2 in lon1, label=another\nChoose a namespace by number or 'x' to exit\nConnected to functions namespace 'ns1' on API host 'https://api.example.com' (label=something)\n\n",
+		},
+		{
+			name: "use argument",
+			namespaceList: []do.OutputNamespace{
+				{
+					Namespace: "ns1",
+					Region:    "nyc1",
+					Label:     "something",
+				},
+				{
+					Namespace: "ns2",
+					Region:    "lon1",
+					Label:     "another",
+				},
+			},
+			doctlArg:       "thing",
+			expectedOutput: "Connected to functions namespace 'ns1' on API host 'https://api.example.com' (label=something)\n\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				buf := &bytes.Buffer{}
+				config.Out = buf
+				if tt.doctlArg != "" {
+					config.Args = append(config.Args, tt.doctlArg)
+				}
+				config.Doit.Set(config.NS, "beta", true)
+				connectChoiceReader = bufio.NewReader(strings.NewReader("0\n"))
+				nsResponse := do.NamespaceListResponse{Namespaces: tt.namespaceList}
+				creds := do.ServerlessCredentials{Namespace: "ns1", APIHost: "https://api.example.com"}
+
+				tm.serverless.EXPECT().CheckServerlessStatus(hashAccessToken(config)).Return(do.ErrServerlessNotConnected)
+				ctx := context.TODO()
+				tm.serverless.EXPECT().ListNamespaces(ctx).Return(nsResponse, nil)
+				if tt.expectedError == nil {
+					tm.serverless.EXPECT().GetNamespace(ctx, "ns1").Return(creds, nil)
+					tm.serverless.EXPECT().WriteCredentials(creds).Return(nil)
+				}
+
+				err := RunServerlessConnect(config)
+				if tt.expectedError != nil {
+					assert.Equal(t, tt.expectedError, err)
+				} else {
+					require.NoError(t, err)
+				}
+				if tt.expectedOutput != "" {
+					assert.Equal(t, tt.expectedOutput, buf.String())
+				}
+
+			})
+		})
+	}
 }
 
 func TestServerlessStatusWhenConnected(t *testing.T) {

--- a/do/mocks/ServerlessService.go
+++ b/do/mocks/ServerlessService.go
@@ -66,6 +66,35 @@ func (mr *MockServerlessServiceMockRecorder) Cmd(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cmd", reflect.TypeOf((*MockServerlessService)(nil).Cmd), arg0, arg1)
 }
 
+// CreateNamespace mocks base method.
+func (m *MockServerlessService) CreateNamespace(arg0 context.Context, arg1, arg2 string) (do.ServerlessCredentials, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNamespace", arg0, arg1, arg2)
+	ret0, _ := ret[0].(do.ServerlessCredentials)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNamespace indicates an expected call of CreateNamespace.
+func (mr *MockServerlessServiceMockRecorder) CreateNamespace(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockServerlessService)(nil).CreateNamespace), arg0, arg1, arg2)
+}
+
+// DeleteNamespace mocks base method.
+func (m *MockServerlessService) DeleteNamespace(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNamespace", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNamespace indicates an expected call of DeleteNamespace.
+func (mr *MockServerlessServiceMockRecorder) DeleteNamespace(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockServerlessService)(nil).DeleteNamespace), arg0, arg1)
+}
+
 // Exec mocks base method.
 func (m *MockServerlessService) Exec(arg0 *exec.Cmd) (do.ServerlessOutput, error) {
 	m.ctrl.T.Helper()
@@ -127,6 +156,21 @@ func (mr *MockServerlessServiceMockRecorder) GetHostInfo(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostInfo", reflect.TypeOf((*MockServerlessService)(nil).GetHostInfo), arg0)
 }
 
+// GetNamespace mocks base method.
+func (m *MockServerlessService) GetNamespace(arg0 context.Context, arg1 string) (do.ServerlessCredentials, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNamespace", arg0, arg1)
+	ret0, _ := ret[0].(do.ServerlessCredentials)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNamespace indicates an expected call of GetNamespace.
+func (mr *MockServerlessServiceMockRecorder) GetNamespace(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockServerlessService)(nil).GetNamespace), arg0, arg1)
+}
+
 // GetServerlessNamespace mocks base method.
 func (m *MockServerlessService) GetServerlessNamespace(arg0 context.Context) (do.ServerlessCredentials, error) {
 	m.ctrl.T.Helper()
@@ -154,6 +198,21 @@ func (m *MockServerlessService) InstallServerless(arg0 string, arg1 bool) error 
 func (mr *MockServerlessServiceMockRecorder) InstallServerless(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallServerless", reflect.TypeOf((*MockServerlessService)(nil).InstallServerless), arg0, arg1)
+}
+
+// ListNamespaces mocks base method.
+func (m *MockServerlessService) ListNamespaces(arg0 context.Context) (do.NamespaceListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNamespaces", arg0)
+	ret0, _ := ret[0].(do.NamespaceListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNamespaces indicates an expected call of ListNamespaces.
+func (mr *MockServerlessServiceMockRecorder) ListNamespaces(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockServerlessService)(nil).ListNamespaces), arg0)
 }
 
 // ReadCredentials mocks base method.


### PR DESCRIPTION
This change
1. adds the _hidden_ command `doctl serverless namespaces` (alias `ns`) 
2. adds the _hidden_ flag `--beta` to the `doctl serverless connect` command.   Alternative syntax and behavior for this command are enabled by the flag.

These changes enable the new multiple namespaces feature as it will be when released except that
1.  To use these features now requires that you be feature-flipped for `serverless_portal_public_api` .
2. When released, the `namespaces` command will no longer be hidden.
3. When released, the `--beta` flag will be dropped and the behavior guarded by it will become the default behavior.

New commands under `doctl serverless namespaces`:

```
  create       Creates a namespace
  delete       Deletes a namespace
  list         Lists your namespaces
  list-regions Lists the accepted 'region' values

/> doctl sls ns create --help
Use `doctl serverless namespaces create` to create a new functions namespace.
Both a region and a label must be specified.

Usage:
  doctl serverless namespaces create [flags]

Flags:
  -l, --label string    the label for the namespace (required)
  -n, --no-connect      don't immediately connect to the created namespace
  -r, --region string   the region for the namespace (required)
```
New behavior of `doctl serverless connect`

```
/> doctl sls ns list
Label         Region    Namespace ID                               API Host
              nyc1      fn-d4a07d1e-a88f-4779-87c9-389c3d5f50b1    https://faas-nyc1-...
experiment    tor1      fn-24694dbc-9ee1-43bc-a399-4c2975268c66    https://faas-tor1-...
another       lon1      fn-2e076bc3-2183-4794-bf4b-7a103bd12e12    https://faas-lon1-....
/> doctl sls connect
Connected to functions namespace 'fn-d4a07d1e-a88f...' on API host 'https://faas-nyc1-....'

/> doctl sls connect --beta
0: fn-d4a07d1e-a88f-... in nyc1, label=
1: fn-24694dbc-9ee1-... in tor1, label=experiment
2: fn-2e076bc3-2183-... in lon1, label=another
Choose a namespace by number or 'x' to exit
```
If I had exactly one functions namespace (as will be the legacy case of a single sandbox namespace) it would have just connected to it.

```
/> doctl sls connect ex
Error: (serverless.connect) command contains unsupported arguments
/> doctl sls connect ex --beta
Connected to functions namespace 'fn-24694dbc-9ee1-...' on API host 'https://faas-tor1-...' (label=experiment)
```

The argument may not contain wildcards but may be a partial match (prefix, infix, suffix) to either the label or the id.  Multiple matches are handled similarly to the case where there is no argument.

With the `--beta` flag (and once the support is released), `doctl sls connect` will only work if you have at least one functions namespace (a legacy sandbox namespace will satisfy this requirement but will show as having no label as in the above).    With no functions namespaces you will get an error message telling you to create a namespace.   This behavior is motivated by the fact that, without region and label arguments, the namespace is probably not going to be what you really want and adding those arguments to `doctl serverless connect` in addition to `doctl serverless namespaces create` would be confusing.   Note that many (perhaps most) new customers would have already created a functions namespace via the UI.

Namespace created via `doctl` and namespaces created via the UI will be equivalent and indistinguishable.   I think this is a good thing, but, I also think we should have a recommended practice of dedicating one (or a few) distinguished namespaces for use by the functions editor in the UI and use different namespaces with `doctl sls deploy|undeploy`.   Otherwise, it is too easy for the two development paths to step on each other and become confused.   I believe we should (not part of this PR) add a handover step if, for a specific namespace, a user wants to stop using the funcitons editor and start using the CLI.    This would be something like `doctl sls import`.