### PR TITLE
Add copy on write support for CNB builds

### DIFF
--- a/commands/apps_dev.go
+++ b/commands/apps_dev.go
@@ -250,7 +250,7 @@ func RunAppsDevBuild(c *CmdConfig) error {
 		}
 	}
 
-	cli, err := c.Doit.GetContainerEngineClient()
+	cli, err := c.Doit.GetDockerEngineClient()
 	if err != nil {
 		return err
 	}
@@ -290,7 +290,8 @@ func RunAppsDevBuild(c *CmdConfig) error {
 	var res builder.ComponentBuilderResult
 	err = func() error {
 		defer cancel()
-		builder, err := c.componentBuilderFactory.NewComponentBuilder(cli, spec, builder.NewBuilderOpts{
+
+		builder, err := c.componentBuilderFactory.NewComponentBuilder(cli, conf.contextDir, spec, builder.NewBuilderOpts{
 			Component:            component,
 			Registry:             registryName,
 			EnvOverride:          envs,

--- a/commands/apps_dev_test.go
+++ b/commands/apps_dev_test.go
@@ -34,8 +34,11 @@ func TestRunAppsDevBuild(t *testing.T) {
 			config.Doit.Set(config.NS, doctl.ArgRegistryName, registryName)
 			config.Doit.Set(config.NS, doctl.ArgInteractive, false)
 
+			conf, err := newAppDevConfig(config)
+			require.NoError(t, err)
+
 			tm.appBuilder.EXPECT().Build(gomock.Any()).Return(builder.ComponentBuilderResult{}, nil)
-			tm.appBuilderFactory.EXPECT().NewComponentBuilder(gomock.Any(), sampleSpec, gomock.Any()).Return(tm.appBuilder, nil)
+			tm.appBuilderFactory.EXPECT().NewComponentBuilder(gomock.Any(), conf.contextDir, sampleSpec, gomock.Any()).Return(tm.appBuilder, nil)
 
 			err = RunAppsDevBuild(config)
 			require.NoError(t, err)
@@ -44,7 +47,9 @@ func TestRunAppsDevBuild(t *testing.T) {
 
 	t.Run("with appID", func(t *testing.T) {
 		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-			tm.appBuilderFactory.EXPECT().NewComponentBuilder(gomock.Any(), sampleSpec, gomock.Any()).Return(tm.appBuilder, nil)
+			conf, err := newAppDevConfig(config)
+			require.NoError(t, err)
+			tm.appBuilderFactory.EXPECT().NewComponentBuilder(gomock.Any(), conf.contextDir, sampleSpec, gomock.Any()).Return(tm.appBuilder, nil)
 			tm.appBuilder.EXPECT().Build(gomock.Any()).Return(builder.ComponentBuilderResult{}, nil)
 
 			tm.apps.EXPECT().Get(appID).Times(1).Return(&godo.App{
@@ -56,7 +61,7 @@ func TestRunAppsDevBuild(t *testing.T) {
 			config.Doit.Set(config.NS, doctl.ArgRegistryName, registryName)
 			config.Doit.Set(config.NS, doctl.ArgInteractive, false)
 
-			err := RunAppsDevBuild(config)
+			err = RunAppsDevBuild(config)
 			require.NoError(t, err)
 		})
 	})

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -147,43 +147,43 @@ func assertCommandNames(t *testing.T, cmd *Command, expected ...string) {
 type testFn func(c *CmdConfig, tm *tcMocks)
 
 type tcMocks struct {
-	account                  *domocks.MockAccountService
-	actions                  *domocks.MockActionsService
-	apps                     *domocks.MockAppsService
-	balance                  *domocks.MockBalanceService
-	billingHistory           *domocks.MockBillingHistoryService
-	databases                *domocks.MockDatabasesService
-	dropletActions           *domocks.MockDropletActionsService
-	droplets                 *domocks.MockDropletsService
-	keys                     *domocks.MockKeysService
-	sizes                    *domocks.MockSizesService
-	regions                  *domocks.MockRegionsService
-	images                   *domocks.MockImagesService
-	imageActions             *domocks.MockImageActionsService
-	invoices                 *domocks.MockInvoicesService
-	reservedIPs              *domocks.MockReservedIPsService
-	reservedIPActions        *domocks.MockReservedIPActionsService
-	domains                  *domocks.MockDomainsService
-	volumes                  *domocks.MockVolumesService
-	volumeActions            *domocks.MockVolumeActionsService
-	tags                     *domocks.MockTagsService
-	snapshots                *domocks.MockSnapshotsService
-	certificates             *domocks.MockCertificatesService
-	loadBalancers            *domocks.MockLoadBalancersService
-	firewalls                *domocks.MockFirewallsService
-	cdns                     *domocks.MockCDNsService
-	projects                 *domocks.MockProjectsService
-	kubernetes               *domocks.MockKubernetesService
-	registry                 *domocks.MockRegistryService
-	sshRunner                *domocks.MockRunner
-	vpcs                     *domocks.MockVPCsService
-	oneClick                 *domocks.MockOneClickService
-	listen                   *domocks.MockListenerService
-	monitoring               *domocks.MockMonitoringService
-	sandbox                  *domocks.MockSandboxService
-	appBuilderFactory        *builder.MockComponentBuilderFactory
-	appBuilder               *builder.MockComponentBuilder
-	appContainerEngineClient *builder.MockContainerEngineClient
+	account               *domocks.MockAccountService
+	actions               *domocks.MockActionsService
+	apps                  *domocks.MockAppsService
+	balance               *domocks.MockBalanceService
+	billingHistory        *domocks.MockBillingHistoryService
+	databases             *domocks.MockDatabasesService
+	dropletActions        *domocks.MockDropletActionsService
+	droplets              *domocks.MockDropletsService
+	keys                  *domocks.MockKeysService
+	sizes                 *domocks.MockSizesService
+	regions               *domocks.MockRegionsService
+	images                *domocks.MockImagesService
+	imageActions          *domocks.MockImageActionsService
+	invoices              *domocks.MockInvoicesService
+	reservedIPs           *domocks.MockReservedIPsService
+	reservedIPActions     *domocks.MockReservedIPActionsService
+	domains               *domocks.MockDomainsService
+	volumes               *domocks.MockVolumesService
+	volumeActions         *domocks.MockVolumeActionsService
+	tags                  *domocks.MockTagsService
+	snapshots             *domocks.MockSnapshotsService
+	certificates          *domocks.MockCertificatesService
+	loadBalancers         *domocks.MockLoadBalancersService
+	firewalls             *domocks.MockFirewallsService
+	cdns                  *domocks.MockCDNsService
+	projects              *domocks.MockProjectsService
+	kubernetes            *domocks.MockKubernetesService
+	registry              *domocks.MockRegistryService
+	sshRunner             *domocks.MockRunner
+	vpcs                  *domocks.MockVPCsService
+	oneClick              *domocks.MockOneClickService
+	listen                *domocks.MockListenerService
+	monitoring            *domocks.MockMonitoringService
+	sandbox               *domocks.MockSandboxService
+	appBuilderFactory     *builder.MockComponentBuilderFactory
+	appBuilder            *builder.MockComponentBuilder
+	appDockerEngineClient *builder.MockDockerEngineClient
 }
 
 func withTestClient(t *testing.T, tFn testFn) {
@@ -191,47 +191,47 @@ func withTestClient(t *testing.T, tFn testFn) {
 	defer ctrl.Finish()
 
 	tm := &tcMocks{
-		account:                  domocks.NewMockAccountService(ctrl),
-		actions:                  domocks.NewMockActionsService(ctrl),
-		apps:                     domocks.NewMockAppsService(ctrl),
-		balance:                  domocks.NewMockBalanceService(ctrl),
-		billingHistory:           domocks.NewMockBillingHistoryService(ctrl),
-		keys:                     domocks.NewMockKeysService(ctrl),
-		sizes:                    domocks.NewMockSizesService(ctrl),
-		regions:                  domocks.NewMockRegionsService(ctrl),
-		images:                   domocks.NewMockImagesService(ctrl),
-		imageActions:             domocks.NewMockImageActionsService(ctrl),
-		invoices:                 domocks.NewMockInvoicesService(ctrl),
-		reservedIPs:              domocks.NewMockReservedIPsService(ctrl),
-		reservedIPActions:        domocks.NewMockReservedIPActionsService(ctrl),
-		droplets:                 domocks.NewMockDropletsService(ctrl),
-		dropletActions:           domocks.NewMockDropletActionsService(ctrl),
-		domains:                  domocks.NewMockDomainsService(ctrl),
-		tags:                     domocks.NewMockTagsService(ctrl),
-		volumes:                  domocks.NewMockVolumesService(ctrl),
-		volumeActions:            domocks.NewMockVolumeActionsService(ctrl),
-		snapshots:                domocks.NewMockSnapshotsService(ctrl),
-		certificates:             domocks.NewMockCertificatesService(ctrl),
-		loadBalancers:            domocks.NewMockLoadBalancersService(ctrl),
-		firewalls:                domocks.NewMockFirewallsService(ctrl),
-		cdns:                     domocks.NewMockCDNsService(ctrl),
-		projects:                 domocks.NewMockProjectsService(ctrl),
-		kubernetes:               domocks.NewMockKubernetesService(ctrl),
-		databases:                domocks.NewMockDatabasesService(ctrl),
-		registry:                 domocks.NewMockRegistryService(ctrl),
-		sshRunner:                domocks.NewMockRunner(ctrl),
-		vpcs:                     domocks.NewMockVPCsService(ctrl),
-		oneClick:                 domocks.NewMockOneClickService(ctrl),
-		listen:                   domocks.NewMockListenerService(ctrl),
-		monitoring:               domocks.NewMockMonitoringService(ctrl),
-		sandbox:                  domocks.NewMockSandboxService(ctrl),
-		appBuilderFactory:        builder.NewMockComponentBuilderFactory(ctrl),
-		appBuilder:               builder.NewMockComponentBuilder(ctrl),
-		appContainerEngineClient: builder.NewMockContainerEngineClient(ctrl),
+		account:               domocks.NewMockAccountService(ctrl),
+		actions:               domocks.NewMockActionsService(ctrl),
+		apps:                  domocks.NewMockAppsService(ctrl),
+		balance:               domocks.NewMockBalanceService(ctrl),
+		billingHistory:        domocks.NewMockBillingHistoryService(ctrl),
+		keys:                  domocks.NewMockKeysService(ctrl),
+		sizes:                 domocks.NewMockSizesService(ctrl),
+		regions:               domocks.NewMockRegionsService(ctrl),
+		images:                domocks.NewMockImagesService(ctrl),
+		imageActions:          domocks.NewMockImageActionsService(ctrl),
+		invoices:              domocks.NewMockInvoicesService(ctrl),
+		reservedIPs:           domocks.NewMockReservedIPsService(ctrl),
+		reservedIPActions:     domocks.NewMockReservedIPActionsService(ctrl),
+		droplets:              domocks.NewMockDropletsService(ctrl),
+		dropletActions:        domocks.NewMockDropletActionsService(ctrl),
+		domains:               domocks.NewMockDomainsService(ctrl),
+		tags:                  domocks.NewMockTagsService(ctrl),
+		volumes:               domocks.NewMockVolumesService(ctrl),
+		volumeActions:         domocks.NewMockVolumeActionsService(ctrl),
+		snapshots:             domocks.NewMockSnapshotsService(ctrl),
+		certificates:          domocks.NewMockCertificatesService(ctrl),
+		loadBalancers:         domocks.NewMockLoadBalancersService(ctrl),
+		firewalls:             domocks.NewMockFirewallsService(ctrl),
+		cdns:                  domocks.NewMockCDNsService(ctrl),
+		projects:              domocks.NewMockProjectsService(ctrl),
+		kubernetes:            domocks.NewMockKubernetesService(ctrl),
+		databases:             domocks.NewMockDatabasesService(ctrl),
+		registry:              domocks.NewMockRegistryService(ctrl),
+		sshRunner:             domocks.NewMockRunner(ctrl),
+		vpcs:                  domocks.NewMockVPCsService(ctrl),
+		oneClick:              domocks.NewMockOneClickService(ctrl),
+		listen:                domocks.NewMockListenerService(ctrl),
+		monitoring:            domocks.NewMockMonitoringService(ctrl),
+		sandbox:               domocks.NewMockSandboxService(ctrl),
+		appBuilderFactory:     builder.NewMockComponentBuilderFactory(ctrl),
+		appBuilder:            builder.NewMockComponentBuilder(ctrl),
+		appDockerEngineClient: builder.NewMockDockerEngineClient(ctrl),
 	}
 
 	testConfig := doctl.NewTestConfig()
-	testConfig.ContainerEngineClient = tm.appContainerEngineClient
+	testConfig.DockerEngineClient = tm.appDockerEngineClient
 
 	config := &CmdConfig{
 		NS:   "test",

--- a/doit.go
+++ b/doit.go
@@ -177,7 +177,7 @@ func (glv *GithubLatestVersioner) LatestVersion() (string, error) {
 // Config is an interface that represent doit's config.
 type Config interface {
 	GetGodoClient(trace bool, accessToken string) (*godo.Client, error)
-	GetContainerEngineClient() (builder.ContainerEngineClient, error)
+	GetDockerEngineClient() (builder.DockerEngineClient, error)
 	SSH(user, host, keyPath string, port int, opts ssh.Options) runner.Runner
 	Listen(url *url.URL, token string, schemaFunc listen.SchemaFunc, out io.Writer) listen.ListenerService
 	Set(ns, key string, val interface{})
@@ -235,8 +235,8 @@ func (c *LiveConfig) GetGodoClient(trace bool, accessToken string) (*godo.Client
 	return godo.New(oauthClient, args...)
 }
 
-// GetContainerEngineClient returns a container engine client.
-func (c *LiveConfig) GetContainerEngineClient() (builder.ContainerEngineClient, error) {
+// GetDockerEngineClient returns a container engine client.
+func (c *LiveConfig) GetDockerEngineClient() (builder.DockerEngineClient, error) {
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, err
@@ -405,11 +405,11 @@ func isRequired(key string) bool {
 
 // TestConfig is an implementation of Config for testing.
 type TestConfig struct {
-	SSHFn                 func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner
-	ListenFn              func(url *url.URL, token string, schemaFunc listen.SchemaFunc, out io.Writer) listen.ListenerService
-	v                     *viper.Viper
-	IsSetMap              map[string]bool
-	ContainerEngineClient builder.ContainerEngineClient
+	SSHFn              func(user, host, keyPath string, port int, opts ssh.Options) runner.Runner
+	ListenFn           func(url *url.URL, token string, schemaFunc listen.SchemaFunc, out io.Writer) listen.ListenerService
+	v                  *viper.Viper
+	IsSetMap           map[string]bool
+	DockerEngineClient builder.DockerEngineClient
 }
 
 var _ Config = &TestConfig{}
@@ -434,10 +434,10 @@ func (c *TestConfig) GetGodoClient(trace bool, accessToken string) (*godo.Client
 	return &godo.Client{}, nil
 }
 
-// GetContainerEngineClient mocks a GetContainerEngineClient call. The returned client will
+// GetDockerEngineClient mocks a GetDockerEngineClient call. The returned client will
 // be nil unless configured in the test config.
-func (c *TestConfig) GetContainerEngineClient() (builder.ContainerEngineClient, error) {
-	return c.ContainerEngineClient, nil
+func (c *TestConfig) GetDockerEngineClient() (builder.DockerEngineClient, error) {
+	return c.DockerEngineClient, nil
 }
 
 // SSH returns a mock SSH runner.

--- a/internal/apps/builder/builder_mock.go
+++ b/internal/apps/builder/builder_mock.go
@@ -36,18 +36,18 @@ func (m *MockComponentBuilderFactory) EXPECT() *MockComponentBuilderFactoryMockR
 }
 
 // NewComponentBuilder mocks base method.
-func (m *MockComponentBuilderFactory) NewComponentBuilder(arg0 ContainerEngineClient, arg1 *godo.AppSpec, arg2 NewBuilderOpts) (ComponentBuilder, error) {
+func (m *MockComponentBuilderFactory) NewComponentBuilder(arg0 DockerEngineClient, arg1 string, arg2 *godo.AppSpec, arg3 NewBuilderOpts) (ComponentBuilder, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewComponentBuilder", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "NewComponentBuilder", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(ComponentBuilder)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewComponentBuilder indicates an expected call of NewComponentBuilder.
-func (mr *MockComponentBuilderFactoryMockRecorder) NewComponentBuilder(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockComponentBuilderFactoryMockRecorder) NewComponentBuilder(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewComponentBuilder", reflect.TypeOf((*MockComponentBuilderFactory)(nil).NewComponentBuilder), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewComponentBuilder", reflect.TypeOf((*MockComponentBuilderFactory)(nil).NewComponentBuilder), arg0, arg1, arg2, arg3)
 }
 
 // MockComponentBuilder is a mock of ComponentBuilder interface.

--- a/internal/apps/builder/builder_test.go
+++ b/internal/apps/builder/builder_test.go
@@ -12,7 +12,7 @@ func TestNewBuilderComponent(t *testing.T) {
 	builderFactory := DefaultComponentBuilderFactory{}
 
 	t.Run("no component argument provided", func(t *testing.T) {
-		_, err := builderFactory.NewComponentBuilder(nil, &godo.AppSpec{
+		_, err := builderFactory.NewComponentBuilder(nil, ".", &godo.AppSpec{
 			Services: []*godo.AppServiceSpec{{
 				Name: "web",
 			}},
@@ -24,7 +24,7 @@ func TestNewBuilderComponent(t *testing.T) {
 
 	t.Run("component does not exist", func(t *testing.T) {
 		missingComponent := "missing-component"
-		_, err := builderFactory.NewComponentBuilder(nil, &godo.AppSpec{
+		_, err := builderFactory.NewComponentBuilder(nil, ".", &godo.AppSpec{
 			Services: []*godo.AppServiceSpec{{
 				Name: "web",
 			}},
@@ -35,7 +35,7 @@ func TestNewBuilderComponent(t *testing.T) {
 	})
 
 	t.Run("cnb builder", func(t *testing.T) {
-		builder, err := builderFactory.NewComponentBuilder(nil, &godo.AppSpec{
+		builder, err := builderFactory.NewComponentBuilder(nil, ".", &godo.AppSpec{
 			Services: []*godo.AppServiceSpec{{
 				Name: "web",
 			}},
@@ -47,7 +47,7 @@ func TestNewBuilderComponent(t *testing.T) {
 	})
 
 	t.Run("dockerfile builder", func(t *testing.T) {
-		builder, err := builderFactory.NewComponentBuilder(nil, &godo.AppSpec{
+		builder, err := builderFactory.NewComponentBuilder(nil, ".", &godo.AppSpec{
 			Services: []*godo.AppServiceSpec{{
 				Name:           "web",
 				DockerfilePath: ".",

--- a/internal/apps/builder/container.go
+++ b/internal/apps/builder/container.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/golang/mock/mockgen -source container.go -package builder -destination container_mock.go ContainerEngineClient
+//go:generate go run github.com/golang/mock/mockgen -source container.go -package builder -destination container_mock.go DockerEngineClient
 
 package builder
 
@@ -12,8 +12,8 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// ContainerEngineClient ...
-type ContainerEngineClient interface {
+// DockerEngineClient ...
+type DockerEngineClient interface {
 	ContainerCreate(ctx context.Context, config *containertypes.Config, hostConfig *containertypes.HostConfig, networkingConfig *networktypes.NetworkingConfig, platform *specs.Platform, containerName string) (containertypes.ContainerCreateCreatedBody, error)
 	ContainerStart(ctx context.Context, containerName string, options types.ContainerStartOptions) error
 	ContainerLogs(ctx context.Context, containerName string, options types.ContainerLogsOptions) (io.ReadCloser, error)
@@ -24,4 +24,5 @@ type ContainerEngineClient interface {
 	ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error
 	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
 	ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
+	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
 }

--- a/internal/apps/builder/container_mock.go
+++ b/internal/apps/builder/container_mock.go
@@ -16,31 +16,31 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// MockContainerEngineClient is a mock of ContainerEngineClient interface.
-type MockContainerEngineClient struct {
+// MockDockerEngineClient is a mock of DockerEngineClient interface.
+type MockDockerEngineClient struct {
 	ctrl     *gomock.Controller
-	recorder *MockContainerEngineClientMockRecorder
+	recorder *MockDockerEngineClientMockRecorder
 }
 
-// MockContainerEngineClientMockRecorder is the mock recorder for MockContainerEngineClient.
-type MockContainerEngineClientMockRecorder struct {
-	mock *MockContainerEngineClient
+// MockDockerEngineClientMockRecorder is the mock recorder for MockDockerEngineClient.
+type MockDockerEngineClientMockRecorder struct {
+	mock *MockDockerEngineClient
 }
 
-// NewMockContainerEngineClient creates a new mock instance.
-func NewMockContainerEngineClient(ctrl *gomock.Controller) *MockContainerEngineClient {
-	mock := &MockContainerEngineClient{ctrl: ctrl}
-	mock.recorder = &MockContainerEngineClientMockRecorder{mock}
+// NewMockDockerEngineClient creates a new mock instance.
+func NewMockDockerEngineClient(ctrl *gomock.Controller) *MockDockerEngineClient {
+	mock := &MockDockerEngineClient{ctrl: ctrl}
+	mock.recorder = &MockDockerEngineClientMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockContainerEngineClient) EXPECT() *MockContainerEngineClientMockRecorder {
+func (m *MockDockerEngineClient) EXPECT() *MockDockerEngineClientMockRecorder {
 	return m.recorder
 }
 
 // ContainerCreate mocks base method.
-func (m *MockContainerEngineClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *v1.Platform, containerName string) (container.ContainerCreateCreatedBody, error) {
+func (m *MockDockerEngineClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *v1.Platform, containerName string) (container.ContainerCreateCreatedBody, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerCreate", ctx, config, hostConfig, networkingConfig, platform, containerName)
 	ret0, _ := ret[0].(container.ContainerCreateCreatedBody)
@@ -49,13 +49,13 @@ func (m *MockContainerEngineClient) ContainerCreate(ctx context.Context, config 
 }
 
 // ContainerCreate indicates an expected call of ContainerCreate.
-func (mr *MockContainerEngineClientMockRecorder) ContainerCreate(ctx, config, hostConfig, networkingConfig, platform, containerName interface{}) *gomock.Call {
+func (mr *MockDockerEngineClientMockRecorder) ContainerCreate(ctx, config, hostConfig, networkingConfig, platform, containerName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerCreate", reflect.TypeOf((*MockContainerEngineClient)(nil).ContainerCreate), ctx, config, hostConfig, networkingConfig, platform, containerName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerCreate", reflect.TypeOf((*MockDockerEngineClient)(nil).ContainerCreate), ctx, config, hostConfig, networkingConfig, platform, containerName)
 }
 
 // ContainerExecAttach mocks base method.
-func (m *MockContainerEngineClient) ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error) {
+func (m *MockDockerEngineClient) ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerExecAttach", ctx, execID, config)
 	ret0, _ := ret[0].(types.HijackedResponse)
@@ -64,13 +64,13 @@ func (m *MockContainerEngineClient) ContainerExecAttach(ctx context.Context, exe
 }
 
 // ContainerExecAttach indicates an expected call of ContainerExecAttach.
-func (mr *MockContainerEngineClientMockRecorder) ContainerExecAttach(ctx, execID, config interface{}) *gomock.Call {
+func (mr *MockDockerEngineClientMockRecorder) ContainerExecAttach(ctx, execID, config interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecAttach", reflect.TypeOf((*MockContainerEngineClient)(nil).ContainerExecAttach), ctx, execID, config)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecAttach", reflect.TypeOf((*MockDockerEngineClient)(nil).ContainerExecAttach), ctx, execID, config)
 }
 
 // ContainerExecCreate mocks base method.
-func (m *MockContainerEngineClient) ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error) {
+func (m *MockDockerEngineClient) ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerExecCreate", ctx, container, config)
 	ret0, _ := ret[0].(types.IDResponse)
@@ -79,13 +79,13 @@ func (m *MockContainerEngineClient) ContainerExecCreate(ctx context.Context, con
 }
 
 // ContainerExecCreate indicates an expected call of ContainerExecCreate.
-func (mr *MockContainerEngineClientMockRecorder) ContainerExecCreate(ctx, container, config interface{}) *gomock.Call {
+func (mr *MockDockerEngineClientMockRecorder) ContainerExecCreate(ctx, container, config interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecCreate", reflect.TypeOf((*MockContainerEngineClient)(nil).ContainerExecCreate), ctx, container, config)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecCreate", reflect.TypeOf((*MockDockerEngineClient)(nil).ContainerExecCreate), ctx, container, config)
 }
 
 // ContainerExecInspect mocks base method.
-func (m *MockContainerEngineClient) ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error) {
+func (m *MockDockerEngineClient) ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerExecInspect", ctx, execID)
 	ret0, _ := ret[0].(types.ContainerExecInspect)
@@ -94,13 +94,13 @@ func (m *MockContainerEngineClient) ContainerExecInspect(ctx context.Context, ex
 }
 
 // ContainerExecInspect indicates an expected call of ContainerExecInspect.
-func (mr *MockContainerEngineClientMockRecorder) ContainerExecInspect(ctx, execID interface{}) *gomock.Call {
+func (mr *MockDockerEngineClientMockRecorder) ContainerExecInspect(ctx, execID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecInspect", reflect.TypeOf((*MockContainerEngineClient)(nil).ContainerExecInspect), ctx, execID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecInspect", reflect.TypeOf((*MockDockerEngineClient)(nil).ContainerExecInspect), ctx, execID)
 }
 
 // ContainerExecStart mocks base method.
-func (m *MockContainerEngineClient) ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error {
+func (m *MockDockerEngineClient) ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerExecStart", ctx, execID, config)
 	ret0, _ := ret[0].(error)
@@ -108,13 +108,13 @@ func (m *MockContainerEngineClient) ContainerExecStart(ctx context.Context, exec
 }
 
 // ContainerExecStart indicates an expected call of ContainerExecStart.
-func (mr *MockContainerEngineClientMockRecorder) ContainerExecStart(ctx, execID, config interface{}) *gomock.Call {
+func (mr *MockDockerEngineClientMockRecorder) ContainerExecStart(ctx, execID, config interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecStart", reflect.TypeOf((*MockContainerEngineClient)(nil).ContainerExecStart), ctx, execID, config)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecStart", reflect.TypeOf((*MockDockerEngineClient)(nil).ContainerExecStart), ctx, execID, config)
 }
 
 // ContainerLogs mocks base method.
-func (m *MockContainerEngineClient) ContainerLogs(ctx context.Context, containerName string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+func (m *MockDockerEngineClient) ContainerLogs(ctx context.Context, containerName string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerLogs", ctx, containerName, options)
 	ret0, _ := ret[0].(io.ReadCloser)
@@ -123,13 +123,13 @@ func (m *MockContainerEngineClient) ContainerLogs(ctx context.Context, container
 }
 
 // ContainerLogs indicates an expected call of ContainerLogs.
-func (mr *MockContainerEngineClientMockRecorder) ContainerLogs(ctx, containerName, options interface{}) *gomock.Call {
+func (mr *MockDockerEngineClientMockRecorder) ContainerLogs(ctx, containerName, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerLogs", reflect.TypeOf((*MockContainerEngineClient)(nil).ContainerLogs), ctx, containerName, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerLogs", reflect.TypeOf((*MockDockerEngineClient)(nil).ContainerLogs), ctx, containerName, options)
 }
 
 // ContainerRemove mocks base method.
-func (m *MockContainerEngineClient) ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error {
+func (m *MockDockerEngineClient) ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerRemove", ctx, container, options)
 	ret0, _ := ret[0].(error)
@@ -137,13 +137,13 @@ func (m *MockContainerEngineClient) ContainerRemove(ctx context.Context, contain
 }
 
 // ContainerRemove indicates an expected call of ContainerRemove.
-func (mr *MockContainerEngineClientMockRecorder) ContainerRemove(ctx, container, options interface{}) *gomock.Call {
+func (mr *MockDockerEngineClientMockRecorder) ContainerRemove(ctx, container, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerRemove", reflect.TypeOf((*MockContainerEngineClient)(nil).ContainerRemove), ctx, container, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerRemove", reflect.TypeOf((*MockDockerEngineClient)(nil).ContainerRemove), ctx, container, options)
 }
 
 // ContainerStart mocks base method.
-func (m *MockContainerEngineClient) ContainerStart(ctx context.Context, containerName string, options types.ContainerStartOptions) error {
+func (m *MockDockerEngineClient) ContainerStart(ctx context.Context, containerName string, options types.ContainerStartOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerStart", ctx, containerName, options)
 	ret0, _ := ret[0].(error)
@@ -151,13 +151,13 @@ func (m *MockContainerEngineClient) ContainerStart(ctx context.Context, containe
 }
 
 // ContainerStart indicates an expected call of ContainerStart.
-func (mr *MockContainerEngineClientMockRecorder) ContainerStart(ctx, containerName, options interface{}) *gomock.Call {
+func (mr *MockDockerEngineClientMockRecorder) ContainerStart(ctx, containerName, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStart", reflect.TypeOf((*MockContainerEngineClient)(nil).ContainerStart), ctx, containerName, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStart", reflect.TypeOf((*MockDockerEngineClient)(nil).ContainerStart), ctx, containerName, options)
 }
 
 // ContainerWait mocks base method.
-func (m *MockContainerEngineClient) ContainerWait(ctx context.Context, containerName string, condition container.WaitCondition) (<-chan container.ContainerWaitOKBody, <-chan error) {
+func (m *MockDockerEngineClient) ContainerWait(ctx context.Context, containerName string, condition container.WaitCondition) (<-chan container.ContainerWaitOKBody, <-chan error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerWait", ctx, containerName, condition)
 	ret0, _ := ret[0].(<-chan container.ContainerWaitOKBody)
@@ -166,13 +166,27 @@ func (m *MockContainerEngineClient) ContainerWait(ctx context.Context, container
 }
 
 // ContainerWait indicates an expected call of ContainerWait.
-func (mr *MockContainerEngineClientMockRecorder) ContainerWait(ctx, containerName, condition interface{}) *gomock.Call {
+func (mr *MockDockerEngineClientMockRecorder) ContainerWait(ctx, containerName, condition interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerWait", reflect.TypeOf((*MockContainerEngineClient)(nil).ContainerWait), ctx, containerName, condition)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerWait", reflect.TypeOf((*MockDockerEngineClient)(nil).ContainerWait), ctx, containerName, condition)
+}
+
+// CopyToContainer mocks base method.
+func (m *MockDockerEngineClient) CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CopyToContainer", ctx, container, path, content, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CopyToContainer indicates an expected call of CopyToContainer.
+func (mr *MockDockerEngineClientMockRecorder) CopyToContainer(ctx, container, path, content, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyToContainer", reflect.TypeOf((*MockDockerEngineClient)(nil).CopyToContainer), ctx, container, path, content, options)
 }
 
 // ImageBuild mocks base method.
-func (m *MockContainerEngineClient) ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
+func (m *MockDockerEngineClient) ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImageBuild", ctx, context, options)
 	ret0, _ := ret[0].(types.ImageBuildResponse)
@@ -181,7 +195,7 @@ func (m *MockContainerEngineClient) ImageBuild(ctx context.Context, context io.R
 }
 
 // ImageBuild indicates an expected call of ImageBuild.
-func (mr *MockContainerEngineClientMockRecorder) ImageBuild(ctx, context, options interface{}) *gomock.Call {
+func (mr *MockDockerEngineClientMockRecorder) ImageBuild(ctx, context, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageBuild", reflect.TypeOf((*MockContainerEngineClient)(nil).ImageBuild), ctx, context, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageBuild", reflect.TypeOf((*MockDockerEngineClient)(nil).ImageBuild), ctx, context, options)
 }

--- a/internal/apps/builder/docker_test.go
+++ b/internal/apps/builder/docker_test.go
@@ -71,7 +71,7 @@ func TestDockerComponentBuild(t *testing.T) {
 			},
 		}
 
-		mockClient := NewMockContainerEngineClient(ctrl)
+		mockClient := NewMockDockerEngineClient(ctrl)
 		builder := &DockerComponentBuilder{
 			baseComponentBuilder: baseComponentBuilder{
 				cli:       mockClient,


### PR DESCRIPTION
### Description

#### What does this pull request accomplish

* Adds copy-on-write semantics to CNB builds
* `forced` to `true` for now because I don't see a reason users would want local CNB build artifacts but it is passed in as an option to be configureable later on
* Rename `ContainerEngineClient` interface to `DockerEngineClient` interface because contracts have docker cli specific types