### PR TITLE
Add doctl serverless trigger support (for scheduled functions)

### DIFF
--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -118,7 +118,7 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			c.Apps = func() do.AppsService { return do.NewAppsService(godoClient) }
 			c.Monitoring = func() do.MonitoringService { return do.NewMonitoringService(godoClient) }
 			c.Serverless = func() do.ServerlessService {
-				return do.NewServerlessService(godoClient, getServerlessDirectory(), hashAccessToken(c))
+				return do.NewServerlessService(godoClient, getServerlessDirectory(), accessToken)
 			}
 
 			return nil

--- a/commands/displayers/triggers.go
+++ b/commands/displayers/triggers.go
@@ -15,6 +15,7 @@ package displayers
 
 import (
 	"io"
+	"time"
 
 	"github.com/digitalocean/doctl/do"
 )
@@ -33,7 +34,7 @@ func (i *Triggers) JSON(out io.Writer) error {
 
 // Cols is the displayer Cols method specialized for triggers list
 func (i *Triggers) Cols() []string {
-	return []string{"Name", "Cron", "Function", "Enabled"}
+	return []string{"Name", "Cron", "Function", "Enabled", "LastRun"}
 }
 
 // ColMap is the displayer ColMap method specialized for triggers list
@@ -43,6 +44,7 @@ func (i *Triggers) ColMap() map[string]string {
 		"Cron":     "Cron Expression",
 		"Function": "Invokes",
 		"Enabled":  "Enabled",
+		"LastRun":  "Last Run At",
 	}
 }
 
@@ -50,11 +52,17 @@ func (i *Triggers) ColMap() map[string]string {
 func (i *Triggers) KV() []map[string]interface{} {
 	out := make([]map[string]interface{}, 0, len(i.List))
 	for _, ii := range i.List {
+		lastRunTime, err := time.Parse(time.RFC3339, ii.LastRun)
+		var lastRun string
+		if err == nil {
+			lastRun = lastRunTime.Local().Format("01/02 03:04:05")
+		}
 		x := map[string]interface{}{
 			"Name":     ii.Name,
 			"Cron":     ii.Cron,
 			"Function": ii.Function,
 			"Enabled":  ii.Enabled,
+			"LastRun":  lastRun,
 		}
 		out = append(out, x)
 	}

--- a/commands/displayers/triggers.go
+++ b/commands/displayers/triggers.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package displayers
+
+import (
+	"io"
+
+	"github.com/digitalocean/doctl/do"
+)
+
+// Triggers is the type of the displayer for triggers list
+type Triggers struct {
+	List []do.ServerlessTrigger
+}
+
+var _ Displayable = &Triggers{}
+
+// JSON is the displayer JSON method specialized for triggers list
+func (i *Triggers) JSON(out io.Writer) error {
+	return writeJSON(i.List, out)
+}
+
+// Cols is the displayer Cols method specialized for triggers list
+func (i *Triggers) Cols() []string {
+	return []string{"Name", "Cron", "Function", "Enabled"}
+}
+
+// ColMap is the displayer ColMap method specialized for triggers list
+func (i *Triggers) ColMap() map[string]string {
+	return map[string]string{
+		"Name":     "Name",
+		"Cron":     "Cron Expression",
+		"Function": "Invokes",
+		"Enabled":  "Enabled",
+	}
+}
+
+// KV is the displayer KV method specialized for triggers list
+func (i *Triggers) KV() []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(i.List))
+	for _, ii := range i.List {
+		x := map[string]interface{}{
+			"Name":     ii.Name,
+			"Cron":     ii.Cron,
+			"Function": ii.Function,
+			"Enabled":  ii.Enabled,
+		}
+		out = append(out, x)
+	}
+
+	return out
+}

