### PR TITLE
Delete packages when cleaning a namespace via 'undeploy --all'

### DIFF
--- a/do/mocks/ServerlessService.go
+++ b/do/mocks/ServerlessService.go
@@ -434,6 +434,21 @@ func (mr *MockServerlessServiceMockRecorder) ListNamespaces(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockServerlessService)(nil).ListNamespaces), arg0)
 }
 
+// ListPackages mocks base method.
+func (m *MockServerlessService) ListPackages() ([]whisk.Package, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPackages")
+	ret0, _ := ret[0].([]whisk.Package)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPackages indicates an expected call of ListPackages.
+func (mr *MockServerlessServiceMockRecorder) ListPackages() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPackages", reflect.TypeOf((*MockServerlessService)(nil).ListPackages))
+}
+
 // ListTriggers mocks base method.
 func (m *MockServerlessService) ListTriggers(arg0 context.Context, arg1 string) ([]do.ServerlessTrigger, error) {
 	m.ctrl.T.Helper()

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -226,6 +226,7 @@ type ServerlessService interface {
 	GetHostInfo(string) (ServerlessHostInfo, error)
 	CheckServerlessStatus() error
 	InstallServerless(string, bool) error
+	ListPackages() ([]whisk.Package, error)
 	DeletePackage(string, bool) error
 	GetFunction(string, bool) (whisk.Action, []FunctionParameter, error)
 	ListFunctions(string, int, int) ([]whisk.Action, error)
@@ -732,7 +733,7 @@ func (s *serverlessService) CleanNamespace() error {
 	}
 
 	// Deletes all functions
-	fns, err := s.ListFunctions("", 0, 0)
+	fns, err := s.ListFunctions("", 0, 200)
 	if err != nil {
 		return err
 	}
@@ -746,6 +747,19 @@ func (s *serverlessService) CleanNamespace() error {
 
 		// All triggers for the namespace are deleted above so we don't need to remove the trigger for each individual function.
 		err := s.DeleteFunction(name, false)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Now delete all packages.  Since the functions are presumably gone, the packages can be deleted non-recursively.
+	pkgs, err := s.ListPackages()
+	if err != nil {
+		return err
+	}
+
+	for _, pkg := range pkgs {
+		err := s.DeletePackage(pkg.Name, false)
 		if err != nil {
 			return err
 		}
@@ -839,15 +853,26 @@ func (s *serverlessService) DeleteFunction(name string, deleteTriggers bool) err
 	return e
 }
 
-// DeletePackage removes a package and all its namespace from the package from the namespace
-// If force is set to true, it will remove all functions in the package.
-func (s *serverlessService) DeletePackage(name string, force bool) error {
+// ListPackages lists the packages of the namespace
+func (s *serverlessService) ListPackages() ([]whisk.Package, error) {
+	err := initWhisk(s)
+	if err != nil {
+		return []whisk.Package{}, err
+	}
+	options := whisk.PackageListOptions{Limit: 200} // 200 is the max and we are also treating it as a safe-enough value here
+	list, _, err := s.owClient.Packages.List(&options)
+	return list, err
+}
+
+// DeletePackage removes a package from the namespace.
+// If recursive is set to true, it will remove all functions in the package.
+func (s *serverlessService) DeletePackage(name string, recursive bool) error {
 	err := initWhisk(s)
 	if err != nil {
 		return err
 	}
 
-	if force {
+	if recursive {
 		pkg, _, err := s.owClient.Packages.Get(name)
 		if err != nil {
 			return err


### PR DESCRIPTION
In PR #1297, the `doctl sls undeploy` command was re-implemented in pure golang.  This change appears in release 1.85.0 and beyond.

There was an omission from the rewrite.  After deleting all the functions of the namespace, the (now-empty) packages that contained some of those functions should also be deleted.   This change restores that behavior.

This should not be considered a critical bug.  As far as I know, no customer has complained about it.  For the most part, the management of packages is done by the functions deployer in a transparent fashion (created on demand, used if present) and empty packages are not very likely to cause semantic problems.   However, 
1.  the contract to remove "all" resources from the namespace is violated unless we remove packages because packages are resources.
2. There _can_ sometimes be semantic problems from reusing packages if environment or parameter or annotation information has been attached to the package, so the omission is still worth fixing.
