### PR TITLE
Minor fixes to serverless deploy

### DIFF
--- a/commands/serverless-extra.go
+++ b/commands/serverless-extra.go
@@ -168,6 +168,11 @@ func RunServerlessExtraDeploy(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
+	// In a snap, local build will not work so ensure that builds (if any) will run remotely
+	_, isSnap := os.LookupEnv("SNAP")
+	if isSnap {
+		c.Doit.Set(c.NS, flagRemoteBuild, true)
+	}
 	output, err := RunServerlessExec("deploy", c, []string{flagInsecure, flagVerboseBuild, flagVerboseZip, flagYarn, flagRemoteBuild, flagIncremental},
 		[]string{flagEnv, flagBuildEnv, flagApihost, flagAuth, flagInclude, flagExclude})
 	if err != nil && len(output.Captured) == 0 {

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -254,7 +254,7 @@ const (
 	// Minimum required version of the serverless plugin code.  The first part is
 	// the version of the incorporated functions deployer and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minServerlessVersion = "5.0.12-2.0.0"
+	minServerlessVersion = "5.0.14-2.0.0"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"


### PR DESCRIPTION
1. Improvement to poll loop behavior when waiting for remote builds.
2. Propagate DO API token to remote builds so trigger deploys work.
3. Make --remote-build the default when running as a snap.

The first two of these are actually changes to the functions deployer component and are brought in by incrementing the `minServerlessVersion`.