--- a/commands/displayers/triggers.go
+++ b/commands/displayers/triggers.go
@@ -53,7 +53,7 @@ func (i *Triggers) KV() []map[string]interface{} {
 	out := make([]map[string]interface{}, 0, len(i.List))
 	for _, ii := range i.List {
 		lastRunTime, err := time.Parse(time.RFC3339, ii.LastRun)
-		var lastRun string
+		lastRun := "_"
 		if err == nil {
 			lastRun = lastRunTime.Local().Format("01/02 03:04:05")
 		}

--- a/commands/serverless_util.go
+++ b/commands/serverless_util.go
@@ -14,8 +14,6 @@ limitations under the License.
 package commands
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -112,11 +110,7 @@ func (c *CmdConfig) PrintServerlessTextOutput(output do.ServerlessOutput) error 
 }
 
 func hashAccessToken(c *CmdConfig) string {
-	token := c.getContextAccessToken()
-	hasher := sha1.New()
-	hasher.Write([]byte(token))
-	sha := hasher.Sum(nil)
-	return hex.EncodeToString(sha[:4])
+	return do.HashAccessToken(c.getContextAccessToken())
 }
 
 // Determines whether the serverless appears to be connected.  The purpose is

--- a/commands/triggers.go
+++ b/commands/triggers.go
@@ -76,7 +76,7 @@ func RunTriggersGet(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(json))
+	fmt.Fprintln(c.Out, string(json))
 	return nil
 }
 

--- a/commands/triggers.go
+++ b/commands/triggers.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/commands/displayers"
+	"github.com/spf13/cobra"
+)
+
+// Triggers generates the serverless 'triggers' subtree for addition to the doctl command
+func Triggers() *Command {
+	cmd := &Command{
+		Command: &cobra.Command{
+			Use:   "triggers",
+			Short: "Manage triggers associated with your functions",
+			Long: `When Functions are deployed by ` + "`" + `doctl serverless deploy` + "`" + `, they may have associated triggers.
+The subcommands of ` + "`" + `doctl serverless triggers` + "`" + ` are used to list, inspect, test-fire, enable,
+or disable triggers.  Each trigger has an event source type, and invokes its associated function
+when events from that source type occur.  Currently, only the ` + "`" + `scheduler` + "`" + ` event source type is supported.`,
+			Aliases: []string{"trig"},
+			Hidden:  true, // trigger support is experimental and currently using a temporary prototype API
+		},
+	}
+	list := CmdBuilder(cmd, RunTriggersList, "list", "Lists your triggers",
+		`Use `+"`"+`doctl serverless triggers list`+"`"+` to list your triggers.`,
+		Writer, displayerType(&displayers.Triggers{}))
+	AddStringFlag(list, "function", "f", "", "list only triggers for the chosen function")
+
+	CmdBuilder(cmd, RunTriggersGet, "get <triggerName>", "Get the details for a trigger",
+		`Use `+"`"+`doctl serverless triggers get <triggerName>`+"`"+` for details about <triggerName>.`,
+		Writer)
+
+	CmdBuilder(cmd, RunTriggersEnable, "enable <triggerName>", "Enable a trigger",
+		`Use `+"`"+`doctl serverless triggers enable <triggerName>`+"`"+` to enable the trigger <triggerName>.`,
+		Writer)
+
+	CmdBuilder(cmd, RunTriggersDisable, "disable <triggerName>", "Disable a trigger",
+		`Use `+"`"+`doctl serverless triggers disable <triggerName>`+"`"+` to disable the trigger <triggerName>.
+When a trigger is disable it does not invoke its target function`,
+		Writer)
+
+	CmdBuilder(cmd, RunTriggersFire, "fire <triggerName>", "Test-fire a trigger",
+		`Use `+"`"+`doctl serverless triggers fire <triggerName>`+"`"+` to invoke the function associated with a trigger using
+the same method and parameters that an event occurence would use`,
+		Writer)
+
+	return cmd
+}
+
+// RunTriggersList provides the logic for 'doctl sls trig list'
+func RunTriggersList(c *CmdConfig) error {
+	if len(c.Args) > 0 {
+		return doctl.NewTooManyArgsErr(c.NS)
+	}
+	fcn, _ := c.Doit.GetString(c.NS, "function")
+	list, err := c.Serverless().ListTriggers(context.TODO(), fcn)
+	if err != nil {
+		return err
+	}
+	return c.Display(&displayers.Triggers{List: list})
+}
+
+// RunTriggersGet provides the logic for 'doctl sls trig get'
+func RunTriggersGet(c *CmdConfig) error {
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
+	}
+	trigger, err := c.Serverless().GetTrigger(context.TODO(), c.Args[0])
+	if err != nil {
+		return err
+	}
+	json, err := json.MarshalIndent(&trigger, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(json))
+	return nil
+}
+
+// RunTriggersEnable provides the logic for 'doctl sls trig enable'
+func RunTriggersEnable(c *CmdConfig) error {
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
+	}
+	newContent, err := c.Serverless().SetTriggerEnablement(context.TODO(), c.Args[0], true)
+	if err != nil {
+		return err
+	}
+	if !newContent.Enabled {
+		return errors.New("failed to enable trigger (cause unknown)")
+	}
+	return nil
+}
+
+// RunTriggersDisable provides the logic for 'doctl sls trig disable'
+func RunTriggersDisable(c *CmdConfig) error {
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
+	}
+	newContent, err := c.Serverless().SetTriggerEnablement(context.TODO(), c.Args[0], false)
+	if err != nil {
+		return err
+	}
+	if newContent.Enabled {
+		return errors.New("failed to disable trigger (cause unknown)")
+	}
+	return nil
+}
+
+// RunTriggersFire provides the logic for 'doctl sls trig fire'
+func RunTriggersFire(c *CmdConfig) error {
+	err := ensureOneArg(c)
+	if err != nil {
+		return err
+	}
+	return c.Serverless().FireTrigger(context.TODO(), c.Args[0])
+}
+
+// cleanTriggers is the subroutine of undeploy that removes all the triggers of a namespace
+func cleanTriggers(c *CmdConfig) error {
+	sls := c.Serverless()
+	ctx := context.TODO()
+	list, err := sls.ListTriggers(ctx, "")
+	if err != nil {
+		return err
+	}
+	for _, trig := range list {
+		err = sls.DeleteTrigger(ctx, trig.Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/commands/triggers.go
+++ b/commands/triggers.go
@@ -31,8 +31,8 @@ func Triggers() *Command {
 			Use:   "triggers",
 			Short: "Manage triggers associated with your functions",
 			Long: `When Functions are deployed by ` + "`" + `doctl serverless deploy` + "`" + `, they may have associated triggers.
-The subcommands of ` + "`" + `doctl serverless triggers` + "`" + ` are used to list, inspect, test-fire, enable,
-or disable triggers.  Each trigger has an event source type, and invokes its associated function
+The subcommands of ` + "`" + `doctl serverless triggers` + "`" + ` are used to list and inspect
+triggers.  Each trigger has an event source type, and invokes its associated function
 when events from that source type occur.  Currently, only the ` + "`" + `scheduler` + "`" + ` event source type is supported.`,
 			Aliases: []string{"trig"},
 			Hidden:  true, // trigger support is experimental and currently using a temporary prototype API
@@ -49,17 +49,17 @@ when events from that source type occur.  Currently, only the ` + "`" + `schedul
 
 	CmdBuilder(cmd, RunTriggersEnable, "enable <triggerName>", "Enable a trigger",
 		`Use `+"`"+`doctl serverless triggers enable <triggerName>`+"`"+` to enable the trigger <triggerName>.`,
-		Writer)
+		Writer, hiddenCmd())
 
 	CmdBuilder(cmd, RunTriggersDisable, "disable <triggerName>", "Disable a trigger",
 		`Use `+"`"+`doctl serverless triggers disable <triggerName>`+"`"+` to disable the trigger <triggerName>.
 When a trigger is disable it does not invoke its target function`,
-		Writer)
+		Writer, hiddenCmd())
 
 	CmdBuilder(cmd, RunTriggersFire, "fire <triggerName>", "Test-fire a trigger",
 		`Use `+"`"+`doctl serverless triggers fire <triggerName>`+"`"+` to invoke the function associated with a trigger using
 the same method and parameters that an event occurence would use`,
-		Writer)
+		Writer, hiddenCmd())
 
 	return cmd
 }
