### PR TITLE
Use the smaller deployer-only plugin instead of the original one

### DIFF
--- a/commands/serverless-extra.go
+++ b/commands/serverless-extra.go
@@ -168,7 +168,7 @@ func RunServerlessExtraDeploy(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	output, err := RunServerlessExec(projectDeploy, c, []string{flagInsecure, flagVerboseBuild, flagVerboseZip, flagYarn, flagRemoteBuild, flagIncremental},
+	output, err := RunServerlessExec("deploy", c, []string{flagInsecure, flagVerboseBuild, flagVerboseZip, flagYarn, flagRemoteBuild, flagIncremental},
 		[]string{flagEnv, flagBuildEnv, flagApihost, flagAuth, flagInclude, flagExclude})
 	if err != nil && len(output.Captured) == 0 {
 		// Just an error, nothing in 'Captured'
@@ -223,7 +223,7 @@ func RunServerlessExtraGetMetadata(c *CmdConfig) error {
 	if r {
 		output, err = c.Serverless().ReadProject(&project, c.Args)
 	} else {
-		output, err = RunServerlessExec(projectGetMetadata, c, []string{flagJSON, flagProjectReader}, []string{flagEnv, flagInclude, flagExclude})
+		output, err = RunServerlessExec("get-metadata", c, []string{flagJSON, flagProjectReader}, []string{flagEnv, flagInclude, flagExclude})
 	}
 	if err != nil {
 		return err
@@ -239,7 +239,7 @@ func RunServerlessExtraWatch(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	return RunServerlessExecStreaming(projectWatch, c, []string{flagInsecure, flagVerboseBuild, flagVerboseZip, flagYarn, flagRemoteBuild},
+	return RunServerlessExecStreaming("watch", c, []string{flagInsecure, flagVerboseBuild, flagVerboseZip, flagYarn, flagRemoteBuild},
 		[]string{flagEnv, flagBuildEnv, flagApihost, flagAuth, flagInclude, flagExclude})
 }
 

--- a/commands/serverless_test.go
+++ b/commands/serverless_test.go
@@ -465,7 +465,7 @@ func TestServerlessDeploy(t *testing.T) {
 				}
 
 				tm.serverless.EXPECT().CheckServerlessStatus().MinTimes(1).Return(nil)
-				tm.serverless.EXPECT().Cmd("project/deploy", tt.expectedNimArgs).Return(fakeCmd, nil)
+				tm.serverless.EXPECT().Cmd("deploy", tt.expectedNimArgs).Return(fakeCmd, nil)
 				tm.serverless.EXPECT().Exec(fakeCmd).Return(do.ServerlessOutput{}, nil)
 
 				err := RunServerlessExtraDeploy(config)
@@ -614,7 +614,7 @@ func TestServerlessWatch(t *testing.T) {
 		{
 			name:            "no flags with path",
 			doctlArgs:       "path/to/project",
-			expectedNimArgs: []string{"project/watch", "path/to/project", "--exclude", "web"},
+			expectedNimArgs: []string{"watch", "path/to/project", "--exclude", "web"},
 		},
 		// TODO: Add additional scenarios for other flags, etc.
 	}

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -235,10 +235,10 @@ type serverlessService struct {
 }
 
 const (
-	// Minimum required version of the sandbox plugin code.  The first part is
-	// the version of the incorporated Nimbella CLI and the second part is the
+	// Minimum required version of the serverless plugin code.  The first part is
+	// the version of the incorporated functions deployer and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minServerlessVersion = "4.2.8-1.3.1"
+	minServerlessVersion = "5.0.12-2.0.0"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"


### PR DESCRIPTION
The purpose of this change is to make the incorporated serverless plugin smaller and simpler to maintain.  Customers will notice no change, since a plugin still has to be installed to support the `deploy`, `get-metadata`, and `watch` commands.  The download time for the plugin, already not too bad, is not that much improved since it is dominated by the size of the `node` binary.   However, from a long-term code maintenance standpoint the change should be a win.

This change goes along with a corresponding change in the plugin repo:
digitalocean/doctl-sandbox-plugin#6.   Most of the important changes are there.  The present change increments the plugin minimum version and makes a few other minor adjustments.