### PR TITLE
registry: prevent panic in list v2

### DIFF
--- a/commands/displayers/registry.go
+++ b/commands/displayers/registry.go
@@ -16,6 +16,7 @@ package displayers
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/digitalocean/doctl/do"
 )
@@ -143,17 +144,25 @@ func (r *RepositoryV2) KV() []map[string]interface{} {
 	out := make([]map[string]interface{}, 0, len(r.Repositories))
 
 	for _, reg := range r.Repositories {
+		var latestManifest string
 		latestTag := "<none>" // default when latest manifest has no tags
-		if len(reg.LatestManifest.Tags) > 0 {
-			latestTag = reg.LatestManifest.Tags[0]
+		var latestUpdate *time.Time
+
+		if reg.LatestManifest != nil {
+			latestManifest = reg.LatestManifest.Digest
+			if len(reg.LatestManifest.Tags) > 0 {
+				latestTag = reg.LatestManifest.Tags[0]
+			}
+			latestUpdate = &reg.LatestManifest.UpdatedAt
 		}
+
 		m := map[string]interface{}{
 			"Name":           reg.Name,
-			"LatestManifest": reg.LatestManifest.Digest,
+			"LatestManifest": latestManifest,
 			"LatestTag":      latestTag,
 			"TagCount":       reg.TagCount,
 			"ManifestCount":  reg.ManifestCount,
-			"UpdatedAt":      reg.LatestManifest.UpdatedAt,
+			"UpdatedAt":      latestUpdate,
 		}
 
 		out = append(out, m)

--- a/integration/registry_repo_list_v2_test.go
+++ b/integration/registry_repo_list_v2_test.go
@@ -82,6 +82,7 @@ var (
 	repositoryListV2Output = `
 Name      Latest Manifest                                                            Latest Tag    Tag Count    Manifest Count    Updated At
 repo-1    sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221    v1            57           82                2021-04-09 23:54:25 +0000 UTC
+repo-2                                                                               <none>        57           82                <nil>
 `
 
 	repositoryListV2Response = `{
@@ -117,10 +118,16 @@ repo-1    sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d22
           }
         ]
       }
+    },
+    {
+      "registry_name": "example-no-latest-manifest",
+      "name": "repo-2",
+      "tag_count": 57,
+      "manifest_count": 82
     }
   ],
   "meta": {
-    "total": 1
+    "total": 2
   }
 }`
 )


### PR DESCRIPTION
Fixes #1390

Prevents a panic in the registry's list V2 command caused by attempting to access fields on a struct that can be `nil`.