@@ -96,6 +96,8 @@ func RunTriggersGet(c *CmdConfig) error {
 }
 
 // RunTriggersEnable provides the logic for 'doctl sls trig enable'
+// This command is hidden.  It will work (if you know about it) when using the prototype API
+// but will not be supported in the real API at first.
 func RunTriggersEnable(c *CmdConfig) error {
 	err := ensureOneArg(c)
 	if err != nil {
@@ -112,6 +114,8 @@ func RunTriggersEnable(c *CmdConfig) error {
 }
 
 // RunTriggersDisable provides the logic for 'doctl sls trig disable'
+// This command is hidden.  It will work (if you know about it) when using the prototype API
+// but will not be supported in the real API at first.
 func RunTriggersDisable(c *CmdConfig) error {
 	err := ensureOneArg(c)
 	if err != nil {
@@ -128,6 +132,8 @@ func RunTriggersDisable(c *CmdConfig) error {
 }
 
 // RunTriggersFire provides the logic for 'doctl sls trig fire'
+// This command is hidden.  It will work (if you know about it) when using the prototype API
+// but will not be supported in the real API at first.
 func RunTriggersFire(c *CmdConfig) error {
 	err := ensureOneArg(c)
 	if err != nil {

--- a/commands/triggers.go
+++ b/commands/triggers.go
@@ -16,7 +16,6 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/digitalocean/doctl"
@@ -46,20 +45,6 @@ when events from that source type occur.  Currently, only the ` + "`" + `schedul
 	CmdBuilder(cmd, RunTriggersGet, "get <triggerName>", "Get the details for a trigger",
 		`Use `+"`"+`doctl serverless triggers get <triggerName>`+"`"+` for details about <triggerName>.`,
 		Writer)
-
-	CmdBuilder(cmd, RunTriggersEnable, "enable <triggerName>", "Enable a trigger",
-		`Use `+"`"+`doctl serverless triggers enable <triggerName>`+"`"+` to enable the trigger <triggerName>.`,
-		Writer, hiddenCmd())
-
-	CmdBuilder(cmd, RunTriggersDisable, "disable <triggerName>", "Disable a trigger",
-		`Use `+"`"+`doctl serverless triggers disable <triggerName>`+"`"+` to disable the trigger <triggerName>.
-When a trigger is disable it does not invoke its target function`,
-		Writer, hiddenCmd())
-
-	CmdBuilder(cmd, RunTriggersFire, "fire <triggerName>", "Test-fire a trigger",
-		`Use `+"`"+`doctl serverless triggers fire <triggerName>`+"`"+` to invoke the function associated with a trigger using
-the same method and parameters that an event occurence would use`,
-		Writer, hiddenCmd())
 
 	return cmd
 }
@@ -93,53 +78,6 @@ func RunTriggersGet(c *CmdConfig) error {
 	}
 	fmt.Println(string(json))
 	return nil
-}
-
-// RunTriggersEnable provides the logic for 'doctl sls trig enable'
-// This command is hidden.  It will work (if you know about it) when using the prototype API
-// but will not be supported in the real API at first.
-func RunTriggersEnable(c *CmdConfig) error {
-	err := ensureOneArg(c)
-	if err != nil {
-		return err
-	}
-	newContent, err := c.Serverless().SetTriggerEnablement(context.TODO(), c.Args[0], true)
-	if err != nil {
-		return err
-	}
-	if !newContent.Enabled {
-		return errors.New("failed to enable trigger (cause unknown)")
-	}
-	return nil
-}
-
-// RunTriggersDisable provides the logic for 'doctl sls trig disable'
-// This command is hidden.  It will work (if you know about it) when using the prototype API
-// but will not be supported in the real API at first.
-func RunTriggersDisable(c *CmdConfig) error {
-	err := ensureOneArg(c)
-	if err != nil {
-		return err
-	}
-	newContent, err := c.Serverless().SetTriggerEnablement(context.TODO(), c.Args[0], false)
-	if err != nil {
-		return err
-	}
-	if newContent.Enabled {
-		return errors.New("failed to disable trigger (cause unknown)")
-	}
-	return nil
-}
-
-// RunTriggersFire provides the logic for 'doctl sls trig fire'
-// This command is hidden.  It will work (if you know about it) when using the prototype API
-// but will not be supported in the real API at first.
-func RunTriggersFire(c *CmdConfig) error {
-	err := ensureOneArg(c)
-	if err != nil {
-		return err
-	}
-	return c.Serverless().FireTrigger(context.TODO(), c.Args[0])
 }
 
 // cleanTriggers is the subroutine of undeploy that removes all the triggers of a namespace

--- a/commands/triggers.go
+++ b/commands/triggers.go
@@ -34,7 +34,7 @@ The subcommands of ` + "`" + `doctl serverless triggers` + "`" + ` are used to l
 triggers.  Each trigger has an event source type, and invokes its associated function
 when events from that source type occur.  Currently, only the ` + "`" + `scheduler` + "`" + ` event source type is supported.`,
 			Aliases: []string{"trig"},
-			Hidden:  true, // trigger support is experimental and currently using a temporary prototype API
+			Hidden:  true, // trigger support uses APIs that are not yet universally available
 		},
 	}
 	list := CmdBuilder(cmd, RunTriggersList, "list", "Lists your triggers",

--- a/commands/triggers_test.go
+++ b/commands/triggers_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/digitalocean/doctl/do"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTriggersCommand(t *testing.T) {
+	cmd := Triggers()
+	assert.NotNil(t, cmd)
+	expected := []string{"disable", "enable", "fire", "get", "list"}
+
+	names := []string{}
+	for _, c := range cmd.Commands() {
+		names = append(names, c.Name())
+	}
+
+	sort.Strings(expected)
+	sort.Strings(names)
+	assert.Equal(t, expected, names)
+}
+
+func TestTriggersDisable(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		buf := &bytes.Buffer{}
+		config.Out = buf
+		config.Args = append(config.Args, "aTrigger")
+
+		disabledTrigger := do.ServerlessTrigger{Enabled: false}
+		tm.serverless.EXPECT().SetTriggerEnablement(context.TODO(), "aTrigger", false).Return(disabledTrigger, nil)
+
+		err := RunTriggersDisable(config)
+
+		require.NoError(t, err)
+		assert.Equal(t, "", buf.String())
+	})
+}
+
+func TestTriggersEnable(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		buf := &bytes.Buffer{}
+		config.Out = buf
+		config.Args = append(config.Args, "aTrigger")
+
+		enabledTrigger := do.ServerlessTrigger{Enabled: true}
+		tm.serverless.EXPECT().SetTriggerEnablement(context.TODO(), "aTrigger", true).Return(enabledTrigger, nil)
+
+		err := RunTriggersEnable(config)
+
+		require.NoError(t, err)
+		assert.Equal(t, "", buf.String())
+	})
+}
+
+func TestTriggersFire(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		buf := &bytes.Buffer{}
+		config.Out = buf
+		config.Args = append(config.Args, "aTrigger")
+
+		tm.serverless.EXPECT().FireTrigger(context.TODO(), "aTrigger")
+
+		err := RunTriggersFire(config)
+
+		require.NoError(t, err)
+		assert.Equal(t, "", buf.String())
+	})
+}
+
+func TestTriggersList(t *testing.T) {
+	theList := []do.ServerlessTrigger{
+		{
+			Name:     "fireGC",
+			Function: "misc/garbageCollect",
+			Cron:     "* * * * *",
+			Enabled:  true,
+		},
+		{
+			Name:     "firePoll1",
+			Function: "misc/pollStatus",
+			Cron:     "5 * * * *",
+			Enabled:  true,
+		},
+		{
+			Name:     "firePoll2",
+			Function: "misc/pollStatus",
+			Cron:     "10 * * * *",
+			Enabled:  false,
+		},
+	}
+	tests := []struct {
+		name           string
+		doctlFlags     map[string]interface{}
+		expectedOutput string
+		listArg        string
+		listResult     []do.ServerlessTrigger
+	}{
+		{
+			name: "simple list",
+			doctlFlags: map[string]interface{}{
+				"no-header": "",
+			},
+			listResult: theList,
+			expectedOutput: `fireGC       * * * * *     misc/garbageCollect    true
+firePoll1    5 * * * *     misc/pollStatus        true
+firePoll2    10 * * * *    misc/pollStatus        false
+`,
+		},
+		{
+			name: "filtered list",
+			doctlFlags: map[string]interface{}{
+				"function":  "misc/pollStatus",
+				"no-header": "",
+			},
+			listArg:    "misc/pollStatus",
+			listResult: theList[1:],
+			expectedOutput: `firePoll1    5 * * * *     misc/pollStatus    true
+firePoll2    10 * * * *    misc/pollStatus    false
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				buf := &bytes.Buffer{}
+				config.Out = buf
+				if tt.doctlFlags != nil {
+					for k, v := range tt.doctlFlags {
+						if v == "" {
+							config.Doit.Set(config.NS, k, true)
+						} else {
+							config.Doit.Set(config.NS, k, v)
+						}
+					}
+				}
+
+				tm.serverless.EXPECT().ListTriggers(context.TODO(), tt.listArg).Return(tt.listResult, nil)
+
+				err := RunTriggersList(config)
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedOutput, buf.String())
+			})
+		})
+	}
+}

