### PR TITLE
function triggers: Use displayer for get sub-command and set displayer type.

### DIFF
--- a/commands/triggers.go
+++ b/commands/triggers.go
@@ -15,8 +15,6 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/commands/displayers"
@@ -76,12 +74,8 @@ func RunTriggersGet(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	json, err := json.MarshalIndent(&trigger, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Fprintln(c.Out, string(json))
-	return nil
+
+	return c.Display(&displayers.Triggers{List: []do.ServerlessTrigger{trigger}})
 }
 
 // RunTriggerToggle provides the logic for 'doctl sls trig enabled/disabled'

--- a/commands/triggers.go
+++ b/commands/triggers.go
@@ -41,12 +41,16 @@ when events from that source type occur.  Currently, only the ` + "`" + `schedul
 		Writer, aliasOpt("ls"), displayerType(&displayers.Triggers{}))
 	AddStringFlag(list, "function", "f", "", "list only triggers for the chosen function")
 
-	CmdBuilder(cmd, RunTriggerToggle(true), "enable <triggerName>", "Enable a trigger", "Use `doctl serverless triggers enable <triggerName>` to enable a trigger", Writer)
-	CmdBuilder(cmd, RunTriggerToggle(false), "disable <triggerName>", "Disable a trigger", "Use `doctl serverless triggers disable <triggerName>` to disable a trigger", Writer)
+	CmdBuilder(cmd, RunTriggerToggle(true), "enable <triggerName>",
+		"Enable a trigger", "Use `doctl serverless triggers enable <triggerName>` to enable a trigger",
+		Writer, displayerType(&displayers.Triggers{}))
+	CmdBuilder(cmd, RunTriggerToggle(false), "disable <triggerName>",
+		"Disable a trigger", "Use `doctl serverless triggers disable <triggerName>` to disable a trigger",
+		Writer, displayerType(&displayers.Triggers{}))
 
 	CmdBuilder(cmd, RunTriggersGet, "get <triggerName>", "Get the details for a trigger",
 		`Use `+"`"+`doctl serverless triggers get <triggerName>`+"`"+` for details about <triggerName>.`,
-		Writer)
+		Writer, displayerType(&displayers.Triggers{}))
 
 	return cmd
 }

--- a/commands/triggers_test.go
+++ b/commands/triggers_test.go
@@ -65,24 +65,8 @@ func TestTriggersGet(t *testing.T) {
 				NextRunAt: &nextRunAt,
 			},
 		}
-		expect := `{
-  "namespace": "123-456",
-  "function": "misc/pollStatus",
-  "type": "SCHEDULED",
-  "name": "firePoll1",
-  "is_enabled": true,
-  "created_at": "2022-10-05T13:46:59Z",
-  "updated_at": "2022-10-17T18:41:30Z",
-  "scheduled_details": {
-    "cron": "5 * * * *",
-    "body": {
-      "foo": "bar"
-    }
-  },
-  "scheduled_runs": {
-    "next_run_at": "2022-11-03T17:03:02Z"
-  }
-}
+		expect := `Name         Cron Expression    Invokes            Enabled    Last Run At
+firePoll1    5 * * * *          misc/pollStatus    true       _
 `
 		tm.serverless.EXPECT().GetTrigger(context.TODO(), "aTrigger").Return(theTrigger, nil)
 


### PR DESCRIPTION
This changes the triggers get sub-command to use the displayer rather than marshaling JSON itself. By default, it will use the table display and the output flag is supported for JSON. It also sets the displayer type so that the `--format` flag is now supported.