### PR TITLE
Add --wait flag to load_balancer create

### DIFF
--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -542,6 +542,7 @@ func buildRequestFromArgs(c *CmdConfig, r *godo.LoadBalancerRequest) error {
 func waitForActiveLoadBalancer(lbs do.LoadBalancersService, lbID string) error {
 	const maxAttempts = 180
 	const wantStatus = "active"
+	const errStatus = "errored"
 	attempts := 0
 	printNewLineSet := false
 
@@ -557,6 +558,13 @@ func waitForActiveLoadBalancer(lbs do.LoadBalancersService, lbID string) error {
 		lb, err := lbs.Get(lbID)
 		if err != nil {
 			return err
+		}
+
+		if lb.Status == errStatus {
+			return fmt.Errorf(
+				"load balancer (%s) entered status `errored`",
+				lbID,
+			)
 		}
 
 		if lb.Status == wantStatus {

--- a/integration/lb_create_test.go
+++ b/integration/lb_create_test.go
@@ -85,6 +85,18 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
 			expect.Equal(strings.TrimSpace(lbCreateOutput), strings.TrimSpace(string(output)))
 		})
+		when("the wait flag is passed", func() {
+			it("creates a load balancer and polls for status", func() {
+				baseArgsWithWait := append([]string{"--wait"}, baseArgs...)
+				args := append([]string{"create"}, baseArgsWithWait...)
+				cmd.Args = append(cmd.Args, args...)
+
+				output, err := cmd.CombinedOutput()
+				expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+				expectedOutput := "Notice: Load balancer creation is in progress, waiting for load balancer to become active\n" + lbCreateOutput
+				expect.Equal(strings.TrimSpace(expectedOutput), strings.TrimSpace(string(output)))
+			})
+		})
 	})
 
 	when("command is c", func() {
@@ -101,6 +113,7 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 
 const (
 	lbCreateOutput = `
+Notice: Load balancer created\n
 ID                                      IP    Name             Status    Created At              Algorithm      Region    Size        Size Unit    VPC UUID                                Tag    Droplet IDs        SSL     Sticky Sessions                                Health Check                                                                                                            Forwarding Rules    Disable Lets Encrypt DNS Records
 4de7ac8b-495b-4884-9a69-1050c6793cd6          example-lb-01    new       2017-02-01T22:22:58Z    round_robin    nyc3      lb-small    <nil>        00000000-0000-4000-8000-000000000000           3164444,3164445    true    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:,port:0,path:,check_interval_seconds:0,response_timeout_seconds:0,healthy_threshold:0,unhealthy_threshold:0                        true
 `

--- a/integration/lb_create_test.go
+++ b/integration/lb_create_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it spec.S) {
+	const testUUID = "4de7ac8b-495b-4884-9a69-1050c6793cd6"
 	var (
 		expect   *require.Assertions
 		server   *httptest.Server
@@ -45,6 +46,19 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 				expect.JSONEq(lbCreateRequest, string(reqBody))
 
 				w.Write([]byte(lbCreateResponse))
+			case "/v2/load_balancers/" + testUUID:
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				w.Write([]byte(lbWaitGetResponse))
 			default:
 				dump, err := httputil.DumpRequest(req, true)
 				if err != nil {
@@ -108,6 +122,18 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
 			expect.Equal(strings.TrimSpace(lbCreateOutput), strings.TrimSpace(string(output)))
 		})
+		when("the wait flag is passed", func() {
+			it("creates a load balancer and polls for status", func() {
+				baseArgsWithWait := append([]string{"--wait"}, baseArgs...)
+				args := append([]string{"c"}, baseArgsWithWait...)
+				cmd.Args = append(cmd.Args, args...)
+
+				output, err := cmd.CombinedOutput()
+				expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+				expectedOutput := "Notice: Load balancer creation is in progress, waiting for load balancer to become active\n" + lbCreateOutput
+				expect.Equal(strings.TrimSpace(expectedOutput), strings.TrimSpace(string(output)))
+			})
+		})
 	})
 })
 
@@ -170,5 +196,44 @@ ID                                      IP    Name             Status    Created
   "enable_backend_keepalive":true,
   "disable_lets_encrypt_dns_records": true,
   "vpc_uuid": "00000000-0000-4000-8000-000000000000"
