### PR TITLE
Unhide the multiple namespaces feature

### DIFF
--- a/commands/namespaces.go
+++ b/commands/namespaces.go
@@ -45,7 +45,6 @@ func Namespaces() *Command {
 The subcommands of ` + "`" + `doctl serverless namespaces` + "`" + ` are used to manage multiple functions namespaces within your account.
 Use ` + "`" + `doctl serverless connect` + "`" + ` with an explicit argument to connect to a specific namespace.  You are connected to one namespace at a time.`,
 			Aliases: []string{"ns"},
-			Hidden:  true, // multiple namespace support is guarded by a feature flipper
 		},
 	}
 	create := CmdBuilder(cmd, RunNamespacesCreate, "create", "Creates a namespace",

--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -81,11 +81,9 @@ The install operation is long-running, and a network connection is required.`,
 	CmdBuilder(cmd, RunServerlessUninstall, "uninstall", "Removes the serverless support", `Removes serverless support from `+"`"+`doctl`+"`",
 		Writer)
 
-	connect := CmdBuilder(cmd, RunServerlessConnect, "connect", "Connects local serverless support to your functions namespace",
+	CmdBuilder(cmd, RunServerlessConnect, "connect", "Connects local serverless support to your functions namespace",
 		`This command connects `+"`"+`doctl serverless`+"`"+` to your functions namespace (needed for testing).`,
 		Writer)
-	AddBoolFlag(connect, "beta", "", false, "use beta features to connect when no namespace is specified")
-	connect.Flags().MarkHidden("beta")
 
 	status := CmdBuilder(cmd, RunServerlessStatus, "status", "Provide information about serverless support",
 		`This command reports the status of serverless support and some details concerning its connected functions namespace.
@@ -165,16 +163,10 @@ func RunServerlessUninstall(c *CmdConfig) error {
 // RunServerlessConnect implements the serverless connect command
 func RunServerlessConnect(c *CmdConfig) error {
 	var (
-		creds do.ServerlessCredentials
-		err   error
+		err error
 	)
 
-	beta, _ := c.Doit.GetBool(c.NS, "beta")
-	maxArgs := 0
-	if beta {
-		maxArgs = 1
-	}
-	if len(c.Args) > maxArgs {
+	if len(c.Args) > 1 {
 		return doctl.NewTooManyArgsErr(c.NS)
 	}
 
@@ -200,26 +192,14 @@ func RunServerlessConnect(c *CmdConfig) error {
 		}
 		return connectFromList(ctx, sls, list, c.Out)
 	}
-
-	// Handle the case where no namespace was specified (originally, this was the only supported behavior)
-	// If requested via the --beta flag, do it the "new way".
-	if beta {
-		list, err := getMatchingNamespaces(ctx, sls, "")
-		if err != nil {
-			return err
-		}
-		if len(list) == 0 {
-			return errors.New("you must create a namespace with `doctl namespace create`, specifying a region and label")
-		}
-		return connectFromList(ctx, sls, list, c.Out)
-	}
-
-	// Legacy path when there is no argument and --beta is not specified
-	creds, err = sls.GetServerlessNamespace(ctx)
+	list, err := getMatchingNamespaces(ctx, sls, "")
 	if err != nil {
 		return err
 	}
-	return finishConnecting(sls, creds, "", c.Out)
+	if len(list) == 0 {
+		return errors.New("you must create a namespace with `doctl namespace create`, specifying a region and label")
+	}
+	return connectFromList(ctx, sls, list, c.Out)
 }
 
 // connectFromList connects a namespace based on a non-empty list of namespaces.  If the list is
@@ -270,8 +250,7 @@ func chooseFromList(list []do.OutputNamespace, out io.Writer) do.OutputNamespace
 	}
 }
 
-// finishConnecting performs the final steps of 'doctl serverless connect' regardless of whether
-// the legacy behavior is chosen or the new behavior (via the 'connectFromList` function)
+// finishConnecting performs the final steps of 'doctl serverless connect'.
 func finishConnecting(sls do.ServerlessService, creds do.ServerlessCredentials, label string, out io.Writer) error {
 	// Store the credentials
 	err := sls.WriteCredentials(creds)

--- a/commands/serverless_test.go
+++ b/commands/serverless_test.go
@@ -31,22 +31,6 @@ import (
 )
 
 func TestServerlessConnect(t *testing.T) {
-	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		buf := &bytes.Buffer{}
-		config.Out = buf
-
-		tm.serverless.EXPECT().CheckServerlessStatus(hashAccessToken(config)).Return(do.ErrServerlessNotConnected)
-		creds := do.ServerlessCredentials{Namespace: "hello", APIHost: "https://api.example.com"}
-		tm.serverless.EXPECT().GetServerlessNamespace(context.TODO()).Return(creds, nil)
-		tm.serverless.EXPECT().WriteCredentials(creds).Return(nil)
-
-		err := RunServerlessConnect(config)
-		require.NoError(t, err)
-		assert.Equal(t, "Connected to functions namespace 'hello' on API host 'https://api.example.com'\n\n", buf.String())
-	})
-}
-
-func TestServerlessConnectBeta(t *testing.T) {
 	tests := []struct {
 		name           string
 		namespaceList  []do.OutputNamespace
@@ -112,7 +96,6 @@ func TestServerlessConnectBeta(t *testing.T) {
 				if tt.doctlArg != "" {
 					config.Args = append(config.Args, tt.doctlArg)
 				}
-				config.Doit.Set(config.NS, "beta", true)
 				connectChoiceReader = bufio.NewReader(strings.NewReader("0\n"))
 				nsResponse := do.NamespaceListResponse{Namespaces: tt.namespaceList}
 				creds := do.ServerlessCredentials{Namespace: "ns1", APIHost: "https://api.example.com"}

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -47,8 +47,8 @@ type ServerlessCredential struct {
 	Auth string `json:"api_key"`
 }
 
-// The type of the "namespace" member of the response to /api/v2/functions/sandbox and
-// /api/v2/functions/namespaces APIs.  Only relevant fields unmarshalled
+// OutputNamespace is the type of the "namespace" member of the response to /api/v2/functions/sandbox
+// and /api/v2/functions/namespaces APIs.  Only relevant fields unmarshalled
 type OutputNamespace struct {
 	Namespace string `json:"namespace"`
 	APIHost   string `json:"api_host"`
@@ -652,11 +652,14 @@ func (s *serverlessService) GetHostInfo(APIHost string) (ServerlessHostInfo, err
 func (s *serverlessService) GetFunction(name string, fetchCode bool) (whisk.Action, []FunctionParameter, error) {
 	err := initWhisk(s)
 	if err != nil {
-		return whisk.Action{}, []FunctionParameter{}, nil
+		return whisk.Action{}, []FunctionParameter{}, err
 	}
 	action, resp, err := s.owClient.Actions.Get(name, fetchCode)
+	if err != nil {
+		return whisk.Action{}, []FunctionParameter{}, err
+	}
 	var parameters []FunctionParameter
-	if resp != nil && err == nil {
+	if resp != nil {
 		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
 		if err == nil {
@@ -668,7 +671,7 @@ func (s *serverlessService) GetFunction(name string, fetchCode bool) (whisk.Acti
 			parameters = reparse.Parameters
 		}
 	}
-	return *action, parameters, err
+	return *action, parameters, nil
 }
 
 // GetConnectedAPIHost retrieves the API host to which the service is currently connected


### PR DESCRIPTION
This change unhides the support for multiple namespaces.

It should probably not be merged until feature flippers are opened to make the capability available to all (it is still in beta as of now).

The change also fixes a bug in error returns from serverless functions get.