### PR TITLE
Add support for listing database options

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -693,8 +693,8 @@ func displayDatabaseRegionOptions(c *CmdConfig, regions map[string][]string) err
 	return c.Display(item)
 }
 
-func displayDatabaseVersionOptions(c *CmdConfig, regions map[string][]string) error {
-	item := &displayers.DatabaseRegionOptions{RegionMap: regions}
+func displayDatabaseVersionOptions(c *CmdConfig, versions map[string][]string) error {
+	item := &displayers.DatabaseVersionOptions{VersionMap: versions}
 	return c.Display(item)
 }
 

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -45,7 +45,7 @@ func Databases() *Command {
 			Use:     "databases",
 			Aliases: []string{"db", "dbs", "d", "database"},
 			Short:   "Display commands that manage databases",
-			Long:    "The commands under `doctl databases` are for managing your database services.",
+			Long:    "The commands under `doctl databases` are for managing your MySQL, Redis, PostgreSQL, and MongoDB database services.",
 		},
 	}
 
@@ -53,12 +53,12 @@ func Databases() *Command {
 
 - The database ID, in UUID format
 - The name you gave the database cluster
-- The database engine (e.g. ` + "`" + `redis` + "`" + `, ` + "`" + `pg` + "`" + `, ` + "`" + `mysql` + "`" + `, ` + "`" + `mongodb` + "`" + `)
-- The engine version (e.g. ` + "`" + `11` + "`" + ` for PostgreSQL version 11)
+- The database engine (e.g. ` + "`redis`, `pg`, `mysql` , or `mongodb`" + `)
+- The engine version (e.g. ` + "`14`" + ` for PostgreSQL version 14)
 - The number of nodes in the database cluster
-- The region the database cluster resides in (e.g. ` + "`" + `sfo2` + "`" + `, ` + "`" + `nyc1` + "`" + `)
-- The current status of the database cluster (e.g. ` + "`" + `online` + "`" + `)
-- The size of the machine running the database instance (e.g. ` + "`" + `db-s-1vcpu-1gb` + "`" + `)`
+- The region the database cluster resides in (e.g. ` + "`sfo2`, " + "`nyc1`" + `)
+- The current status of the database cluster (e.g. ` + "`online`" + `)
+- The size of the machine running the database instance (e.g. ` + "`db-s-1vcpu-1gb`" + `)`
 
 	CmdBuilder(cmd, RunDatabaseList, "list", "List your database clusters", `This command lists the database clusters associated with your account. The following details are provided:`+clusterDetails, Writer, aliasOpt("ls"), displayerType(&displayers.Databases{}))
 	CmdBuilder(cmd, RunDatabaseGet, "get <database-id>", "Get details for a database cluster", `This command retrieves the following details about the specified database cluster: `+clusterDetails+`
@@ -74,8 +74,8 @@ There are a number of flags that customize the configuration, all of which are o
 	AddIntFlag(cmdDatabaseCreate, doctl.ArgDatabaseNumNodes, "", defaultDatabaseNodeCount, nodeNumberDetails)
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgRegionSlug, "", defaultDatabaseRegion, "The region where the database cluster will be created, e.g. `nyc1` or `sfo2`")
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgSizeSlug, "", defaultDatabaseNodeSize, nodeSizeDetails)
-	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseEngine, "", defaultDatabaseEngine, "The database engine to be used for the cluster. Possible values are: `pg` for PostgreSQL, `mysql` for MySQL, `redis` for Redis, and `mongodb` for MongoDB.")
-	AddStringFlag(cmdDatabaseCreate, doctl.ArgVersion, "", "", "The database engine version, e.g. 11 for PostgreSQL version 11")
+	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseEngine, "", defaultDatabaseEngine, "The database engine to be used for the cluster. Possible values are: `pg` for PostgreSQL, `mysql`, `redis`, and `mongodb`.")
+	AddStringFlag(cmdDatabaseCreate, doctl.ArgVersion, "", "", "The database engine version, e.g. 14 for PostgreSQL version 14")
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgPrivateNetworkUUID, "", "", "The UUID of a VPC to create the database cluster in; the default VPC for the region will be used if excluded")
 
 	cmdDatabaseDelete := CmdBuilder(cmd, RunDatabaseDelete, "delete <database-id>", "Delete a database cluster", `This command deletes the database cluster with the given ID.
@@ -107,7 +107,7 @@ The list contains the size in GB, and the date and time the backup was taken.`, 
 You must specify the desired number of nodes and size of the nodes. For example:
 
 	doctl databases resize ca9f591d-9999-5555-a0ef-1c02d1d1e352 --num-nodes 2 --size db-s-16vcpu-64gb
-			
+
 Database nodes cannot be resized to smaller sizes due to the risk of data loss.`, Writer,
 		aliasOpt("rs"))
 	AddIntFlag(cmdDatabaseResize, doctl.ArgDatabaseNumNodes, "", 0, nodeNumberDetails, requiredOpt())
@@ -1374,14 +1374,14 @@ This command requires the ID of a database cluster, which you can retrieve by ca
 	databaseFirewallUpdateDetails := `
 Use this command to replace the firewall rules of a given database. This command requires the ID of a database cluster, which you can retrieve by calling:
 
-	doctl databases list 
-	
+	doctl databases list
+
 This command also requires a --rule flag. You can pass in multiple --rule flags. Each rule passed in to the --rule flag must be of format type:value
 	- "type" is the type of resource that the firewall rule allows to access the database cluster. The possible values for type are:  "droplet", "k8s", "ip_addr", "tag", or "app"
 	- "value" is either the ID of the specific resource, the name of a tag applied to a group of resources, or the IP address that the firewall rule allows to access the database cluster
 
 For example:
-	
+
 	doctl databases firewalls replace d1234-1c12-1234-b123-12345c4789 --rule tag:backend --rule ip_addr:0.0.0.0
 
 	or

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -689,7 +689,11 @@ func displayDatabaseEngineOptions(c *CmdConfig, options *do.DatabaseOptions) err
 	return c.Display(item)
 }
 
-func displayDatabaseRegionsOptions(c *CmdConfig, regions map[string][]string) error {
+func displayDatabaseRegionOptions(c *CmdConfig, regions map[string][]string) error {
+	item := &displayers.DatabaseRegionOptions{RegionMap: regions}
+	return c.Display(item)
+}
+func displayDatabaseVersionOptions(c *CmdConfig, regions map[string][]string) error {
 	item := &displayers.DatabaseRegionOptions{RegionMap: regions}
 	return c.Display(item)
 }
@@ -737,15 +741,12 @@ func RunDatabaseRegionOptions(c *CmdConfig) error {
 		regions["redis"] = options.RedisOptions.Regions
 	}
 
-	return displayDatabaseRegionsOptions(c, regions)
+	return displayDatabaseRegionOptions(c, regions)
 }
 
 // RunDatabaseVersionOptions retrieves a list of the available versions for a given database engine
 func RunDatabaseVersionOptions(c *CmdConfig) error {
-	engine, err := c.Doit.GetString(c.NS, doctl.ArgDatabaseEngine)
-	if err != nil {
-		engine = ""
-	}
+	engine, _ := c.Doit.GetString(c.NS, doctl.ArgDatabaseEngine)
 
 	options, err := c.Databases().ListOptions()
 	if err != nil {
@@ -769,7 +770,7 @@ func RunDatabaseVersionOptions(c *CmdConfig) error {
 		versions["redis"] = options.RedisOptions.Versions
 	}
 
-	return displayDatabaseKeyValues(c, versions, "Engine", "Version")
+	return displayDatabaseVersionOptions(c, versions)
 }
 
 // RunDatabaseSlugOptions retrieves a list of the available slugs for a given database engine

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -16,7 +16,6 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/digitalocean/doctl"
@@ -693,25 +692,14 @@ func displayDatabaseRegionOptions(c *CmdConfig, regions map[string][]string) err
 	item := &displayers.DatabaseRegionOptions{RegionMap: regions}
 	return c.Display(item)
 }
+
 func displayDatabaseVersionOptions(c *CmdConfig, regions map[string][]string) error {
 	item := &displayers.DatabaseRegionOptions{RegionMap: regions}
 	return c.Display(item)
 }
 
-func displayDatabaseKeyValues(c *CmdConfig, in map[string][]string, keyName string, valName string) error {
-	pairs := make([]do.KeyValue, 0)
-	for k, v := range in {
-		for _, r := range v {
-			kv := do.KeyValue{Key: k, Value: r}
-			pairs = append(pairs, kv)
-		}
-	}
-
-	item := &displayers.KeyValues{KeyValues: do.KeyValues{
-		Pairs:            pairs,
-		KeyDescription:   keyName,
-		ValueDescription: valName,
-	}}
+func displayDatabaseLayoutOptions(c *CmdConfig, layouts []godo.DatabaseLayout) error {
+	item := &displayers.DatabaseLayoutOptions{Layouts: layouts}
 	return c.Display(item)
 }
 
@@ -785,7 +773,6 @@ func RunDatabaseSlugOptions(c *CmdConfig) error {
 		return err
 	}
 
-	slugs := make(map[string][]string, 0)
 	layouts := make([]godo.DatabaseLayout, 0)
 	switch engine {
 	case "mongodb":
@@ -797,11 +784,8 @@ func RunDatabaseSlugOptions(c *CmdConfig) error {
 	case "redis":
 		layouts = options.RedisOptions.Layouts
 	}
-	for _, layout := range layouts {
-		slugs[strconv.Itoa(layout.NodeNum)] = append(slugs[strconv.Itoa(layout.NodeNum)], layout.Sizes...)
-	}
 
-	return displayDatabaseKeyValues(c, slugs, "NodeNum", "Slug")
+	return displayDatabaseLayoutOptions(c, layouts)
 }
 
 func databasePool() *Command {

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -689,6 +689,11 @@ func displayDatabaseEngineOptions(c *CmdConfig, options *do.DatabaseOptions) err
 	return c.Display(item)
 }
 
+func displayDatabaseRegionsOptions(c *CmdConfig, regions map[string][]string) error {
+	item := &displayers.DatabaseRegionOptions{RegionMap: regions}
+	return c.Display(item)
+}
+
 func displayDatabaseKeyValues(c *CmdConfig, in map[string][]string, keyName string, valName string) error {
 	pairs := make([]do.KeyValue, 0)
 	for k, v := range in {
@@ -708,9 +713,7 @@ func displayDatabaseKeyValues(c *CmdConfig, in map[string][]string, keyName stri
 
 // RunDatabaseRegionOptions retrieves a list of the available regions for a given database engine
 func RunDatabaseRegionOptions(c *CmdConfig) error {
-	engine, err := c.Doit.GetString(c.NS, doctl.ArgDatabaseEngine)
-	if err != nil {
-	}
+	engine, _ := c.Doit.GetString(c.NS, doctl.ArgDatabaseEngine)
 
 	options, err := c.Databases().ListOptions()
 	if err != nil {
@@ -734,7 +737,7 @@ func RunDatabaseRegionOptions(c *CmdConfig) error {
 		regions["redis"] = options.RedisOptions.Regions
 	}
 
-	return displayDatabaseKeyValues(c, regions, "Engine", "Region")
+	return displayDatabaseRegionsOptions(c, regions)
 }
 
 // RunDatabaseVersionOptions retrieves a list of the available versions for a given database engine

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -16,6 +16,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/digitalocean/doctl"
@@ -44,7 +45,7 @@ func Databases() *Command {
 			Use:     "databases",
 			Aliases: []string{"db", "dbs", "d", "database"},
 			Short:   "Display commands that manage databases",
-			Long:    "The commands under `doctl databases` are for managing your MySQL, Redis, PostgreSQL, and MongoDB database services.",
+			Long:    "The commands under `doctl databases` are for managing your database services.",
 		},
 	}
 
@@ -52,12 +53,12 @@ func Databases() *Command {
 
 - The database ID, in UUID format
 - The name you gave the database cluster
-- The database engine (e.g. ` + "`redis`, `pg`, `mysql` , or `mongodb`" + `)
-- The engine version (e.g. ` + "`14`" + ` for PostgreSQL version 14)
+- The database engine (e.g. ` + "`" + `redis` + "`" + `, ` + "`" + `pg` + "`" + `, ` + "`" + `mysql` + "`" + `, ` + "`" + `mongodb` + "`" + `)
+- The engine version (e.g. ` + "`" + `11` + "`" + ` for PostgreSQL version 11)
 - The number of nodes in the database cluster
-- The region the database cluster resides in (e.g. ` + "`sfo2`, " + "`nyc1`" + `)
-- The current status of the database cluster (e.g. ` + "`online`" + `)
-- The size of the machine running the database instance (e.g. ` + "`db-s-1vcpu-1gb`" + `)`
+- The region the database cluster resides in (e.g. ` + "`" + `sfo2` + "`" + `, ` + "`" + `nyc1` + "`" + `)
+- The current status of the database cluster (e.g. ` + "`" + `online` + "`" + `)
+- The size of the machine running the database instance (e.g. ` + "`" + `db-s-1vcpu-1gb` + "`" + `)`
 
 	CmdBuilder(cmd, RunDatabaseList, "list", "List your database clusters", `This command lists the database clusters associated with your account. The following details are provided:`+clusterDetails, Writer, aliasOpt("ls"), displayerType(&displayers.Databases{}))
 	CmdBuilder(cmd, RunDatabaseGet, "get <database-id>", "Get details for a database cluster", `This command retrieves the following details about the specified database cluster: `+clusterDetails+`
@@ -73,8 +74,8 @@ There are a number of flags that customize the configuration, all of which are o
 	AddIntFlag(cmdDatabaseCreate, doctl.ArgDatabaseNumNodes, "", defaultDatabaseNodeCount, nodeNumberDetails)
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgRegionSlug, "", defaultDatabaseRegion, "The region where the database cluster will be created, e.g. `nyc1` or `sfo2`")
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgSizeSlug, "", defaultDatabaseNodeSize, nodeSizeDetails)
-	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseEngine, "", defaultDatabaseEngine, "The database engine to be used for the cluster. Possible values are: `pg` for PostgreSQL, `mysql`, `redis`, and `mongodb`.")
-	AddStringFlag(cmdDatabaseCreate, doctl.ArgVersion, "", "", "The database engine version, e.g. 14 for PostgreSQL version 14")
+	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseEngine, "", defaultDatabaseEngine, "The database engine to be used for the cluster. Possible values are: `pg` for PostgreSQL, `mysql` for MySQL, `redis` for Redis, and `mongodb` for MongoDB.")
+	AddStringFlag(cmdDatabaseCreate, doctl.ArgVersion, "", "", "The database engine version, e.g. 11 for PostgreSQL version 11")
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgPrivateNetworkUUID, "", "", "The UUID of a VPC to create the database cluster in; the default VPC for the region will be used if excluded")
 
 	cmdDatabaseDelete := CmdBuilder(cmd, RunDatabaseDelete, "delete <database-id>", "Delete a database cluster", `This command deletes the database cluster with the given ID.
@@ -106,7 +107,7 @@ The list contains the size in GB, and the date and time the backup was taken.`, 
 You must specify the desired number of nodes and size of the nodes. For example:
 
 	doctl databases resize ca9f591d-9999-5555-a0ef-1c02d1d1e352 --num-nodes 2 --size db-s-16vcpu-64gb
-
+			
 Database nodes cannot be resized to smaller sizes due to the risk of data loss.`, Writer,
 		aliasOpt("rs"))
 	AddIntFlag(cmdDatabaseResize, doctl.ArgDatabaseNumNodes, "", 0, nodeNumberDetails, requiredOpt())
@@ -124,6 +125,7 @@ Database nodes cannot be resized to smaller sizes due to the risk of data loss.`
 	cmd.AddCommand(databasePool())
 	cmd.AddCommand(sqlMode())
 	cmd.AddCommand(databaseFirewalls())
+	cmd.AddCommand(databaseOptions())
 
 	return cmd
 }