--- a/commands/triggers_test.go
+++ b/commands/triggers_test.go
@@ -120,9 +120,9 @@ func TestTriggersList(t *testing.T) {
 				"no-header": "",
 			},
 			listResult: theList,
-			expectedOutput: `fireGC       * * * * *     misc/garbageCollect    true
-firePoll1    5 * * * *     misc/pollStatus        true
-firePoll2    10 * * * *    misc/pollStatus        false
+			expectedOutput: `fireGC       * * * * *     misc/garbageCollect    true     
+firePoll1    5 * * * *     misc/pollStatus        true     
+firePoll2    10 * * * *    misc/pollStatus        false    
 `,
 		},
 		{
@@ -133,8 +133,8 @@ firePoll2    10 * * * *    misc/pollStatus        false
 			},
 			listArg:    "misc/pollStatus",
 			listResult: theList[1:],
-			expectedOutput: `firePoll1    5 * * * *     misc/pollStatus    true
-firePoll2    10 * * * *    misc/pollStatus    false
+			expectedOutput: `firePoll1    5 * * * *     misc/pollStatus    true     
+firePoll2    10 * * * *    misc/pollStatus    false    
 `,
 		},
 	}

--- a/do/mocks/ServerlessService.go
+++ b/do/mocks/ServerlessService.go
@@ -95,6 +95,20 @@ func (mr *MockServerlessServiceMockRecorder) DeleteNamespace(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockServerlessService)(nil).DeleteNamespace), arg0, arg1)
 }
 
