### PR TITLE
Fix typo causing incorrect token highlighting

### DIFF
--- a/commands/command.go
+++ b/commands/command.go
@@ -98,7 +98,7 @@ func cmdBuilderWithInit(parent *Command, cr CmdRunner, cliText, shortdesc string
 	}
 
 	if cols := c.fmtCols; cols != nil {
-		formatHelp := fmt.Sprintf("Columns for output in a comma-separated list. Possible values: ```%s`.",
+		formatHelp := fmt.Sprintf("Columns for output in a comma-separated list. Possible values: `%s`.",
 			strings.Join(cols, "`"+", "+"`"))
 		AddStringFlag(c, doctl.ArgFormat, "", "", formatHelp)
 		AddBoolFlag(c, doctl.ArgNoHeader, "", false, "Return raw data with no headers")


### PR DESCRIPTION
I think the triple backtick that I changed is the reason that [this page](https://docs.digitalocean.com/reference/doctl/reference/compute/droplet/create/) has this content:

<img width="1016" alt="image" src="https://github.com/digitalocean/doctl/assets/543973/4eb9b25a-e7be-4abf-9294-06239d5754ae">