### PR TITLE
databases: Support setting tags a create time.

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -82,6 +82,7 @@ There are a number of flags that customize the configuration, all of which are o
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseRestoreFromClusterName, "", "", "The name of an existing database cluster from which the backup will be restored.")
 	AddStringFlag(cmdDatabaseCreate, doctl.ArgDatabaseRestoreFromTimestamp, "", "", "The timestamp of an existing database cluster backup in UTC combined date and time format (2006-01-02 15:04:05 +0000 UTC). The most recent backup will be used if excluded.")
 	AddBoolFlag(cmdDatabaseCreate, doctl.ArgCommandWait, "", false, "Boolean that specifies whether to wait for a database to complete before returning control to the terminal")
+	AddStringSliceFlag(cmdDatabaseCreate, doctl.ArgTag, "", nil, "Comma-separated list of tags to apply to the database cluster.")
 
 	cmdDatabaseDelete := CmdBuilder(cmd, RunDatabaseDelete, "delete <database-id>", "Delete a database cluster", `This command deletes the database cluster with the given ID.
 
@@ -258,6 +259,12 @@ func buildDatabaseCreateRequestFromArgs(c *CmdConfig) (*godo.DatabaseCreateReque
 		return nil, err
 	}
 	r.PrivateNetworkUUID = privateNetworkUUID
+
+	tags, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTag)
+	if err != nil {
+		return nil, err
+	}
+	r.Tags = tags
 
 	restoreFromCluster, err := c.Doit.GetString(c.NS, doctl.ArgDatabaseRestoreFromClusterName)
 	if err != nil {

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -61,6 +61,7 @@ var (
 				*testGODOUser,
 			},
 			PrivateNetworkUUID: "1fe49b6c-ac8e-11e9-98cb-3bec94f411bc",
+			Tags:               []string{"testing"},
 		},
 	}
 
@@ -320,6 +321,7 @@ func TestDatabasesCreate(t *testing.T) {
 		NumNodes:           testDBCluster.NumNodes,
 		SizeSlug:           testDBCluster.SizeSlug,
 		PrivateNetworkUUID: testDBCluster.PrivateNetworkUUID,
+		Tags:               testDBCluster.Tags,
 	}
 
 	// Successful call
@@ -333,6 +335,7 @@ func TestDatabasesCreate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, testDBCluster.EngineSlug)
 		config.Doit.Set(config.NS, doctl.ArgDatabaseNumNodes, testDBCluster.NumNodes)
 		config.Doit.Set(config.NS, doctl.ArgPrivateNetworkUUID, testDBCluster.PrivateNetworkUUID)
+		config.Doit.Set(config.NS, doctl.ArgTag, testDBCluster.Tags)
 
 		err := RunDatabaseCreate(config)
 		assert.NoError(t, err)

--- a/integration/database_create_test.go
+++ b/integration/database_create_test.go
@@ -46,11 +46,12 @@ var _ = suite("database/create", func(t *testing.T, when spec.G, it spec.S) {
 				expect.NoError(err)
 
 				request := struct {
-					Name    string `json:"name"`
-					Engine  string `json:"engine"`
-					Version string `json:"version"`
-					Region  string `json:"region"`
-					Nodes   int    `json:"num_nodes"`
+					Name    string   `json:"name"`
+					Engine  string   `json:"engine"`
+					Version string   `json:"version"`
+					Region  string   `json:"region"`
+					Nodes   int      `json:"num_nodes"`
+					Tags    []string `json:"tags"`
 				}{}
 
 				err = json.Unmarshal(reqBody, &request)
@@ -103,6 +104,7 @@ var _ = suite("database/create", func(t *testing.T, when spec.G, it spec.S) {
 				"--region", "nyc3",
 				"--size", "biggest",
 				"--version", "what-version",
+				"--tag", "test",
 			)
 
 			output, err := cmd.CombinedOutput()
@@ -126,6 +128,7 @@ var _ = suite("database/create", func(t *testing.T, when spec.G, it spec.S) {
 				"--region", "nyc3",
 				"--size", "biggest",
 				"--version", "what-version",
+				"--tag", "test",
 				"--wait",
 			)
 
@@ -169,9 +172,7 @@ some-id    my-database-name    mysql     what-version    100                nyc3
     "created_at": "2019-01-11T18:37:36Z",
     "maintenance_window": null,
     "size": "biggest",
-    "tags": [
-      "production"
-    ]
+    "tags": ["{{.Tags}}"]
   }
 }`
 
@@ -193,7 +194,7 @@ some-id    my-database-name    mysql     what-version    100                nyc3
     "maintenance_window": null,
     "size": "biggest",
     "tags": [
-      "production"
+      "test"
     ]
   }
 }`


### PR DESCRIPTION
We're missing support setting tags when creating a database cluster. This adds it. 