+}`
+
+	lbWaitGetResponse = `
+{
+  "load_balancer": {
+    "id": "4de7ac8b-495b-4884-9a69-1050c6793cd6",
+    "name": "example-lb-01",
+    "ip": "",
+    "algorithm": "round_robin",
+    "status": "active",
+    "created_at": "2017-02-01T22:22:58Z",
+    "forwarding_rules": [],
+    "health_check": {},
+    "sticky_sessions": {
+      "type": "none"
+    },
+    "region": {
+      "name": "New York 3",
+      "slug": "nyc3",
+      "sizes": [
+        "s-32vcpu-192gb"
+      ],
+      "features": [
+        "install_agent"
+      ],
+      "available": true
+	},
+	"size": "lb-small",
+    "vpc_uuid": "00000000-0000-4000-8000-000000000000",
+    "tag": "",
+    "droplet_ids": [
+      3164444,
+      3164445
+    ],
+    "redirect_http_to_https": true,
+    "enable_proxy_protocol": true,
+	"disable_lets_encrypt_dns_records": true,
+    "enable_backend_keepalive": true
+  }
 }`
 )

--- a/integration/lb_create_test.go
+++ b/integration/lb_create_test.go
@@ -107,8 +107,7 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 
 				output, err := cmd.CombinedOutput()
 				expect.NoError(err, fmt.Sprintf("received error output: %s", output))
-				expectedOutput := "Notice: Load balancer creation is in progress, waiting for load balancer to become active\n" + lbCreateOutput
-				expect.Equal(strings.TrimSpace(expectedOutput), strings.TrimSpace(string(output)))
+				expect.Equal(strings.TrimSpace(lbWaitCreateOutput), strings.TrimSpace(string(output)))
 			})
 		})
 	})
@@ -122,27 +121,23 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
 			expect.Equal(strings.TrimSpace(lbCreateOutput), strings.TrimSpace(string(output)))
 		})
-		when("the wait flag is passed", func() {
-			it("creates a load balancer and polls for status", func() {
-				baseArgsWithWait := append([]string{"--wait"}, baseArgs...)
-				args := append([]string{"c"}, baseArgsWithWait...)
-				cmd.Args = append(cmd.Args, args...)
-
-				output, err := cmd.CombinedOutput()
-				expect.NoError(err, fmt.Sprintf("received error output: %s", output))
-				expectedOutput := "Notice: Load balancer creation is in progress, waiting for load balancer to become active\n" + lbCreateOutput
-				expect.Equal(strings.TrimSpace(expectedOutput), strings.TrimSpace(string(output)))
-			})
-		})
 	})
 })
 
 const (
 	lbCreateOutput = `
-Notice: Load balancer created\n
+Notice: Load balancer created
 ID                                      IP    Name             Status    Created At              Algorithm      Region    Size        Size Unit    VPC UUID                                Tag    Droplet IDs        SSL     Sticky Sessions                                Health Check                                                                                                            Forwarding Rules    Disable Lets Encrypt DNS Records
 4de7ac8b-495b-4884-9a69-1050c6793cd6          example-lb-01    new       2017-02-01T22:22:58Z    round_robin    nyc3      lb-small    <nil>        00000000-0000-4000-8000-000000000000           3164444,3164445    true    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:,port:0,path:,check_interval_seconds:0,response_timeout_seconds:0,healthy_threshold:0,unhealthy_threshold:0                        true
 `
+
+	lbWaitCreateOutput = `
+Notice: Load balancer creation is in progress, waiting for load balancer to become active
+Notice: Load balancer created
+ID                                      IP    Name             Status    Created At              Algorithm      Region    Size        Size Unit    VPC UUID                                Tag    Droplet IDs        SSL     Sticky Sessions                                Health Check                                                                                                            Forwarding Rules    Disable Lets Encrypt DNS Records
+4de7ac8b-495b-4884-9a69-1050c6793cd6          example-lb-01    active    2017-02-01T22:22:58Z    round_robin    nyc3      lb-small    <nil>        00000000-0000-4000-8000-000000000000           3164444,3164445    true    type:none,cookie_name:,cookie_ttl_seconds:0    protocol:,port:0,path:,check_interval_seconds:0,response_timeout_seconds:0,healthy_threshold:0,unhealthy_threshold:0                        true
+`
+
 	lbCreateResponse = `
 {
   "load_balancer": {


### PR DESCRIPTION
## Description

Adds `--wait` flag to the doctl compute load-balancer create command. 

It polls the [/v2/load_balancers/$LOAD_BALANCER_ID endpoint](https://docs.digitalocean.com/reference/api/api-reference/#operation/loadBalancers_get), blocking until the load balancer's status attribute moves from new to active.

## Motivation and context

Closes #1264 

## Types of changes

Feature enhancement.

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.