### PR TITLE
Fix bug: web=false was ignored on remote build

### DIFF
--- a/do/serverless.go
+++ b/do/serverless.go
@@ -254,7 +254,7 @@ const (
 	// Minimum required version of the serverless plugin code.  The first part is
 	// the version of the incorporated functions deployer and the second part is the
 	// version of the bridge code in the sandbox plugin repository.
-	minServerlessVersion = "5.0.14-2.0.0"
+	minServerlessVersion = "5.0.16-2.0.0"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v16.13.0"


### PR DESCRIPTION
The fix is in deployer version 5.0.16