### PR TITLE
Replace deprecated package io/ioutil with io and os

### DIFF
--- a/commands/apps.go
+++ b/commands/apps.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -953,7 +952,7 @@ func readAppAlertDestination(stdin io.Reader, path string) (*godo.AlertDestinati
 		alertDestinations = alertDestinationsFile
 	}
 
-	byt, err := ioutil.ReadAll(alertDestinations)
+	byt, err := io.ReadAll(alertDestinations)
 	if err != nil {
 		return nil, fmt.Errorf("reading app alert destinations: %w", err)
 	}

--- a/commands/apps_dev_config_test.go
+++ b/commands/apps_dev_config_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -202,7 +201,7 @@ func tempAppSpec(t *testing.T, spec *godo.AppSpec) (path string) {
 	path = tempFile(t, "app.yaml")
 	specYaml, err := yaml.Marshal(spec)
 	require.NoError(t, err, "marshaling app spec")
-	err = ioutil.WriteFile(path, specYaml, 0664)
+	err = os.WriteFile(path, specYaml, 0664)
 	require.NoError(t, err, "writing app spec to disk")
 	return
 }

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"testing"
@@ -130,12 +129,9 @@ var (
 
 func TestRunAppsCreate(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		specFile, err := ioutil.TempFile("", "spec")
+		specFile, err := os.CreateTemp(t.TempDir(), "spec")
 		require.NoError(t, err)
-		defer func() {
-			os.Remove(specFile.Name())
-			specFile.Close()
-		}()
+		defer specFile.Close()
 
 		err = json.NewEncoder(specFile).Encode(&testAppSpec)
 		require.NoError(t, err)
@@ -195,12 +191,9 @@ func TestRunAppsList(t *testing.T) {
 
 func TestRunAppsUpdate(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		specFile, err := ioutil.TempFile("", "spec")
+		specFile, err := os.CreateTemp(t.TempDir(), "spec")
 		require.NoError(t, err)
-		defer func() {
-			os.Remove(specFile.Name())
-			specFile.Close()
-		}()
+		defer specFile.Close()
 
 		err = json.NewEncoder(specFile).Encode(&testAppSpec)
 		require.NoError(t, err)
@@ -543,7 +536,7 @@ var validAppSpec = &godo.AppSpec{
 func testTempFile(t *testing.T, data []byte) string {
 	t.Helper()
 	file := t.TempDir() + "/file"
-	err := ioutil.WriteFile(file, data, 0644)
+	err := os.WriteFile(file, data, 0644)
 	require.NoError(t, err, "writing temp file")
 	return file
 }
@@ -769,12 +762,9 @@ func TestRunAppsListAlerts(t *testing.T) {
 
 func TestRunAppsUpdateAlertDestinations(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		destinationsFile, err := ioutil.TempFile("", "dest")
+		destinationsFile, err := os.CreateTemp(t.TempDir(), "dest")
 		require.NoError(t, err)
-		defer func() {
-			os.Remove(destinationsFile.Name())
-			destinationsFile.Close()
-		}()
+		defer destinationsFile.Close()
 
 		err = json.NewEncoder(destinationsFile).Encode(&testAlertUpdate)
 		require.NoError(t, err)

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -48,7 +47,7 @@ func TestAuthInit(t *testing.T) {
 		return "valid-token", nil
 	}
 
-	cfgFileWriter = func() (io.WriteCloser, error) { return &nopWriteCloser{Writer: ioutil.Discard}, nil }
+	cfgFileWriter = func() (io.WriteCloser, error) { return &nopWriteCloser{Writer: io.Discard}, nil }
 
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.oauth.EXPECT().TokenInfo(gomock.Any()).Return(&do.OAuthTokenInfo{}, nil)
@@ -114,7 +113,7 @@ func TestAuthInitWithProvidedToken(t *testing.T) {
 		return "", errors.New("should not have called this")
 	}
 
-	cfgFileWriter = func() (io.WriteCloser, error) { return &nopWriteCloser{Writer: ioutil.Discard}, nil }
+	cfgFileWriter = func() (io.WriteCloser, error) { return &nopWriteCloser{Writer: io.Discard}, nil }
 
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.oauth.EXPECT().TokenInfo(gomock.Any()).Return(&do.OAuthTokenInfo{}, nil)
@@ -136,7 +135,7 @@ func TestAuthForcesLowercase(t *testing.T) {
 		return "", errors.New("should not have called this")
 	}
 
-	cfgFileWriter = func() (io.WriteCloser, error) { return &nopWriteCloser{Writer: ioutil.Discard}, nil }
+	cfgFileWriter = func() (io.WriteCloser, error) { return &nopWriteCloser{Writer: io.Discard}, nil }
 
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.oauth.EXPECT().TokenInfo(gomock.Any()).Return(&do.OAuthTokenInfo{}, nil)

--- a/commands/certificates.go
+++ b/commands/certificates.go
@@ -14,7 +14,7 @@ limitations under the License.
 package commands
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/commands/displayers"
@@ -217,7 +217,7 @@ func RunCertificateDelete(c *CmdConfig) error {
 }
 
 func readInputFromFile(path string) (string, error) {
-	fileBytes, err := ioutil.ReadFile(path)
+	fileBytes, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/commands/certificates_test.go
+++ b/commands/certificates_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -106,21 +105,21 @@ func TestCertificatesCreate(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 				if test.privateKeyPath != "" {
-					pkErr := ioutil.WriteFile(test.privateKeyPath, []byte("-----BEGIN PRIVATE KEY-----"), 0600)
+					pkErr := os.WriteFile(test.privateKeyPath, []byte("-----BEGIN PRIVATE KEY-----"), 0600)
 					assert.NoError(t, pkErr)
 
 					defer os.Remove(test.privateKeyPath)
 				}
 
 				if test.certLeafPath != "" {
-					certErr := ioutil.WriteFile(test.certLeafPath, []byte("-----BEGIN CERTIFICATE-----"), 0600)
+					certErr := os.WriteFile(test.certLeafPath, []byte("-----BEGIN CERTIFICATE-----"), 0600)
 					assert.NoError(t, certErr)
 
 					defer os.Remove(test.certLeafPath)
 				}
 
 				if test.certChainPath != "" {
-					certErr := ioutil.WriteFile(test.certChainPath, []byte("-----BEGIN CERTIFICATE-----"), 0600)
+					certErr := os.WriteFile(test.certChainPath, []byte("-----BEGIN CERTIFICATE-----"), 0600)
 					assert.NoError(t, certErr)
 
 					defer os.Remove(test.certChainPath)

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -14,7 +14,7 @@ limitations under the License.
 package commands
 
 import (
-	"io/ioutil"
+	"io"
 	"sort"
 	"testing"
 
@@ -241,7 +241,7 @@ func withTestClient(t *testing.T, tFn testFn) {
 	config := &CmdConfig{
 		NS:   "test",
 		Doit: testConfig,
-		Out:  ioutil.Discard,
+		Out:  io.Discard,
 
 		// can stub this out, since the return is dictated by the mocks.
 		initServices: func(c *CmdConfig) error { return nil },

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -15,7 +15,7 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -413,7 +413,7 @@ func extractSSHKeys(keys []string) []godo.DropletCreateSSHKey {
 
 func extractUserData(userData, filename string) (string, error) {
 	if userData == "" && filename != "" {
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		if err != nil {
 			return "", err
 		}

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -15,7 +15,6 @@ package commands
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -163,9 +162,8 @@ coreos:
       command: start
 `
 
-		tmpFile, err := ioutil.TempFile(os.TempDir(), "doctlDropletsTest-*.yml")
+		tmpFile, err := os.CreateTemp(t.TempDir(), "doctlDropletsTest-*.yml")
 		assert.NoError(t, err)
-		defer os.Remove(tmpFile.Name())
 
 		_, err = tmpFile.WriteString(userData)
 		assert.NoError(t, err)

--- a/commands/invoices.go
+++ b/commands/invoices.go
@@ -15,7 +15,7 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/commands/displayers"
@@ -145,7 +145,7 @@ func RunInvoicesGetPDF(c *CmdConfig) error {
 
 	outputFile := getOutputFileArg("pdf", c.Args)
 
-	err = ioutil.WriteFile(outputFile, pdf, 0644)
+	err = os.WriteFile(outputFile, pdf, 0644)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func RunInvoicesGetCSV(c *CmdConfig) error {
 
 	outputFile := getOutputFileArg("csv", c.Args)
 
-	err = ioutil.WriteFile(outputFile, csv, 0644)
+	err = os.WriteFile(outputFile, csv, 0644)
 	if err != nil {
 		return err
 	}

--- a/commands/invoices_test.go
+++ b/commands/invoices_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package commands
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -185,7 +184,7 @@ func TestInvoicesGetPDF(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Assert the file exists
-		result, err := ioutil.ReadFile(fpath)
+		result, err := os.ReadFile(fpath)
 		assert.NoError(t, err)
 		assert.Equal(t, content, result)
 
@@ -208,7 +207,7 @@ func TestInvoicesGetCSV(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Assert the file exists
-		result, err := ioutil.ReadFile(fpath)
+		result, err := os.ReadFile(fpath)
 		assert.NoError(t, err)
 		assert.Equal(t, content, result)
 

--- a/commands/serverless_test.go
+++ b/commands/serverless_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -688,17 +687,12 @@ func TestGetCredentialDirectory(t *testing.T) {
 
 func TestPreserveCredsMovesExistingToStaging(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tmp, err := ioutil.TempDir("", "test-dir")
-		require.NoError(t, err)
-		defer func() {
-			err := os.RemoveAll(tmp)
-			require.NoError(t, err, "error cleaning tmp dir")
-		}()
+		tmp := t.TempDir()
 
 		// Set up "existing" creds in the "sandbox" dir
 		serverlessDir := filepath.Join(tmp, "sandbox")
 		serverlessCredsDir := filepath.Join(serverlessDir, "creds", "d5b388f2")
-		err = os.MkdirAll(serverlessCredsDir, os.FileMode(0755))
+		err := os.MkdirAll(serverlessCredsDir, os.FileMode(0755))
 		require.NoError(t, err)
 		serverlessCreds := filepath.Join(serverlessCredsDir, "credentials.json")
 		creds, err := os.Create(serverlessCreds)
@@ -726,17 +720,12 @@ func TestPreserveCredsMovesLegacyCreds(t *testing.T) {
 			return "a7bbe7e8af7411ec912e47a270a2ee78a7bbe7e8af7411ec912e47a270a2ee78"
 		}
 
-		tmp, err := ioutil.TempDir("", "test-dir")
-		require.NoError(t, err)
-		defer func() {
-			err := os.RemoveAll(tmp)
-			require.NoError(t, err, "error cleaning tmp dir")
-		}()
+		tmp := t.TempDir()
 
 		// Set up "existing" legacy creds in the "sandbox" dir
 		serverlessDir := filepath.Join(tmp, "sandbox")
 		legacyCredsDir := filepath.Join(serverlessDir, ".nimbella")
-		err = os.MkdirAll(legacyCredsDir, os.FileMode(0755))
+		err := os.MkdirAll(legacyCredsDir, os.FileMode(0755))
 		require.NoError(t, err)
 		legacyCreds := filepath.Join(legacyCredsDir, "credentials.json")
 		creds, err := os.Create(legacyCreds)

--- a/commands/sshkeys.go
+++ b/commands/sshkeys.go
@@ -14,7 +14,7 @@ limitations under the License.
 package commands
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/commands/displayers"
@@ -149,7 +149,7 @@ func RunKeyImport(c *CmdConfig) error {
 
 	keyName := c.Args[0]
 
-	keyFile, err := ioutil.ReadFile(keyPath)
+	keyFile, err := os.ReadFile(keyPath)
 	if err != nil {
 		return err
 	}

--- a/commands/sshkeys_test.go
+++ b/commands/sshkeys_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package commands
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -141,7 +140,7 @@ func TestKeysUpdateByFingerprint(t *testing.T) {
 func TestSSHPublicKeyImportWithName(t *testing.T) {
 	pubkey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6eZ8ve0ha04rPRZuoPXK1AQ/h21qslWCzoDcOciXn5OcyafkZw+31k/afaBTeW62D8fXd8e/1xWbFfp/2GqmslYpNCTPrtpNhsE8I0yKjJ8FxX9FfsCOu/Sv83dWgSpiT7pNWVKarZjW9KdKKRQljq1i+H5pX3r5Q9I1v+66mYTe7qsKGas9KWy0vkGoNSqmTCl+d+Y0286chtqBqBjSCUCI8oLKPnJB86Lj344tFGmzDIsJKXMVHTL0dF8n3u6iWN4qiRU+JvkoIkI3v0JvyZXxhR2uPIS1yUAY2GC+2O5mfxydJQzBdtag5Uw8Y7H5yYR1gar/h16bAy5XzRvp testkey"
 	path := filepath.Join(os.TempDir(), "key.pub")
-	err := ioutil.WriteFile(path, []byte(pubkey), 0600)
+	err := os.WriteFile(path, []byte(pubkey), 0600)
 	assert.NoError(t, err)
 	defer os.Remove(path)
 

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -418,7 +417,7 @@ func (s *serverlessService) InstallServerless(leafCredsDir string, upgrading boo
 	// will require an additional copy rather than a simple rename.
 
 	os.Mkdir(filepath.Dir(serverlessDir), 0700) // in case using config dir and it doesn't exist yet
-	tmp, err := ioutil.TempDir(filepath.Dir(serverlessDir), "sbx-install")
+	tmp, err := os.MkdirTemp(filepath.Dir(serverlessDir), "sbx-install")
 	if err != nil {
 		return err
 	}
@@ -1162,7 +1161,7 @@ func readTopLevel(project *ServerlessProject) error {
 		Config   = "project.yml"
 		Packages = "packages"
 	)
-	files, err := ioutil.ReadDir(project.ProjectPath)
+	files, err := os.ReadDir(project.ProjectPath)
 	if err != nil {
 		return err
 	}
@@ -1185,7 +1184,7 @@ func readTopLevel(project *ServerlessProject) error {
 func readProjectConfig(configPath string) (*ServerlessSpec, error) {
 	spec := ServerlessSpec{}
 	// reading config file content
-	content, err := ioutil.ReadFile(configPath)
+	content, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1300,7 +1299,7 @@ func serverlessUptodate(serverlessDir string) bool {
 // Otherwise, returns the version string stored in the serverless directory.
 func GetCurrentServerlessVersion(serverlessDir string) string {
 	versionFile := filepath.Join(serverlessDir, "version")
-	contents, err := ioutil.ReadFile(versionFile)
+	contents, err := os.ReadFile(versionFile)
 	if err != nil {
 		return "0"
 	}

--- a/integration/apps_test.go
+++ b/integration/apps_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -249,12 +248,9 @@ var _ = suite("apps/create", func(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it("creates an app", func() {
-		specFile, err := ioutil.TempFile("", "spec")
+		specFile, err := os.CreateTemp(t.TempDir(), "spec")
 		require.NoError(t, err)
-		defer func() {
-			os.Remove(specFile.Name())
-			specFile.Close()
-		}()
+		defer specFile.Close()
 
 		err = json.NewEncoder(specFile).Encode(&testAppSpec)
 		require.NoError(t, err)
@@ -276,12 +272,10 @@ var _ = suite("apps/create", func(t *testing.T, when spec.G, it spec.S) {
 	})
 	when("the wait flag is passed", func() {
 		it("creates an app and polls for status", func() {
-			specFile, err := ioutil.TempFile("", "spec")
+			specFile, err := os.CreateTemp(t.TempDir(), "spec")
 			require.NoError(t, err)
-			defer func() {
-				os.Remove(specFile.Name())
-				specFile.Close()
-			}()
+			defer specFile.Close()
+
 			err = json.NewEncoder(specFile).Encode(&testAppSpec)
 			require.NoError(t, err)
 			cmd := exec.Command(builtBinaryPath,
@@ -301,12 +295,10 @@ var _ = suite("apps/create", func(t *testing.T, when spec.G, it spec.S) {
 	})
 	when("the upsert flag is passed", func() {
 		it("creates an app or updates if already exists", func() {
-			specFile, err := ioutil.TempFile("", "spec")
+			specFile, err := os.CreateTemp(t.TempDir(), "spec")
 			require.NoError(t, err)
-			defer func() {
-				os.Remove(specFile.Name())
-				specFile.Close()
-			}()
+			defer specFile.Close()
+
 			err = json.NewEncoder(specFile).Encode(&testAppSpec)
 			require.NoError(t, err)
 			cmd := exec.Command(builtBinaryPath,
@@ -400,12 +392,9 @@ var _ = suite("apps/create-upsert", func(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it("uses upsert to update existing app", func() {
-		specFile, err := ioutil.TempFile("", "spec")
+		specFile, err := os.CreateTemp(t.TempDir(), "spec")
 		require.NoError(t, err)
-		defer func() {
-			os.Remove(specFile.Name())
-			specFile.Close()
-		}()
+		defer specFile.Close()
 
 		err = json.NewEncoder(specFile).Encode(&testAppSpec)
 		require.NoError(t, err)
@@ -611,12 +600,9 @@ var _ = suite("apps/update", func(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it("updates an app", func() {
-		specFile, err := ioutil.TempFile("", "spec")
+		specFile, err := os.CreateTemp(t.TempDir(), "spec")
 		require.NoError(t, err)
-		defer func() {
-			os.Remove(specFile.Name())
-			specFile.Close()
-		}()
+		defer specFile.Close()
 
 		err = json.NewEncoder(specFile).Encode(&testAppSpec)
 		require.NoError(t, err)
@@ -639,12 +625,10 @@ var _ = suite("apps/update", func(t *testing.T, when spec.G, it spec.S) {
 	})
 	when("the wait flag is passed", func() {
 		it("updates an app and polls for status", func() {
-			specFile, err := ioutil.TempFile("", "spec")
+			specFile, err := os.CreateTemp(t.TempDir(), "spec")
 			require.NoError(t, err)
-			defer func() {
-				os.Remove(specFile.Name())
-				specFile.Close()
-			}()
+			defer specFile.Close()
+
 			err = json.NewEncoder(specFile).Encode(&testAppSpec)
 			require.NoError(t, err)
 			cmd := exec.Command(builtBinaryPath,

--- a/integration/auth_remove_context_test.go
+++ b/integration/auth_remove_context_test.go
@@ -4,7 +4,7 @@
 package integration
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -32,7 +32,7 @@ auth-contexts:
 context: default
 `)
 
-		expect.NoError(ioutil.WriteFile(testConfig, testConfigBytes, 0644))
+		expect.NoError(os.WriteFile(testConfig, testConfigBytes, 0644))
 
 	})
 
@@ -65,7 +65,7 @@ context: default
 			_, err := cmd.CombinedOutput()
 			expect.NoError(err)
 
-			fileBytes, err := ioutil.ReadFile(testConfig)
+			fileBytes, err := os.ReadFile(testConfig)
 			expect.NoError(err)
 			expect.NotContains(string(fileBytes), "first-token")
 		})
@@ -85,7 +85,7 @@ context: default
 			_, err := cmd.CombinedOutput()
 			expect.NoError(err)
 
-			fileBytes, err := ioutil.ReadFile(testConfig)
+			fileBytes, err := os.ReadFile(testConfig)
 			expect.NoError(err)
 			expect.NotContains(string(fileBytes), "second-token")
 		})

--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -101,7 +100,7 @@ var _ = suite("auth/init", func(t *testing.T, when spec.G, it spec.S) {
 			expect.Contains(buf.String(), "Validating token...")
 			expect.Contains(buf.String(), "✔")
 
-			fileBytes, err := ioutil.ReadFile(testConfig)
+			fileBytes, err := os.ReadFile(testConfig)
 			expect.NoError(err)
 
 			expect.Contains(string(fileBytes), "access-token: some-magic-token-that-is-64-characters-long-1a1a1a1a1a11a1a1a1a1")
@@ -126,7 +125,7 @@ var _ = suite("auth/init", func(t *testing.T, when spec.G, it spec.S) {
 			_, err := cmd.CombinedOutput()
 			expect.NoError(err)
 
-			fileBytes, err := ioutil.ReadFile(testConfig)
+			fileBytes, err := os.ReadFile(testConfig)
 			expect.NoError(err)
 
 			expect.Contains(string(fileBytes), "access-token: some-magic-token")
@@ -139,7 +138,7 @@ context: default
 
 			tmpDir := t.TempDir()
 			testConfig := filepath.Join(tmpDir, "test-config.yml")
-			expect.NoError(ioutil.WriteFile(testConfig, testConfigBytes, 0644))
+			expect.NoError(os.WriteFile(testConfig, testConfigBytes, 0644))
 
 			cmd := exec.Command(builtBinaryPath,
 				"-u", server.URL,
@@ -153,7 +152,7 @@ context: default
 			_, err := cmd.CombinedOutput()
 			expect.NoError(err)
 
-			fileBytes, err := ioutil.ReadFile(testConfig)
+			fileBytes, err := os.ReadFile(testConfig)
 			expect.NoError(err)
 
 			expect.Contains(string(fileBytes), "access-token: some-magic-token")
@@ -195,7 +194,7 @@ context: default
 			location, err := getDefaultConfigLocation()
 			expect.NoError(err)
 
-			fileBytes, err := ioutil.ReadFile(location)
+			fileBytes, err := os.ReadFile(location)
 			expect.NoError(err)
 
 			expect.Contains(string(fileBytes), "access-token: some-magic-token-that-is-64-characters-long-1a1a1a1a1a11a1a1a1a1")
@@ -257,7 +256,7 @@ context: default
 
 			tmpDir := t.TempDir()
 			testConfig := filepath.Join(tmpDir, "test-config.yml")
-			expect.NoError(ioutil.WriteFile(testConfig, testConfigBytes, 0644))
+			expect.NoError(os.WriteFile(testConfig, testConfigBytes, 0644))
 
 			cmd := exec.Command(builtBinaryPath,
 				"-u", server.URL,
@@ -270,7 +269,7 @@ context: default
 			_, err := cmd.CombinedOutput()
 			expect.NoError(err)
 
-			fileBytes, err := ioutil.ReadFile(testConfig)
+			fileBytes, err := os.ReadFile(testConfig)
 			expect.NoError(err)
 			expect.Contains(string(fileBytes), "context: next")
 
@@ -302,7 +301,7 @@ context: default
 
 			tmpDir := t.TempDir()
 			testConfig := filepath.Join(tmpDir, "test-config.yml")
-			expect.NoError(ioutil.WriteFile(testConfig, testConfigBytes, 0644))
+			expect.NoError(os.WriteFile(testConfig, testConfigBytes, 0644))
 
 			cmd := exec.Command(builtBinaryPath,
 				"-u", server.URL,
@@ -313,7 +312,7 @@ context: default
 			_, err := cmd.CombinedOutput()
 			expect.NoError(err)
 
-			fileBytes, err := ioutil.ReadFile(testConfig)
+			fileBytes, err := os.ReadFile(testConfig)
 			expect.NoError(err)
 			expect.Contains(string(fileBytes), "test@example.com: second-token")
 
@@ -332,7 +331,7 @@ context: default
 
 			tmpDir := t.TempDir()
 			testConfig := filepath.Join(tmpDir, "test-config.yml")
-			expect.NoError(ioutil.WriteFile(testConfig, testConfigBytes, 0644))
+			expect.NoError(os.WriteFile(testConfig, testConfigBytes, 0644))
 
 			cmd := exec.Command(builtBinaryPath,
 				"-u", server.URL,

--- a/integration/cdn_create_test.go
+++ b/integration/cdn_create_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -40,7 +40,7 @@ var _ = suite("compute/cdn/create", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := struct {

--- a/integration/cdn_flush_test.go
+++ b/integration/cdn_flush_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -37,7 +37,7 @@ var _ = suite("compute/cdn/flush", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := struct {

--- a/integration/cdn_update_test.go
+++ b/integration/cdn_update_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -38,7 +38,7 @@ var _ = suite("compute/cdn/update", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				requestBodies = append(requestBodies, string(reqBody))

--- a/integration/certificate_create_test.go
+++ b/integration/certificate_create_test.go
@@ -2,10 +2,11 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -38,7 +39,7 @@ var _ = suite("compute/certificate/create", func(t *testing.T, when spec.G, it s
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				matchedRequest := certCustomCreateJSONReq
@@ -85,7 +86,7 @@ var _ = suite("compute/certificate/create", func(t *testing.T, when spec.G, it s
 			dir := t.TempDir()
 
 			for _, f := range testFiles {
-				err := ioutil.WriteFile(filepath.Join(dir, f), []byte(f), 0600)
+				err := os.WriteFile(filepath.Join(dir, f), []byte(f), 0600)
 				expect.NoError(err)
 			}
 

--- a/integration/compute_droplet_action_test.go
+++ b/integration/compute_droplet_action_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -72,7 +72,7 @@ var _ = suite("compute/droplet-action", func(t *testing.T, when spec.G, it spec.
 			}
 
 			if matchRequest.body != "{}" {
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(matchRequest.body, string(reqBody))

--- a/integration/compute_floating_ip_action_test.go
+++ b/integration/compute_floating_ip_action_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -50,7 +50,7 @@ var _ = suite("compute/floating-ip-action", func(t *testing.T, when spec.G, it s
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(`{"type":"unassign"}`, string(reqBody))
@@ -68,7 +68,7 @@ var _ = suite("compute/floating-ip-action", func(t *testing.T, when spec.G, it s
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(`{"droplet_id":1414,"type":"assign"}`, string(reqBody))

--- a/integration/compute_image_action_test.go
+++ b/integration/compute_image_action_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -50,7 +50,7 @@ var _ = suite("compute/image-action", func(t *testing.T, when spec.G, it spec.S)
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(`{"region":"saturn","type":"transfer"}`, string(reqBody))

--- a/integration/compute_reserved_ip_action_test.go
+++ b/integration/compute_reserved_ip_action_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -50,7 +50,7 @@ var _ = suite("compute/reserved-ip-action", func(t *testing.T, when spec.G, it s
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(`{"type":"unassign"}`, string(reqBody))
@@ -68,7 +68,7 @@ var _ = suite("compute/reserved-ip-action", func(t *testing.T, when spec.G, it s
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(`{"droplet_id":1414,"type":"assign"}`, string(reqBody))

--- a/integration/compute_volume_action_test.go
+++ b/integration/compute_volume_action_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -37,7 +37,7 @@ var _ = suite("compute/volume-action", func(t *testing.T, when spec.G, it spec.S
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(`{"region":"moonbase","size_gigabytes":100,"type":"resize"}`, string(reqBody))
@@ -55,7 +55,7 @@ var _ = suite("compute/volume-action", func(t *testing.T, when spec.G, it spec.S
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(`{"droplet_id":11,"type":"attach"}`, string(reqBody))
@@ -73,7 +73,7 @@ var _ = suite("compute/volume-action", func(t *testing.T, when spec.G, it spec.S
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(`{"droplet_id":14,"type":"detach"}`, string(reqBody))

--- a/integration/database_create_fork_test.go
+++ b/integration/database_create_fork_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -40,7 +40,7 @@ var _ = suite("database/create/fork", func(t *testing.T, when spec.G, it spec.S)
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := struct {

--- a/integration/database_create_restore_from_cluster.go
+++ b/integration/database_create_restore_from_cluster.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -40,7 +40,7 @@ var _ = suite("database/create/backup-restore", func(t *testing.T, when spec.G, 
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := struct {

--- a/integration/database_create_test.go
+++ b/integration/database_create_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -42,7 +42,7 @@ var _ = suite("database/create", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := struct {

--- a/integration/database_firewall_update_test.go
+++ b/integration/database_firewall_update_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -30,7 +30,7 @@ var _ = suite("database/firewalls", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 				if req.Method == http.MethodPut {
-					reqBody, err := ioutil.ReadAll(req.Body)
+					reqBody, err := io.ReadAll(req.Body)
 					expect.NoError(err)
 					t.Log(string(reqBody))
 					t.Log(databasesUpdateFirewallUpdateRequest)

--- a/integration/database_sql_mode_test.go
+++ b/integration/database_sql_mode_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -38,7 +38,7 @@ var _ = suite("database/sql-mode/set", func(t *testing.T, when spec.G, it spec.S
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(databaseGetSQLModeRequest, string(reqBody))

--- a/integration/database_user_create_test.go
+++ b/integration/database_user_create_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -39,7 +39,7 @@ var _ = suite("database/user/create", func(t *testing.T, when spec.G, it spec.S)
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := struct {

--- a/integration/domain_create_test.go
+++ b/integration/domain_create_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -38,7 +38,7 @@ var _ = suite("compute/domain/create", func(t *testing.T, when spec.G, it spec.S
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(domainCreateRequest, string(reqBody))

--- a/integration/domain_records_create_test.go
+++ b/integration/domain_records_create_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -37,7 +37,7 @@ var _ = suite("compute/domain/records/create", func(t *testing.T, when spec.G, i
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 				expect.JSONEq(domainRecordsCreateRequest, string(reqBody))
 
@@ -55,7 +55,7 @@ var _ = suite("compute/domain/records/create", func(t *testing.T, when spec.G, i
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 				expect.JSONEq(domainRecordsCreateWithoutPortRequest, string(reqBody))
 

--- a/integration/domain_records_delete_test.go
+++ b/integration/domain_records_delete_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -37,7 +37,7 @@ var _ = suite("compute/domain/records/delete", func(t *testing.T, when spec.G, i
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 				expect.Empty(string(reqBody))
 
@@ -55,7 +55,7 @@ var _ = suite("compute/domain/records/delete", func(t *testing.T, when spec.G, i
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 				expect.Empty(string(reqBody))
 

--- a/integration/domain_records_update_test.go
+++ b/integration/domain_records_update_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -37,7 +37,7 @@ var _ = suite("compute/domain/records/update", func(t *testing.T, when spec.G, i
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(domainRecordUpdateNameRequest, string(reqBody))

--- a/integration/droplet_create_test.go
+++ b/integration/droplet_create_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -44,7 +44,7 @@ var _ = suite("compute/droplet/create", func(t *testing.T, when spec.G, it spec.
 				}
 
 				var err error
-				reqBody, err = ioutil.ReadAll(req.Body)
+				reqBody, err = io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				var dr dropletRequest

--- a/integration/droplet_get_test.go
+++ b/integration/droplet_get_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -30,7 +29,7 @@ var _ = suite("compute/droplet/get", func(t *testing.T, when spec.G, it spec.S) 
 
 		configPath = filepath.Join(dir, "config.yaml")
 
-		err := ioutil.WriteFile(configPath, []byte(dropletGetConfig), 0644)
+		err := os.WriteFile(configPath, []byte(dropletGetConfig), 0644)
 		expect.NoError(err)
 
 		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/integration/droplet_neighbors_test.go
+++ b/integration/droplet_neighbors_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -30,7 +29,7 @@ var _ = suite("compute/droplet/neighbors", func(t *testing.T, when spec.G, it sp
 
 		configPath = filepath.Join(dir, "config.yaml")
 
-		err := ioutil.WriteFile(configPath, []byte(dropletNeighborsConfig), 0644)
+		err := os.WriteFile(configPath, []byte(dropletNeighborsConfig), 0644)
 		expect.NoError(err)
 
 		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/integration/droplet_tag_test.go
+++ b/integration/droplet_tag_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -48,7 +48,7 @@ var _ = suite("compute/droplet/tag", func(t *testing.T, when spec.G, it spec.S) 
 
 				w.Write([]byte(`{"droplets":[{"name":"some-droplet-name", "id": 1337}]}`))
 			case "/v2/tags/my-tag/resources":
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				var tagRequest tagRequest

--- a/integration/firewall_create_test.go
+++ b/integration/firewall_create_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -37,7 +37,7 @@ var _ = suite("compute/firewall/create", func(t *testing.T, when spec.G, it spec
 					return
 				}
 
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 				expect.JSONEq(firewallCreateRequestBody, string(body))
 

--- a/integration/firewall_update_test.go
+++ b/integration/firewall_update_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -37,7 +37,7 @@ var _ = suite("compute/firewall/update", func(t *testing.T, when spec.G, it spec
 					return
 				}
 
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 				expect.JSONEq(firewallUpdateRequestBody, string(body))
 

--- a/integration/floating_ip_create_test.go
+++ b/integration/floating_ip_create_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -38,7 +38,7 @@ var _ = suite("compute/floating-ip/create", func(t *testing.T, when spec.G, it s
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				responseJSON := floatingIPCreateResponse

--- a/integration/image_list_test.go
+++ b/integration/image_list_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -133,12 +133,12 @@ var _ = suite("compute/image/list", func(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal(err)
 			}
 
-			stdoutString, err := ioutil.ReadAll(stdout)
+			stdoutString, err := io.ReadAll(stdout)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			stderrString, err := ioutil.ReadAll(stderr)
+			stderrString, err := io.ReadAll(stderr)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/integration/image_update_test.go
+++ b/integration/image_update_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -37,7 +37,7 @@ var _ = suite("compute/image/update", func(t *testing.T, when spec.G, it spec.S)
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(imageUpdateRequest, string(reqBody))

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -30,7 +29,7 @@ func TestRun(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	tmpDir, err := ioutil.TempDir("", "integration-doctl")
+	tmpDir, err := os.MkdirTemp("", "integration-doctl")
 	if err != nil {
 		panic("failed to create temp dir")
 	}
@@ -56,7 +55,7 @@ func TestMain(m *testing.M) {
 
 	var contents []byte
 	if _, err := os.Stat(location); !os.IsNotExist(err) {
-		contents, err = ioutil.ReadFile(location)
+		contents, err = os.ReadFile(location)
 		if err != nil {
 			panic("failed to copy config")
 		}
@@ -70,7 +69,7 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	if len(contents) != 0 {
-		err = ioutil.WriteFile(location, contents, 0644)
+		err = os.WriteFile(location, contents, 0644)
 		if err != nil {
 			panic("failed to restore contents of config")
 		}

--- a/integration/invoice_csv_test.go
+++ b/integration/invoice_csv_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -59,7 +58,7 @@ var _ = suite("invoices/csv", func(t *testing.T, when spec.G, it spec.S) {
 		expect.NoError(err, fmt.Sprintf("received error output: %s", output))
 		expect.Equal(strings.TrimSpace(invoiceCSVOutput), strings.TrimSpace(string(output)))
 
-		result, err := ioutil.ReadFile(fpath)
+		result, err := os.ReadFile(fpath)
 		expect.NoError(err)
 		expect.Equal([]byte(invoiceCSVResponse), result)
 

--- a/integration/invoice_pdf_test.go
+++ b/integration/invoice_pdf_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -59,7 +58,7 @@ var _ = suite("invoices/pdf", func(t *testing.T, when spec.G, it spec.S) {
 		expect.NoError(err, fmt.Sprintf("received error output: %s", output))
 		expect.Equal(strings.TrimSpace(invoicePDFOutput), strings.TrimSpace(string(output)))
 
-		result, err := ioutil.ReadFile(fpath)
+		result, err := os.ReadFile(fpath)
 		expect.NoError(err)
 		expect.Equal([]byte(invoicePDFResponse), result)
 

--- a/integration/kubernetes_clusters_create_test.go
+++ b/integration/kubernetes_clusters_create_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -44,7 +44,7 @@ var _ = suite("kubernetes/clusters/create", func(t *testing.T, when spec.G, it s
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
 				}
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				matchedRequest := kubeClustersCreateJSONReq
@@ -89,12 +89,11 @@ var _ = suite("kubernetes/clusters/create", func(t *testing.T, when spec.G, it s
 
 	when("not using node-pool", func() {
 		it("creates a kube cluster with defaults", func() {
-			f, err := ioutil.TempFile("", "fake-kube-config")
+			f, err := os.CreateTemp(t.TempDir(), "fake-kube-config")
 			expect.NoError(err)
 
 			err = f.Close()
 			expect.NoError(err)
-			defer os.Remove(f.Name())
 
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
@@ -121,12 +120,11 @@ var _ = suite("kubernetes/clusters/create", func(t *testing.T, when spec.G, it s
 
 	when("using node-pool", func() {
 		it("creates a kube cluster with the node-pool", func() {
-			f, err := ioutil.TempFile("", "fake-kube-config")
+			f, err := os.CreateTemp(t.TempDir(), "fake-kube-config")
 			expect.NoError(err)
 
 			err = f.Close()
 			expect.NoError(err)
-			defer os.Remove(f.Name())
 
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
@@ -151,12 +149,11 @@ var _ = suite("kubernetes/clusters/create", func(t *testing.T, when spec.G, it s
 
 		when("specifying size as well", func() {
 			it("returns an error", func() {
-				f, err := ioutil.TempFile("", "fake-kube-config")
+				f, err := os.CreateTemp(t.TempDir(), "fake-kube-config")
 				expect.NoError(err)
 
 				err = f.Close()
 				expect.NoError(err)
-				defer os.Remove(f.Name())
 
 				cmd := exec.Command(builtBinaryPath,
 					"-t", "some-magic-token",

--- a/integration/kubernetes_clusters_kubeconfig_save_test.go
+++ b/integration/kubernetes_clusters_kubeconfig_save_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -57,10 +57,8 @@ var _ = suite("kubernetes/clusters/kubeconfig/save", func(t *testing.T, when spe
 
 	when("passing defaults", func() {
 		it("creates a kubeconfig using exec-credentials", func() {
-			f, err := ioutil.TempFile("", "fake-kube-config")
+			f, err := os.CreateTemp(t.TempDir(), "fake-kube-config")
 			expect.NoError(err)
-
-			defer os.Remove(f.Name())
 
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
@@ -79,7 +77,7 @@ var _ = suite("kubernetes/clusters/kubeconfig/save", func(t *testing.T, when spe
 			output, err := cmd.CombinedOutput()
 			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
 
-			fileBytes, err := ioutil.ReadAll(f)
+			fileBytes, err := io.ReadAll(f)
 			expect.NoError(err)
 			err = f.Close()
 			expect.NoError(err)
@@ -89,10 +87,8 @@ var _ = suite("kubernetes/clusters/kubeconfig/save", func(t *testing.T, when spe
 
 	when("passing expiry-seconds", func() {
 		it("creates a kubeconfig using a token", func() {
-			f, err := ioutil.TempFile("", "fake-kube-config")
+			f, err := os.CreateTemp(t.TempDir(), "fake-kube-config")
 			expect.NoError(err)
-
-			defer os.Remove(f.Name())
 
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
@@ -112,7 +108,7 @@ var _ = suite("kubernetes/clusters/kubeconfig/save", func(t *testing.T, when spe
 			output, err := cmd.CombinedOutput()
 			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
 
-			fileBytes, err := ioutil.ReadAll(f)
+			fileBytes, err := io.ReadAll(f)
 			expect.NoError(err)
 			err = f.Close()
 			expect.NoError(err)
@@ -121,10 +117,8 @@ var _ = suite("kubernetes/clusters/kubeconfig/save", func(t *testing.T, when spe
 	})
 	when("passing alias", func() {
 		it("creates an alias for a config", func() {
-			f, err := ioutil.TempFile("", "fake-kube-config")
+			f, err := os.CreateTemp(t.TempDir(), "fake-kube-config")
 			expect.NoError(err)
-
-			defer os.Remove(f.Name())
 
 			cmd := exec.Command(builtBinaryPath,
 				"-t", "some-magic-token",
@@ -145,7 +139,7 @@ var _ = suite("kubernetes/clusters/kubeconfig/save", func(t *testing.T, when spe
 
 			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
 
-			fileBytes, err := ioutil.ReadAll(f)
+			fileBytes, err := io.ReadAll(f)
 			expect.NoError(err)
 			err = f.Close()
 			expect.NoError(err)

--- a/integration/lb_add_droplets_test.go
+++ b/integration/lb_add_droplets_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -36,7 +36,7 @@ var _ = suite("compute/load-balancer/add-droplets", func(t *testing.T, when spec
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(lbAddDropletsRequest, string(reqBody))

--- a/integration/lb_add_forwarding_rules_test.go
+++ b/integration/lb_add_forwarding_rules_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -36,7 +36,7 @@ var _ = suite("compute/load-balancer/add-forwarding-rules", func(t *testing.T, w
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(lbAddForwardingRulesRequest, string(reqBody))

--- a/integration/lb_create_test.go
+++ b/integration/lb_create_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -40,7 +40,7 @@ var _ = suite("compute/load-balancer/create", func(t *testing.T, when spec.G, it
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(lbCreateRequest, string(reqBody))

--- a/integration/lb_remove_droplets_test.go
+++ b/integration/lb_remove_droplets_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -36,7 +36,7 @@ var _ = suite("compute/load-balancer/remove-droplets", func(t *testing.T, when s
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(lbRemoveDropletsRequest, string(reqBody))

--- a/integration/lb_remove_forwarding_rules_test.go
+++ b/integration/lb_remove_forwarding_rules_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -36,7 +36,7 @@ var _ = suite("compute/load-balancer/remove-forwarding-rules", func(t *testing.T
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(lbRemoveForwardingRulesRequest, string(reqBody))

--- a/integration/lb_update_test.go
+++ b/integration/lb_update_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -39,7 +39,7 @@ var _ = suite("compute/load-balancer/update", func(t *testing.T, when spec.G, it
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(lbUpdateRequest, string(reqBody))

--- a/integration/projects_create_test.go
+++ b/integration/projects_create_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -40,7 +40,7 @@ var _ = suite("projects/create", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := struct {

--- a/integration/projects_resources_assign_test.go
+++ b/integration/projects_resources_assign_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -38,7 +38,7 @@ var _ = suite("projects/resources/assign", func(t *testing.T, when spec.G, it sp
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := struct {

--- a/integration/projects_update_test.go
+++ b/integration/projects_update_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -40,7 +40,7 @@ var _ = suite("projects/update", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := struct {

--- a/integration/registry_create_test.go
+++ b/integration/registry_create_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -42,7 +42,7 @@ var _ = suite("registry/create", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				var expectedJSON string

--- a/integration/registry_garbagecollection_test.go
+++ b/integration/registry_garbagecollection_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"encoding/json"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -126,7 +126,7 @@ var _ = suite("registry/garbage-collection", func(t *testing.T, when spec.G, it 
 			case "/v2/registry/" + validRegistryName + "/garbage-collection/" + validGCUUID:
 				switch req.Method {
 				case http.MethodPut:
-					reqBody, err := ioutil.ReadAll(req.Body)
+					reqBody, err := io.ReadAll(req.Body)
 					expect.NoError(err)
 
 					expectJSON := &strings.Builder{}

--- a/integration/registry_login_test.go
+++ b/integration/registry_login_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -89,7 +88,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 			output, err := cmd.CombinedOutput()
 			expect.NoError(err)
 
-			fileBytes, err := ioutil.ReadFile(config)
+			fileBytes, err := os.ReadFile(config)
 			expect.NoError(err)
 
 			var dc dockerConfig
@@ -123,7 +122,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 			output, err := cmd.CombinedOutput()
 			expect.NoError(err)
 
-			fileBytes, err := ioutil.ReadFile(config)
+			fileBytes, err := os.ReadFile(config)
 			expect.NoError(err)
 
 			var dc dockerConfig
@@ -159,7 +158,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 			output, err := cmd.CombinedOutput()
 			expect.NoError(err)
 
-			fileBytes, err := ioutil.ReadFile(config)
+			fileBytes, err := os.ReadFile(config)
 			expect.NoError(err)
 
 			var dc dockerConfig

--- a/integration/registry_logout_test.go
+++ b/integration/registry_logout_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -64,7 +63,7 @@ var _ = suite("registry/logout", func(t *testing.T, when spec.G, it spec.S) {
 		tmpDir := t.TempDir()
 
 		config := filepath.Join(tmpDir, "config.json")
-		err := ioutil.WriteFile(config, []byte(registryDockerCredentialsResponse), 0600)
+		err := os.WriteFile(config, []byte(registryDockerCredentialsResponse), 0600)
 		expect.NoError(err)
 
 		cmd := exec.Command(builtBinaryPath,
@@ -80,7 +79,7 @@ var _ = suite("registry/logout", func(t *testing.T, when spec.G, it spec.S) {
 		output, err := cmd.CombinedOutput()
 		expect.NoError(err, string(output))
 
-		fileBytes, err := ioutil.ReadFile(config)
+		fileBytes, err := os.ReadFile(config)
 		expect.NoError(err)
 
 		expect.Equal("Removing login credentials for registry.digitalocean.com\n", string(output))

--- a/integration/reserved_ip_create_test.go
+++ b/integration/reserved_ip_create_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -38,7 +38,7 @@ var _ = suite("compute/reserved-ip/create", func(t *testing.T, when spec.G, it s
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				responseJSON := reservedIPCreateResponse

--- a/integration/tags_apply_test.go
+++ b/integration/tags_apply_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -58,7 +58,7 @@ var _ = suite("compute/tags/apply", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := godo.TagResourcesRequest{}
@@ -80,7 +80,7 @@ var _ = suite("compute/tags/apply", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := godo.TagResourcesRequest{}

--- a/integration/tags_delete_test.go
+++ b/integration/tags_delete_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -37,7 +37,7 @@ var _ = suite("compute/tags/delete", func(t *testing.T, when spec.G, it spec.S) 
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 				expect.Empty(string(reqBody))
 
@@ -55,7 +55,7 @@ var _ = suite("compute/tags/delete", func(t *testing.T, when spec.G, it spec.S) 
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 				expect.Empty(string(reqBody))
 

--- a/integration/tags_remove_test.go
+++ b/integration/tags_remove_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -58,7 +58,7 @@ var _ = suite("compute/tags/remove", func(t *testing.T, when spec.G, it spec.S) 
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := godo.UntagResourcesRequest{}
@@ -80,7 +80,7 @@ var _ = suite("compute/tags/remove", func(t *testing.T, when spec.G, it spec.S) 
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := godo.UntagResourcesRequest{}

--- a/integration/volume_create_test.go
+++ b/integration/volume_create_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -38,7 +38,7 @@ var _ = suite("compute/volume/create", func(t *testing.T, when spec.G, it spec.S
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(volumeCreateRequest, string(reqBody))

--- a/integration/volume_snapshot_test.go
+++ b/integration/volume_snapshot_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -42,7 +42,7 @@ var _ = suite("compute/volume/snapshot", func(t *testing.T, when spec.G, it spec
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				expect.JSONEq(volumeSnapshotRequest, string(reqBody))

--- a/integration/vpc_create_test.go
+++ b/integration/vpc_create_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -40,7 +40,7 @@ var _ = suite("vpcs/create", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := struct {

--- a/integration/vpc_update_test.go
+++ b/integration/vpc_update_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -40,7 +40,7 @@ var _ = suite("vpcs/update", func(t *testing.T, when spec.G, it spec.S) {
 					return
 				}
 
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				expect.NoError(err)
 
 				request := struct {

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/digitalocean/godo"
@@ -28,7 +27,7 @@ func ReadAppSpec(stdin io.Reader, path string) (*godo.AppSpec, error) {
 		spec = specFile
 	}
 
-	byt, err := ioutil.ReadAll(spec)
+	byt, err := io.ReadAll(spec)
 	if err != nil {
 		return nil, fmt.Errorf("reading app spec: %w", err)
 	}

--- a/internal/apps/apps_test.go
+++ b/internal/apps/apps_test.go
@@ -3,7 +3,7 @@ package apps
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/digitalocean/godo"
@@ -160,7 +160,7 @@ var validAppSpec = &godo.AppSpec{
 func testTempFile(t *testing.T, data []byte) string {
 	t.Helper()
 	file := t.TempDir() + "/file"
-	err := ioutil.WriteFile(file, data, 0644)
+	err := os.WriteFile(file, data, 0644)
 	require.NoError(t, err, "writing temp file")
 	return file
 }

--- a/internal/apps/builder/cnb_test.go
+++ b/internal/apps/builder/cnb_test.go
@@ -5,8 +5,8 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -25,7 +25,7 @@ import (
 func TestCNBComponentBuild(t *testing.T) {
 	ctx := context.Background()
 	dockerSocketPath = filepath.Join(t.TempDir(), "docker.sock")
-	require.NoError(t, ioutil.WriteFile(dockerSocketPath, nil, 0644))
+	require.NoError(t, os.WriteFile(dockerSocketPath, nil, 0644))
 
 	t.Run("no component", func(t *testing.T) {
 		builder := &CNBComponentBuilder{}
@@ -386,7 +386,7 @@ func TestCNBComponentBuild(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			nginxConf, err := ioutil.ReadAll(nginxConfR)
+			nginxConf, err := io.ReadAll(nginxConfR)
 			require.NoError(t, err)
 			require.Equal(t, `
 server {
@@ -425,7 +425,7 @@ server {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			dockerfile, err := ioutil.ReadAll(dockerfileR)
+			dockerfile, err := io.ReadAll(dockerfileR)
 			require.NoError(t, err)
 			require.Equal(t, `
 ARG nginx_image

--- a/internal/apps/builder/docker.go
+++ b/internal/apps/builder/docker.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -173,7 +172,7 @@ func (b *DockerComponentBuilder) buildStaticSiteImage(ctx context.Context) error
 
 	lw := b.getLogWriter()
 	template.Render(lw, `{{success checkmark}} building static site image with built assets from {{highlight .}}{{nl 2}}`, c.GetOutputDir())
-	tmpDir, err := ioutil.TempDir("", "static-*")
+	tmpDir, err := os.MkdirTemp("", "static-*")
 	if err != nil {
 		return fmt.Errorf("creating temporary build directory: %w", err)
 	}

--- a/internal/apps/builder/docker_test.go
+++ b/internal/apps/builder/docker_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -171,7 +170,7 @@ func TestDockerComponentBuild(t *testing.T) {
 			},
 			NoCache: true,
 		}).Return(types.ImageBuildResponse{
-			Body: ioutil.NopCloser(strings.NewReader("")),
+			Body: io.NopCloser(strings.NewReader("")),
 		}, nil)
 
 		_, err := builder.Build(ctx)
@@ -211,7 +210,7 @@ func TestDockerComponentBuild(t *testing.T) {
 		err := os.Mkdir(filepath.Join(contextDir, "subdir"), 0775)
 		require.NoError(t, err)
 		// Dockerfile is outside of source_dir
-		err = ioutil.WriteFile(filepath.Join(contextDir, "Dockerfile"), []byte("FROM scratch"), 0664)
+		err = os.WriteFile(filepath.Join(contextDir, "Dockerfile"), []byte("FROM scratch"), 0664)
 		require.NoError(t, err)
 
 		builder := &DockerComponentBuilder{
@@ -394,7 +393,7 @@ func assertArchiveContents(t *testing.T, archive io.Reader, tcs map[string]func(
 			t.Fatalf("unexpected file %s", name)
 		}
 
-		content, err := ioutil.ReadAll(r)
+		content, err := io.ReadAll(r)
 		require.NoError(t, err, "reading %s", name)
 
 		filesFound[name] = struct{}{}

--- a/internal/apps/config/appdev.go
+++ b/internal/apps/config/appdev.go
@@ -3,7 +3,6 @@ package config
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"time"
@@ -85,7 +84,7 @@ func ensureStringInFile(file string, val string) error {
 		return err
 	}
 
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/internal/apps/workspace/workspace.go
+++ b/internal/apps/workspace/workspace.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -350,7 +349,7 @@ func ensureStringInFile(file string, val string) error {
 		return err
 	}
 
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/internal/apps/workspace/workspace_test.go
+++ b/internal/apps/workspace/workspace_test.go
@@ -1,7 +1,6 @@
 package workspace
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -55,7 +54,7 @@ func Test_ensureStringInFile(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			file, err := ioutil.TempFile("", "dev-config.*.yaml")
+			file, err := os.CreateTemp("", "dev-config.*.yaml")
 			require.NoError(t, err, "creating temp file")
 			file.Close()
 
@@ -71,7 +70,7 @@ func Test_ensureStringInFile(t *testing.T) {
 			err = ensureStringInFile(file.Name(), ensureValue)
 			require.NoError(t, err, "ensuring string in file")
 
-			b, err := ioutil.ReadFile(file.Name())
+			b, err := os.ReadFile(file.Name())
 			require.NoError(t, err)
 			require.Equal(t, string(tc.expect), string(b))
 		})

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,20 +15,12 @@ import (
 )
 
 func TestExtractTarGz(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "test-materials")
-	require.NoError(t, err, "error creating tmp dir")
-	out, err := ioutil.TempDir("", "output")
-	require.NoError(t, err, "error creating out dir")
-	defer func() {
-		err := os.RemoveAll(tmp)
-		require.NoError(t, err, "error cleaning tmp dir")
-		err = os.RemoveAll(out)
-		require.NoError(t, err, "error cleaning out dir")
-	}()
+	tmp := t.TempDir()
+	out := t.TempDir()
 
 	files := []string{"test.txt", "test/test.txt"}
 	testTarGz := setUpTarGz(t, tmp, files)
-	err = Extract(testTarGz, out)
+	err := Extract(testTarGz, out)
 	require.NoError(t, err, "error extracting archive")
 
 	for _, f := range files {
@@ -40,20 +31,12 @@ func TestExtractTarGz(t *testing.T) {
 }
 
 func TestExtractZip(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "test-materials")
-	require.NoError(t, err, "error creating tmp dir")
-	out, err := ioutil.TempDir("", "output")
-	require.NoError(t, err, "error creating out dir")
-	defer func() {
-		err := os.RemoveAll(tmp)
-		require.NoError(t, err, "error cleaning tmp dir")
-		err = os.RemoveAll(out)
-		require.NoError(t, err, "error cleaning out dir")
-	}()
+	tmp := t.TempDir()
+	out := t.TempDir()
 
 	files := []string{"test.txt", "test/test.txt"}
 	testZip := setUpZip(t, tmp, files)
-	err = Extract(testZip, out)
+	err := Extract(testZip, out)
 	require.NoError(t, err, "error extracting archive")
 
 	for _, f := range files {


### PR DESCRIPTION
This PR replaces function usages of `io/ioutil` functions with the same functions from `io` and `os`. 

### Changes

- replace `ioutil.ReadFile` with `os.ReadFile`;
- replace `ioutil.WriteFile` with `os.WriteFile`;
- replace `ioutil.ReadAll` with `io.ReadAll`;
- replace `ioutil.Discard` with `io.Discard`;
- replace `ioutil.TempFile` with `os.CreateTemp`.

### Motivation
[io/ioutil](https://pkg.go.dev/io/ioutil) is deprecated:

> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.