### PR TITLE
changes to support usage in serverless backend development

### DIFF
--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -381,8 +381,9 @@ func RunServerlessStatus(c *CmdConfig) error {
 			Auth      string `json:auth`
 			APIHost   string `json:apihost`
 			Namespace string `json:namespace`
+			Path      string `json:path`
 		}
-		toShow := showCreds{Auth: auth, APIHost: creds.APIHost, Namespace: creds.Namespace}
+		toShow := showCreds{Auth: auth, APIHost: creds.APIHost, Namespace: creds.Namespace, Path: sls.CredentialsPath()}
 		credsOutput, err := json.MarshalIndent(toShow, "", "  ")
 		if err != nil {
 			return err

--- a/do/mocks/ServerlessService.go
+++ b/do/mocks/ServerlessService.go
@@ -465,6 +465,18 @@ func (mr *MockServerlessServiceMockRecorder) ReadProject(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadProject", reflect.TypeOf((*MockServerlessService)(nil).ReadProject), arg0, arg1)
 }
 
+// SetEffectiveCredentials mocks base method.
+func (m *MockServerlessService) SetEffectiveCredentials(auth, apihost string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetEffectiveCredentials", auth, apihost)
+}
+
+// SetEffectiveCredentials indicates an expected call of SetEffectiveCredentials.
+func (mr *MockServerlessServiceMockRecorder) SetEffectiveCredentials(auth, apihost interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEffectiveCredentials", reflect.TypeOf((*MockServerlessService)(nil).SetEffectiveCredentials), auth, apihost)
+}
+
 // Stream mocks base method.
 func (m *MockServerlessService) Stream(arg0 *exec.Cmd) error {
 	m.ctrl.T.Helper()

--- a/do/mocks/ServerlessService.go
+++ b/do/mocks/ServerlessService.go
@@ -95,6 +95,20 @@ func (mr *MockServerlessServiceMockRecorder) CreateNamespace(arg0, arg1, arg2 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockServerlessService)(nil).CreateNamespace), arg0, arg1, arg2)
 }
 
+// CredentialsPath mocks base method.
+func (m *MockServerlessService) CredentialsPath() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CredentialsPath")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// CredentialsPath indicates an expected call of CredentialsPath.
+func (mr *MockServerlessServiceMockRecorder) CredentialsPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CredentialsPath", reflect.TypeOf((*MockServerlessService)(nil).CredentialsPath))
+}
+
 // DeleteFunction mocks base method.
 func (m *MockServerlessService) DeleteFunction(arg0 string, arg1 bool) error {
 	m.ctrl.T.Helper()

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -222,6 +222,7 @@ type ServerlessService interface {
 	ReadProject(*ServerlessProject, []string) (ServerlessOutput, error)
 	WriteProject(ServerlessProject) (string, error)
 	SetEffectiveCredentials(auth string, apihost string)
+	CredentialsPath() string
 }
 
 type serverlessService struct {
@@ -1211,6 +1212,11 @@ func (s *serverlessService) WriteCredentials(creds ServerlessCredentials) error 
 		return err
 	}
 	return os.WriteFile(credsPath, bytes, 0600)
+}
+
+// CredentialsPath simply returns the directory path where credentials are stored
+func (s *serverlessService) CredentialsPath() string {
+	return s.credsDir
 }
 
 // ReadCredentials reads the current serverless credentials from the appropriate 'creds' diretory


### PR DESCRIPTION
A corollary to recent efforts to reduce dependence on the serverless plugin:  we are also trying to eliminate internal usages of `nim` in our own development processes, replacing it with `doctl`.   In order for that to work, `doctl` needs some enhancements to work with serverless backend clusters that are not in production (and hence not (yet) known to the portal).

The changes are all in the area of credential management.    Basically, they allow both setting and interrogating credentials via their low-level OpenWhisk characteristics without using the namespace APIs.

Only those commands whose `nim` equivalents are actually used in this way have been changed.   The additional flags are all hidden, since this low-level credential manipulation is not something DigitalOcean customers would ordinarily do (although there is nothing insecure about it).   Having these features show up in help texts would be distracting and might lead to the impression that this feature had an important mainstream use case.