### PR TITLE
bump dockerfile version 1.16 -> 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1: Build
-FROM golang:1.16-alpine AS build
+FROM golang:1.18-alpine AS build
 
 ARG GOARCH=amd64
 ENV OUT_D /out


### PR DESCRIPTION
**Why**

The instructions presented in [Building with Docker](https://github.com/digitalocean/doctl#building-with-docker) are no longer possible, `doctl` requires go v1.18. See below:

```
docker build . --tag=doctl . 

[+] Building 44.5s (16/18)
 => [internal] load build definition from Dockerfile
...
#16 13.94 ../../commands/displayers/functions.go:58:16: undefined: time.UnixMilli
#16 13.94 note: module requires Go 1.18
#16 23.31 make: *** [Makefile:48: _build] Error 2
------
executor failed running [/bin/sh -c cd /go/src/[github.com/digitalocean/doctl](http://github.com/digitalocean/doctl) &&     make build GOARCH=$GOARCH]: exit code: 2
```

To keep `doctl` usable with just Docker, this PR bumps the Dockerfile from `golang:1.16-alpine` to `golang:1.18-alpine`


**Result**

Able to build, run, and get results from doctl without Go v1.18 configured on dev machine

```
 docker build --tag=doctl .
```
    
```
docker run --rm --interactive --tty --env=DIGITALOCEAN_ACCESS_TOKEN=$DO_TOKEN doctl database list
```

```                                     
ID    Name     Engine    Version    Number of Nodes    Region    Status    Size
24e7c206-0d9b...    db-postgresql-foo-bar    pg        11         1                  nyc3      online    db-s-1vcpu-1gb
```