### PR TITLE
Add support for typescript in the nodejs runtime

### DIFF
--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -39,17 +39,16 @@ var (
 	// Note: this table has all languages for which we possess samples.  Only those with currently
 	// active runtimes will display.
 	languageKeywords map[string][]string = map[string][]string{
-		"nodejs":     {"javascript", "js"},
-		"deno":       {"deno"},
-		"go":         {"go", "golang"},
-		"java":       {"java"},
-		"php":        {"php"},
-		"python":     {"python", "py"},
-		"ruby":       {"ruby"},
-		"rust":       {"rust"},
-		"swift":      {"swift"},
-		"dotnet":     {"csharp", "cs"},
-		"typescript": {"typescript", "ts"},
+		"nodejs": {"javascript", "js", "typescript", "ts"},
+		"deno":   {"deno"},
+		"go":     {"go", "golang"},
+		"java":   {"java"},
+		"php":    {"php"},
+		"python": {"python", "py"},
+		"ruby":   {"ruby"},
+		"rust":   {"rust"},
+		"swift":  {"swift"},
+		"dotnet": {"csharp", "cs"},
 	}
 )
 

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -227,7 +227,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minServerlessVersion = "4.1.0-1.3.1"
+	minServerlessVersion = "4.2.3-1.3.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"


### PR DESCRIPTION
The set of supported languages in DigitalOcean Functions actually includes TypeScript.   TypeScript does not require its own runtime but is supported by setting up the function project correctly to run in one of the `nodejs` runtimes.

This change (1) corrects the "languages" display (which is actually organized by runtime) to stop assuming there will eventually be a TypeScript runtime but rather correctly indicating that TypeScript is supported in the `nodejs` runtime.

(2) It also incorporates a later version of the serverless plugin which knows how to properly set up a functions project for Typescript and correctly associates the `.ts` file suffix with the `nodejs` runtime.