### PR TITLE
Auth "init", "switch", "remove" Forces Lowercase

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -146,9 +146,9 @@ To create new contexts, see the help for `+"`"+`doctl auth init`+"`"+`.`, Writer
 func RunAuthInit(retrieveUserTokenFunc func() (string, error)) func(c *CmdConfig) error {
 	return func(c *CmdConfig) error {
 		token := c.getContextAccessToken()
-		context := Context
+		context := strings.ToLower(Context)
 		if context == "" {
-			context = viper.GetString("context")
+			context = strings.ToLower(viper.GetString("context"))
 		}
 
 		if token == "" {
@@ -188,7 +188,7 @@ func RunAuthInit(retrieveUserTokenFunc func() (string, error)) func(c *CmdConfig
 
 // RunAuthRemove remove available auth contexts from the user's doctl config.
 func RunAuthRemove(c *CmdConfig) error {
-	context := Context
+	context := strings.ToLower(Context)
 
 	if context == "" {
 		return fmt.Errorf("You must provide a context name")
@@ -243,9 +243,9 @@ func displayAuthContexts(out io.Writer, currentContext string, contexts map[stri
 // RunAuthSwitch changes the default context and writes it to the
 // configuration.
 func RunAuthSwitch(c *CmdConfig) error {
-	context := Context
+	context := strings.ToLower(Context)
 	if context == "" {
-		context = viper.GetString("context")
+		context = strings.ToLower(viper.GetString("context"))
 	}
 
 	// The two lines below aren't required for doctl specific functionality,

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -107,7 +107,7 @@ To remove accounts from the configuration file, you can run ` + "`" + `doctl aut
 
 You will need an API token, which you can generate in the control panel at https://cloud.digitalocean.com/account/api/tokens.
 
-You can provide a name to this initialization via the `+"`"+`--context`+"`"+` flag, and then it will be saved as an "authentication context". Authentication contexts are accessible via `+"`"+`doctl auth switch`+"`"+`, which re-initializes doctl, or by providing the `+"`"+`--context`+"`"+` flag when using any doctl command (to specify that auth context for just one command). This enables you to use multiple DigitalOcean accounts with doctl, or tokens that have different authentication scopes.
+You can provide a (case insensitive) name to this initialization via the `+"`"+`--context`+"`"+` flag, and then it will be saved as an "authentication context". Authentication contexts are accessible via `+"`"+`doctl auth switch`+"`"+`, which re-initializes doctl, or by providing the `+"`"+`--context`+"`"+` flag when using any doctl command (to specify that auth context for just one command). This enables you to use multiple DigitalOcean accounts with doctl, or tokens that have different authentication scopes.
 
 If the `+"`"+`--context`+"`"+` flag is not specified, a default authentication context will be created during initialization.
 
@@ -246,6 +246,25 @@ func RunAuthSwitch(c *CmdConfig) error {
 	context := strings.ToLower(Context)
 	if context == "" {
 		context = strings.ToLower(viper.GetString("context"))
+	}
+
+	// check that context exists
+	contextsAvail := viper.GetStringMap("auth-contexts")
+	contextsAvail[doctl.ArgDefaultContext] = true
+	keys := make([]string, 0)
+	for ctx := range contextsAvail {
+		keys = append(keys, ctx)
+	}
+
+	var contextExists bool
+	for _, ctx := range keys {
+		if ctx == context {
+			contextExists = true
+		}
+	}
+
+	if !contextExists {
+		return errors.New("context does not exist")
 	}
 
 	// The two lines below aren't required for doctl specific functionality,

--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -16,7 +16,6 @@ package commands
 import (
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/commands/displayers"
@@ -134,7 +133,7 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 		getContextAccessToken: func() string {
 			context := Context
 			if context == "" {
-				context = strings.ToLower(viper.GetString("context"))
+				context = viper.GetString("context")
 			}
 			token := ""
 
@@ -153,7 +152,7 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 		setContextAccessToken: func(token string) {
 			context := Context
 			if context == "" {
-				context = strings.ToLower(viper.GetString("context"))
+				context = viper.GetString("context")
 			}
 
 			switch context {

--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -16,6 +16,7 @@ package commands
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/commands/displayers"
@@ -133,7 +134,7 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 		getContextAccessToken: func() string {
 			context := Context
 			if context == "" {
-				context = viper.GetString("context")
+				context = strings.ToLower(viper.GetString("context"))
 			}
 			token := ""
 
@@ -152,7 +153,7 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 		setContextAccessToken: func(token string) {
 			context := Context
 			if context == "" {
-				context = viper.GetString("context")
+				context = strings.ToLower(viper.GetString("context"))
 			}
 
 			switch context {

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -112,6 +112,7 @@ func initConfig() {
 
 	viper.SetDefault("output", "text")
 	viper.SetDefault(doctl.ArgContext, doctl.ArgDefaultContext)
+	Context = strings.ToLower(Context)
 
 	if _, err := os.Stat(cfgFile); err == nil {
 		if err := viper.ReadInConfig(); err != nil {


### PR DESCRIPTION
**Background**
We've had several requests report that they are seeing a discrepancy in doctl authentication. When they create a context with an uppercase letter, the context name is stored in all lowercase and causes the following:
- When the context is used in uppercase, doctl accepts it but doesn't allow the authentication.
- When the context is used in lowercase, doctl accepts it and allows the authentication.

Currently, this is what happens:
```
$ doctl auth init --context Chandan
Please authenticate doctl for use with your DigitalOcean account. You can generate a token in the control panel at https://cloud.digitalocean.com/account/api/tokens


