### PR TITLE
Reveal trigger support

### DIFF
--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -110,7 +110,6 @@ the entire packages are removed.`, Writer)
 	AddBoolFlag(undeploy, "packages", "p", false, "interpret simple name arguments as packages")
 	AddBoolFlag(undeploy, "triggers", "", false, "interpret all arguments as triggers")
 	AddBoolFlag(undeploy, "all", "", false, "remove all packages and functions")
-	undeploy.Flags().MarkHidden("triggers") // support is experimental at this point
 
 	cmd.AddCommand(Activations())
 	cmd.AddCommand(Functions())

--- a/commands/triggers.go
+++ b/commands/triggers.go
@@ -34,7 +34,6 @@ The subcommands of ` + "`" + `doctl serverless triggers` + "`" + ` are used to l
 triggers.  Each trigger has an event source type, and invokes its associated function
 when events from that source type occur.  Currently, only the ` + "`" + `scheduler` + "`" + ` event source type is supported.`,
 			Aliases: []string{"trig"},
-			Hidden:  true, // trigger support uses APIs that are not yet universally available
 		},
 	}
 	list := CmdBuilder(cmd, RunTriggersList, "list", "Lists your triggers",

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -239,7 +239,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minServerlessVersion = "4.2.6-1.3.1"
+	minServerlessVersion = "4.2.7-1.3.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"


### PR DESCRIPTION
This change removes the "Hidden" option from the cobra sequences defining trigger support (that is, from `doctl sls triggers` and from `doctl sls undeploy --triggers`). 

The latest `nim` version is also adopted, which provides more robustness in the deletion of triggers when trigger deletion fails for some reason.