@@ -626,6 +628,176 @@ func RunDatabaseUserDelete(c *CmdConfig) error {
 func displayDatabaseUsers(c *CmdConfig, users ...do.DatabaseUser) error {
 	item := &displayers.DatabaseUsers{DatabaseUsers: users}
 	return c.Display(item)
+}
+
+func databaseOptions() *Command {
+	cmd := &Command{
+		Command: &cobra.Command{
+			Use:     "options",
+			Aliases: []string{"o"},
+			Short:   `Display available database options (regions, version, layouts, etc.) for all available database engines`,
+			Long:    `The subcommands under ` + "`" + `doctl databases options` + "`" + ` enable the navigation of available options under each database engine`,
+		},
+	}
+	databaseOptionEngines := `
+This command lists the available database engines:
+
+- The key of the database engine. Possible values are: "pg" for PostgreSQL, "mysql"" for MySQL, "redis"" for Redis, and "mongodb" for MongoDB
+`
+	databaseOptionRegions := `
+- The region of the database engine.
+`
+	databaseOptionVersions := `
+- The version of the database engine.
+`
+	databaseOptionSlugs := `
+- The slug of the database engine. These are prefixed with "db" for basic nodes, "gd" for general purpose nodes, "sol" for storage optimized nodes, and "m" for memory optimized nodes
+`
+	CmdBuilder(cmd, RunDatabaseEngineOptions, "engines", "Retrieves a list of the available database engines", databaseOptionEngines,
+		Writer, aliasOpt("eng"))
+
+	cmdRegionOptions := CmdBuilder(cmd, RunDatabaseRegionOptions, "regions", "Retrieves a list of the available regions for a given database engine", databaseOptionEngines+databaseOptionRegions,
+		Writer, aliasOpt("r"))
+	AddStringFlag(cmdRegionOptions, doctl.ArgDatabaseEngine, "",
+		"", "The database engine")
+
+	cmdVersionOptions := CmdBuilder(cmd, RunDatabaseVersionOptions, "versions", "Retrieves a list of the available versions for a given database engine", databaseOptionEngines+databaseOptionVersions,
+		Writer, aliasOpt("v"))
+	AddStringFlag(cmdVersionOptions, doctl.ArgDatabaseEngine, "",
+		"", "The database engine")
+
+	cmdSlugOptions := CmdBuilder(cmd, RunDatabaseSlugOptions, "slugs", "Retrieves a list of the available slugs for a given database engine", databaseOptionEngines+databaseOptionSlugs,
+		Writer, aliasOpt("s"))
+	AddStringFlag(cmdSlugOptions, doctl.ArgDatabaseEngine, "",
+		"", "The database engine", requiredOpt())
+
+	return cmd
+}
+
+// RunDatabaseEngineOptions retrieves a list of the available database engines
+func RunDatabaseEngineOptions(c *CmdConfig) error {
+	options, err := c.Databases().ListOptions()
+	if err != nil {
+		return err
+	}
+
+	return displayDatabaseEngineOptions(c, options)
+}
+
+func displayDatabaseEngineOptions(c *CmdConfig, options *do.DatabaseOptions) error {
+	item := &displayers.DatabaseOptions{DatabaseOptions: *options}
+	return c.Display(item)
+}
+
+func displayDatabaseKeyValues(c *CmdConfig, in map[string][]string, keyName string, valName string) error {
+	pairs := make([]do.KeyValue, 0)
+	for k, v := range in {
+		for _, r := range v {
+			kv := do.KeyValue{Key: k, Value: r}
+			pairs = append(pairs, kv)
+		}
+	}
+
+	item := &displayers.KeyValues{KeyValues: do.KeyValues{
+		Pairs:            pairs,
+		KeyDescription:   keyName,
+		ValueDescription: valName,
+	}}
+	return c.Display(item)
+}
+
+// RunDatabaseRegionOptions retrieves a list of the available regions for a given database engine
+func RunDatabaseRegionOptions(c *CmdConfig) error {
+	engine, err := c.Doit.GetString(c.NS, doctl.ArgDatabaseEngine)
+	if err != nil {
+	}
+
+	options, err := c.Databases().ListOptions()
+	if err != nil {
+		return err
+	}
+
+	regions := make(map[string][]string, 0)
+	switch engine {
+	case "mongodb":
+		regions["mongodb"] = options.MongoDBOptions.Regions
+	case "mysql":
+		regions["mysql"] = options.MySQLOptions.Regions
+	case "pg":
+		regions["pg"] = options.PostgresSQLOptions.Regions
+	case "redis":
+		regions["redis"] = options.RedisOptions.Regions
+	case "":
+		regions["mongodb"] = options.MongoDBOptions.Regions
+		regions["mysql"] = options.MySQLOptions.Regions
+		regions["pg"] = options.PostgresSQLOptions.Regions
+		regions["redis"] = options.RedisOptions.Regions
+	}
+
+	return displayDatabaseKeyValues(c, regions, "Engine", "Region")
+}
+
+// RunDatabaseVersionOptions retrieves a list of the available versions for a given database engine
+func RunDatabaseVersionOptions(c *CmdConfig) error {
+	engine, err := c.Doit.GetString(c.NS, doctl.ArgDatabaseEngine)
+	if err != nil {
+		engine = ""
+	}
+
+	options, err := c.Databases().ListOptions()
+	if err != nil {
+		return err
+	}
+
+	versions := make(map[string][]string, 0)
+	switch engine {
+	case "mongodb":
+		versions["mongodb"] = options.MongoDBOptions.Versions
+	case "mysql":
+		versions["mysql"] = options.MySQLOptions.Versions
+	case "pg":
+		versions["pg"] = options.PostgresSQLOptions.Versions
+	case "redis":
+		versions["redis"] = options.RedisOptions.Versions
+	case "":
+		versions["mongodb"] = options.MongoDBOptions.Versions
+		versions["mysql"] = options.MySQLOptions.Versions
+		versions["pg"] = options.PostgresSQLOptions.Versions
+		versions["redis"] = options.RedisOptions.Versions
+	}
+
+	return displayDatabaseKeyValues(c, versions, "Engine", "Version")
+}
+
+// RunDatabaseSlugOptions retrieves a list of the available slugs for a given database engine
+func RunDatabaseSlugOptions(c *CmdConfig) error {
+	engine, err := c.Doit.GetString(c.NS, doctl.ArgDatabaseEngine)
+	if err != nil {
+		return doctl.NewMissingArgsErr(c.NS)
+	}
+
+	options, err := c.Databases().ListOptions()
+	if err != nil {
+		return err
+	}
+
+	slugs := make(map[string][]string, 0)
+	layouts := make([]godo.DatabaseLayout, 0)
+	switch engine {
+	case "mongodb":
+		layouts = options.MongoDBOptions.Layouts
+	case "mysql":
+		layouts = options.MySQLOptions.Layouts
+	case "pg":
+		layouts = options.PostgresSQLOptions.Layouts
+	case "redis":
+		layouts = options.RedisOptions.Layouts
+	}
+	for _, layout := range layouts {
+		slugs[strconv.Itoa(layout.NodeNum)] = append(slugs[strconv.Itoa(layout.NodeNum)], layout.Sizes...)
+	}
+
+	return displayDatabaseKeyValues(c, slugs, "NodeNum", "Slug")
 }
 
 func databasePool() *Command {
@@ -1202,14 +1374,14 @@ This command requires the ID of a database cluster, which you can retrieve by ca
 	databaseFirewallUpdateDetails := `
 Use this command to replace the firewall rules of a given database. This command requires the ID of a database cluster, which you can retrieve by calling:
 
-	doctl databases list
-
+	doctl databases list 
+	
 This command also requires a --rule flag. You can pass in multiple --rule flags. Each rule passed in to the --rule flag must be of format type:value
 	- "type" is the type of resource that the firewall rule allows to access the database cluster. The possible values for type are:  "droplet", "k8s", "ip_addr", "tag", or "app"
 	- "value" is either the ID of the specific resource, the name of a tag applied to a group of resources, or the IP address that the firewall rule allows to access the database cluster
 
 For example:
-
+	
 	doctl databases firewalls replace d1234-1c12-1234-b123-12345c4789 --rule tag:backend --rule ip_addr:0.0.0.0
 
 	or

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -145,6 +145,10 @@ var (
 		godo.SQLModeNoTableOptions,
 	}
 
+	testDBEngineOptions = &do.DatabaseOptions{
+		DatabaseOptions: &godo.DatabaseOptions{},
+	}
+
 	errTest = errors.New("error")
 )
 
@@ -222,6 +226,17 @@ func TestDatabaseReplicaCommand(t *testing.T) {
 		"create",
 		"delete",
 		"connection",
+	)
+}
+
+func TestDatabaseOptionsCommand(t *testing.T) {
+	cmd := databaseOptions()
+	assert.NotNil(t, cmd)
+	assertCommandNames(t, cmd,
+		"engines",
+		"regions",
+		"slugs",
+		"versions",
 	)
 }
 
@@ -1000,5 +1015,21 @@ func TestDatabaseSetSQLModes(t *testing.T) {
 			err := RunDatabaseSetSQLModes(config)
 			assert.Error(t, err)
 		})
+	})
+}
+
+func TestDatabaseListOptions(t *testing.T) {
+	// Successful call
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.databases.EXPECT().ListOptions().Return(testDBEngineOptions, nil)
+		err := RunDatabaseEngineOptions(config)
+		assert.NoError(t, err)
+	})
+
+	// Error
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.databases.EXPECT().ListOptions().Return(nil, errTest)
+		err := RunDatabaseEngineOptions(config)
+		assert.EqualError(t, err, errTest.Error())
 	})
 }

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -166,6 +166,7 @@ func TestDatabasesCommand(t *testing.T) {
 		"firewalls",
 		"backups",
 		"replica",
+		"options",
 		"maintenance-window",
 		"user",
 		"pool",

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -14,6 +14,7 @@ limitations under the License.
 package displayers
 
 import (
+	"github.com/digitalocean/godo"
 	"io"
 
 	"github.com/digitalocean/doctl/do"
@@ -427,38 +428,40 @@ func (dbv *DatabaseVersionOptions) KV() []map[string]interface{} {
 	return out
 }
 
-type KeyValues struct {
-	KeyValues do.KeyValues
+type DatabaseLayoutOptions struct {
+	Layouts []godo.DatabaseLayout
 }
 
-var _ Displayable = &KeyValues{}
+var _ Displayable = &DatabaseLayoutOptions{}
 
-func (dkv *KeyValues) JSON(out io.Writer) error {
-	return writeJSON(dkv.KeyValues, out)
+func (dbl *DatabaseLayoutOptions) JSON(out io.Writer) error {
+	return writeJSON(dbl.Layouts, out)
 }
 
-func (dkv *KeyValues) Cols() []string {
+func (dbl *DatabaseLayoutOptions) Cols() []string {
 	return []string{
-		dkv.KeyValues.KeyDescription,
-		dkv.KeyValues.ValueDescription,
+		"NodeNum",
+		"Slug",
 	}
 }
 
-func (dkv *KeyValues) ColMap() map[string]string {
+func (dbl *DatabaseLayoutOptions) ColMap() map[string]string {
 	return map[string]string{
-		dkv.KeyValues.KeyDescription:   dkv.KeyValues.KeyDescription,
-		dkv.KeyValues.ValueDescription: dkv.KeyValues.ValueDescription,
+		"NodeNum": "NodeNum",
+		"Slug":    "Slug",
 	}
 }
 
-func (dkv *KeyValues) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(dbEngines))
-	for _, p := range dkv.KeyValues.Pairs {
-		o := map[string]interface{}{
-			dkv.KeyValues.KeyDescription:   p.Key,
-			dkv.KeyValues.ValueDescription: p.Value,
+func (dbl *DatabaseLayoutOptions) KV() []map[string]interface{} {
+	out := make([]map[string]interface{}, 0)
+	for _, l := range dbl.Layouts {
+		for _, s := range l.Sizes {
+			o := map[string]interface{}{
+				"NodeNum": l.NodeNum,
+				"Slug":    s,
+			}
+			out = append(out, o)
 		}
-		out = append(out, o)
 	}
 	return out
 }

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -351,6 +351,44 @@ func (do *DatabaseOptions) KV() []map[string]interface{} {
 	return out
 }
 
+type DatabaseRegionOptions struct {
+	RegionMap map[string][]string
+}
+
+var _ Displayable = &DatabaseRegionOptions{}
+
+func (dbr *DatabaseRegionOptions) JSON(out io.Writer) error {
+	return writeJSON(dbr.RegionMap, out)
+}
+
+func (dbr *DatabaseRegionOptions) Cols() []string {
+	return []string{
+		"Engine",
+		"Region",
+	}
+}
+
+func (dbr *DatabaseRegionOptions) ColMap() map[string]string {
+	return map[string]string{
+		"Engine": "Engine",
+		"Region": "Region",
+	}
+}
+
+func (dbr *DatabaseRegionOptions) KV() []map[string]interface{} {
+	out := make([]map[string]interface{}, 0)
+	for eng, regions := range dbr.RegionMap {
+		for _, region := range regions {
+			o := map[string]interface{}{
+				"Engine": eng,
+				"Region": region,
+			}
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
 type KeyValues struct {
 	KeyValues do.KeyValues
 }

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -327,8 +327,22 @@ func (do *DatabaseOptions) ColMap() map[string]string {
 }
 
 func (do *DatabaseOptions) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(dbEngines))
-	for _, eng := range dbEngines {
+	engines := make([]string, 0)
+	if &do.DatabaseOptions.MongoDBOptions != nil {
+		engines = append(engines, "mongodb")
+	}
+	if &do.DatabaseOptions.RedisOptions != nil {
+		engines = append(engines, "redis")
+	}
+	if &do.DatabaseOptions.MySQLOptions != nil {
+		engines = append(engines, "mysql")
+	}
+	if &do.DatabaseOptions.PostgresSQLOptions != nil {
+		engines = append(engines, "pg")
+	}
+
+	out := make([]map[string]interface{}, 0, len(engines))
+	for _, eng := range engines {
 		o := map[string]interface{}{
 			"Engine": eng,
 		}

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -17,6 +17,8 @@ import (
 	"io"
 
 	"github.com/digitalocean/doctl/do"
+
+	"github.com/digitalocean/godo"
 )
 
 type Databases struct {
@@ -424,7 +426,7 @@ func (dbv *DatabaseVersionOptions) KV() []map[string]interface{} {
 }
 
 type DatabaseLayoutOptions struct {
-	Layouts []do.DatabaseLayout
+	Layouts []godo.DatabaseLayout
 }
 
 var _ Displayable = &DatabaseLayoutOptions{}

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -378,10 +378,48 @@ func (dbr *DatabaseRegionOptions) ColMap() map[string]string {
 func (dbr *DatabaseRegionOptions) KV() []map[string]interface{} {
 	out := make([]map[string]interface{}, 0)
 	for eng, regions := range dbr.RegionMap {
-		for _, region := range regions {
+		for _, r := range regions {
 			o := map[string]interface{}{
 				"Engine": eng,
-				"Region": region,
+				"Region": r,
+			}
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+type DatabaseVersionOptions struct {
+	VersionMap map[string][]string
+}
+
+var _ Displayable = &DatabaseVersionOptions{}
+
+func (dbv *DatabaseVersionOptions) JSON(out io.Writer) error {
+	return writeJSON(dbv.VersionMap, out)
+}
+
+func (dbv *DatabaseVersionOptions) Cols() []string {
+	return []string{
+		"Engine",
+		"Version",
+	}
+}
+
+func (dbv *DatabaseVersionOptions) ColMap() map[string]string {
+	return map[string]string{
+		"Engine":  "Engine",
+		"Version": "Version",
+	}
+}
+
+func (dbv *DatabaseVersionOptions) KV() []map[string]interface{} {
+	out := make([]map[string]interface{}, 0)
+	for eng, versions := range dbv.VersionMap {
+		for _, v := range versions {
+			o := map[string]interface{}{
+				"Engine":   eng,
+				"Versions": v,
 			}
 			out = append(out, o)
 		}

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -14,14 +14,9 @@ limitations under the License.
 package displayers
 
 import (
-	"github.com/digitalocean/godo"
 	"io"
 
 	"github.com/digitalocean/doctl/do"
-)
-
-var (
-	dbEngines = []string{"mongodb", "pg", "mysql", "redis"}
 )
 
 type Databases struct {
@@ -429,7 +424,7 @@ func (dbv *DatabaseVersionOptions) KV() []map[string]interface{} {
 }
 
 type DatabaseLayoutOptions struct {
-	Layouts []godo.DatabaseLayout
+	Layouts []do.DatabaseLayout
 }
 
 var _ Displayable = &DatabaseLayoutOptions{}

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -19,6 +19,10 @@ import (
 	"github.com/digitalocean/doctl/do"
 )
 
+var (
+	dbEngines = []string{"mongodb", "pg", "mysql", "redis"}
+)
+
 type Databases struct {
 	Databases do.Databases
 	Short     bool
@@ -297,6 +301,75 @@ func (dr *DatabaseReplicas) KV() []map[string]interface{} {
 		out = append(out, o)
 	}
 
+	return out
+}
+
+type DatabaseOptions struct {
+	DatabaseOptions do.DatabaseOptions
+}
+
+var _ Displayable = &DatabaseOptions{}
+
+func (do *DatabaseOptions) JSON(out io.Writer) error {
+	return writeJSON(do.DatabaseOptions, out)
+}
+
+func (do *DatabaseOptions) Cols() []string {
+	return []string{
+		"Engine",
+	}
+}
+
+func (do *DatabaseOptions) ColMap() map[string]string {
+	return map[string]string{
+		"Engine": "Engine",
+	}
+}
+
+func (do *DatabaseOptions) KV() []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(dbEngines))
+	for _, eng := range dbEngines {
+		o := map[string]interface{}{
+			"Engine": eng,
+		}
+		out = append(out, o)
+	}
+	return out
+}
+
+type KeyValues struct {
+	KeyValues do.KeyValues
+}
+
+var _ Displayable = &KeyValues{}
+
+func (dkv *KeyValues) JSON(out io.Writer) error {
+	return writeJSON(dkv.KeyValues, out)
+}
+
+func (dkv *KeyValues) Cols() []string {
+	return []string{
+		dkv.KeyValues.KeyDescription,
+		dkv.KeyValues.ValueDescription,
+	}
+}
+
+func (dkv *KeyValues) ColMap() map[string]string {
+	return map[string]string{
+		dkv.KeyValues.KeyDescription:   dkv.KeyValues.KeyDescription,
+		dkv.KeyValues.ValueDescription: dkv.KeyValues.ValueDescription,
+	}
+}
+
+func (dkv *KeyValues) KV() []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(dbEngines))
+	for _, p := range dkv.KeyValues.Pairs {
+		o := map[string]interface{}{
+			dkv.KeyValues.KeyDescription:   p.Key,
+			dkv.KeyValues.ValueDescription: p.Value,
+		}
+		out = append(out, o)
+	}
 	return out
 }
 

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -14,12 +14,12 @@ limitations under the License.
 package displayers
 
 import (
-	"github.com/digitalocean/doctl/do"
 	"io"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/digitalocean/doctl/do"
 	"github.com/digitalocean/godo"
 )
 

--- a/do/databases.go
+++ b/do/databases.go
@@ -86,6 +86,22 @@ type DatabaseFirewallRule struct {
 // DatabaseFirewallRules is a slice of DatabaseFirewallRule
 type DatabaseFirewallRules []DatabaseFirewallRule
 
+// DatabaseOptions is a wrapper for
+type DatabaseOptions struct {
+	*godo.DatabaseOptions
+}
+
+type KeyValues struct {
+	Pairs            []KeyValue
+	KeyDescription   string
+	ValueDescription string
+}
+
+type KeyValue struct {
+	Key   string
+	Value string
+}
+
 // DatabasesService is an interface for interacting with DigitalOcean's Database API
 type DatabasesService interface {
 	List() (Databases, error)
@@ -127,6 +143,8 @@ type DatabasesService interface {
 
 	GetFirewallRules(string) (DatabaseFirewallRules, error)
 	UpdateFirewallRules(databaseID string, req *godo.DatabaseUpdateFirewallRulesRequest) error
+
+	ListOptions() (*DatabaseOptions, error)
 }
 
 type databasesService struct {
@@ -531,4 +549,13 @@ func (ds *databasesService) UpdateFirewallRules(databaseID string, req *godo.Dat
 	_, err := ds.client.Databases.UpdateFirewallRules(context.TODO(), databaseID, req)
 
 	return err
+}
+
+func (ds *databasesService) ListOptions() (*DatabaseOptions, error) {
+	options, _, err := ds.client.Databases.ListOptions(context.TODO())
+
+	if err != nil {
+		return nil, err
+	}
+	return &DatabaseOptions{DatabaseOptions: options}, nil
 }

--- a/do/databases.go
+++ b/do/databases.go
@@ -91,15 +91,9 @@ type DatabaseOptions struct {
 	*godo.DatabaseOptions
 }
 
-type KeyValues struct {
-	Pairs            []KeyValue
-	KeyDescription   string
-	ValueDescription string
-}
-
-type KeyValue struct {
-	Key   string
-	Value string
+// DatabaseLayout is a wrapper for
+type DatabaseLayout struct {
+	*godo.DatabaseLayout
 }
 
 // DatabasesService is an interface for interacting with DigitalOcean's Database API

--- a/do/mocks/DatabasesService.go
+++ b/do/mocks/DatabasesService.go
@@ -18,6 +18,20 @@ type MockDatabasesService struct {
 	recorder *MockDatabasesServiceMockRecorder
 }
 
+func (m *MockDatabasesService) ListOptions() (*do.DatabaseOptions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListOptions")
+	ret0, _ := ret[0].(*do.DatabaseOptions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListOptions indicates an expected call of ListOptions.
+func (mr *MockDatabasesServiceMockRecorder) ListOptions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOptions", reflect.TypeOf((*MockDatabasesService)(nil).ListOptions))
+}
+
 // MockDatabasesServiceMockRecorder is the mock recorder for MockDatabasesService.
 type MockDatabasesServiceMockRecorder struct {
 	mock *MockDatabasesService

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/creack/pty v1.1.11
-	github.com/digitalocean/godo v1.81.0
+	github.com/digitalocean/godo v1.83.0
 	github.com/docker/cli v20.10.17+incompatible
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,8 @@ github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8l
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.81.0 h1:sjb3fOfPfSlUQUK22E87BcI8Zx2qtnF7VUCCO4UK3C8=
-github.com/digitalocean/godo v1.81.0/go.mod h1:BPCqvwbjbGqxuUnIKB4EvS/AX7IDnNmt5fwvIkWo+ew=
+github.com/digitalocean/godo v1.83.0 h1:K9CveJyECNLwrQnGZG+ovgapr7l5OuvQ6xZSKKW9Nz0=
+github.com/digitalocean/godo v1.83.0/go.mod h1:BPCqvwbjbGqxuUnIKB4EvS/AX7IDnNmt5fwvIkWo+ew=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.17+incompatible h1:eO2KS7ZFeov5UJeaDmIs1NFEDRf32PaqRpvoEkKBy5M=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [v1.83.0] - 2022-08-10
+
+- #546 - @DWizGuy58 - Add support for database options
+
+## [v1.82.0] - 2022-08-04
+
+- #544 - @andrewsomething - apps: Add URN() method.
+- #542 - @andrewsomething - databases: Support advanced config endpoints.
+- #543 - @nicktate - Ntate/detection models
+- #541 - @andrewsomething - droplets: Support listing Droplets filtered by name.
+- #540 - @bentranter - Update links to API documentation
+
 ## [v1.81.0] - 2022-06-15
 
 - #532 - @senorprogrammer - Add support for Reserved IP addresses

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -523,6 +523,11 @@ type AppCreateRequest struct {
 	Spec *AppSpec `json:"spec"`
 }
 
+// DeployTemplate struct for DeployTemplate
+type DeployTemplate struct {
+	Spec *AppSpec `json:"spec,omitempty"`
+}
+
 // Deployment struct for Deployment
 type Deployment struct {
 	ID                   string                  `json:"id,omitempty"`
@@ -657,6 +662,75 @@ type DeploymentWorker struct {
 	Name             string `json:"name,omitempty"`
 	SourceCommitHash string `json:"source_commit_hash,omitempty"`
 }
+
+// DetectRequest struct for DetectRequest
+type DetectRequest struct {
+	Git    *GitSourceSpec    `json:"git,omitempty"`
+	GitHub *GitHubSourceSpec `json:"github,omitempty"`
+	GitLab *GitLabSourceSpec `json:"gitlab,omitempty"`
+	// An optional commit hash to use instead of the branch specified in the source spec.
+	CommitSHA string `json:"commit_sha,omitempty"`
+	// An optional path to the working directory for the detection process.
+	SourceDir string `json:"source_dir,omitempty"`
+}
+
+// DetectResponse struct for DetectResponse
+type DetectResponse struct {
+	Components    []*DetectResponseComponent `json:"components,omitempty"`
+	Template      *DeployTemplate            `json:"template,omitempty"`
+	TemplateFound bool                       `json:"template_found,omitempty"`
+	TemplateValid bool                       `json:"template_valid,omitempty"`
+	TemplateError string                     `json:"template_error,omitempty"`
+}
+
+// DetectResponseComponent struct for DetectResponseComponent
+type DetectResponseComponent struct {
+	Strategy DetectResponseType `json:"strategy,omitempty"`
+	Types    []string           `json:"types,omitempty"`
+	// A list of Dockerfiles that were found for this component. The recommendation is to use the first Dockerfile.
+	Dockerfiles     []string `json:"dockerfiles,omitempty"`
+	BuildCommand    string   `json:"build_command,omitempty"`
+	RunCommand      string   `json:"run_command,omitempty"`
+	EnvironmentSlug string   `json:"environment_slug,omitempty"`
+	// A list of HTTP ports that this component may listen on. The recommendation is to use the last port in the list.
+	HTTPPorts          []int64                            `json:"http_ports,omitempty"`
+	EnvVars            []*AppVariableDefinition           `json:"env_vars,omitempty"`
+	ServerlessPackages []*DetectResponseServerlessPackage `json:"serverless_packages,omitempty"`
+	SourceDir          string                             `json:"source_dir,omitempty"`
+}
+
+// DetectResponseServerlessFunction struct for DetectResponseServerlessFunction
+type DetectResponseServerlessFunction struct {
+	Name    string                                  `json:"name,omitempty"`
+	Package string                                  `json:"package,omitempty"`
+	Runtime string                                  `json:"runtime,omitempty"`
+	Limits  *DetectResponseServerlessFunctionLimits `json:"limits,omitempty"`
+}
+
+// DetectResponseServerlessFunctionLimits struct for DetectResponseServerlessFunctionLimits
+type DetectResponseServerlessFunctionLimits struct {
+	Timeout string `json:"timeout,omitempty"`
+	Memory  string `json:"memory,omitempty"`
+	Logs    string `json:"logs,omitempty"`
+}
+
+// DetectResponseServerlessPackage struct for DetectResponseServerlessPackage
+type DetectResponseServerlessPackage struct {
+	Name      string                              `json:"name,omitempty"`
+	Functions []*DetectResponseServerlessFunction `json:"functions,omitempty"`
+}
+
+// DetectResponseType the model 'DetectResponseType'
+type DetectResponseType string
+
+// List of DetectResponseType
+const (
+	DetectResponseType_Unspecified DetectResponseType = "UNSPECIFIED"
+	DetectResponseType_Dockerfile  DetectResponseType = "DOCKERFILE"
+	DetectResponseType_Buildpack   DetectResponseType = "BUILDPACK"
+	DetectResponseType_HTML        DetectResponseType = "HTML"
+	DetectResponseType_Serverless  DetectResponseType = "SERVERLESS"
+)
 
 // DeploymentCauseDetailsDigitalOceanUserActionName the model 'CauseDetailsDigitalOceanUserActionName'
 type DeploymentCauseDetailsDigitalOceanUserActionName string

--- a/vendor/github.com/digitalocean/godo/apps.go
+++ b/vendor/github.com/digitalocean/godo/apps.go
@@ -48,6 +48,8 @@ type AppsService interface {
 
 	ListAlerts(ctx context.Context, appID string) ([]*AppAlert, *Response, error)
 	UpdateAlertDestinations(ctx context.Context, appID, alertID string, update *AlertDestinationUpdateRequest) (*AppAlert, *Response, error)
+
+	Detect(ctx context.Context, detect *DetectRequest) (*DetectResponse, *Response, error)
 }
 
 // AppLogs represent app logs.
@@ -123,6 +125,11 @@ type appAlertRoot struct {
 // AppsServiceOp handles communication with Apps methods of the DigitalOcean API.
 type AppsServiceOp struct {
 	client *Client
+}
+
+// URN returns a URN identifier for the app
+func (a App) URN() string {
+	return ToURN("app", a.ID)
 }
 
 // Create an app.
@@ -418,4 +425,20 @@ func (s *AppsServiceOp) UpdateAlertDestinations(ctx context.Context, appID, aler
 		return nil, resp, err
 	}
 	return root.Alert, resp, nil
+}
+
+// Detect an app.
+func (s *AppsServiceOp) Detect(ctx context.Context, detect *DetectRequest) (*DetectResponse, *Response, error) {
+	path := fmt.Sprintf("%s/detect", appsBasePath)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, detect)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res := &DetectResponse{}
+	resp, err := s.client.Do(ctx, req, res)
+	if err != nil {
+		return nil, resp, err
+	}
+	return res, resp, nil
 }

--- a/vendor/github.com/digitalocean/godo/balance.go
+++ b/vendor/github.com/digitalocean/godo/balance.go
@@ -8,7 +8,7 @@ import (
 
 // BalanceService is an interface for interfacing with the Balance
 // endpoints of the DigitalOcean API
-// See: https://docs.digitalocean.com/reference/api/api-reference/#operation/get_customer_balance
+// See: https://docs.digitalocean.com/reference/api/api-reference/#operation/balance_get
 type BalanceService interface {
 	Get(context.Context) (*Balance, *Response, error)
 }

--- a/vendor/github.com/digitalocean/godo/billing_history.go
+++ b/vendor/github.com/digitalocean/godo/billing_history.go
@@ -10,7 +10,7 @@ const billingHistoryBasePath = "v2/customers/my/billing_history"
 
 // BillingHistoryService is an interface for interfacing with the BillingHistory
 // endpoints of the DigitalOcean API
-// See: https://docs.digitalocean.com/reference/api/api-reference/#operation/list_billing_history
+// See: https://docs.digitalocean.com/reference/api/api-reference/#operation/billingHistory_list
 type BillingHistoryService interface {
 	List(context.Context, *ListOptions) (*BillingHistory, *Response, error)
 }

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -12,6 +12,7 @@ const (
 	databaseBasePath           = "/v2/databases"
 	databaseSinglePath         = databaseBasePath + "/%s"
 	databaseCAPath             = databaseBasePath + "/%s/ca"
+	databaseConfigPath         = databaseBasePath + "/%s/config"
 	databaseResizePath         = databaseBasePath + "/%s/resize"
 	databaseMigratePath        = databaseBasePath + "/%s/migrate"
 	databaseMaintenancePath    = databaseBasePath + "/%s/maintenance"
@@ -28,6 +29,7 @@ const (
 	databaseEvictionPolicyPath = databaseBasePath + "/%s/eviction_policy"
 	databaseSQLModePath        = databaseBasePath + "/%s/sql_mode"
 	databaseFirewallRulesPath  = databaseBasePath + "/%s/firewall"
+	databaseOptionsPath        = databaseBasePath + "/options"
 )
 
 // SQL Mode constants allow for MySQL-specific SQL flavor configuration.
@@ -80,6 +82,16 @@ const (
 	EvictionPolicyVolatileTTL    = "volatile_ttl"
 )
 
+// evictionPolicyMap is used to normalize the eviction policy string in requests
+// to the advanced Redis configuration endpoint from the consts used with SetEvictionPolicy.
+var evictionPolicyMap = map[string]string{
+	EvictionPolicyAllKeysLRU:     "allkeys-lru",
+	EvictionPolicyAllKeysRandom:  "allkeys-random",
+	EvictionPolicyVolatileLRU:    "volatile-lru",
+	EvictionPolicyVolatileRandom: "volatile-random",
+	EvictionPolicyVolatileTTL:    "volatile-ttl",
+}
+
 // The DatabasesService provides access to the DigitalOcean managed database
 // suite of products through the public API. Customers can create new database
 // clusters, migrate them  between regions, create replicas and interact with
@@ -122,6 +134,13 @@ type DatabasesService interface {
 	SetSQLMode(context.Context, string, ...string) (*Response, error)
 	GetFirewallRules(context.Context, string) ([]DatabaseFirewallRule, *Response, error)
 	UpdateFirewallRules(context.Context, string, *DatabaseUpdateFirewallRulesRequest) (*Response, error)
+	GetPostgreSQLConfig(context.Context, string) (*PostgreSQLConfig, *Response, error)
+	GetRedisConfig(context.Context, string) (*RedisConfig, *Response, error)
+	GetMySQLConfig(context.Context, string) (*MySQLConfig, *Response, error)
+	UpdatePostgreSQLConfig(context.Context, string, *PostgreSQLConfig) (*Response, error)
+	UpdateRedisConfig(context.Context, string, *RedisConfig) (*Response, error)
+	UpdateMySQLConfig(context.Context, string, *MySQLConfig) (*Response, error)
+	ListOptions(todo context.Context) (*DatabaseOptions, *Response, error)
 }
 
 // DatabasesServiceOp handles communication with the Databases related methods
@@ -318,6 +337,125 @@ type DatabaseFirewallRule struct {
 	CreatedAt   time.Time `json:"created_at"`
 }
 
+// PostgreSQLConfig holds advanced configurations for PostgreSQL database clusters.
+type PostgreSQLConfig struct {
+	AutovacuumFreezeMaxAge          *int                         `json:"autovacuum_freeze_max_age,omitempty"`
+	AutovacuumMaxWorkers            *int                         `json:"autovacuum_max_workers,omitempty"`
+	AutovacuumNaptime               *int                         `json:"autovacuum_naptime,omitempty"`
+	AutovacuumVacuumThreshold       *int                         `json:"autovacuum_vacuum_threshold,omitempty"`
+	AutovacuumAnalyzeThreshold      *int                         `json:"autovacuum_analyze_threshold,omitempty"`
+	AutovacuumVacuumScaleFactor     *float32                     `json:"autovacuum_vacuum_scale_factor,omitempty"`
+	AutovacuumAnalyzeScaleFactor    *float32                     `json:"autovacuum_analyze_scale_factor,omitempty"`
+	AutovacuumVacuumCostDelay       *int                         `json:"autovacuum_vacuum_cost_delay,omitempty"`
+	AutovacuumVacuumCostLimit       *int                         `json:"autovacuum_vacuum_cost_limit,omitempty"`
+	BGWriterDelay                   *int                         `json:"bgwriter_delay,omitempty"`
+	BGWriterFlushAfter              *int                         `json:"bgwriter_flush_after,omitempty"`
+	BGWriterLRUMaxpages             *int                         `json:"bgwriter_lru_maxpages,omitempty"`
+	BGWriterLRUMultiplier           *float32                     `json:"bgwriter_lru_multiplier,omitempty"`
+	DeadlockTimeoutMillis           *int                         `json:"deadlock_timeout,omitempty"`
+	DefaultToastCompression         *string                      `json:"default_toast_compression,omitempty"`
+	IdleInTransactionSessionTimeout *int                         `json:"idle_in_transaction_session_timeout,omitempty"`
+	JIT                             *bool                        `json:"jit,omitempty"`
+	LogAutovacuumMinDuration        *int                         `json:"log_autovacuum_min_duration,omitempty"`
+	LogErrorVerbosity               *string                      `json:"log_error_verbosity,omitempty"`
+	LogLinePrefix                   *string                      `json:"log_line_prefix,omitempty"`
+	LogMinDurationStatement         *int                         `json:"log_min_duration_statement,omitempty"`
+	MaxFilesPerProcess              *int                         `json:"max_files_per_process,omitempty"`
+	MaxPreparedTransactions         *int                         `json:"max_prepared_transactions,omitempty"`
+	MaxPredLocksPerTransaction      *int                         `json:"max_pred_locks_per_transaction,omitempty"`
+	MaxLocksPerTransaction          *int                         `json:"max_locks_per_transaction,omitempty"`
+	MaxStackDepth                   *int                         `json:"max_stack_depth,omitempty"`
+	MaxStandbyArchiveDelay          *int                         `json:"max_standby_archive_delay,omitempty"`
+	MaxStandbyStreamingDelay        *int                         `json:"max_standby_streaming_delay,omitempty"`
+	MaxReplicationSlots             *int                         `json:"max_replication_slots,omitempty"`
+	MaxLogicalReplicationWorkers    *int                         `json:"max_logical_replication_workers,omitempty"`
+	MaxParallelWorkers              *int                         `json:"max_parallel_workers,omitempty"`
+	MaxParallelWorkersPerGather     *int                         `json:"max_parallel_workers_per_gather,omitempty"`
+	MaxWorkerProcesses              *int                         `json:"max_worker_processes,omitempty"`
+	PGPartmanBGWRole                *string                      `json:"pg_partman_bgw.role,omitempty"`
+	PGPartmanBGWInterval            *int                         `json:"pg_partman_bgw.interval,omitempty"`
+	PGStatStatementsTrack           *string                      `json:"pg_stat_statements.track,omitempty"`
+	TempFileLimit                   *int                         `json:"temp_file_limit,omitempty"`
+	Timezone                        *string                      `json:"timezone,omitempty"`
+	TrackActivityQuerySize          *int                         `json:"track_activity_query_size,omitempty"`
+	TrackCommitTimestamp            *string                      `json:"track_commit_timestamp,omitempty"`
+	TrackFunctions                  *string                      `json:"track_functions,omitempty"`
+	TrackIOTiming                   *string                      `json:"track_io_timing,omitempty"`
+	MaxWalSenders                   *int                         `json:"max_wal_senders,omitempty"`
+	WalSenderTimeout                *int                         `json:"wal_sender_timeout,omitempty"`
+	WalWriterDelay                  *int                         `json:"wal_writer_delay,omitempty"`
+	SharedBuffersPercentage         *float32                     `json:"shared_buffers_percentage,omitempty"`
+	PgBouncer                       *PostgreSQLBouncerConfig     `json:"pgbouncer,omitempty"`
+	BackupHour                      *int                         `json:"backup_hour,omitempty"`
+	BackupMinute                    *int                         `json:"backup_minute,omitempty"`
+	WorkMem                         *int                         `json:"work_mem,omitempty"`
+	TimeScaleDB                     *PostgreSQLTimeScaleDBConfig `json:"timescaledb,omitempty"`
+}
+
+// PostgreSQLBouncerConfig configuration
+type PostgreSQLBouncerConfig struct {
+	ServerResetQueryAlways  *bool     `json:"server_reset_query_always,omitempty"`
+	IgnoreStartupParameters *[]string `json:"ignore_startup_parameters,omitempty"`
+	MinPoolSize             *int      `json:"min_pool_size,omitempty"`
+	ServerLifetime          *int      `json:"server_lifetime,omitempty"`
+	ServerIdleTimeout       *int      `json:"server_idle_timeout,omitempty"`
+	AutodbPoolSize          *int      `json:"autodb_pool_size,omitempty"`
+	AutodbPoolMode          *string   `json:"autodb_pool_mode,omitempty"`
+	AutodbMaxDbConnections  *int      `json:"autodb_max_db_connections,omitempty"`
+	AutodbIdleTimeout       *int      `json:"autodb_idle_timeout,omitempty"`
+}
+
+// PostgreSQLTimeScaleDBConfig configuration
+type PostgreSQLTimeScaleDBConfig struct {
+	MaxBackgroundWorkers *int `json:"max_background_workers,omitempty"`
+}
+
+// RedisConfig holds advanced configurations for Redis database clusters.
+type RedisConfig struct {
+	RedisMaxmemoryPolicy               *string `json:"redis_maxmemory_policy,omitempty"`
+	RedisPubsubClientOutputBufferLimit *int    `json:"redis_pubsub_client_output_buffer_limit,omitempty"`
+	RedisNumberOfDatabases             *int    `json:"redis_number_of_databases,omitempty"`
+	RedisIOThreads                     *int    `json:"redis_io_threads,omitempty"`
+	RedisLFULogFactor                  *int    `json:"redis_lfu_log_factor,omitempty"`
+	RedisLFUDecayTime                  *int    `json:"redis_lfu_decay_time,omitempty"`
+	RedisSSL                           *bool   `json:"redis_ssl,omitempty"`
+	RedisTimeout                       *int    `json:"redis_timeout,omitempty"`
+	RedisNotifyKeyspaceEvents          *string `json:"redis_notify_keyspace_events,omitempty"`
+	RedisPersistence                   *string `json:"redis_persistence,omitempty"`
+	RedisACLChannelsDefault            *string `json:"redis_acl_channels_default,omitempty"`
+}
+
+// MySQLConfig holds advanced configurations for MySQL database clusters.
+type MySQLConfig struct {
+	ConnectTimeout               *int     `json:"connect_timeout,omitempty"`
+	DefaultTimeZone              *string  `json:"default_time_zone,omitempty"`
+	InnodbLogBufferSize          *int     `json:"innodb_log_buffer_size,omitempty"`
+	InnodbOnlineAlterLogMaxSize  *int     `json:"innodb_online_alter_log_max_size,omitempty"`
+	InnodbLockWaitTimeout        *int     `json:"innodb_lock_wait_timeout,omitempty"`
+	InteractiveTimeout           *int     `json:"interactive_timeout,omitempty"`
+	MaxAllowedPacket             *int     `json:"max_allowed_packet,omitempty"`
+	NetReadTimeout               *int     `json:"net_read_timeout,omitempty"`
+	SortBufferSize               *int     `json:"sort_buffer_size,omitempty"`
+	SQLMode                      *string  `json:"sql_mode,omitempty"`
+	SQLRequirePrimaryKey         *bool    `json:"sql_require_primary_key,omitempty"`
+	WaitTimeout                  *int     `json:"wait_timeout,omitempty"`
+	NetWriteTimeout              *int     `json:"net_write_timeout,omitempty"`
+	GroupConcatMaxLen            *int     `json:"group_concat_max_len,omitempty"`
+	InformationSchemaStatsExpiry *int     `json:"information_schema_stats_expiry,omitempty"`
+	InnodbFtMinTokenSize         *int     `json:"innodb_ft_min_token_size,omitempty"`
+	InnodbFtServerStopwordTable  *string  `json:"innodb_ft_server_stopword_table,omitempty"`
+	InnodbPrintAllDeadlocks      *bool    `json:"innodb_print_all_deadlocks,omitempty"`
+	InnodbRollbackOnTimeout      *bool    `json:"innodb_rollback_on_timeout,omitempty"`
+	InternalTmpMemStorageEngine  *string  `json:"internal_tmp_mem_storage_engine,omitempty"`
+	MaxHeapTableSize             *int     `json:"max_heap_table_size,omitempty"`
+	TmpTableSize                 *int     `json:"tmp_table_size,omitempty"`
+	SlowQueryLog                 *bool    `json:"slow_query_log,omitempty"`
+	LongQueryTime                *float32 `json:"long_query_time,omitempty"`
+	BackupHour                   *int     `json:"backup_hour,omitempty"`
+	BackupMinute                 *int     `json:"backup_minute,omitempty"`
+	BinlogRetentionPeriod        *int     `json:"binlog_retention_period,omitempty"`
+}
+
 type databaseUserRoot struct {
 	User *DatabaseUser `json:"user"`
 }
@@ -344,6 +482,18 @@ type databaseRoot struct {
 
 type databaseCARoot struct {
 	CA *DatabaseCA `json:"ca"`
+}
+
+type databasePostgreSQLConfigRoot struct {
+	Config *PostgreSQLConfig `json:"config"`
+}
+
+type databaseRedisConfigRoot struct {
+	Config *RedisConfig `json:"config"`
+}
+
+type databaseMySQLConfigRoot struct {
+	Config *MySQLConfig `json:"config"`
 }
 
 type databaseBackupsRoot struct {
@@ -376,6 +526,32 @@ type sqlModeRoot struct {
 
 type databaseFirewallRuleRoot struct {
 	Rules []DatabaseFirewallRule `json:"rules"`
+}
+
+// databaseOptionsRoot represents the root of all available database options (i.e. engines, regions, version, etc.)
+type databaseOptionsRoot struct {
+	Options *DatabaseOptions `json:"options"`
+}
+
+// DatabaseOptions represents the available database engines
+type DatabaseOptions struct {
+	MongoDBOptions     DatabaseEngineOptions `json:"mongodb"`
+	MySQLOptions       DatabaseEngineOptions `json:"mysql"`
+	PostgresSQLOptions DatabaseEngineOptions `json:"pg"`
+	RedisOptions       DatabaseEngineOptions `json:"redis"`
+}
+
+// DatabaseEngineOptions represents the configuration options that are available for a given database engine
+type DatabaseEngineOptions struct {
+	Regions  []string         `json:"regions"`
+	Versions []string         `json:"versions"`
+	Layouts  []DatabaseLayout `json:"layouts"`
+}
+
+// DatabaseLayout represents the slugs available for a given database engine at various node counts
+type DatabaseLayout struct {
+	NodeNum int      `json:"num_nodes"`
+	Sizes   []string `json:"sizes"`
 }
 
 // URN returns a URN identifier for the database
@@ -878,4 +1054,127 @@ func (svc *DatabasesServiceOp) UpdateFirewallRules(ctx context.Context, database
 		return nil, err
 	}
 	return svc.client.Do(ctx, req, nil)
+}
+
+// GetPostgreSQLConfig retrieves the config for a PostgreSQL database cluster.
+func (svc *DatabasesServiceOp) GetPostgreSQLConfig(ctx context.Context, databaseID string) (*PostgreSQLConfig, *Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databasePostgreSQLConfigRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Config, resp, nil
+}
+
+// UpdatePostgreSQLConfig updates the config for a PostgreSQL database cluster.
+func (svc *DatabasesServiceOp) UpdatePostgreSQLConfig(ctx context.Context, databaseID string, config *PostgreSQLConfig) (*Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	root := &databasePostgreSQLConfigRoot{
+		Config: config,
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// GetRedisConfig retrieves the config for a Redis database cluster.
+func (svc *DatabasesServiceOp) GetRedisConfig(ctx context.Context, databaseID string) (*RedisConfig, *Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databaseRedisConfigRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Config, resp, nil
+}
+
+// UpdateRedisConfig updates the config for a Redis database cluster.
+func (svc *DatabasesServiceOp) UpdateRedisConfig(ctx context.Context, databaseID string, config *RedisConfig) (*Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+
+	// We provide consts for use with SetEvictionPolicy method. Unfortunately, those are
+	// in a different format than what can be used for RedisConfig.RedisMaxmemoryPolicy.
+	// So we attempt to normalize them here to use dashes as separators if provided in
+	// the old format (underscores). Other values are passed through untouched.
+	if config.RedisMaxmemoryPolicy != nil {
+		if policy, ok := evictionPolicyMap[*config.RedisMaxmemoryPolicy]; ok {
+			config.RedisMaxmemoryPolicy = &policy
+		}
+	}
+
+	root := &databaseRedisConfigRoot{
+		Config: config,
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// GetMySQLConfig retrieves the config for a MySQL database cluster.
+func (svc *DatabasesServiceOp) GetMySQLConfig(ctx context.Context, databaseID string) (*MySQLConfig, *Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databaseMySQLConfigRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Config, resp, nil
+}
+
+// UpdateMySQLConfig updates the config for a MySQL database cluster.
+func (svc *DatabasesServiceOp) UpdateMySQLConfig(ctx context.Context, databaseID string, config *MySQLConfig) (*Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	root := &databaseMySQLConfigRoot{
+		Config: config,
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// ListOptions gets the database options available.
+func (svc *DatabasesServiceOp) ListOptions(ctx context.Context) (*DatabaseOptions, *Response, error) {
+	root := new(databaseOptionsRoot)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, databaseOptionsPath, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Options, resp, nil
 }

--- a/vendor/github.com/digitalocean/godo/droplets.go
+++ b/vendor/github.com/digitalocean/godo/droplets.go
@@ -17,6 +17,7 @@ var errNoNetworks = errors.New("no networks have been defined")
 // See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Droplets
 type DropletsService interface {
 	List(context.Context, *ListOptions) ([]Droplet, *Response, error)
+	ListByName(context.Context, string, *ListOptions) ([]Droplet, *Response, error)
 	ListByTag(context.Context, string, *ListOptions) ([]Droplet, *Response, error)
 	Get(context.Context, int) (*Droplet, *Response, error)
 	Create(context.Context, *DropletCreateRequest) (*Droplet, *Response, error)
@@ -312,6 +313,18 @@ func (s *DropletsServiceOp) list(ctx context.Context, path string) ([]Droplet, *
 // List all Droplets.
 func (s *DropletsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Droplet, *Response, error) {
 	path := dropletBasePath
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s.list(ctx, path)
+}
+
+// ListByName lists all Droplets filtered by name returning only exact matches.
+// It is case-insensitive
+func (s *DropletsServiceOp) ListByName(ctx context.Context, name string, opt *ListOptions) ([]Droplet, *Response, error) {
+	path := fmt.Sprintf("%s?name=%s", dropletBasePath, name)
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.81.0"
+	libraryVersion = "1.83.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -20,7 +20,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.81.0
+# github.com/digitalocean/godo v1.83.0
 ## explicit; go 1.18
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
**What**

Supports fetching database options for the following dimensions:

- engines
- regions
- versions
- layouts (node counts + available slugs)

**Why**

Support for this was added on the [public openapi docs](https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_list_options). Being able to interact with this via `doctl` will enable discovery of available database options when users consider creating a cluster