### PR TITLE
Add 'syd' region and 'syd1' data center to allowed values for namespace create

### DIFF
--- a/commands/namespaces.go
+++ b/commands/namespaces.go
@@ -32,7 +32,7 @@ import (
 // actually host Functions).
 var validRegions = map[string]string{
 	"ams": "ams3", "blr": "blr1", "fra": "fra1", "lon": "lon1",
-	"nyc": "nyc1", "sfo": "sfo3", "sgp": "sgp1", "tor": "tor1",
+	"nyc": "nyc1", "sfo": "sfo3", "sgp": "sgp1", "syd": "syd1", "tor": "tor1",
 }
 
 // Namespaces generates the serverless 'namespaces' subtree for addition to the doctl command

--- a/commands/namespaces_test.go
+++ b/commands/namespaces_test.go
@@ -145,7 +145,7 @@ func TestNamespacesListRegions(t *testing.T) {
 		buf := &bytes.Buffer{}
 		config.Out = buf
 
-		expectedOutput := "[ams ams3 blr blr1 fra fra1 lon lon1 nyc nyc1 sfo sfo3 sgp sgp1 tor tor1]\n"
+		expectedOutput := "[ams ams3 blr blr1 fra fra1 lon lon1 nyc nyc1 sfo sfo3 sgp sgp1 syd syd1 tor tor1]\n"
 
 		err := RunNamespacesListRegions(config)
 


### PR DESCRIPTION
We are currently using a static list of regions and datacenters that are known to support the creation of namespaces.   Switching to a more dynamic approach is desirable and is a future objective but, for now, we need to add the new Sydney cluster to the list.