### PR TITLE
serverless: work-a-round for installing in snap build.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,7 @@ parts:
     build-environment:
     # Results in installation to /snap/doctl/current/opt/sandbox
     - OVERRIDE_SANDBOX_DIR: "$SNAPCRAFT_PART_INSTALL/opt/sandbox"
+    - SNAP_SANDBOX_INSTALL: "true"
     # Override to prevent 'invalid cross-device link' calling doctl
     - XDG_CONFIG_HOME: "$SNAPCRAFT_PART_INSTALL/tmp/.config"
     override-pull: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,8 +59,9 @@ parts:
       mv doctl $SNAPCRAFT_PART_INSTALL/bin/
 
       # Install the sandbox
+      mkdir -p $OVERRIDE_SANDBOX_DIR
       $SNAPCRAFT_PART_INSTALL/bin/doctl sandbox install
-      rm -r $XDG_CONFIG_HOME/doctl
+      rm -rf $XDG_CONFIG_HOME/doctl
     organize:
       bin/doctl: bin/doctl.real
 


### PR DESCRIPTION
The snap builds have failed after the serverless refactor as the command now requires doctl to be configured with an API token. 

https://github.com/digitalocean/doctl/runs/8207250662?check_suite_focus=true#step:4:610

This change allows us to by pass that requirement if `SNAP_SANDBOX_INSTALL` is  set.