### PR TITLE
Include label in credentials store and status msg

### DIFF
--- a/commands/serverless_test.go
+++ b/commands/serverless_test.go
@@ -98,7 +98,7 @@ func TestServerlessConnect(t *testing.T) {
 				}
 				connectChoiceReader = bufio.NewReader(strings.NewReader("0\n"))
 				nsResponse := do.NamespaceListResponse{Namespaces: tt.namespaceList}
-				creds := do.ServerlessCredentials{Namespace: "ns1", APIHost: "https://api.example.com"}
+				creds := do.ServerlessCredentials{Namespace: "ns1", APIHost: "https://api.example.com", Label: "something"}
 
 				tm.serverless.EXPECT().CheckServerlessStatus().Return(do.ErrServerlessNotConnected)
 				ctx := context.TODO()

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -44,6 +44,7 @@ import (
 type ServerlessCredentials struct {
 	APIHost     string                                     `json:"currentHost"`
 	Namespace   string                                     `json:"currentNamespace"`
+	Label       string                                     `json:"label"`
 	Credentials map[string]map[string]ServerlessCredential `json:"credentials"`
 }
 
@@ -627,6 +628,7 @@ func executeNamespaceRequest(ctx context.Context, s *serverlessService, req *htt
 	ans := ServerlessCredentials{
 		APIHost:     host,
 		Namespace:   namespace,
+		Label:       decoded.Namespace.Label,
 		Credentials: map[string]map[string]ServerlessCredential{host: {namespace: credential}},
 	}
 	return ans, nil


### PR DESCRIPTION
Up until now, the output of `doctl sls connect` included the label but the output of `doctl sls status` did not.   The reason was that the label was not stored locally and so an additional protocol handshake would be needed to obtain it.  

This change makes the status message more similar to the connect message by including the label in the stored credentials so it is available on the same basis as other relevant information about the namespace, then using common code to format the output message in both cases.

It would arguably be possible to go further with this change, making the label more prominent (and the generated id less prominent) in the message.   I did not do this because a major change in the format of these output messages could break some scripts.  I do not think we commit to exact compatibility on human-readable messages, so this would not be a "breaking change" but I thought it was better to err in the direction of least disruption by keeping the label as an optional field at the end.

Note that the label actually _is_ optional.   For typical customers, where only production  backends are used, it would always be present.   But, for certain development use cases (connecting to non-production backends) there will be no label.