### PR TITLE
Connect ReadProject service to the get-metadata command to support testing and further progress

### DIFF
--- a/commands/serverless-extra.go
+++ b/commands/serverless-extra.go
@@ -155,19 +155,23 @@ func RunServerlessExtraGetMetadata(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	r, _ := c.Doit.GetBool(c.NS, flagProjectReader)
+	useProjectReader, _ := c.Doit.GetBool(c.NS, flagProjectReader)
 
 	var output do.ServerlessOutput
 	project := do.ServerlessProject{
 		ProjectPath: c.Args[0],
 	}
-	if r {
-		output, err = c.Serverless().ReadProject(&project, c.Args)
+	if useProjectReader {
+		spec, err := c.Serverless().ReadProject(&project)
+		if err != nil {
+			return err
+		}
+		output.Entity = spec
 	} else {
 		output, err = RunServerlessExec(projectGetMetadata, c, []string{flagJSON, flagProjectReader}, []string{flagEnv, flagInclude, flagExclude})
-	}
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
 	}
 	return c.PrintServerlessTextOutput(output)
 }

--- a/do/mocks/ServerlessService.go
+++ b/do/mocks/ServerlessService.go
@@ -260,18 +260,18 @@ func (mr *MockServerlessServiceMockRecorder) ReadCredentials() *gomock.Call {
 }
 
 // ReadProject mocks base method.
-func (m *MockServerlessService) ReadProject(arg0 *do.ServerlessProject, arg1 []string) (do.ServerlessOutput, error) {
+func (m *MockServerlessService) ReadProject(arg0 *do.ServerlessProject) (do.ProjectSpec, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadProject", arg0, arg1)
-	ret0, _ := ret[0].(do.ServerlessOutput)
+	ret := m.ctrl.Call(m, "ReadProject", arg0)
+	ret0, _ := ret[0].(do.ProjectSpec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadProject indicates an expected call of ReadProject.
-func (mr *MockServerlessServiceMockRecorder) ReadProject(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockServerlessServiceMockRecorder) ReadProject(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadProject", reflect.TypeOf((*MockServerlessService)(nil).ReadProject), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadProject", reflect.TypeOf((*MockServerlessService)(nil).ReadProject), arg0)
 }
 
 // Stream mocks base method.

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -194,7 +194,7 @@ type ServerlessService interface {
 	InvokeFunction(string, interface{}, bool, bool) (map[string]interface{}, error)
 	InvokeFunctionViaWeb(string, map[string]interface{}) error
 	GetConnectedAPIHost() (string, error)
-	ReadProject(*ServerlessProject, []string) (ServerlessOutput, error)
+	ReadProject(*ServerlessProject) (ProjectSpec, error)
 	WriteProject(ServerlessProject) (string, error)
 }
 
@@ -724,16 +724,17 @@ func (s *serverlessService) GetConnectedAPIHost() (string, error) {
 // ReadProject takes the path where project lies and validates the project.yml.
 // once project.yml is validated it reads the directory for all the files and sub-directory
 // and returns the struct of the files
-func (s *serverlessService) ReadProject(project *ServerlessProject, args []string) (ServerlessOutput, error) {
+func (s *serverlessService) ReadProject(project *ServerlessProject) (ProjectSpec, error) {
+	var ans ProjectSpec
 	err := readTopLevel(project)
 	if err != nil {
-		return ServerlessOutput{}, err
+		return ans, err
 	}
-	_, err = readProjectConfig(project.ConfigPath)
+	spec, err := readProjectConfig(project.ConfigPath)
 	if err != nil {
-		return ServerlessOutput{}, err
+		return ans, err
 	}
-	return ServerlessOutput{}, fmt.Errorf("not implemented")
+	return *spec, nil
 }
 
 // WriteProject ...


### PR DESCRIPTION
After the merge of PR #1198 there was a (hidden) partly implemented `ReadProject` service and a hidden flag in the `get-metadata` command that would cause it to be exercised.   However, the two were not meaningfully connected to each other, so, the intent (comparing `get-metadata` results with and without the flag to guide the next phase of implementation) was not accomplished.

This change rectifies the omission in the earlier PR, then, based on some actual testing, fills in some more of the `ReadProject` functionality to the point where the outputs, with and without the flag, are easier to compare.   The result is not ready to be unhidden and used in production, but we didn't expect that, this just brings us a step closer.