### PR TITLE
Incorporate package.json in serverless plugin

### DIFF
--- a/do/serverless.go
+++ b/do/serverless.go
@@ -164,7 +164,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minServerlessVersion = "4.1.0-1.3.0"
+	minServerlessVersion = "4.1.0-1.3.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"


### PR DESCRIPTION
Historically, we have not incorporated a `package.json` file in the serverless plugin.   There is a copy of `nodejs`, a primary javascript source file, and a `node_modules` directory which is almost always enough to get a valid execution.

However, `nodejs` will start by looking for, and optionally reading, `package.json`.   If it is not there, it goes up the parent directory hierarchy until it finds one and reads that.  The result is harmless if there is none or if there is a valid one (the results don't end up getting used in our case).   However, if there is an _invalid_ one in a parent directory, the serverless plugin will fail to initialize with a hopelessly confusing error.

This has only been reported by a user once, but once is enough.  This change includes the purely defensive change of including a a valid `package.json` in the plugin directory (it is the one used to build the plugin).

The actual change is in the plugin build and increments the patch version for the plugin bridge code.   The only changed line here is to the `minServerlessVersion` constant.