### PR TITLE
APICLI-1692: Add backup-restore functionality to db create

### DIFF
--- a/.do/.gitignore
+++ b/.do/.gitignore
@@ -1,0 +1,1 @@
+dev-config.yaml

--- a/args.go
+++ b/args.go
@@ -328,6 +328,10 @@ const (
 	// ArgProjectResource is a flag for your resource URNs
 	ArgProjectResource = "resource"
 
+	// ArgDatabaseRestoreFromCluster is a flag for specifying the name of an existing database cluster from which the backup will be restored.
+	ArgDatabaseRestoreFromCluster = "restore-from-cluster"
+	// ArgDatabaseRestoreFromTimestamp is a flag for specifying the timestamp of an existing database cluster backup in ISO8601 combined date and time format. The most recent backup will be used if excluded.
+	ArgDatabaseRestoreFromTimestamp = "restore-from-timestamp"
 	// ArgDatabaseEngine is a flag for specifying which database engine to use
 	ArgDatabaseEngine = "engine"
 	// ArgDatabaseNumNodes is the number of nodes in the database cluster

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -258,12 +258,10 @@ func buildDatabaseCreateRequestFromArgs(c *CmdConfig) (*godo.DatabaseCreateReque
 			return nil, err
 		}
 		if restoreFromTimestamp != "" {
-			// accepts UTC time format from user (to match db list output) and converts it to ISO8601 for api parity.
-			date, error := time.Parse("2006-01-02 15:04:05 +0000 UTC", restoreFromTimestamp)
-			if error != nil {
-				return nil, fmt.Errorf("Invalid format for --restore-from-timestamp. Must be in UTC format: 2006-01-02 15:04:05 +0000 UTC")
+			dateFormatted, err := convertUTCtoISO8601(restoreFromTimestamp)
+			if err != nil {
+				return nil, err
 			}
-			dateFormatted := date.Format(time.RFC3339)
 			backUpRestore.BackupCreatedAt = dateFormatted
 		}
 		r.BackupRestore = backUpRestore
@@ -272,6 +270,17 @@ func buildDatabaseCreateRequestFromArgs(c *CmdConfig) (*godo.DatabaseCreateReque
 	r.PrivateNetworkUUID = privateNetworkUUID
 
 	return r, nil
+}
+
+func convertUTCtoISO8601(restoreFromTimestamp string) (string, error) {
+	// accepts UTC time format from user (to match db list output) and converts it to ISO8601 for api parity.
+	date, error := time.Parse("2006-01-02 15:04:05 +0000 UTC", restoreFromTimestamp)
+	if error != nil {
+		return "", fmt.Errorf("Invalid format for --restore-from-timestamp. Must be in UTC format: 2006-01-02 15:04:05 +0000 UTC")
+	}
+	dateFormatted := date.Format(time.RFC3339)
+
+	return dateFormatted, nil
 }
 
 // RunDatabaseDelete deletes a database cluster

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -79,7 +79,7 @@ There are a number of flags that customize the configuration, all of which are o
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgVersion, "", "", "The database engine version, e.g. 14 for PostgreSQL version 14")
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgPrivateNetworkUUID, "", "", "The UUID of a VPC to create the database cluster in; the default VPC for the region will be used if excluded")
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseRestoreFromCluster, "", "", "The name of an existing database cluster from which the backup will be restored.")
-	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseRestoreFromTimestamp, "", "", "The timestamp of an existing database cluster backup in ISO8601 combined date and time format. The most recent backup will be used if excluded.")
+	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseRestoreFromTimestamp, "", "", "The timestamp of an existing database cluster backup in UTC combined date and time format (2006-01-02 15:04:05 +0000 UTC). The most recent backup will be used if excluded.")
 	AddBoolFlag(cmdDatabaseCreate, doctl.ArgCommandWait, "", false, "Boolean that specifies whether to wait for a database to complete before returning control to the terminal")
 
 	cmdDatabaseDelete := CmdBuilder(cmd, RunDatabaseDelete, "delete <database-id>", "Delete a database cluster", `This command deletes the database cluster with the given ID.
@@ -252,12 +252,20 @@ func buildDatabaseCreateRequestFromArgs(c *CmdConfig) (*godo.DatabaseCreateReque
 	if restoreFromCluster != "" {
 		backUpRestore := &godo.DatabaseBackupRestore{}
 		backUpRestore.DatabaseName = restoreFromCluster
-		// only set the restore from timestamp if restore from cluster is set.
+		// only set the restore-from-timestamp if restore-from-cluster is set.
 		restoreFromTimestamp, err := c.Doit.GetString(c.NS, doctl.ArgDatabaseRestoreFromTimestamp)
 		if err != nil {
 			return nil, err
 		}
-		backUpRestore.BackupCreatedAt = restoreFromTimestamp
+		if restoreFromTimestamp != "" {
+			// accepts UTC time format from user (to match db list output) and converts it to ISO8601 for api parity.
+			date, error := time.Parse("2006-01-02 15:04:05 +0000 UTC", restoreFromTimestamp)
+			if error != nil {
+				return nil, fmt.Errorf("Invalid format for --restore-from-timestamp. Must be in UTC format: 2006-01-02 15:04:05 +0000 UTC")
+			}
+			dateFormatted := date.Format(time.RFC3339)
+			backUpRestore.BackupCreatedAt = dateFormatted
+		}
 		r.BackupRestore = backUpRestore
 	}
 

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -1140,3 +1140,12 @@ func TestDatabaseListOptions(t *testing.T) {
 		assert.EqualError(t, err, errTest.Error())
 	})
 }
+
+func TestConvertUTCtoISO8601(t *testing.T) {
+	utcTime := "2023-02-01 17:32:15 +0000 UTC"
+	isoTime, err := convertUTCtoISO8601(utcTime)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "2023-02-01T17:32:15Z", isoTime)
+}

--- a/integration/database_create_backup_test.go
+++ b/integration/database_create_backup_test.go
@@ -1,0 +1,146 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite("database/create/backup-restore", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/databases":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				reqBody, err := ioutil.ReadAll(req.Body)
+				expect.NoError(err)
+
+				request := struct {
+					Name          string      `json:"name"`
+					Engine        string      `json:"engine"`
+					Version       string      `json:"version"`
+					Region        string      `json:"region"`
+					Nodes         int         `json:"num_nodes"`
+					BackupRestore interface{} `json:"backup_restore"`
+				}{}
+
+				err = json.Unmarshal(reqBody, &request)
+				expect.NoError(err)
+
+				t, err := template.New("response").Parse(databaseRestoreBackUpCreateResponse)
+				expect.NoError(err)
+
+				var b []byte
+				buffer := bytes.NewBuffer(b)
+				err = t.Execute(buffer, request)
+				expect.NoError(err)
+
+				w.Write(buffer.Bytes())
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	when("the minimum required flags are provided", func() {
+		it("creates a backup database", func() {
+			aliases := []string{"create", "c"}
+
+			for _, alias := range aliases {
+				cmd := exec.Command(builtBinaryPath,
+					"-t", "some-magic-token",
+					"-u", server.URL,
+					"databases",
+					"create",
+					"new-db-name",
+					"--restore-from-cluster", "old-db-name",
+					"--engine", "mysql",
+					"--num-nodes", "100",
+					"--region", "nyc3",
+					"--size", "biggest",
+					"--version", "what-version",
+				)
+
+				output, err := cmd.CombinedOutput()
+				expect.NoError(err, fmt.Sprintf("received error output from command %s: %s", alias, output))
+				expect.Equal(strings.TrimSpace(databasesCreateRestoreBackUpOutput), strings.TrimSpace(string(output)))
+			}
+		})
+	})
+})
+
+const (
+	databasesCreateRestoreBackUpOutput = `
+Notice: Database created
+ID         Name           Engine    Version         Number of Nodes    Region    Status      Size       URI                                                                                     Created At
+some-id    new-db-name    mysql     what-version    100                nyc3      creating    biggest    mysql://doadmin:secret@aaa-bbb-ccc-111-222-333.db.ondigitalocean.com:25060/defaultdb    2019-01-11 18:37:36 +0000 UTC
+`
+	databaseRestoreBackUpCreateRequestBody = `{
+	"name":"new-db-name",
+	"engine": "mysql",
+	"num_nodes": "100",
+	"region": "nyc3",
+	"size": "biggest",
+	"backup_restore":{
+	  "database_name":"old-db-name"
+	}
+  }`
+
+	databaseRestoreBackUpCreateResponse = `
+  {
+	"database": {
+	  "id": "some-id",
+	  "name": "new-db-name",
+	  "engine": "mysql",
+	  "version": "what-version",
+	  "connection": {
+		"uri": "mysql://doadmin:secret@aaa-bbb-ccc-111-222-333.db.ondigitalocean.com:25060/defaultdb"
+	  },
+	  "private_connection": {},
+	  "users": null,
+	  "db_names": null,
+	  "num_nodes": 100,
+	  "region": "nyc3",
+	  "status": "creating",
+	  "created_at": "2019-01-11T18:37:36Z",
+	  "maintenance_window": null,
+	  "size": "biggest",
+	  "tags": [
+		"production"
+	  ]
+	}
+  }`
+)

--- a/integration/database_create_restore_from_cluster.go
+++ b/integration/database_create_restore_from_cluster.go
@@ -87,6 +87,7 @@ var _ = suite("database/create/backup-restore", func(t *testing.T, when spec.G, 
 					"create",
 					"new-db-name",
 					"--restore-from-cluster", "old-db-name",
+					"--restore-from-timestamp", "2023-02-01 17:32:15 +0000 UTC",
 					"--engine", "mysql",
 					"--num-nodes", "100",
 					"--region", "nyc3",
@@ -100,9 +101,33 @@ var _ = suite("database/create/backup-restore", func(t *testing.T, when spec.G, 
 			}
 		})
 	})
+
+	when("the wrong time format is passed", func() {
+		it("errors out with wrong time format", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"databases",
+				"create",
+				"new-db-name",
+				"--restore-from-cluster", "old-db-name",
+				"--restore-from-timestamp", "2009-11-10T23:00:00Z",
+				"--engine", "mysql",
+				"--num-nodes", "100",
+				"--region", "nyc3",
+				"--size", "biggest",
+				"--version", "what-version",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expect.Equal(strings.TrimSpace(restoreFromTimestampError), strings.TrimSpace(string(output)))
+		})
+	})
 })
 
 const (
+	restoreFromTimestampError          = "Error: Invalid format for --restore-from-timestamp. Must be in UTC format: 2006-01-02 15:04:05 +0000 UTC"
 	databasesCreateRestoreBackUpOutput = `
 Notice: Database created
 ID         Name           Engine    Version         Number of Nodes    Region    Status      Size       URI                                                                                     Created At


### PR DESCRIPTION
Adds the following command:
`doctl db create new_db_name --restore-from-cluster=original-cluster-name —engine="pg1" —num_nodes=100 —seize=biggest —region="nyc3"`

Note: This does not mimic the control panel behavior. This is parity to the API. To mimic the control panel behavior, we'd do something more like this:
`doctl databases fork new_db_name --restore-from-cluster=original-cluster-name`

which will be in another PR.