Enter your access token: 
Validating token... OK


$ doctl auth ls
chandan
default (current)

$ doctl auth switch --context Chandan
Now using context [Chandan] by default

$ doctl auth ls                  
chandan
default

$ doctl registry login
Error: Unable to initialize DigitalOcean API client: access token is required. (hint: run 'doctl auth init')

$ doctl auth switch --context chandan
Now using context [chandan] by default

$ doctl registry login           
Logging Docker in to registry.digitalocean.com  
```

In this code snippet, you can see that the context is created as Chandan but it is stored as chandan. When the context Chandan is used you can see it is accepted but the authentication fails. But when the context is used as chandan authentication works.

Ideally, when the uppercase context is used it should throw an error. This is an issue with Viper, a third party package doctl uses. This seems to be the most requested feature that the tool has yet to be supported:
https://github.com/spf13/viper/issues/1014


**Solution**
Though not ideal, I'm presenting a rather simple work around of lower-casing the `context` behind the scenes for the user and disclosing that the context names are case insensitive in the doctl man pages. With these changes, this is what would happen in the above scenario instead:

```
$ go run cmd/doctl/main.go auth init --context Sammy    
Please authenticate doctl for use with your DigitalOcean account. You can generate a token in the control panel at https://cloud.digitalocean.com/account/api/tokens

❯ Enter your access token:  ●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●

Validating token... ✔

$  go run cmd/doctl/main.go auth ls                      
default (current)
sammy

$  go run cmd/doctl/main.go auth switch --context Sammy
Now using context [sammy] by default

$ go run cmd/doctl/main.go auth ls                      
default
sammy (current)

$ go run cmd/doctl/main.go registry login 
Logging Docker in to registry.digitalocean.com

$  go run cmd/doctl/main.go auth ls                    
default
sammy (current)

$  go run cmd/doctl/main.go auth switch --context shark
Error: context does not exist
exit status 1
```

As you can see, the context is case insensitive now and can switch between existing contexts smoothly. It will also error when the context does not exist. 


**Considerations**
Unless I'm missing a specific case scenario, I do not believe this introduces a breaking change as all previously created contexts have been stored in all lowercase. 


APICLI-1828
Addresses: #411
