### PR TITLE
Fix warm/cold start categorization.

### DIFF
--- a/commands/displayers/activations.go
+++ b/commands/displayers/activations.go
@@ -72,10 +72,10 @@ func (a *Activation) KV() []map[string]interface{} {
 }
 
 func getActivationStartType(a whisk.Activation) string {
-	if getActivationAnnotationValue(a, "init") == "" {
-		return "cold"
+	if getActivationAnnotationValue(a, "initTime") == nil {
+		return "warm"
 	}
-	return "warm"
+	return "cold"
 }
 
 // Gets the full function name for the activation.


### PR DESCRIPTION
This fixes an issue with `activation list` where all activations were categorized as `warm` (incorrectly). The annotation is called `initTime` (not `init`) and if it is only present when the activation is `cold` so a `nil` result fetching the activation implies a warm start.

Now the output is correctly formatted.
```
01/13 02:52:47    success            python:3.9    0.0.3      44386f88573a4287b86f88573a128774    warm     39      507ms       f
01/13 02:52:45    success            python:3.9    0.0.3      5d6cd4e61b2d4c67acd4e61b2d6c677b    warm     42      515ms       f
01/13 02:50:47    success            python:3.9    0.0.3      e0a5156653e244c6a5156653e214c606    cold     1072    942ms       f
01/13 01:50:19    developer error    python:3.9    0.0.2      fe0db7fe7a91413b8db7fe7a91513bf5    cold     1215    20739ms     f
```