### PR TITLE
commands: fix test asserts

### DIFF
--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -432,8 +432,8 @@ func TestRunAppsGetLogs(t *testing.T) {
 
 			tc := config.Doit.(*doctl.TestConfig)
 			tc.ListenFn = func(url *url.URL, token string, schemaFunc listen.SchemaFunc, out io.Writer) listen.ListenerService {
-				assert.Equal(t, token, "aa-bb-11-cc-33")
-				assert.Equal(t, url.String(), "wss://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=aa-bb-11-cc-33")
+				assert.Equal(t, "aa-bb-11-cc-33", token)
+				assert.Equal(t, "wss://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=aa-bb-11-cc-33", url.String())
 				return tm.listen
 			}
 

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -97,7 +97,7 @@ func TestAuthInitConfig(t *testing.T) {
 				"unset": map[interface{}]interface{}{"dev-config": ""},
 			},
 		)
-		assert.Equal(t, devConfigSetting, expectedConfigSetting, "unexpected setting for 'dev.config'")
+		assert.Equal(t, expectedConfigSetting, devConfigSetting, "unexpected setting for 'dev.config'")
 	})
 }
 

--- a/commands/monitoring_test.go
+++ b/commands/monitoring_test.go
@@ -203,7 +203,7 @@ func TestAlertPolicyCreate_ValidTypes(t *testing.T) {
 			config.Doit.Set(config.NS, doctl.ArgAlertPolicySlackURLs, slackURLsStr)
 
 			err := RunCmdAlertPolicyCreate(config)
-			assert.Equal(t, err, tt.expectedErr)
+			assert.Equal(t, tt.expectedErr, err)
 		})
 	}
 }

--- a/commands/registry_test.go
+++ b/commands/registry_test.go
@@ -700,11 +700,7 @@ func TestRegistryLogin(t *testing.T) {
 
 				config.Out = os.Stderr
 				err := RunRegistryLogin(config)
-				if test.err != nil {
-					assert.Error(t, test.err, err)
-				} else {
-					assert.NoError(t, err)
-				}
+				assert.Equal(t, test.err, err)
 			})
 		})
 	}


### PR DESCRIPTION
This PR fixes the commands test. It reverses passed parameters to the [assert.Equal](https://pkg.go.dev/github.com/stretchr/testify@v1.8.0/assert#Equal) according to the signature (`actual` after `expected`):

```
func Equal(t TestingT), expected, actual interface{}, msgAndArgs ...interface{}) bool
```

Additionally, the PR replaces `assert.Error(t, test.err, err)` with `assert.Equal(t, test.err, err)`.