### PR TITLE
serverless: fix hint for creating functions namespace.

### DIFF
--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -276,7 +276,7 @@ func RunServerlessConnect(c *CmdConfig) error {
 		return err
 	}
 	if len(list) == 0 {
-		return errors.New("you must create a namespace with `doctl namespace create`, specifying a region and label")
+		return errors.New("you must create a namespace with `doctl serverless namespaces create`, specifying a region and label")
 	}
 	return connectFromList(ctx, sls, list, c.Out)
 }

--- a/commands/serverless_test.go
+++ b/commands/serverless_test.go
@@ -41,7 +41,7 @@ func TestServerlessConnect(t *testing.T) {
 		{
 			name:          "no namespaces",
 			namespaceList: []do.OutputNamespace{},
-			expectedError: errors.New("you must create a namespace with `doctl namespace create`, specifying a region and label"),
+			expectedError: errors.New("you must create a namespace with `doctl serverless namespaces create`, specifying a region and label"),
 		},
 		{
 			name: "one namespace",


### PR DESCRIPTION
Updates error message to point at the actual command.

```
$ doctl serverless connect
Error: you must create a namespace with `doctl namespace create`, specifying a region and label

$ doctl namespace create
Error: unknown command "namespace" for "doctl"
Run 'doctl --help' for usage.

$ doctl serverless namespace create -h
`Use `doctl serverless namespaces create` to create a new functions namespace.
Both a region and a label must be specified.

Usage:
  doctl serverless namespaces create [flags]

Flags:
  -h, --help            help for create
  -l, --label string    the label for the namespace (required)
  -n, --no-connect      don't immediately connect to the created namespace
  -r, --region string   the region for the namespace (required)

Global Flags:
  -t, --access-token string   API V2 access token
  -u, --api-url string        Override default API endpoint
  -c, --config string         Specify a custom config file (default "/home/asb/.config/doctl/config.yaml")
      --context string        Specify a custom authentication context name
      --interactive           Enable interactive behavior. Defaults to true if the terminal supports it (default true)
  -o, --output string         Desired output format [text|json] (default "text")
      --trace                 Show a log of network activity while performing a command
  -v, --verbose               Enable verbose output
```