+// DeleteTrigger mocks base method.
+func (m *MockServerlessService) DeleteTrigger(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTrigger", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTrigger indicates an expected call of DeleteTrigger.
+func (mr *MockServerlessServiceMockRecorder) DeleteTrigger(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTrigger", reflect.TypeOf((*MockServerlessService)(nil).DeleteTrigger), arg0, arg1)
+}
+
 // Exec mocks base method.
 func (m *MockServerlessService) Exec(arg0 *exec.Cmd) (do.ServerlessOutput, error) {
 	m.ctrl.T.Helper()
@@ -108,6 +122,20 @@ func (m *MockServerlessService) Exec(arg0 *exec.Cmd) (do.ServerlessOutput, error
 func (mr *MockServerlessServiceMockRecorder) Exec(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockServerlessService)(nil).Exec), arg0)
+}
+
+// FireTrigger mocks base method.
+func (m *MockServerlessService) FireTrigger(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FireTrigger", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FireTrigger indicates an expected call of FireTrigger.
+func (mr *MockServerlessServiceMockRecorder) FireTrigger(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FireTrigger", reflect.TypeOf((*MockServerlessService)(nil).FireTrigger), arg0, arg1)
 }
 
 // GetConnectedAPIHost mocks base method.
@@ -186,6 +214,21 @@ func (mr *MockServerlessServiceMockRecorder) GetServerlessNamespace(arg0 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServerlessNamespace", reflect.TypeOf((*MockServerlessService)(nil).GetServerlessNamespace), arg0)
 }
 
+// GetTrigger mocks base method.
+func (m *MockServerlessService) GetTrigger(arg0 context.Context, arg1 string) (do.ServerlessTrigger, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTrigger", arg0, arg1)
+	ret0, _ := ret[0].(do.ServerlessTrigger)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTrigger indicates an expected call of GetTrigger.
+func (mr *MockServerlessServiceMockRecorder) GetTrigger(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrigger", reflect.TypeOf((*MockServerlessService)(nil).GetTrigger), arg0, arg1)
+}
+
 // InstallServerless mocks base method.
 func (m *MockServerlessService) InstallServerless(arg0 string, arg1 bool) error {
 	m.ctrl.T.Helper()
@@ -244,6 +287,21 @@ func (mr *MockServerlessServiceMockRecorder) ListNamespaces(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockServerlessService)(nil).ListNamespaces), arg0)
 }
 
