### PR TITLE
Improve help texts taking into account multiple namespaces

### DIFF
--- a/commands/serverless-extra.go
+++ b/commands/serverless-extra.go
@@ -36,7 +36,7 @@ to choose your sample language for `+"`"+`doctl serverless init`+"`"+`.`,
 	AddStringFlag(create, "language", "l", "javascript", "Language for the initial sample code")
 	AddBoolFlag(create, "overwrite", "", false, "Clears and reuses an existing directory")
 
-	deploy := CmdBuilder(cmd, RunServerlessExtraDeploy, "deploy <directories>", "Deploy a functions project to your functions namespace",
+	deploy := CmdBuilder(cmd, RunServerlessExtraDeploy, "deploy <directory>", "Deploy a functions project to your functions namespace",
 		`At any time you can use `+"`"+`doctl serverless deploy`+"`"+` to upload the contents of a functions project in your file system for
 testing in your serverless namespace.  The project must be organized in the fashion expected by an App Platform Functions
 component.  The `+"`"+`doctl serverless init`+"`"+` command will create a properly organized directory for you to work in.`,

--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -58,12 +58,12 @@ func Serverless() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
 			Use:   "serverless",
-			Short: "Develop and test serverless functions",
-			Long: `The ` + "`" + `doctl serverless` + "`" + ` commands provide an environment for developing and testing serverless functions.
-One or more local file system areas are employed, along with a 'functions namespace' in the cloud.
+			Short: "Develop, test, and deploy serverless functions",
+			Long: `The ` + "`" + `doctl serverless` + "`" + ` commands provide an environment for developing, testing, and deploying serverless functions.
+One or more local file system areas are employed, along with one or more 'functions namespaces' in the cloud.
 A one-time install of the serverless software is needed (use ` + "`" + `doctl serverless install` + "`" + ` to install the software,
-then ` + "`" + `doctl serverless connect` + "`" + ` to connect to a functions namespace provided with your account).
-Other ` + "`" + `doctl serverless` + "`" + ` commands are used to develop and test.`,
+then ` + "`" + `doctl serverless connect` + "`" + ` to connect to a functions namespace associated with your account).
+Other ` + "`" + `doctl serverless` + "`" + ` commands are used to develop, test, and deploy.`,
 			Aliases: []string{"sandbox", "sbx", "sls"},
 		},
 	}
@@ -81,8 +81,13 @@ The install operation is long-running, and a network connection is required.`,
 	CmdBuilder(cmd, RunServerlessUninstall, "uninstall", "Removes the serverless support", `Removes serverless support from `+"`"+`doctl`+"`",
 		Writer)
 
-	CmdBuilder(cmd, RunServerlessConnect, "connect", "Connects local serverless support to your functions namespace",
-		`This command connects `+"`"+`doctl serverless`+"`"+` to your functions namespace (needed for testing).`,
+	CmdBuilder(cmd, RunServerlessConnect, "connect [<hint>]", "Connects local serverless support to a functions namespace",
+		`This command connects `+"`"+`doctl serverless`+"`"+` support to a functions namespace of your choice.
+The optional argument should be a (complete or partial) match to a namespace label or id.
+If there is no argument, all namespaces are matched.  If the result is exactly one namespace,
+you are connected to it.  If there are multiple namespaces, you have an opportunity to choose
+the one you want from a dialog.  Use `+"`"+`doctl serverless namespaces`+"`"+` to create, delete, and
+list your namespaces.`,
 		Writer)
 
 	status := CmdBuilder(cmd, RunServerlessStatus, "status", "Provide information about serverless support",


### PR DESCRIPTION
In the run-up to `doctl` release 1.80 I neglected to amend the help text for `doctl serverless connect` to properly reflect what is now possible with multiple namespaces.   Since this capability was hidden during the beta, the text did not get amended earlier.

In amending that text, I also touched on a few other help texts as I will note in comments.