### PR TITLE
functions: action.Exec.Code is nil when saving env.

### DIFF
--- a/commands/functions.go
+++ b/commands/functions.go
@@ -123,7 +123,7 @@ func RunFunctionsGet(c *CmdConfig) error {
 	return c.PrintServerlessTextOutput(output)
 }
 
-// doSaveFunctionCode performs the save operations for code and for environment variables.
+// doSaveFunctionCode performs the save operations for code
 func doSaveFunctionCode(action whisk.Action, save bool, saveAs string) error {
 	var extension string // used only when save and !saveAs
 	var data []byte

--- a/commands/functions.go
+++ b/commands/functions.go
@@ -125,7 +125,6 @@ func RunFunctionsGet(c *CmdConfig) error {
 
 // doSaveFunctionCode performs the save operations for code and for environment variables.
 func doSaveFunctionCode(action whisk.Action, save bool, saveAs string) error {
-	// First process save and saveAs
 	var extension string // used only when save and !saveAs
 	var data []byte
 	if *action.Exec.Binary {


### PR DESCRIPTION
`doctl sbx fn get` panics when passing the `--save-env` or `--save-env-json` flags. This is because  `action.Exec.Code` is nil when calling `doSavingForFunctionGet` since we only fetch the code when `codeFlag || saveFlag || saveAsFlag` is true. I've broken the environment saving out of the code saving function to make their individual purposes more clear.

As an additional follow up, we may want to error if some of these flags are used together as they seem to be mutually exclusive.