### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         id: build
         run: |
           make _build_snap && \
-          find doctl_v*.snap -exec echo "snap={}" >> $GITHUB_OUTPUT \;
+          find doctl_v*.snap -exec echo "snap={}" >> "$GITHUB_OUTPUT" \;
 
       - uses: snapcore/action-publish@master
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         id: build
         run: |
           make _build_snap && \
-          find doctl_v*.snap -print -exec echo ::set-output name=snap::{} \;
+          find doctl_v*.snap -exec echo "snap={}" >> $GITHUB_OUTPUT \;
 
       - uses: snapcore/action-publish@master
         env:

--- a/.github/workflows/snapcraft-candidate.yml
+++ b/.github/workflows/snapcraft-candidate.yml
@@ -26,7 +26,7 @@ jobs:
         id: build
         run: |
           make _build_snap && \
-          find doctl_v*.snap -print -exec echo ::set-output name=snap::{} \;
+          find doctl_v*.snap -exec echo "snap={}" >> $GITHUB_OUTPUT \;
 
       - uses: snapcore/action-publish@master
         env:

--- a/.github/workflows/snapcraft-candidate.yml
+++ b/.github/workflows/snapcraft-candidate.yml
@@ -26,7 +26,7 @@ jobs:
         id: build
         run: |
           make _build_snap && \
-          find doctl_v*.snap -exec echo "snap={}" >> $GITHUB_OUTPUT \;
+          find doctl_v*.snap -exec echo "snap={}" >> "$GITHUB_OUTPUT" \;
 
       - uses: snapcore/action-publish@master
         env:


### PR DESCRIPTION
## Description

Closes #1420 

Update `.github/workflows/stack-ci.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
find doctl_v*.snap -print -exec echo ::set-output name=snap::{} \;
```

**TO-BE**

```yaml
find doctl_v*.snap -exec echo "snap={}" >> $GITHUB_OUTPUT \;
```
