### PR TITLE
AppPlatform: update cnb builder image to v0.58.0

### DIFF
--- a/internal/apps/builder/cnb.go
+++ b/internal/apps/builder/cnb.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// CNBBuilderImage represents the local cnb builder.
-	CNBBuilderImage = "digitaloceanapps/cnb-local-builder:v0.50.4"
+	CNBBuilderImage = "digitaloceanapps/cnb-local-builder:v0.58.0"
 
 	appVarAllowListKey = "APP_VARS"
 	appVarPrefix       = "APP_VAR_"


### PR DESCRIPTION
[APPS-7185](https://jira.internal.digitalocean.com/browse/APPS-7185)

Update the App Platform CNB builder image to v0.58.0