### PR TITLE
Implement sls undeploy in native golang

### DIFF
--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -449,7 +449,7 @@ func RunServerlessUndeploy(c *CmdConfig) error {
 		if trigFlag {
 			err = sls.DeleteTrigger(ctx, arg)
 		} else if strings.Contains(arg, "/") || !pkgFlag {
-			err = sls.DeleteFunction(arg, false)
+			err = sls.DeleteFunction(arg, true)
 		} else {
 			err = sls.DeletePackage(arg, true)
 		}

--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -118,6 +118,7 @@ the entire packages are removed.`, Writer)
 	AddBoolFlag(undeploy, "triggers", "", false, "interpret all arguments as triggers")
 	AddBoolFlag(undeploy, "all", "", false, "remove all packages and functions")
 	AddBoolFlag(undeploy, doctl.ArgForce, doctl.ArgShortForce, false, "Delete namespace resources without confirmation prompt")
+	undeploy.Flags().MarkHidden(doctl.ArgForce)
 	undeploy.Flags().MarkHidden("triggers") // support is experimental at this point
 
 	cmd.AddCommand(Activations())
@@ -401,7 +402,6 @@ func RunServerlessUndeploy(c *CmdConfig) error {
 	haveArgs := len(c.Args) > 0
 	pkgFlag, _ := c.Doit.GetBool(c.NS, "packages")
 	trigFlag, _ := c.Doit.GetBool(c.NS, "triggers")
-	forceFlag, err := c.Doit.GetBool(c.NS, doctl.ArgForce)
 
 	all, _ := c.Doit.GetBool(c.NS, "all")
 
@@ -421,14 +421,7 @@ func RunServerlessUndeploy(c *CmdConfig) error {
 	}
 
 	if all {
-		if !forceFlag {
-			err = AskForConfirm("Are you sure you want to delete all resources in this namespace.")
-			if err != nil {
-				return err
-			}
-		}
-
-		err = sls.CleanNamespace()
+		err := sls.CleanNamespace()
 		if err != nil {
 			return err
 		}

--- a/commands/serverless_test.go
+++ b/commands/serverless_test.go
@@ -482,104 +482,64 @@ func TestServerlessUndeploy(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                 string
-		doctlArgs            []string
-		doctlFlags           map[string]string
-		expectedNimCmds      []testNimCmd
-		expectedError        error
-		expectTriggerDeletes []string
-		expectTriggerList    bool
+		name          string
+		doctlArgs     []string
+		doctlFlags    map[string]string
+		expectedError error
 	}{
 		{
-			name:            "no arguments or flags",
-			doctlArgs:       nil,
-			doctlFlags:      nil,
-			expectedNimCmds: nil,
-			expectedError:   errUndeployTooFewArgs,
+			name:          "no arguments or flags",
+			doctlArgs:     nil,
+			doctlFlags:    nil,
+			expectedError: errUndeployTooFewArgs,
 		},
 		{
-			name:       "with --all flag only",
-			doctlArgs:  nil,
-			doctlFlags: map[string]string{"all": ""},
-			expectedNimCmds: []testNimCmd{
-				{
-					cmd:  "namespace/clean",
-					args: []string{"--force"},
-				},
-			},
+			name:          "with --all flag only",
+			doctlArgs:     nil,
+			doctlFlags:    map[string]string{"all": "", "force": ""},
 			expectedError: nil,
 		},
 		{
-			name:       "mixed args, no flags",
-			doctlArgs:  []string{"foo/bar", "baz"},
-			doctlFlags: nil,
-			expectedNimCmds: []testNimCmd{
-				{
-					cmd:  "action/delete",
-					args: []string{"foo/bar"},
-				},
-				{
-					cmd:  "action/delete",
-					args: []string{"baz"},
-				},
-			},
+			name:          "mixed args, no flags",
+			doctlArgs:     []string{"foo/bar", "baz"},
+			doctlFlags:    nil,
 			expectedError: nil,
 		},
 		{
-			name:       "mixed args, --packages flag",
-			doctlArgs:  []string{"foo/bar", "baz"},
-			doctlFlags: map[string]string{"packages": ""},
-			expectedNimCmds: []testNimCmd{
-				{
-					cmd:  "action/delete",
-					args: []string{"foo/bar"},
-				},
-				{
-					cmd:  "package/delete",
-					args: []string{"baz", "--recursive"},
-				},
-			},
+			name:          "mixed args, --packages flag",
+			doctlArgs:     []string{"foo/bar", "baz"},
+			doctlFlags:    map[string]string{"packages": ""},
 			expectedError: nil,
 		},
 		{
-			name:            "mixed args, --all flag",
-			doctlArgs:       []string{"foo/bar", "baz"},
-			doctlFlags:      map[string]string{"all": ""},
-			expectedNimCmds: nil,
-			expectedError:   errUndeployAllAndArgs,
+			name:          "mixed args, --all flag",
+			doctlArgs:     []string{"foo/bar", "baz"},
+			doctlFlags:    map[string]string{"all": ""},
+			expectedError: errUndeployAllAndArgs,
 		},
 		{
-			name:            "--triggers and --packages",
-			doctlArgs:       []string{"foo/bar", "baz"},
-			doctlFlags:      map[string]string{"triggers": "", "packages": ""},
-			expectedNimCmds: nil,
-			expectedError:   errUndeployTrigPkg,
+			name:          "--triggers and --packages",
+			doctlArgs:     []string{"foo/bar", "baz"},
+			doctlFlags:    map[string]string{"triggers": "", "packages": ""},
+			expectedError: errUndeployTrigPkg,
 		},
 		{
-			name:                 "--triggers and args",
-			doctlArgs:            []string{"fire1", "fire2"},
-			doctlFlags:           map[string]string{"triggers": ""},
-			expectedNimCmds:      nil,
-			expectedError:        nil,
-			expectTriggerDeletes: []string{"fire1", "fire2"},
+			name:          "--triggers and args",
+			doctlArgs:     []string{"fire1", "fire2"},
+			doctlFlags:    map[string]string{"triggers": ""},
+			expectedError: nil,
 		},
 		{
-			name:                 "--triggers and --all",
-			doctlArgs:            nil,
-			doctlFlags:           map[string]string{"triggers": "", "all": ""},
-			expectedNimCmds:      nil,
-			expectedError:        nil,
-			expectTriggerDeletes: []string{"fireA", "fireB"},
-			expectTriggerList:    true,
+			name:          "--triggers and --all",
+			doctlArgs:     nil,
+			doctlFlags:    map[string]string{"triggers": "", "all": ""},
+			expectedError: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-				fakeCmd := &exec.Cmd{
-					Stdout: config.Out,
-				}
 				cannedTriggerList := []do.ServerlessTrigger{
 					{Name: "fireA"},
 					{Name: "fireB"},
@@ -589,8 +549,25 @@ func TestServerlessUndeploy(t *testing.T) {
 					config.Args = append(config.Args, tt.doctlArgs...)
 				}
 
+				// var force bool
+				var pkg bool = false
+				var trig bool = false
+				var all bool = false
+
 				if tt.doctlFlags != nil {
 					for k, v := range tt.doctlFlags {
+						if k == "all" {
+							all = true
+						}
+
+						if k == "packages" {
+							pkg = true
+						}
+
+						if k == "triggers" {
+							trig = true
+						}
+
 						if v == "" {
 							config.Doit.Set(config.NS, k, true)
 						} else {
@@ -599,20 +576,29 @@ func TestServerlessUndeploy(t *testing.T) {
 					}
 				}
 
-				if tt.expectedError == nil && len(tt.expectedNimCmds) > 0 {
-					tm.serverless.EXPECT().CheckServerlessStatus().MinTimes(1).Return(nil)
-				}
-				if tt.expectTriggerList {
+				if all && !trig && !pkg && len(config.Args) == 0 {
+					tm.serverless.EXPECT().CleanNamespace().Return(nil)
+				} else if all && trig && len(config.Args) == 0 {
 					tm.serverless.EXPECT().ListTriggers(context.TODO(), "").Return(cannedTriggerList, nil)
-				}
-				for i := range tt.expectedNimCmds {
-					tm.serverless.EXPECT().Cmd(tt.expectedNimCmds[i].cmd, tt.expectedNimCmds[i].args).Return(fakeCmd, nil)
-					tm.serverless.EXPECT().Exec(fakeCmd).Return(do.ServerlessOutput{}, nil)
-				}
-				for _, trig := range tt.expectTriggerDeletes {
-					tm.serverless.EXPECT().DeleteTrigger(context.TODO(), trig)
+					for _, st := range cannedTriggerList {
+						tm.serverless.EXPECT().DeleteTrigger(context.TODO(), st.Name)
+					}
+
+				} else if !all && !trig && len(config.Args) > 0 {
+					for _, arg := range config.Args {
+						if !pkg || strings.Contains(arg, "/") {
+							tm.serverless.EXPECT().DeleteFunction(arg, true).Return(nil)
+						} else {
+							tm.serverless.EXPECT().DeletePackage(arg, true).Return(nil)
+						}
+					}
+				} else if !all && trig && !pkg && len(config.Args) > 0 {
+					for _, t := range config.Args {
+						tm.serverless.EXPECT().DeleteTrigger(context.TODO(), t)
+					}
 				}
 				err := RunServerlessUndeploy(config)
+
 				if tt.expectedError != nil {
 					require.Error(t, err)
 					assert.ErrorIs(t, err, tt.expectedError)

--- a/commands/serverless_test.go
+++ b/commands/serverless_test.go
@@ -476,11 +476,6 @@ func TestServerlessDeploy(t *testing.T) {
 }
 
 func TestServerlessUndeploy(t *testing.T) {
-	type testNimCmd struct {
-		cmd  string
-		args []string
-	}
-
 	tests := []struct {
 		name          string
 		doctlArgs     []string
@@ -496,7 +491,7 @@ func TestServerlessUndeploy(t *testing.T) {
 		{
 			name:          "with --all flag only",
 			doctlArgs:     nil,
-			doctlFlags:    map[string]string{"all": "", "force": ""},
+			doctlFlags:    map[string]string{"all": ""},
 			expectedError: nil,
 		},
 		{
@@ -549,7 +544,6 @@ func TestServerlessUndeploy(t *testing.T) {
 					config.Args = append(config.Args, tt.doctlArgs...)
 				}
 
-				// var force bool
 				var pkg bool = false
 				var trig bool = false
 				var all bool = false

--- a/do/mocks/ServerlessService.go
+++ b/do/mocks/ServerlessService.go
@@ -51,6 +51,20 @@ func (mr *MockServerlessServiceMockRecorder) CheckServerlessStatus() *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckServerlessStatus", reflect.TypeOf((*MockServerlessService)(nil).CheckServerlessStatus))
 }
 
+// CleanNamespace mocks base method.
+func (m *MockServerlessService) CleanNamespace() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanNamespace")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanNamespace indicates an expected call of CleanNamespace.
+func (mr *MockServerlessServiceMockRecorder) CleanNamespace() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanNamespace", reflect.TypeOf((*MockServerlessService)(nil).CleanNamespace))
+}
+
 // Cmd mocks base method.
 func (m *MockServerlessService) Cmd(arg0 string, arg1 []string) (*exec.Cmd, error) {
 	m.ctrl.T.Helper()
@@ -81,6 +95,20 @@ func (mr *MockServerlessServiceMockRecorder) CreateNamespace(arg0, arg1, arg2 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockServerlessService)(nil).CreateNamespace), arg0, arg1, arg2)
 }
 
+// DeleteFunction mocks base method.
+func (m *MockServerlessService) DeleteFunction(arg0 string, arg1 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteFunction", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteFunction indicates an expected call of DeleteFunction.
+func (mr *MockServerlessServiceMockRecorder) DeleteFunction(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFunction", reflect.TypeOf((*MockServerlessService)(nil).DeleteFunction), arg0, arg1)
+}
+
 // DeleteNamespace mocks base method.
 func (m *MockServerlessService) DeleteNamespace(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -93,6 +121,20 @@ func (m *MockServerlessService) DeleteNamespace(arg0 context.Context, arg1 strin
 func (mr *MockServerlessServiceMockRecorder) DeleteNamespace(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockServerlessService)(nil).DeleteNamespace), arg0, arg1)
+}
+
+// DeletePackage mocks base method.
+func (m *MockServerlessService) DeletePackage(arg0 string, arg1 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePackage", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeletePackage indicates an expected call of DeletePackage.
+func (mr *MockServerlessServiceMockRecorder) DeletePackage(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePackage", reflect.TypeOf((*MockServerlessService)(nil).DeletePackage), arg0, arg1)
 }
 
 // DeleteTrigger mocks base method.

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -683,19 +683,17 @@ func (s *serverlessService) DeleteNamespace(ctx context.Context, name string) er
 
 func (s *serverlessService) CleanNamespace() error {
 	// Deletes all triggers
-	// ctx := context.TODO()
-	// triggers, err := s.ListTriggers(ctx, "")
+	ctx := context.TODO()
+	triggers, err := s.ListTriggers(ctx, "")
 
-	// if err != nil {
-	// 	return err
-	// }
-
-	// for _, trig := range triggers {
-	// 	err = s.DeleteTrigger(ctx, trig.Name)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// }
+	if err == nil {
+		for _, trig := range triggers {
+			err = s.DeleteTrigger(ctx, trig.Name)
+			if err != nil {
+				return err
+			}
+		}
+	}
 
 	// Deletes all functions
 	fns, err := s.ListFunctions("", 0, 0)
@@ -787,14 +785,12 @@ func (s *serverlessService) DeleteFunction(name string, deleteTriggers bool) err
 		ctx := context.TODO()
 		triggers, err := s.ListTriggers(ctx, name)
 
-		if err != nil {
-			return err
-		}
-
-		for _, trig := range triggers {
-			err = s.DeleteTrigger(ctx, trig.Name)
-			if err != nil {
-				return err
+		if err == nil {
+			for _, trig := range triggers {
+				err = s.DeleteTrigger(ctx, trig.Name)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -821,7 +817,7 @@ func (s *serverlessService) DeletePackage(name string, force bool) error {
 		for _, fn := range pkg.Actions {
 			funcName := name + "/" + fn.Name
 
-			err = s.DeleteFunction(funcName, false)
+			err = s.DeleteFunction(funcName, true)
 
 			if err != nil {
 				return err

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -686,6 +686,8 @@ func (s *serverlessService) CleanNamespace() error {
 	ctx := context.TODO()
 	triggers, err := s.ListTriggers(ctx, "")
 
+	// Intentionally ignore errors when listing triggers, the trigger API is behind a
+	// feature flag and may will return an error for users not enabled.
 	if err == nil {
 		for _, trig := range triggers {
 			err = s.DeleteTrigger(ctx, trig.Name)
@@ -708,6 +710,7 @@ func (s *serverlessService) CleanNamespace() error {
 			name = pkg[1] + "/" + fn.Name
 		}
 
+		// All triggers for the namespace are deleted above so we don't need to remove the trigger for each individual function.
 		err := s.DeleteFunction(name, false)
 		if err != nil {
 			return err
@@ -785,6 +788,8 @@ func (s *serverlessService) DeleteFunction(name string, deleteTriggers bool) err
 		ctx := context.TODO()
 		triggers, err := s.ListTriggers(ctx, name)
 
+		// Intentionally ignore errors when listing triggers, the trigger API is behind a
+		// feature flag and may will return an error for users not enabled.
 		if err == nil {
 			for _, trig := range triggers {
 				err = s.DeleteTrigger(ctx, trig.Name)


### PR DESCRIPTION
Implements `doctl sls undeploy` subtree in goland instead of using the nim plugin. 