### PR TITLE
Bump godo to v1.86.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/creack/pty v1.1.11
-	github.com/digitalocean/godo v1.85.0
+	github.com/digitalocean/godo v1.86.0
 	github.com/docker/cli v20.10.17+incompatible
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8l
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.85.0 h1:25H79kPw4+WY5PGeJp8oISJJ0Qylx+UtGeYdz6UCzfc=
-github.com/digitalocean/godo v1.85.0/go.mod h1:jELt1jkHVifd0rKaY0pt/m1QxGzbkkvoVVrDkR15/5A=
+github.com/digitalocean/godo v1.86.0 h1:GKB2HS+6lnYPn+9XLLsIVBWk3xk7v568EJnmdHuyhKA=
+github.com/digitalocean/godo v1.86.0/go.mod h1:jELt1jkHVifd0rKaY0pt/m1QxGzbkkvoVVrDkR15/5A=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.17+incompatible h1:eO2KS7ZFeov5UJeaDmIs1NFEDRf32PaqRpvoEkKBy5M=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.86.0] - 2022-09-23
+
+- #561 - @jonfriesen - apps: add docr image deploy on push
+
 ## [v1.85.0] - 2022-09-21
 
 - #560 - @andrewsomething - Bump golang.org/x/net (fixes: #557).

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -522,6 +522,18 @@ type DeploymentCauseDetailsDigitalOceanUserAction struct {
 	Name DeploymentCauseDetailsDigitalOceanUserActionName `json:"name,omitempty"`
 }
 
+// DeploymentCauseDetailsDOCRPush struct for DeploymentCauseDetailsDOCRPush
+type DeploymentCauseDetailsDOCRPush struct {
+	// The registry name.
+	Registry string `json:"registry,omitempty"`
+	// The repository name.
+	Repository string `json:"repository,omitempty"`
+	// The repository tag.
+	Tag string `json:"tag,omitempty"`
+	// OCI Image digest.
+	ImageDigest string `json:"image_digest,omitempty"`
+}
+
 // DeploymentCauseDetailsGitPush struct for DeploymentCauseDetailsGitPush
 type DeploymentCauseDetailsGitPush struct {
 	GitHub        *GitHubSourceSpec `json:"github,omitempty"`
@@ -584,6 +596,7 @@ type Deployment struct {
 type DeploymentCauseDetails struct {
 	DigitalOceanUserAction *DeploymentCauseDetailsDigitalOceanUserAction `json:"digitalocean_user_action,omitempty"`
 	GitPush                *DeploymentCauseDetailsGitPush                `json:"git_push,omitempty"`
+	DOCRPush               *DeploymentCauseDetailsDOCRPush               `json:"docr_push,omitempty"`
 	Internal               bool                                          `json:"internal,omitempty"`
 	Type                   DeploymentCauseDetailsType                    `json:"type,omitempty"`
 }
@@ -886,7 +899,14 @@ type ImageSourceSpec struct {
 	// The repository name.
 	Repository string `json:"repository,omitempty"`
 	// The repository tag. Defaults to `latest` if not provided.
-	Tag string `json:"tag,omitempty"`
+	Tag          string                       `json:"tag,omitempty"`
+	DeployOnPush *ImageSourceSpecDeployOnPush `json:"deploy_on_push,omitempty"`
+}
+
+// ImageSourceSpecDeployOnPush struct for ImageSourceSpecDeployOnPush
+type ImageSourceSpecDeployOnPush struct {
+	// Automatically deploy new images. Only for DOCR images.
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 // ImageSourceSpecRegistryType  - DOCR: The DigitalOcean container registry type.  - DOCKER_HUB: The DockerHub container registry type.

--- a/vendor/github.com/digitalocean/godo/apps_accessors.go
+++ b/vendor/github.com/digitalocean/godo/apps_accessors.go
@@ -2110,6 +2110,14 @@ func (d *DeploymentCauseDetails) GetDigitalOceanUserAction() *DeploymentCauseDet
 	return d.DigitalOceanUserAction
 }
 
+// GetDOCRPush returns the DOCRPush field.
+func (d *DeploymentCauseDetails) GetDOCRPush() *DeploymentCauseDetailsDOCRPush {
+	if d == nil {
+		return nil
+	}
+	return d.DOCRPush
+}
+
 // GetGitPush returns the GitPush field.
 func (d *DeploymentCauseDetails) GetGitPush() *DeploymentCauseDetailsGitPush {
 	if d == nil {
@@ -2172,6 +2180,38 @@ func (d *DeploymentCauseDetailsDigitalOceanUserAction) GetUser() *DeploymentCaus
 		return nil
 	}
 	return d.User
+}
+
+// GetImageDigest returns the ImageDigest field.
+func (d *DeploymentCauseDetailsDOCRPush) GetImageDigest() string {
+	if d == nil {
+		return ""
+	}
+	return d.ImageDigest
+}
+
+// GetRegistry returns the Registry field.
+func (d *DeploymentCauseDetailsDOCRPush) GetRegistry() string {
+	if d == nil {
+		return ""
+	}
+	return d.Registry
+}
+
+// GetRepository returns the Repository field.
+func (d *DeploymentCauseDetailsDOCRPush) GetRepository() string {
+	if d == nil {
+		return ""
+	}
+	return d.Repository
+}
+
+// GetTag returns the Tag field.
+func (d *DeploymentCauseDetailsDOCRPush) GetTag() string {
+	if d == nil {
+		return ""
+	}
+	return d.Tag
 }
 
 // GetCommitAuthor returns the CommitAuthor field.
@@ -2782,6 +2822,14 @@ func (g *GitSourceSpec) GetRepoCloneURL() string {
 	return g.RepoCloneURL
 }
 
+// GetDeployOnPush returns the DeployOnPush field.
+func (i *ImageSourceSpec) GetDeployOnPush() *ImageSourceSpecDeployOnPush {
+	if i == nil {
+		return nil
+	}
+	return i.DeployOnPush
+}
+
 // GetRegistry returns the Registry field.
 func (i *ImageSourceSpec) GetRegistry() string {
 	if i == nil {
@@ -2812,6 +2860,14 @@ func (i *ImageSourceSpec) GetTag() string {
 		return ""
 	}
 	return i.Tag
+}
+
+// GetEnabled returns the Enabled field.
+func (i *ImageSourceSpecDeployOnPush) GetEnabled() bool {
+	if i == nil {
+		return false
+	}
+	return i.Enabled
 }
 
 // GetAppID returns the AppID field.

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.85.0"
+	libraryVersion = "1.86.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -86,7 +86,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.85.0
+# github.com/digitalocean/godo v1.86.0
 ## explicit; go 1.18
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
Bump godo to v1.86.0 to support DOCR push to deploy for app platform.