### PR TITLE
auth: init recognizes --access-token

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -146,7 +146,14 @@ To create new contexts, see the help for `+"`"+`doctl auth init`+"`"+`.`, Writer
 // XDG_CONFIG_HOME is not set, use $HOME/.config. On Windows use %APPDATA%/doctl/config.
 func RunAuthInit(retrieveUserTokenFunc func() (string, error)) func(c *CmdConfig) error {
 	return func(c *CmdConfig) error {
-		token := c.getContextAccessToken()
+		token := viper.GetString(doctl.ArgAccessToken)
+
+		// if --access-token is passed, set the context.
+		if token != "" {
+			c.setContextAccessToken(token)
+		}
+
+		token = c.getContextAccessToken()
 		context := strings.ToLower(Context)
 		if context == "" {
 			context = strings.ToLower(viper.GetString("context"))


### PR DESCRIPTION
Addresses #1394

Before:
```
go run cmd/doctl/main.go auth init --access-token "$token" --context=anotherone
Please authenticate doctl for use with your DigitalOcean account. You can generate a token in the control panel at https://cloud.digitalocean.com/account/api/tokens

❯ Enter your access token:
```

After:
```
go run cmd/doctl/main.go auth init --access-token "$token" --context=anotherone
Using token for context anotherone

Validating token... ✔
```