### PR TITLE
Add snap support for docker interface for app dev builds

### DIFF
--- a/commands/apps_dev.go
+++ b/commands/apps_dev.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"sync"
 
@@ -311,6 +312,11 @@ func RunAppsDevBuild(c *CmdConfig) error {
 		}
 		res, err = builder.Build(ctx)
 		if err != nil {
+			_, isSnap := os.LookupEnv("SNAP")
+			if errors.Is(err, fs.ErrPermission) && isSnap {
+				template.Buffered(logWriter, `{{warning "Using the doctl Snap? Grant access to the doctl:app-dev-build plug to use this command with: sudo snap connect doctl:app-dev-build docker:docker-daemon"}}{{nl}}`, nil)
+				return err
+			}
 			return err
 		}
 		return nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,6 +64,8 @@ parts:
       bin/doctl: bin/doctl.real
 
 plugs:
+  app-dev-build:
+    interface: docker
   dot-docker:
     interface: personal-files
     write:
@@ -88,3 +90,4 @@ apps:
       - dot-docker
       - doctl-config
       - kube-config
+      - app-dev-build


### PR DESCRIPTION
### Description

#### What does this pull request accomplish

Adds `app-dev-build` plug w/ the `docker` interface

> This will require the user to have docker installed via snap and execute `snap connect doctl:app-dev-build docker:docker-daemon` to grant permissions