### PR TITLE
Fix possible failures in undeploy

### DIFF
--- a/do/serverless.go
+++ b/do/serverless.go
@@ -239,7 +239,7 @@ const (
 	// Minimum required version of the sandbox plugin code.  The first part is
 	// the version of the incorporated Nimbella CLI and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minServerlessVersion = "4.2.6-1.3.1"
+	minServerlessVersion = "4.2.8-1.3.1"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"


### PR DESCRIPTION
The current `doctl` release uses `nim` 4.2.6, which has two known problems affecting `doctl sls undeploy` operations.

1.  If a user is not in the scheduled functions beta, an `undeploy` operation will nevertheless try to find any triggers that need to be undeployed.  In the process of doing so, it wiIl fail (because the triggers API is blocked) and so there will be a visible (somewhat cryptic) error and a non-zero exit code.  In fact, the `undeploy` operation as requested has actually succeeded (fixed in 4.2.8).
2. In the unlikely event of a failure in the middle of an undeploy operation, triggers can be left even though their function has been removed (fixed in 4.2.7).

This change simply increments the `nim` version to 4.2.8 to pick of fixes for these issues.