### PR TITLE
Remove broken link to AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ This allows `doctl` to add DigitalOcean container registry credentials to your D
 
     sudo pacman -S doctl
 
-As an alternative, you can install it from the [AUR](https://aur.archlinux.org/packages/doctl-bin/).
-
 #### Fedora
 
 `doctl` is available in the official Fedora repository:


### PR DESCRIPTION
I *think* that https://archlinux.org/packages/community/x86_64/doctl/
is part of the official Arch Linux repository, so it's not necessary
to link to it separately.

Fixes #1291