### PR TITLE
disable stdin from `app dev build` command

### DIFF
--- a/commands/apps_dev.go
+++ b/commands/apps_dev.go
@@ -71,7 +71,7 @@ func AppsDev() *Command {
 	AddStringFlag(
 		build, doctl.ArgAppSpec,
 		"", "",
-		`Path to an app spec in JSON or YAML format. Set to "-" to read from stdin.`,
+		`Path to an app spec in JSON or YAML format.`,
 	)
 
 	AddStringFlag(

--- a/internal/apps/workspace/workspace.go
+++ b/internal/apps/workspace/workspace.go
@@ -258,12 +258,8 @@ func (c *AppDevConfig) loadAppSpec() error {
 	}
 
 	if c.appSpecPath != "" {
-		tmplPath := c.appSpecPath
-		if tmplPath == "-" {
-			tmplPath = "stdin"
-		}
-		template.Print(`{{success checkmark}} using app spec from {{highlight .}}{{nl}}`, tmplPath)
-		c.AppSpec, err = apps.ReadAppSpec(os.Stdin, c.appSpecPath)
+		template.Print(`{{success checkmark}} using app spec from {{highlight .}}{{nl}}`, c.appSpecPath)
+		c.AppSpec, err = apps.ReadAppSpec(nil, c.appSpecPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description

#### What does this pull request accomplish

Accepting an app spec via `stdin` does not play well with the `Interactivity` config. Rather than implicitly disable interactivity in that scenario we are removing support for `stdin` to `app dev build --spec=-`; users can still load arbitrary specs with a path based syntax.