### PR TITLE
Add support for retrying failed requests.

### DIFF
--- a/commands/account_test.go
+++ b/commands/account_test.go
@@ -59,6 +59,7 @@ func TestAccountGet(t *testing.T) {
 
 func TestAccountGetRateLimit(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		RetryMax = 0
 		now := time.Now()
 		testRateLimit.Reset = godo.Timestamp{Time: now}
 		tm.account.EXPECT().RateLimit().Return(testRateLimit, nil)

--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -85,7 +85,7 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 
 		initServices: func(c *CmdConfig) error {
 			accessToken := c.getContextAccessToken()
-			godoClient, err := c.Doit.GetGodoClient(Trace, accessToken)
+			godoClient, err := c.Doit.GetGodoClient(Trace, true, accessToken)
 			if err != nil {
 				return fmt.Errorf("Unable to initialize DigitalOcean API client: %s", err)
 			}

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -61,6 +61,11 @@ var (
 	//Interactive toggle interactive behavior
 	Interactive bool
 
+	// Retry settings to pass through to godo.RetryConfig
+	RetryMax     int
+	RetryWaitMax int
+	RetryWaitMin int
+
 	requiredColor = color.New(color.Bold).SprintfFunc()
 )
 
@@ -98,6 +103,17 @@ func init() {
 		interactiveHelpText += " (default false)"
 	}
 	rootPFlagSet.BoolVarP(&Interactive, doctl.ArgInteractive, "", interactive, interactiveHelpText)
+
+	rootPFlagSet.IntVar(&RetryMax, "http-retry-max", 5, "Set maximum number of retries for requests that fail with a 429 or 500-level error")
+	viper.BindPFlag("http-retry-max", rootPFlagSet.Lookup("http-retry-max"))
+
+	rootPFlagSet.IntVar(&RetryWaitMax, "http-retry-wait-max", 30, "Set the minimum number of seconds to wait before retrying a failed request")
+	viper.BindPFlag("http-retry-wait-max", rootPFlagSet.Lookup("http-retry-wait-max"))
+	DoitCmd.PersistentFlags().MarkHidden("http-retry-wait-max")
+
+	rootPFlagSet.IntVar(&RetryWaitMin, "http-retry-wait-min", 1, "Set the maximum number of seconds to wait before retrying a failed request")
+	viper.BindPFlag("http-retry-wait-min", rootPFlagSet.Lookup("http-retry-wait-min"))
+	DoitCmd.PersistentFlags().MarkHidden("http-retry-wait-min")
 
 	addCommands()
 

--- a/integration/account_test.go
+++ b/integration/account_test.go
@@ -167,7 +167,7 @@ var _ = suite("account/ratelimit", func(t *testing.T, when spec.G, it spec.S) {
 		expect.Equal(expectedOutput, strings.TrimSpace(string(output)))
 	})
 
-	it("doesn't return an error when rate-limted", func() {
+	it("doesn't return an error when rate-limited", func() {
 		cmd := exec.Command(builtBinaryPath,
 			"-t", "token-with-ratelimit-exhausted",
 			"-u", server.URL,
@@ -176,11 +176,25 @@ var _ = suite("account/ratelimit", func(t *testing.T, when spec.G, it spec.S) {
 		)
 
 		output, err := cmd.CombinedOutput()
-		expect.NoError(err)
+		expect.NoError(err, string(output))
 
 		t := time.Unix(1565385881, 0)
 		expectedOutput := strings.TrimSpace(fmt.Sprintf(ratelimitExhaustedOutput, t))
 		expect.Equal(expectedOutput, strings.TrimSpace(string(output)))
+	})
+
+	it("doesn't retry when rate-limited", func() {
+		cmd := exec.Command(builtBinaryPath,
+			"-t", "token-with-ratelimit-exhausted",
+			"-u", server.URL,
+			"account",
+			"ratelimit", "--trace",
+		)
+
+		output, err := cmd.CombinedOutput()
+		expect.NoError(err, string(output))
+
+		expect.NotContains(strings.TrimSpace(string(output)), "retrying in")
 	})
 })
 

--- a/integration/projects_delete_test.go
+++ b/integration/projects_delete_test.go
@@ -55,6 +55,7 @@ var _ = suite("projects/delete", func(t *testing.T, when spec.G, it spec.S) {
 				"test-project-1",
 				"test-project-2",
 				"-f",
+				"--http-retry-max", "0",
 			)
 
 			output, err := cmd.CombinedOutput()

--- a/integration/retry_flag_test.go
+++ b/integration/retry_flag_test.go
@@ -1,0 +1,145 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite("retries/server-error", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		var (
+			requestCount int
+			errResp      = `{"id": "server_error", "message": "something broke"}`
+		)
+		expect = require.New(t)
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Add("content-type", "application/json")
+
+			switch req.URL.Path {
+			case "/v2/account":
+				requestCount++
+
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				if req.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				if requestCount < 5 {
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write([]byte(errResp))
+					return
+				}
+
+				w.Write([]byte(accountGetResponse))
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	it("retries five time by default and succeeds", func() {
+		cmd := exec.Command(builtBinaryPath,
+			"-t", "some-magic-token",
+			"-u", server.URL,
+			"account",
+			"get",
+		)
+
+		output, err := cmd.CombinedOutput()
+		expect.NoError(err)
+
+		expect.Equal(strings.TrimSpace(accountOutput), strings.TrimSpace(string(output)))
+	})
+
+	it("retries are logged with trace flag", func() {
+		cmd := exec.Command(builtBinaryPath,
+			"-t", "some-magic-token",
+			"-u", server.URL,
+			"account",
+			"get",
+			"--trace",
+		)
+
+		output, err := cmd.CombinedOutput()
+		expect.NoError(err)
+
+		expect.Contains(strings.TrimSpace(string(output)), "retrying in")
+	})
+
+	when("respects the http-retry-max flag and gives up", func() {
+		it("only displays the correct fields", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"account",
+				"get",
+				"--http-retry-max", "2",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+			expectedErr := fmt.Sprintf("Error: GET %s/v2/account: 500 something broke; giving up after 3 attempt(s)", server.URL)
+			expect.Equal(strings.TrimSpace(string(output)), expectedErr)
+		})
+	})
+
+	when("retries are disabled when http-retry-max is set to 0", func() {
+		it("only displays the correct fields", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"account",
+				"get",
+				"--http-retry-max", "0",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+
+			// Does not contain "giving up after"
+			expectedErr := fmt.Sprintf("Error: GET %s/v2/account: 500 something broke", server.URL)
+			expect.Equal(strings.TrimSpace(string(output)), expectedErr)
+		})
+	})
+
+	when("doesn't retry 400-level errors", func() {
+		it("only displays the correct fields", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "bad-token",
+				"-u", server.URL,
+				"account",
+				"get",
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.Error(err)
+
+			expect.NotContains(strings.TrimSpace(string(output)), "giving up after")
+			expect.Contains(strings.TrimSpace(string(output)), "401")
+		})
+	})
+})


### PR DESCRIPTION
This enables support for retrying failed requests. A few things to note:

- I've chosen to expose the `http-retry-max` flag to users to give them insight into the new default behavior. I've marked the `http-retry-wait-max` and `http-retry-wait-min` flags as hidden as the defaults should be fine for most users, but it still allows for configuration if needed.
- For the wait settings, I've used an `int` rather than a `float64` as I feel that it is friendlier on the command line.
- I've used the `http` prefix on these so that the environment variables end up consistent with the same settings ion Terraform, e.g. `DIGITALOCEAN_HTTP_RETRY_MAX`.
- I've bypassed retries for the `doctl account ratelimit` command. The purpose of the command is to return the rate-limit headers regardless of response status. So retrying here just hides the current status and delays returning a response for no real gain.