### PR TITLE
Finish eliminating plugin usage in 'doctl sls functions' + testing improvements

### DIFF
--- a/commands/functions_test.go
+++ b/commands/functions_test.go
@@ -333,7 +333,7 @@ func TestFunctionsList(t *testing.T) {
 	}
 
 	theList := []whisk.Action{
-		whisk.Action{
+		{
 			Name:      "hello",
 			Namespace: "theNamespace/daily",
 			Updated:   timestamps[0],
@@ -345,7 +345,7 @@ func TestFunctionsList(t *testing.T) {
 				},
 			},
 		},
-		whisk.Action{
+		{
 			Name:      "goodbye",
 			Namespace: "theNamespace/daily",
 			Updated:   timestamps[1],
@@ -357,7 +357,7 @@ func TestFunctionsList(t *testing.T) {
 				},
 			},
 		},
-		whisk.Action{
+		{
 			Name:      "meAgain",
 			Namespace: "theNamespace/sometimes",
 			Version:   "0.0.3",

--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -91,8 +91,6 @@ you are connected to it.  If there are multiple namespaces, you have an opportun
 the one you want from a dialog.  Use `+"`"+`doctl serverless namespaces`+"`"+` to create, delete, and
 list your namespaces.`,
 		Writer)
-	AddBoolFlag(connect, "beta", "", false, "use beta features to connect when no namespace is specified")
-	connect.Flags().MarkHidden("beta")
 	// The apihost and auth flags will always be hidden.  They support testing using doctl on clusters that are not in production
 	// and hence are unknown to the portal.
 	AddStringFlag(connect, "apihost", "", "", "")

--- a/do/mocks/ServerlessService.go
+++ b/do/mocks/ServerlessService.go
@@ -272,6 +272,21 @@ func (mr *MockServerlessServiceMockRecorder) InvokeFunctionViaWeb(arg0, arg1 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvokeFunctionViaWeb", reflect.TypeOf((*MockServerlessService)(nil).InvokeFunctionViaWeb), arg0, arg1)
 }
 
+// ListFunctions mocks base method.
+func (m *MockServerlessService) ListFunctions(arg0 string, arg1, arg2 int) ([]whisk.Action, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListFunctions", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]whisk.Action)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListFunctions indicates an expected call of ListFunctions.
+func (mr *MockServerlessServiceMockRecorder) ListFunctions(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFunctions", reflect.TypeOf((*MockServerlessService)(nil).ListFunctions), arg0, arg1, arg2)
+}
+
 // ListNamespaces mocks base method.
 func (m *MockServerlessService) ListNamespaces(arg0 context.Context) (do.NamespaceListResponse, error) {
 	m.ctrl.T.Helper()

--- a/do/mocks/ServerlessService.go
+++ b/do/mocks/ServerlessService.go
@@ -199,6 +199,21 @@ func (mr *MockServerlessServiceMockRecorder) GetNamespace(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockServerlessService)(nil).GetNamespace), arg0, arg1)
 }
 
+// GetNamespaceFromCluster mocks base method.
+func (m *MockServerlessService) GetNamespaceFromCluster(arg0, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNamespaceFromCluster", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNamespaceFromCluster indicates an expected call of GetNamespaceFromCluster.
+func (mr *MockServerlessServiceMockRecorder) GetNamespaceFromCluster(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespaceFromCluster", reflect.TypeOf((*MockServerlessService)(nil).GetNamespaceFromCluster), arg0, arg1)
+}
+
 // GetServerlessNamespace mocks base method.
 func (m *MockServerlessService) GetServerlessNamespace(arg0 context.Context) (do.ServerlessCredentials, error) {
 	m.ctrl.T.Helper()

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -217,6 +217,7 @@ type ServerlessService interface {
 	CheckServerlessStatus(string) error
 	InstallServerless(string, bool) error
 	GetFunction(string, bool) (whisk.Action, []FunctionParameter, error)
+	ListFunctions(string, int, int) ([]whisk.Action, error)
 	InvokeFunction(string, interface{}, bool, bool) (map[string]interface{}, error)
 	InvokeFunctionViaWeb(string, map[string]interface{}) error
 	GetConnectedAPIHost() (string, error)
@@ -695,6 +696,23 @@ func (s *serverlessService) GetFunction(name string, fetchCode bool) (whisk.Acti
 		}
 	}
 	return *action, parameters, nil
+}
+
+// ListFunctions lists the functions of the connected namespace
+func (s *serverlessService) ListFunctions(pkg string, skip int, limit int) ([]whisk.Action, error) {
+	err := initWhisk(s)
+	if err != nil {
+		return []whisk.Action{}, err
+	}
+	if limit == 0 {
+		limit = 30
+	}
+	options := &whisk.ActionListOptions{
+		Skip:  skip,
+		Limit: limit,
+	}
+	list, _, err := s.owClient.Actions.List(pkg, options)
+	return list, err
 }
 
 // InvokeFunction invokes a function via POST with authentication

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -241,7 +241,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minServerlessVersion = "4.2.6-1.3.1"
+	minServerlessVersion = "4.2.7-1.3.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"


### PR DESCRIPTION
This change covers internal improvements not intended to be visible to typical `doctl` users.

1. Toward the goal of reducing the separate plugin for serverless:
     1.  Remove dependence on the plugin for `doctl sls fn list`
     2. Remove dependence on the plugin for `doctl sls status`
2.  Adds a (permanently) hidden pair of flags to `doctl sls connect` permitting connection to serverless clusters that are not in production (and hence unknown to the serverless portal).   This is needed to support internal testing and debugging use cases for which we currently use the `nim` CLI (which should be phased out).