### PR TITLE
Add more support for project_id in doctl

### DIFF
--- a/args.go
+++ b/args.go
@@ -36,6 +36,8 @@ const (
 	ArgActionType = "action-type"
 	// ArgApp is the app ID.
 	ArgApp = "app"
+	// ArgWithProjects will determine whether project ids should be fetched along with listed apps.
+	ArgWithProjects = "with-projects"
 	// ArgAppSpec is a path to an app spec.
 	ArgAppSpec = "spec"
 	// ArgAppLogType the type of log.

--- a/args.go
+++ b/args.go
@@ -36,8 +36,8 @@ const (
 	ArgActionType = "action-type"
 	// ArgApp is the app ID.
 	ArgApp = "app"
-	// ArgWithProjects will determine whether project ids should be fetched along with listed apps.
-	ArgWithProjects = "with-projects"
+	// ArgAppWithProjects will determine whether project ids should be fetched along with listed apps.
+	ArgAppWithProjects = "with-projects"
 	// ArgAppSpec is a path to an app spec.
 	ArgAppSpec = "spec"
 	// ArgAppLogType the type of log.

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -89,7 +89,7 @@ Only basic information is included with the text output format. For complete app
 		aliasOpt("ls"),
 		displayerType(&displayers.Apps{}),
 	)
-	AddBoolFlag(list, doctl.ArgWithProjects, "", false, "Boolean that specifies whether project ids should be fetched along with listed apps")
+	AddBoolFlag(list, doctl.ArgAppWithProjects, "", false, "Boolean that specifies whether project ids should be fetched along with listed apps")
 
 	update := CmdBuilder(
 		cmd,
@@ -322,7 +322,7 @@ func RunAppsGet(c *CmdConfig) error {
 
 // RunAppsList lists all apps.
 func RunAppsList(c *CmdConfig) error {
-	withProjects, err := c.Doit.GetBool(c.NS, doctl.ArgWithProjects)
+	withProjects, err := c.Doit.GetBool(c.NS, doctl.ArgAppWithProjects)
 	if err != nil {
 		return err
 	}

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -250,7 +250,13 @@ func RunAppsCreate(c *CmdConfig) error {
 		return err
 	}
 
-	app, err := c.Apps().Create(&godo.AppCreateRequest{Spec: appSpec})
+	projectID, err := c.Doit.GetString(c.NS, doctl.ArgProjectID)
+	if err != nil {
+		return err
+	}
+
+	// Do this
+	app, err := c.Apps().Create(&godo.AppCreateRequest{Spec: appSpec, ProjectID: projectID})
 	if err != nil {
 		if gerr, ok := err.(*godo.ErrorResponse); ok && gerr.Response.StatusCode == 409 && upsert {
 			notice("App already exists, updating")

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -62,6 +62,7 @@ func Apps() *Command {
 	AddBoolFlag(create, doctl.ArgCommandWait, "", false,
 		"Boolean that specifies whether to wait for an app to complete before returning control to the terminal")
 	AddBoolFlag(create, doctl.ArgCommandUpsert, "", false, "Boolean that specifies whether the app should be updated if it already exists")
+	AddStringFlag(create, doctl.ArgProjectID, "", "", "The id of the project to assign the created app and resources to. If not provided, the default project will be used.")
 
 	CmdBuilder(
 		cmd,
@@ -76,7 +77,7 @@ Only basic information is included with the text output format. For complete app
 		displayerType(&displayers.Apps{}),
 	)
 
-	CmdBuilder(
+	list := CmdBuilder(
 		cmd,
 		RunAppsList,
 		"list",
@@ -88,6 +89,7 @@ Only basic information is included with the text output format. For complete app
 		aliasOpt("ls"),
 		displayerType(&displayers.Apps{}),
 	)
+	AddBoolFlag(list, doctl.ArgWithProjects, "", false, "Boolean that specifies whether project ids should be fetched along with listed apps")
 
 	update := CmdBuilder(
 		cmd,
@@ -253,7 +255,7 @@ func RunAppsCreate(c *CmdConfig) error {
 		if gerr, ok := err.(*godo.ErrorResponse); ok && gerr.Response.StatusCode == 409 && upsert {
 			notice("App already exists, updating")
 
-			apps, err := c.Apps().List()
+			apps, err := c.Apps().List(false)
 			if err != nil {
 				return err
 			}
@@ -315,7 +317,12 @@ func RunAppsGet(c *CmdConfig) error {
 
 // RunAppsList lists all apps.
 func RunAppsList(c *CmdConfig) error {
-	apps, err := c.Apps().List()
+	withProjects, err := c.Doit.GetBool(c.NS, doctl.ArgWithProjects)
+	if err != nil {
+		return err
+	}
+
+	apps, err := c.Apps().List(withProjects)
 	if err != nil {
 		return err
 	}

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -62,7 +62,7 @@ func Apps() *Command {
 	AddBoolFlag(create, doctl.ArgCommandWait, "", false,
 		"Boolean that specifies whether to wait for an app to complete before returning control to the terminal")
 	AddBoolFlag(create, doctl.ArgCommandUpsert, "", false, "Boolean that specifies whether the app should be updated if it already exists")
-	AddStringFlag(create, doctl.ArgProjectID, "", "", "The id of the project to assign the created app and resources to. If not provided, the default project will be used.")
+	AddStringFlag(create, doctl.ArgProjectID, "", "", "The ID of the project to assign the created app and resources to. If not provided, the default project will be used.")
 
 	CmdBuilder(
 		cmd,

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -255,7 +255,6 @@ func RunAppsCreate(c *CmdConfig) error {
 		return err
 	}
 
-	// Do this
 	app, err := c.Apps().Create(&godo.AppCreateRequest{Spec: appSpec, ProjectID: projectID})
 	if err != nil {
 		if gerr, ok := err.(*godo.ErrorResponse); ok && gerr.Response.StatusCode == 409 && upsert {

--- a/commands/apps_dev.go
+++ b/commands/apps_dev.go
@@ -678,7 +678,7 @@ func appsDevBuildSpecRequired(ws *workspace.AppDev, appsService do.AppsService) 
 func appsDevSelectApp(appsService do.AppsService) (*godo.App, error) {
 	// TODO: consider updating the list component to accept an itemsFunc and displays its own loading screen
 	template.Print(`listing apps on your account...`, nil)
-	apps, err := appsService.List()
+	apps, err := appsService.List(false)
 	if err != nil {
 		return nil, fmt.Errorf("listing apps: %w", err)
 	}

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -174,7 +174,7 @@ func TestRunAppsList(t *testing.T) {
 			UpdatedAt: time.Now(),
 		}}
 
-		tm.apps.EXPECT().List().Times(1).Return(apps, nil)
+		tm.apps.EXPECT().List(false).Times(1).Return(apps, nil)
 
 		err := RunAppsList(config)
 		require.NoError(t, err)

--- a/do/apps.go
+++ b/do/apps.go
@@ -23,7 +23,7 @@ import (
 type AppsService interface {
 	Create(req *godo.AppCreateRequest) (*godo.App, error)
 	Get(appID string) (*godo.App, error)
-	List() ([]*godo.App, error)
+	List(withProjects bool) ([]*godo.App, error)
 	Update(appID string, req *godo.AppUpdateRequest) (*godo.App, error)
 	Delete(appID string) error
 	Propose(req *godo.AppProposeRequest) (*godo.AppProposeResponse, error)
@@ -77,8 +77,9 @@ func (s *appsService) Get(appID string) (*godo.App, error) {
 	return app, nil
 }
 
-func (s *appsService) List() ([]*godo.App, error) {
+func (s *appsService) List(withProjects bool) ([]*godo.App, error) {
 	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+		opt.WithProjects = withProjects
 		list, resp, err := s.client.Apps.List(s.ctx, opt)
 		if err != nil {
 			return nil, nil, err

--- a/do/mocks/AppsService.go
+++ b/do/mocks/AppsService.go
@@ -154,18 +154,18 @@ func (mr *MockAppsServiceMockRecorder) GetTier(slug interface{}) *gomock.Call {
 }
 
 // List mocks base method.
-func (m *MockAppsService) List() ([]*godo.App, error) {
+func (m *MockAppsService) List(withProjects bool) ([]*godo.App, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List")
+	ret := m.ctrl.Call(m, "List", withProjects)
 	ret0, _ := ret[0].([]*godo.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // List indicates an expected call of List.
-func (mr *MockAppsServiceMockRecorder) List() *gomock.Call {
+func (mr *MockAppsServiceMockRecorder) List(withProjects interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockAppsService)(nil).List))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockAppsService)(nil).List), withProjects)
 }
 
 // ListAlerts mocks base method.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/creack/pty v1.1.11
-	github.com/digitalocean/godo v1.87.0
+	github.com/digitalocean/godo v1.89.0
 	github.com/docker/cli v20.10.17+incompatible
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8l
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.87.0 h1:U6jyE7Ga+6NkAa8pnpgrKk0lEU1e3Fc/kWipC9tARds=
-github.com/digitalocean/godo v1.87.0/go.mod h1:NRpFznZFvhHjBoqZAaOD3khVzsJ3EibzKqFL4R60dmA=
+github.com/digitalocean/godo v1.89.0 h1:UL3Ii4qfk86m4qEKg2iSwop0puvgOCKvwzXvwArU05E=
+github.com/digitalocean/godo v1.89.0/go.mod h1:NRpFznZFvhHjBoqZAaOD3khVzsJ3EibzKqFL4R60dmA=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.17+incompatible h1:eO2KS7ZFeov5UJeaDmIs1NFEDRf32PaqRpvoEkKBy5M=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [v1.89.0] - 2022-11-02
+
+- #575 - @ghostlandr - apps: add option to get projects data from Apps List endpoint
+
+## [v1.88.0] - 2022-10-31
+
+- #573 - @kamaln7 - apps: add ListBuildpacks, UpgradeBuildpack
+- #572 - @ghostlandr - Apps: add project id as a parameter to CreateApp and to the App struct
+- #570 - @kraai - Fix copy-and-paste error in comment
+- #568 - @StephenVarela - LBAAS-2321 Add project_id to load balancers structs
+
 ## [v1.87.0] - 2022-10-12
 
 - #564 - @DWizGuy58 - Add public monitoring alert policies for dbaas

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -94,6 +94,8 @@ type App struct {
 	Domains                 []*AppDomain    `json:"domains,omitempty"`
 	PinnedDeployment        *Deployment     `json:"pinned_deployment,omitempty"`
 	BuildConfig             *AppBuildConfig `json:"build_config,omitempty"`
+	// The id of the project for the app. This will be empty if there is a lookup failure.
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 // AppAlertSpec Configuration of an alert for the app or a individual component.
@@ -563,6 +565,8 @@ type AppCORSPolicy struct {
 // AppCreateRequest struct for AppCreateRequest
 type AppCreateRequest struct {
 	Spec *AppSpec `json:"spec"`
+	// Optional. The UUID of the project the app should be assigned.
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 // DeployTemplate struct for DeployTemplate
@@ -1005,18 +1009,6 @@ type AppTier struct {
 	Slug                 string `json:"slug,omitempty"`
 	EgressBandwidthBytes string `json:"egress_bandwidth_bytes,omitempty"`
 	BuildSeconds         string `json:"build_seconds,omitempty"`
-}
-
-// UpgradeBuildpackRequest struct for UpgradeBuildpackRequest
-type UpgradeBuildpackRequest struct {
-	// The ID of the app to upgrade buildpack versions for.
-	AppID string `json:"app_id,omitempty"`
-	// The ID of the buildpack to upgrade.
-	BuildpackID string `json:"buildpack_id,omitempty"`
-	// The Major Version to upgrade the buildpack to. If omitted, the latest available major version will be used.
-	MajorVersion int32 `json:"major_version,omitempty"`
-	// Whether or not to trigger a deployment for the app after upgrading the buildpack.
-	TriggerDeployment bool `json:"trigger_deployment,omitempty"`
 }
 
 // UpgradeBuildpackResponse struct for UpgradeBuildpackResponse

--- a/vendor/github.com/digitalocean/godo/apps_accessors.go
+++ b/vendor/github.com/digitalocean/godo/apps_accessors.go
@@ -118,6 +118,14 @@ func (a *App) GetPinnedDeployment() *Deployment {
 	return a.PinnedDeployment
 }
 
+// GetProjectID returns the ProjectID field.
+func (a *App) GetProjectID() string {
+	if a == nil {
+		return ""
+	}
+	return a.ProjectID
+}
+
 // GetRegion returns the Region field.
 func (a *App) GetRegion() *AppRegion {
 	if a == nil {
@@ -396,6 +404,14 @@ func (a *AppCORSPolicy) GetMaxAge() string {
 		return ""
 	}
 	return a.MaxAge
+}
+
+// GetProjectID returns the ProjectID field.
+func (a *AppCreateRequest) GetProjectID() string {
+	if a == nil {
+		return ""
+	}
+	return a.ProjectID
 }
 
 // GetSpec returns the Spec field.
@@ -2868,38 +2884,6 @@ func (i *ImageSourceSpecDeployOnPush) GetEnabled() bool {
 		return false
 	}
 	return i.Enabled
-}
-
-// GetAppID returns the AppID field.
-func (u *UpgradeBuildpackRequest) GetAppID() string {
-	if u == nil {
-		return ""
-	}
-	return u.AppID
-}
-
-// GetBuildpackID returns the BuildpackID field.
-func (u *UpgradeBuildpackRequest) GetBuildpackID() string {
-	if u == nil {
-		return ""
-	}
-	return u.BuildpackID
-}
-
-// GetMajorVersion returns the MajorVersion field.
-func (u *UpgradeBuildpackRequest) GetMajorVersion() int32 {
-	if u == nil {
-		return 0
-	}
-	return u.MajorVersion
-}
-
-// GetTriggerDeployment returns the TriggerDeployment field.
-func (u *UpgradeBuildpackRequest) GetTriggerDeployment() bool {
-	if u == nil {
-		return false
-	}
-	return u.TriggerDeployment
 }
 
 // GetAffectedComponents returns the AffectedComponents field.

--- a/vendor/github.com/digitalocean/godo/droplet_actions.go
+++ b/vendor/github.com/digitalocean/godo/droplet_actions.go
@@ -293,7 +293,7 @@ func (s *DropletActionsServiceOp) Get(ctx context.Context, dropletID, actionID i
 	return s.get(ctx, path)
 }
 
-// GetByURI gets an action for a particular Droplet by id.
+// GetByURI gets an action for a particular Droplet by URI.
 func (s *DropletActionsServiceOp) GetByURI(ctx context.Context, rawurl string) (*Action, *Response, error) {
 	u, err := url.Parse(rawurl)
 	if err != nil {

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.87.0"
+	libraryVersion = "1.89.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -103,6 +103,9 @@ type ListOptions struct {
 
 	// For paginated result sets, the number of results to include per page.
 	PerPage int `url:"per_page,omitempty"`
+
+	// Whether App responses should include project_id fields. The field will be empty if false or if omitted. (ListApps)
+	WithProjects bool `url:"with_projects,omitempty"`
 }
 
 // TokenListOptions specifies the optional parameters to various List methods that support token pagination.

--- a/vendor/github.com/digitalocean/godo/load_balancers.go
+++ b/vendor/github.com/digitalocean/godo/load_balancers.go
@@ -51,6 +51,7 @@ type LoadBalancer struct {
 	VPCUUID                      string           `json:"vpc_uuid,omitempty"`
 	DisableLetsEncryptDNSRecords *bool            `json:"disable_lets_encrypt_dns_records,omitempty"`
 	ValidateOnly                 bool             `json:"validate_only,omitempty"`
+	ProjectID                    string           `json:"project_id,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancer.
@@ -81,6 +82,7 @@ func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 		VPCUUID:                      l.VPCUUID,
 		DisableLetsEncryptDNSRecords: l.DisableLetsEncryptDNSRecords,
 		ValidateOnly:                 l.ValidateOnly,
+		ProjectID:                    l.ProjectID,
 	}
 
 	if l.DisableLetsEncryptDNSRecords != nil {
@@ -165,6 +167,7 @@ type LoadBalancerRequest struct {
 	VPCUUID                      string           `json:"vpc_uuid,omitempty"`
 	DisableLetsEncryptDNSRecords *bool            `json:"disable_lets_encrypt_dns_records,omitempty"`
 	ValidateOnly                 bool             `json:"validate_only,omitempty"`
+	ProjectID                    string           `json:"project_id,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancerRequest.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,7 +85,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.87.0
+# github.com/digitalocean/godo v1.89.0
 ## explicit; go 1.18
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
Specifically, I'm adding support for project ids in two places:

* `doctl apps create` can now take in a `--project-id` parameter. This parameter will be used to assign the created app and resources to the project you specified!
* `doctl apps list` can now take a `--with-projects` flag. Adding this flag will make the `project_id` field populate on each app.

This also bumps the godo version to 1.89