+// ListTriggers mocks base method.
+func (m *MockServerlessService) ListTriggers(arg0 context.Context, arg1 string) ([]do.ServerlessTrigger, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTriggers", arg0, arg1)
+	ret0, _ := ret[0].([]do.ServerlessTrigger)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTriggers indicates an expected call of ListTriggers.
+func (mr *MockServerlessServiceMockRecorder) ListTriggers(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTriggers", reflect.TypeOf((*MockServerlessService)(nil).ListTriggers), arg0, arg1)
+}
+
 // ReadCredentials mocks base method.
 func (m *MockServerlessService) ReadCredentials() (do.ServerlessCredentials, error) {
 	m.ctrl.T.Helper()
@@ -272,6 +330,21 @@ func (m *MockServerlessService) ReadProject(arg0 *do.ServerlessProject, arg1 []s
 func (mr *MockServerlessServiceMockRecorder) ReadProject(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadProject", reflect.TypeOf((*MockServerlessService)(nil).ReadProject), arg0, arg1)
+}
+
+// SetTriggerEnablement mocks base method.
+func (m *MockServerlessService) SetTriggerEnablement(arg0 context.Context, arg1 string, arg2 bool) (do.ServerlessTrigger, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetTriggerEnablement", arg0, arg1, arg2)
+	ret0, _ := ret[0].(do.ServerlessTrigger)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetTriggerEnablement indicates an expected call of SetTriggerEnablement.
+func (mr *MockServerlessServiceMockRecorder) SetTriggerEnablement(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTriggerEnablement", reflect.TypeOf((*MockServerlessService)(nil).SetTriggerEnablement), arg0, arg1, arg2)
 }
 
 // Stream mocks base method.

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -864,7 +864,11 @@ func (s *serverlessService) DeleteTrigger(ctx context.Context, name string) erro
 		return err
 	}
 	path := "v2/functions/trigger/" + creds.Namespace + "/" + name
-	_, err = s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	_, err = s.client.Do(ctx, req, nil)
 	return err
 }
 

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -239,7 +239,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minServerlessVersion = "4.2.3-1.3.1"
+	minServerlessVersion = "4.2.4-1.3.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -340,9 +340,7 @@ func HashAccessToken(token string) string {
 // InitWhisk is an on-demand initializer for the OpenWhisk client, called when that client
 // is needed.
 func initWhisk(s *serverlessService) error {
-	var client *whisk.Client
-	client = s.owClient
-	if client != nil {
+	if s.owClient != nil {
 		return nil
 	}
 	creds, err := s.ReadCredentials()
@@ -351,7 +349,7 @@ func initWhisk(s *serverlessService) error {
 	}
 	credential := creds.Credentials[creds.APIHost][creds.Namespace]
 	config := whisk.Config{Host: creds.APIHost, AuthToken: credential.Auth}
-	client, err = whisk.NewClient(http.DefaultClient, &config)
+	client, err := whisk.NewClient(http.DefaultClient, &config)
 	if err != nil {
 		return err
 	}

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -788,6 +788,10 @@ func (s *serverlessService) WriteProject(project ServerlessProject) (string, err
 // of that function are listed.  If 'fcn' is empty all triggers are listed.
 func (s *serverlessService) ListTriggers(ctx context.Context, fcn string) ([]ServerlessTrigger, error) {
 	empty := []ServerlessTrigger{}
+	err := s.CheckServerlessStatus(HashAccessToken(s.accessToken))
+	if err != nil {
+		return empty, err
+	}
 	creds, err := s.ReadCredentials()
 	if err != nil {
 		return empty, err
@@ -838,6 +842,10 @@ func fixBaseDate(trigger ServerlessTrigger) ServerlessTrigger {
 // GetTrigger gets the contents of a trigger for display
 func (s *serverlessService) GetTrigger(ctx context.Context, name string) (ServerlessTrigger, error) {
 	empty := ServerlessTrigger{}
+	err := s.CheckServerlessStatus(HashAccessToken(s.accessToken))
+	if err != nil {
+		return empty, err
+	}
 	creds, err := s.ReadCredentials()
 	if err != nil {
 		return empty, err

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -264,7 +264,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minServerlessVersion = "4.2.5-1.3.1"
+	minServerlessVersion = "4.2.6-1.3.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -794,7 +794,10 @@ func (s *serverlessService) WriteProject(project ServerlessProject) (string, err
 func (s *serverlessService) ListTriggers(ctx context.Context, fcn string) ([]ServerlessTrigger, error) {
 	empty := []ServerlessTrigger{}
 	// TODO eventually this must be replaced by a call to the permanent API in DigitalOcean edge
-	initWhisk(s, true)
+	err := initWhisk(s, true)
+	if err != nil {
+		return empty, err
+	}
 	var params interface{}
 	if fcn != "" {
 		params = map[string]interface{}{"function": fcn}
@@ -829,7 +832,10 @@ func (s *serverlessService) ListTriggers(ctx context.Context, fcn string) ([]Ser
 func (s *serverlessService) GetTrigger(ctx context.Context, name string) (ServerlessTrigger, error) {
 	empty := ServerlessTrigger{}
 	// TODO eventually this must be replaced by a call to the permanent API in DigitalOcean edge
-	initWhisk(s, true)
+	err := initWhisk(s, true)
+	if err != nil {
+		return empty, err
+	}
 	params := map[string]interface{}{
 		"triggerName": name,
 	}
@@ -858,11 +864,14 @@ func (s *serverlessService) GetTrigger(ctx context.Context, name string) (Server
 // FireTrigger fires a trigger
 func (s *serverlessService) FireTrigger(ctx context.Context, name string) error {
 	// TODO eventually this must be replaced by a call to the permanent API in DigitalOcean edge
-	initWhisk(s, true)
+	err := initWhisk(s, true)
+	if err != nil {
+		return err
+	}
 	params := map[string]interface{}{
 		"triggerName": name,
 	}
-	_, _, err := s.owClientSys.Actions.Invoke("triggers/fire", params, true, true)
+	_, _, err = s.owClientSys.Actions.Invoke("triggers/fire", params, true, true)
 	return err
 }
 
@@ -870,7 +879,10 @@ func (s *serverlessService) FireTrigger(ctx context.Context, name string) error 
 func (s *serverlessService) SetTriggerEnablement(ctx context.Context, name string, enabled bool) (ServerlessTrigger, error) {
 	empty := ServerlessTrigger{}
 	// TODO eventually this must be replaced by a call to the permanent API in DigitalOcean edge
-	initWhisk(s, true)
+	err := initWhisk(s, true)
+	if err != nil {
+		return empty, err
+	}
 	params := map[string]interface{}{
 		"triggerName": name,
 		"enabled":     enabled,
@@ -901,11 +913,14 @@ func (s *serverlessService) SetTriggerEnablement(ctx context.Context, name strin
 // SetTriggerEnablement sets the isEnabled property of a trigger
 func (s *serverlessService) DeleteTrigger(ctx context.Context, name string) error {
 	// TODO eventually this must be replaced by a call to the permanent API in DigitalOcean edge
-	initWhisk(s, true)
+	err := initWhisk(s, true)
+	if err != nil {
+		return err
+	}
 	params := map[string]interface{}{
 		"triggerName": name,
 	}
-	_, _, err := s.owClientSys.Actions.Invoke("triggers/delete", params, true, true)
+	_, _, err = s.owClientSys.Actions.Invoke("triggers/delete", params, true, true)
 	return err
 }
 

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -802,8 +802,18 @@ func (s *serverlessService) ListTriggers(ctx context.Context, fcn string) ([]Ser
 	if err != nil {
 		return empty, err
 	}
-	ans := fixBaseDates(decoded.Triggers)
-	return ans, nil
+	triggers := decoded.Triggers
+	// The API does not filter by function; that is done here.
+	if fcn != "" {
+		filtered := []ServerlessTrigger{}
+		for _, trigger := range triggers {
+			if trigger.Function == fcn {
+				filtered = append(filtered, trigger)
+			}
+		}
+		triggers = filtered
+	}
+	return fixBaseDates(triggers), nil
 }
 
 // fixBaseDates applies fixBaseDate to an array of triggers
@@ -842,8 +852,7 @@ func (s *serverlessService) GetTrigger(ctx context.Context, name string) (Server
 	if err != nil {
 		return empty, err
 	}
-	ans := fixBaseDate(decoded.Trigger)
-	return ans, nil
+	return fixBaseDate(decoded.Trigger), nil
 }
 
 // Delete Trigger deletes a trigger from the namespace (used when undeploying triggers explicitly,


### PR DESCRIPTION
This PR adds support (still hidden) for a future release of `doctl serverless` that includes support for scheduled functions.   Concretely, it supports triggers, associated with functions, where the trigger has a `cron` expression governing when the function is invoked.

Support consists of the following:

1.  In `doctl sls deploy`, if the `project.yml` contains a `triggers` object nested in a function object, the triggers are deployed, associated with the function.   This is accomplished by adopting the latest serverless plugin version, which incorporates the latest deployer version.
2. In `doctl sls undeploy`, if there are triggers associated with any functions that are being undeployed, they are undeployed as well.   There is also a new flag, `--triggers` (currently hidden) which allows triggers to be undeployed independent of the functions they are attached to.   This is accomplished by a combination of changes in the deployer, and direct calls to the triggers API (when deleting only triggers).
3. There is a new command `doctl sls triggers` (currently hidden) with subcommands `list` and `get` that allows discovery of what triggers exist and permits further details to be inspected.   These commands do not use the plugin but go directly to the triggers API.