### PR TITLE
commands/auth: stop printing the token to stdout

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -139,7 +139,6 @@ func RunAuthInit(retrieveUserTokenFunc func() (string, error)) func(c *CmdConfig
 			}
 			token = strings.TrimSpace(in)
 		} else {
-			fmt.Fprintf(c.Out, "Using token [%v]", token)
 			fmt.Fprintln(c.Out)
 		}
 


### PR DESCRIPTION
Token shouldn't be output in cleartext.