### PR TITLE
add "singular" aliases for "plural" serverless commands

### DIFF
--- a/commands/activations.go
+++ b/commands/activations.go
@@ -46,7 +46,7 @@ func Activations() *Command {
 			Short: "Work with activation records",
 			Long: `The subcommands of ` + "`" + `doctl serverless activations` + "`" + ` will list or retrieve results, logs, or complete
 "activation records" which result from invoking functions deployed to your functions namespace.`,
-			Aliases: []string{"actv"},
+			Aliases: []string{"activation", "actv"},
 		},
 	}
 

--- a/commands/functions.go
+++ b/commands/functions.go
@@ -38,7 +38,7 @@ func Functions() *Command {
 			Short: "Work with the functions in your namespace",
 			Long: `The subcommands of ` + "`" + `doctl serverless functions` + "`" + ` operate on your functions namespace.
 You are able to inspect and list these functions to know what is deployed.  You can also invoke functions to test them.`,
-			Aliases: []string{"fn"},
+			Aliases: []string{"function", "fn"},
 		},
 	}
 

--- a/commands/namespaces.go
+++ b/commands/namespaces.go
@@ -44,7 +44,7 @@ func Namespaces() *Command {
 			Long: `Functions namespaces (in the cloud) contain the result of deploying packages and functions with ` + "`" + `doctl serverless deploy` + "`" + `.
 The subcommands of ` + "`" + `doctl serverless namespaces` + "`" + ` are used to manage multiple functions namespaces within your account.
 Use ` + "`" + `doctl serverless connect` + "`" + ` with an explicit argument to connect to a specific namespace.  You are connected to one namespace at a time.`,
-			Aliases: []string{"ns"},
+			Aliases: []string{"namespace", "ns"},
 		},
 	}
 	create := CmdBuilder(cmd, RunNamespacesCreate, "create", "Creates a namespace",

--- a/commands/triggers.go
+++ b/commands/triggers.go
@@ -32,7 +32,7 @@ func Triggers() *Command {
 The subcommands of ` + "`" + `doctl serverless triggers` + "`" + ` are used to list and inspect
 triggers.  Each trigger has an event source type, and invokes its associated function
 when events from that source type occur.  Currently, only the ` + "`" + `scheduler` + "`" + ` event source type is supported.`,
-			Aliases: []string{"trig"},
+			Aliases: []string{"trigger", "trig"},
 			Hidden:  true, // trigger support uses APIs that are not yet universally available
 		},
 	}


### PR DESCRIPTION
This change simply adds aliases, allowing the singular words `activation`, `function`, `namespace` and `trigger` to be used for their plural counterparts.