### PR TITLE
Adds ubuntu 22 stack support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,11 @@ endif
 ifeq ($(GOARCH),)
   GOARCH = amd64
   ifneq ($(UNAME_M), x86_64)
-    GOARCH = 386
+    ifeq ($(UNAME_M), arm64)
+      GOARCH = arm64
+    else
+      GOARCH = 386
+    endif
   endif
 endif
 

--- a/commands/apps_dev.go
+++ b/commands/apps_dev.go
@@ -511,11 +511,13 @@ func appDevPrepareEnvironment(ctx context.Context, ws *workspace.AppDev, cli bui
 		if ws.Config.CNBBuilderImage != "" {
 			images = append(images, ws.Config.CNBBuilderImage)
 		} else {
-			images = append(images, builder.CNBBuilderImage)
+			images = append(images, builder.CNBBuilderImage_Heroku18)
+			images = append(images, builder.CNBBuilderImage_Heroku22)
 		}
 
 		// TODO: get stack run image from builder image md after we pull it, see below
-		images = append(images, "digitaloceanapps/apps-run:7858f2c")
+		images = append(images, "digitaloceanapps/apps-run:heroku-18_1b6264d")
+		images = append(images, "digitaloceanapps/apps-run:heroku-22_1b6264d")
 	}
 
 	if componentSpec.GetType() == godo.AppComponentTypeStaticSite {

--- a/internal/apps/builder/cnb.go
+++ b/internal/apps/builder/cnb.go
@@ -25,7 +25,8 @@ import (
 
 const (
 	// CNBBuilderImage represents the local cnb builder.
-	CNBBuilderImage = "digitaloceanapps/cnb-local-builder:v0.58.0"
+	CNBBuilderImage_Heroku18 = "digitaloceanapps/cnb-local-builder:heroku-18_63b9615"
+	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_63b9615"
 
 	appVarAllowListKey = "APP_VARS"
 	appVarPrefix       = "APP_VAR_"
@@ -375,6 +376,11 @@ func (b *CNBComponentBuilder) builderImage() string {
 	if b.builderImageOverride != "" {
 		return b.builderImageOverride
 	}
+	for _, f := range b.spec.Features {
+		if strings.EqualFold(f, "buildpack-stack=ubuntu-22") {
+			return CNBBuilderImage_Heroku22
+		}
+	}
 
-	return CNBBuilderImage
+	return CNBBuilderImage_Heroku18
 }


### PR DESCRIPTION
This change adds support for locally building app platform apps that use both ubuntu 18 base (default) and also ubuntu-22 stack which is behind an app spec feature flag. 