### PR TITLE
Avoid plugin in serverless activations [ get | result ]

### DIFF
--- a/commands/activations.go
+++ b/commands/activations.go
@@ -14,10 +14,15 @@ limitations under the License.
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"regexp"
+	"time"
 
 	"github.com/apache/openwhisk-client-go/whisk"
 	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/commands/charm/text"
 	"github.com/spf13/cobra"
 )
 
@@ -94,10 +99,21 @@ func RunActivationsGet(c *CmdConfig) error {
 	}
 	logsFlag, _ := c.Doit.GetBool(c.NS, flagLogs)
 	resultFlag, _ := c.Doit.GetBool(c.NS, flagResult)
+	quietFlag, _ := c.Doit.GetBool(c.NS, flagQuiet)
+	// There is also a 'last' flag, which is historical.  Since it's behavior is the
+	// default, and the past convention was to ignore it if a single id was specified,
+	// (rather than indicating an error), it is completely ignored here but accepted for
+	// backward compatibility.  In the aio implementation (incorporated in nim, previously
+	// incorporated here), the flag had to be set explicitly (rather than just implied) in
+	// order to get a "banner" (additional informational line)  when requesting logs or
+	// result only.  This seems pointless and we will always display the banner for a
+	// single logs or result output unless --quiet is specified.
 	flagSkip, _ := c.Doit.GetInt(c.NS, flagSkip) // 0 if not there
 	functionFlag, _ := c.Doit.GetString(c.NS, flagFunction)
 	sls := c.Serverless()
 	if id == "" {
+		// If there is no id, the convention is to retrieve the last activation, subject to possible
+		// filtering or skipping
 		options := whisk.ActivationListOptions{Limit: 1, Skip: flagSkip}
 		if functionFlag != "" {
 			options.Name = functionFlag
@@ -111,22 +127,110 @@ func RunActivationsGet(c *CmdConfig) error {
 		}
 		activation := list[0]
 		id = activation.ActivationID
+		if !quietFlag && (logsFlag || resultFlag) {
+			makeBanner(c.Out, activation)
+		}
 	}
-	if logFlag {
-		result, err := sls.GetActivationLogs(id)
+	if logsFlag {
+		activation, err := sls.GetActivationLogs(id)
 		if err != nil {
 			return err
 		}
-		if len(result.Logs) == 0 {
+		if len(activation.Logs) == 0 {
 			return fmt.Errorf("no logs available")
 		}
-		printLogs(result)
+		printLogs(c.Out, true, activation)
 	} else if resultFlag {
-
+		response, err := sls.GetActivationResult(id)
+		if err != nil {
+			return err
+		}
+		if response.Result == nil {
+			return fmt.Errorf("no result available")
+		}
+		printResult(c.Out, response.Result)
 	} else {
-
+		activation, err := sls.GetActivation(id)
+		if err != nil {
+			return err
+		}
+		printActivationRecord(c.Out, activation)
 	}
-	return nil // TODO write the rest
+	return nil
+}
+
+// makeBanner is a subroutine that prints a single "banner" line summarizing information about an
+// activation.  This is done in conjunction with a request to print only logs or only the result, since,
+// otherwise, it is difficult to know what activation is being talked about.
+func makeBanner(writer io.Writer, activation whisk.Activation) {
+	end := time.UnixMilli(activation.End).Format("01/02 03:04:05")
+	init := text.NewStyled("=== ").Muted()
+	body := fmt.Sprintf("%s %s %s %s:%s", activation.ActivationID, statusToString(activation.StatusCode),
+		end, activation.Name, activation.Version)
+	msg := text.NewStyled(body).Highlight()
+	fmt.Fprintln(writer, init.String()+msg.String())
+}
+
+// statusToString converts numeric status codes to typical string
+func statusToString(statusCode int) string {
+	switch statusCode {
+	case 0:
+		return "success"
+	case 1:
+		return "application error"
+	case 2:
+		return "developer error"
+	case 3:
+		return "system error"
+	default:
+		return "??"
+	}
+}
+
+// printLog is a subroutine for printing just the logs of an activation
+func printLogs(writer io.Writer, strip bool, activation whisk.Activation) {
+	for _, log := range activation.Logs {
+		if strip {
+			log = stripLog(log)
+		}
+		fmt.Println(log)
+	}
+}
+
+// dtsRegex is a regular expression that matches the prefix of some activation log entries.
+// It is used by stripLog to remove that prefix
+var dtsRegex = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:.*: `)
+
+// stripLog strips the prefix from log entries
+func stripLog(entry string) string {
+	// `2019-10-11T19:08:57.298Z       stdout: login-success ::  { code: ...`
+	// should become: `login-success ::  { code: ...`
+	found := dtsRegex.FindString(entry)
+	return entry[len(found):]
+}
+
+// printResult is a subroutine for printing just the result of an activation
+func printResult(writer io.Writer, result *whisk.Result) {
+	var msg string
+	bytes, err := json.MarshalIndent(result, "", "  ")
+	if err == nil {
+		msg = string(bytes)
+	} else {
+		msg = "<unable to represent the result as JSON>"
+	}
+	fmt.Fprintln(writer, msg)
+}
+
+// printActivationRecord is a subroutine for printing the entire activation record
+func printActivationRecord(writer io.Writer, activation whisk.Activation) {
+	var msg string
+	bytes, err := json.MarshalIndent(activation, "", "  ")
+	if err == nil {
+		msg = string(bytes)
+	} else {
+		msg = "<unable to represent the activation as JSON>"
+	}
+	fmt.Fprintln(writer, msg)
 }
 
 // RunActivationsList supports the 'activations list' command

--- a/commands/functions_test.go
+++ b/commands/functions_test.go
@@ -253,7 +253,7 @@ func TestFunctionsInvoke(t *testing.T) {
 func TestFunctionsList(t *testing.T) {
 	// The displayer for function list is time-zone sensitive so we need to pre-convert the timestamps using the local
 	// time-zone to get exact matches.
-	timestamps := []int64{1662610000, 1662620000, 1662630000}
+	timestamps := []int64{1664538810000, 1664538820000, 1664538830000}
 	symbols := []string{"%DATE1%", "%DATE2%", "%DATE3%"}
 	dates := []string{
 		time.UnixMilli(timestamps[0]).Format("01/02 03:04:05"),

--- a/do/mocks/ServerlessService.go
+++ b/do/mocks/ServerlessService.go
@@ -124,18 +124,49 @@ func (mr *MockServerlessServiceMockRecorder) Exec(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockServerlessService)(nil).Exec), arg0)
 }
 
-// FireTrigger mocks base method.
-func (m *MockServerlessService) FireTrigger(arg0 context.Context, arg1 string) error {
+// GetActivation mocks base method.
+func (m *MockServerlessService) GetActivation(arg0 string) (whisk.Activation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FireTrigger", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetActivation", arg0)
+	ret0, _ := ret[0].(whisk.Activation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// FireTrigger indicates an expected call of FireTrigger.
-func (mr *MockServerlessServiceMockRecorder) FireTrigger(arg0, arg1 interface{}) *gomock.Call {
+// GetActivation indicates an expected call of GetActivation.
+func (mr *MockServerlessServiceMockRecorder) GetActivation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FireTrigger", reflect.TypeOf((*MockServerlessService)(nil).FireTrigger), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActivation", reflect.TypeOf((*MockServerlessService)(nil).GetActivation), arg0)
+}
+
+// GetActivationLogs mocks base method.
+func (m *MockServerlessService) GetActivationLogs(arg0 string) (whisk.Activation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActivationLogs", arg0)
+	ret0, _ := ret[0].(whisk.Activation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetActivationLogs indicates an expected call of GetActivationLogs.
+func (mr *MockServerlessServiceMockRecorder) GetActivationLogs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActivationLogs", reflect.TypeOf((*MockServerlessService)(nil).GetActivationLogs), arg0)
+}
+
+// GetActivationResult mocks base method.
+func (m *MockServerlessService) GetActivationResult(arg0 string) (whisk.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActivationResult", arg0)
+	ret0, _ := ret[0].(whisk.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetActivationResult indicates an expected call of GetActivationResult.
+func (mr *MockServerlessServiceMockRecorder) GetActivationResult(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActivationResult", reflect.TypeOf((*MockServerlessService)(nil).GetActivationResult), arg0)
 }
 
 // GetConnectedAPIHost mocks base method.
@@ -287,6 +318,21 @@ func (mr *MockServerlessServiceMockRecorder) InvokeFunctionViaWeb(arg0, arg1 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvokeFunctionViaWeb", reflect.TypeOf((*MockServerlessService)(nil).InvokeFunctionViaWeb), arg0, arg1)
 }
 
+// ListActivations mocks base method.
+func (m *MockServerlessService) ListActivations(arg0 whisk.ActivationListOptions) ([]whisk.Activation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListActivations", arg0)
+	ret0, _ := ret[0].([]whisk.Activation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListActivations indicates an expected call of ListActivations.
+func (mr *MockServerlessServiceMockRecorder) ListActivations(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActivations", reflect.TypeOf((*MockServerlessService)(nil).ListActivations), arg0)
+}
+
 // ListFunctions mocks base method.
 func (m *MockServerlessService) ListFunctions(arg0 string, arg1, arg2 int) ([]whisk.Action, error) {
 	m.ctrl.T.Helper()
@@ -360,21 +406,6 @@ func (m *MockServerlessService) ReadProject(arg0 *do.ServerlessProject, arg1 []s
 func (mr *MockServerlessServiceMockRecorder) ReadProject(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadProject", reflect.TypeOf((*MockServerlessService)(nil).ReadProject), arg0, arg1)
-}
-
-// SetTriggerEnablement mocks base method.
-func (m *MockServerlessService) SetTriggerEnablement(arg0 context.Context, arg1 string, arg2 bool) (do.ServerlessTrigger, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetTriggerEnablement", arg0, arg1, arg2)
-	ret0, _ := ret[0].(do.ServerlessTrigger)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SetTriggerEnablement indicates an expected call of SetTriggerEnablement.
-func (mr *MockServerlessServiceMockRecorder) SetTriggerEnablement(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTriggerEnablement", reflect.TypeOf((*MockServerlessService)(nil).SetTriggerEnablement), arg0, arg1, arg2)
 }
 
 // Stream mocks base method.

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -349,6 +349,10 @@ func initWhisk(s *serverlessService) error {
 	if s.owClient != nil {
 		return nil
 	}
+	err := s.CheckServerlessStatus(HashAccessToken(s.accessToken))
+	if err != nil {
+		return err
+	}
 	creds, err := s.ReadCredentials()
 	if err != nil {
 		return err

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -221,6 +221,10 @@ type ServerlessService interface {
 	ListFunctions(string, int, int) ([]whisk.Action, error)
 	InvokeFunction(string, interface{}, bool, bool) (map[string]interface{}, error)
 	InvokeFunctionViaWeb(string, map[string]interface{}) error
+	ListActivations(whisk.ActivationListOptions) ([]whisk.Activation, error)
+	GetActivation(string) (whisk.Activation, error)
+	GetActivationLogs(string) (whisk.Activation, error)
+	GetActivationResult(string) (whisk.Response, error)
 	GetConnectedAPIHost() (string, error)
 	ReadProject(*ServerlessProject, []string) (ServerlessOutput, error)
 	WriteProject(ServerlessProject) (string, error)
@@ -791,6 +795,50 @@ func (s *serverlessService) InvokeFunctionViaWeb(name string, params map[string]
 		theURL += "?" + encoded.Encode()
 	}
 	return browser.OpenURL(theURL)
+}
+
+// ListActivations drives the OpenWhisk API for listing activations
+func (s *serverlessService) ListActivations(options whisk.ActivationListOptions) ([]whisk.Activation, error) {
+	empty := []whisk.Activation{}
+	err := initWhisk(s)
+	if err != nil {
+		return empty, err
+	}
+	resp, _, err := s.owClient.Activations.List(&options)
+	return resp, err
+}
+
+// GetActivation drives the OpenWhisk API getting an activation
+func (s *serverlessService) GetActivation(id string) (whisk.Activation, error) {
+	empty := whisk.Activation{}
+	err := initWhisk(s)
+	if err != nil {
+		return empty, err
+	}
+	resp, _, err := s.owClient.Activations.Get(id)
+	return *resp, err
+}
+
+// GetActivationLogs drives the OpenWhisk API getting the logs of an activation
+func (s *serverlessService) GetActivationLogs(id string) (whisk.Activation, error) {
+	empty := whisk.Activation{}
+	err := initWhisk(s)
+	if err != nil {
+		return empty, err
+	}
+	resp, _, err := s.owClient.Activations.Logs(id)
+	return *resp, err
+}
+
+// GetActivationResult drives the OpenWhisk API getting the result of an activation
+func (s *serverlessService) GetActivationResult(id string) (whisk.Response, error) {
+	empty := whisk.Response{}
+	err := initWhisk(s)
+	if err != nil {
+		return empty, err
+	}
+	resp, _, err := s.owClient.Activations.Result(id)
+	return *resp, err
 }
 
 // GetConnectedAPIHost retrieves the API host to which the service is currently connected

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -1093,8 +1093,8 @@ func (s *serverlessService) ReadCredentials() (ServerlessCredentials, error) {
 	return creds, err
 }
 
-// Determines whether the serverlessUptodate appears to be connected.  The purpose is
-// to fail fast (when feasible) on sandboxes that are clearly not connected.
+// Determines whether the serverless support appears to be connected.  The purpose is
+// to fail fast (when feasible) when it clearly is not connected.
 // However, it is important not to add excessive overhead on each call (e.g.
 // asking the plugin to validate credentials), so the test is not foolproof.
 // It merely tests whether a credentials directory has been created for the
@@ -1106,15 +1106,15 @@ func isServerlessConnected(leafCredsDir string, serverlessDir string) bool {
 	return !os.IsNotExist(err)
 }
 
-// serverlessUptodate answers whether the installed version of the serverlessUptodate is at least
+// serverlessUptodate answers whether the installed version of the serverless support is at least
 // what is required by doctl
 func serverlessUptodate(serverlessDir string) bool {
 	return GetCurrentServerlessVersion(serverlessDir) >= GetMinServerlessVersion()
 }
 
-// GetCurrentServerlessVersion gets the version of the current serverless.
-// To be called only when serverless is known to exist.
-// Returns "0" if the installed serverless pre-dates the versioning system
+// GetCurrentServerlessVersion gets the version of the current plugin.
+// To be called only when the plugin is known to exist.
+// Returns "0" if the installed plugin pre-dates the versioning system
 // Otherwise, returns the version string stored in the serverless directory.
 func GetCurrentServerlessVersion(serverlessDir string) string {
 	versionFile := filepath.Join(serverlessDir, "version")


### PR DESCRIPTION
This change alters the logic for `doctl sls actv get` and `doctl sls actv result` to use the OpenWhisk API directly rather than using the plugin.   The `list` and `logs` commands are still using the plugin (to be addressed in a future PR).