### PR TITLE
Allow container image installs and 'doctl sls get-metadata' to run without credentials

### DIFF
--- a/do/serverless.go
+++ b/do/serverless.go
@@ -419,6 +419,7 @@ func (s *serverlessService) InstallServerless(leafCredsDir string, upgrading boo
 	// that might be on a separate file system, meaning that the final install step
 	// will require an additional copy rather than a simple rename.
 
+	os.Mkdir(filepath.Dir(serverlessDir), 0700) // in case using config dir and it doesn't exist yet
 	tmp, err := ioutil.TempDir(filepath.Dir(serverlessDir), "sbx-install")
 	if err != nil {
 		return err


### PR DESCRIPTION
This allows `doctl serverless get-metadata` to execute without a valid DO API token (or any OpenWhisk credentials).   It doesn't need these things because it's a purely file-system local operation and does not use any remote APIs.

The idea is to support this operation in contexts where a DO API token is not available, such as the App Platform detection phase.

Note that the plugin has to get installed somehow.    To support installing without the need for a DO API token, this PR also supports a special flag for installing in container images:

```
DOCKER_SANDBOX_INSTALL=true doctl serverless install
```
This basically reuses support already in place for snap installs.   IMO it would not be a good idea to make _all_ installs run without credentials.   It's not a security problem, but, in the steady state, users really should be authenticated to `doctl` and be able to make full use of all the capabilities.  Also, some of the checks to prevent unnecessary installs won't work unless a full initialization is done.