### PR TITLE
doit: respect json output flag

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/digitalocean/doctl"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // Version creates a version command.
@@ -48,7 +49,14 @@ func Version() *Command {
 					doctl.DoitVersion.Label = doctl.Label
 				}
 
-				fmt.Println(doctl.DoitVersion.Complete(&doctl.GithubLatestVersioner{}))
+				var output string
+				if viper.GetString("output") == "json" {
+					output = doctl.DoitVersion.CompleteJSON(&doctl.GithubLatestVersioner{})
+				} else {
+					output = doctl.DoitVersion.Complete(&doctl.GithubLatestVersioner{})
+				}
+
+				fmt.Println(output)
 			},
 		},
 	}

--- a/doit.go
+++ b/doit.go
@@ -139,6 +139,37 @@ func (v Version) Complete(lv LatestVersioner) string {
 	return buffer.String()
 }
 
+// CompleteJSON is the complete version for doit, formatted as JSON.
+func (v Version) CompleteJSON(lv LatestVersioner) string {
+	versionInfo := &struct {
+		Version      string `json:"version,omitempty"`
+		Commit       string `json:"commit,omitempty"`
+		Notification string `json:"notification,omitempty"`
+	}{
+		Version: fmt.Sprintf("doctl version %s", v.String()),
+	}
+
+	if v.Build != "" {
+		versionInfo.Commit = fmt.Sprintf("\nGit commit hash: %s", v.Build)
+	}
+
+	if tagName, err := lv.LatestVersion(); err == nil {
+		v0, err1 := semver.Make(tagName)
+		v1, err2 := semver.Make(v.String())
+
+		if len(v0.Build) == 0 {
+			v0, err1 = semver.Make(tagName + "-release")
+		}
+
+		if err1 == nil && err2 == nil && v0.GT(v1) {
+			versionInfo.Notification = fmt.Sprintf("release %s is available, check it out!", tagName)
+		}
+	}
+
+	data, _ := json.MarshalIndent(versionInfo, "", "  ")
+	return string(data)
+}
+
 // LatestVersioner an interface for detecting the latest version.
 type LatestVersioner interface {
 	LatestVersion() (string, error)

--- a/doit.go
+++ b/doit.go
@@ -146,11 +146,8 @@ func (v Version) CompleteJSON(lv LatestVersioner) string {
 		Commit       string `json:"commit,omitempty"`
 		Notification string `json:"notification,omitempty"`
 	}{
-		Version: fmt.Sprintf("doctl version %s", v.String()),
-	}
-
-	if v.Build != "" {
-		versionInfo.Commit = fmt.Sprintf("\nGit commit hash: %s", v.Build)
+		Version: v.String(),
+		Commit:  v.Build,
 	}
 
 	if tagName, err := lv.LatestVersion(); err == nil {

--- a/doit_test.go
+++ b/doit_test.go
@@ -51,52 +51,59 @@ func TestVersion(t *testing.T) {
 	slr2 := &stubLatestRelease{version: "1.0.0"}
 
 	cases := []struct {
-		v   Version
-		s   string
-		ver string
-		slr LatestVersioner
+		v    Version
+		s    string
+		json string
+		ver  string
+		slr  LatestVersioner
 	}{
 		// version with no label
 		{
-			v:   Version{Major: 0, Minor: 1, Patch: 2},
-			s:   `doctl version 0.1.2`,
-			ver: "0.1.2",
-			slr: slr1,
+			v:    Version{Major: 0, Minor: 1, Patch: 2},
+			s:    `doctl version 0.1.2`,
+			json: "{\n  \"version\": \"0.1.2\"\n}",
+			ver:  "0.1.2",
+			slr:  slr1,
 		},
 		// version with label
 		{
-			v:   Version{Major: 0, Minor: 1, Patch: 2, Label: "dev"},
-			s:   `doctl version 0.1.2-dev`,
-			ver: "0.1.2-dev",
-			slr: slr1,
+			v:    Version{Major: 0, Minor: 1, Patch: 2, Label: "dev"},
+			s:    `doctl version 0.1.2-dev`,
+			json: "{\n  \"version\": \"0.1.2-dev\"\n}",
+			ver:  "0.1.2-dev",
+			slr:  slr1,
 		},
 		// version with label and build
 		{
-			v:   Version{Major: 0, Minor: 1, Patch: 2, Label: "dev", Build: "12345"},
-			s:   "doctl version 0.1.2-dev\nGit commit hash: 12345",
-			ver: "0.1.2-dev",
-			slr: slr1,
+			v:    Version{Major: 0, Minor: 1, Patch: 2, Label: "dev", Build: "12345"},
+			s:    "doctl version 0.1.2-dev\nGit commit hash: 12345",
+			json: "{\n  \"version\": \"0.1.2-dev\",\n  \"commit\": \"12345\"\n}",
+			ver:  "0.1.2-dev",
+			slr:  slr1,
 		},
 		// version with no label and higher released version
 		{
-			v:   Version{Major: 0, Minor: 1, Patch: 2},
-			s:   "doctl version 0.1.2\nrelease 1.0.0 is available, check it out! ",
-			ver: `0.1.2`,
-			slr: slr2,
+			v:    Version{Major: 0, Minor: 1, Patch: 2},
+			s:    "doctl version 0.1.2\nrelease 1.0.0 is available, check it out! ",
+			json: "{\n  \"version\": \"0.1.2\",\n  \"notification\": \"release 1.0.0 is available, check it out!\"\n}",
+			ver:  `0.1.2`,
+			slr:  slr2,
 		},
 		// version with dev label and released version
 		{
-			v:   Version{Major: 1, Minor: 0, Patch: 0, Label: "dev"},
-			s:   "doctl version 1.0.0-dev\nrelease 1.0.0 is available, check it out! ",
-			ver: `1.0.0-dev`,
-			slr: slr2,
+			v:    Version{Major: 1, Minor: 0, Patch: 0, Label: "dev"},
+			s:    "doctl version 1.0.0-dev\nrelease 1.0.0 is available, check it out! ",
+			json: "{\n  \"version\": \"1.0.0-dev\",\n  \"notification\": \"release 1.0.0 is available, check it out!\"\n}",
+			ver:  `1.0.0-dev`,
+			slr:  slr2,
 		},
 		// version with release label and released version available
 		{
-			v:   Version{Major: 1, Minor: 0, Patch: 0, Label: "release"},
-			s:   "doctl version 1.0.0-release",
-			ver: `1.0.0-release`,
-			slr: slr2,
+			v:    Version{Major: 1, Minor: 0, Patch: 0, Label: "release"},
+			s:    "doctl version 1.0.0-release",
+			json: "{\n  \"version\": \"1.0.0-release\"\n}",
+			ver:  `1.0.0-release`,
+			slr:  slr2,
 		},
 	}
 
@@ -107,7 +114,13 @@ func TestVersion(t *testing.T) {
 		if got, want := c.v.Complete(c.slr), c.s; got != want {
 			t.Errorf("complete version string for %#v = %q; want = %q", c.v, got, want)
 		}
+		if got, want := c.v.CompleteJSON(c.slr), c.json; got != want {
+			t.Errorf("complete version json for %#v = %q; want = %q", c.v, got, want)
+		}
 	}
+
+	// Ensure that JSON output works as expected.
+
 }
 
 type stubLatestRelease struct {


### PR DESCRIPTION
Updates the `version` command to respect the `-o json` flag. Opening as a draft since this is missing a test and the output is ugly.

Example output:

``` 
$ go run cmd/doctl/main.go version -o json

{
  "version": "doctl version 0.0.0-dev",
  "notification": "release 1.94.0 is available, check it out!"
}
```