### PR TITLE
databases: fix replica promote doc string

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -1305,8 +1305,8 @@ This command requires that you pass in the replica's name, which you can retriev
 
 	CmdBuilder(cmd, RunDatabaseReplicaPromote,
 		"promote <database-id> <replica-name>", "Promote a read-only database replica to become a primary cluster",
-		`Delete the specified read-only replica for the specified database cluster.`+howToGetReplica+databaseListDetails,
-		Writer, aliasOpt("rm"))
+		`This command promotes a read-only database replica to become a primary cluster.`+howToGetReplica+databaseListDetails,
+		Writer, aliasOpt("p"))
 
 	CmdBuilder(cmd, RunDatabaseReplicaConnectionGet,
 		"connection <database-id> <replica-name>",


### PR DESCRIPTION
Previously, the docs for `replica promote` was the same as that of `replica delete`. This was probably from a copy-paste error. This change fixes that, and updates the command alias so that it's not also `rm` (it's now `p`).

Not sure how I feel about the `p` alias, so if you have any ideas on a better one, let me know and I can change it.