### PR TITLE
Fix typos in command descriptions, comments, and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,7 +200,7 @@ Changelog moved to Release Notes in [Github Releases](https://github.com/digital
 - #222 docs: improve package manager part in readme - @xmudrii
 
 ### Fixed
-- #198 Hiding public images by deault - @xmudrii
+- #198 Hiding public images by default - @xmudrii
 - #194 Use apk's --no-cache option instead of updating and removing cache - @cspicer
 - #201 fix vektra/{errors,mockery} to static vendoring instead submodule - @zchee
 - #223 completion: fix command description typos - @xmudrii

--- a/commands/charm/confirm/confirm.go
+++ b/commands/charm/confirm/confirm.go
@@ -70,7 +70,7 @@ const (
 	PersistPromptIfNo
 )
 
-// WithPersistPrompt configures the prompt persistance behavior.
+// WithPersistPrompt configures the prompt persistence behavior.
 func WithPersistPrompt(v PersistPrompt) Option {
 	return func(p *Prompt) {
 		p.persistPrompt = v

--- a/commands/databases.go
+++ b/commands/databases.go
@@ -68,7 +68,7 @@ func Databases() *Command {
 - The date and time when the database cluster was created`+databaseListDetails, Writer, aliasOpt("g"), displayerType(&displayers.Databases{}))
 
 	nodeSizeDetails := "The size of the nodes in the database cluster, e.g. `db-s-1vcpu-1gb`` for a 1 CPU, 1GB node. For a list of available size slugs, visit: https://docs.digitalocean.com/reference/api/api-reference/#tag/Databases"
-	nodeNumberDetails := "The number of nodes in the database cluster. Valid values are are 1-3. In addition to the primary node, up to two standby nodes may be added for high availability."
+	nodeNumberDetails := "The number of nodes in the database cluster. Valid values are 1-3. In addition to the primary node, up to two standby nodes may be added for high availability."
 	cmdDatabaseCreate := CmdBuilder(cmd, RunDatabaseCreate, "create <name>", "Create a database cluster", `This command creates a database cluster with the specified name.
 
 There are a number of flags that customize the configuration, all of which are optional. Without any flags set, a single-node, single-CPU PostgreSQL database cluster will be created.`, Writer,
@@ -547,7 +547,7 @@ Maintenance windows are hour-long blocks of time during which DigitalOcean perfo
 
 - The day of the week the maintenance window occurs
 - The hour in UTC when maintenance updates will be applied, in 24 hour format (e.g. "16:00")
-- A boolean representing whether maintence updates are currently pending
+- A boolean representing whether maintenance updates are currently pending
 
 To see a list of your databases and their IDs, run `+"`"+`doctl databases list`+"`"+`.`, Writer, aliasOpt("g"),
 		displayerType(&displayers.DatabaseMaintenanceWindow{}))

--- a/commands/namespaces.go
+++ b/commands/namespaces.go
@@ -177,7 +177,7 @@ func RunNamespacesListRegions(c *CmdConfig) error {
 	return nil
 }
 
-// getValidRegions returns all the region values that are accepted (region slugs and datacanter slugs)
+// getValidRegions returns all the region values that are accepted (region slugs and datacenter slugs)
 func getValidRegions() []string {
 	vrs := make([]string, len(validRegions)*2)
 	i := 0

--- a/commands/projects.go
+++ b/commands/projects.go
@@ -54,10 +54,10 @@ Projects allow you to organize your DigitalOcean resources (like Droplets, Space
 	}
 
 	CmdBuilder(cmd, RunProjectsList, "list", "List existing projects",
-		"List details for for your DigitalOcean projects, including:"+projectDetails,
+		"List details for your DigitalOcean projects, including:"+projectDetails,
 		Writer, aliasOpt("ls"), displayerType(&displayers.Project{}))
 	CmdBuilder(cmd, RunProjectsGet, "get <id>", "Retrieve details for a specific project",
-		"Display the following details for an existing project specified by its ID (use `default` for <id> to retieve your default project):"+projectDetails,
+		"Display the following details for an existing project specified by its ID (use `default` for <id> to retrieve your default project):"+projectDetails,
 		Writer, aliasOpt("g"), displayerType(&displayers.Project{}))
 
 	cmdProjectsCreate := CmdBuilder(cmd, RunProjectsCreate, "create",

--- a/commands/serverless.go
+++ b/commands/serverless.go
@@ -119,7 +119,7 @@ With the `+"`"+`--version flag, it will show just version information about the 
 namespace.  In general, deploying new content does not remove old content although it may overwrite it.
 Use `+"`"+`doctl serverless undeploy`+"`"+` to effect removal.  The command accepts a list of functions or packages.
 Functions should be listed in `+"`"+`pkgName/fnName`+"`"+` form, or `+"`"+`fnName`+"`"+` for a function not in any package.
-The `+"`"+`--packages`+"`"+` flag causes arguments without slash separators to be intepreted as packages, in which case
+The `+"`"+`--packages`+"`"+` flag causes arguments without slash separators to be interpreted as packages, in which case
 the entire packages are removed.`, Writer)
 	AddBoolFlag(undeploy, "packages", "p", false, "interpret simple name arguments as packages")
 	AddBoolFlag(undeploy, "triggers", "", false, "interpret all arguments as triggers")

--- a/commands/serverless_samples.go
+++ b/commands/serverless_samples.go
@@ -167,7 +167,7 @@ namespace Nimbella.Example.Dotnet
 		"typescript": typescriptSample,
 	}
 
-	// gitignores contains the contents of a "standard" .gitigore file
+	// gitignores contains the contents of a "standard" .gitignore file
 	// Note that we do not attempt to list typical IDE and editor temporaries here.
 	// It is considered best practice for developers to list these in a personal global
 	// ignore file (`core.excludesfile` in the git config) and not in a committed .gitignore.

--- a/commands/ssh_test.go
+++ b/commands/ssh_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSSHComand(t *testing.T) {
+func TestSSHCommand(t *testing.T) {
 	parent := &Command{
 		Command: &cobra.Command{
 			Use:   "compute",

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -1261,7 +1261,7 @@ func (s *serverlessService) CredentialsPath() string {
 	return s.credsDir
 }
 
-// ReadCredentials reads the current serverless credentials from the appropriate 'creds' diretory
+// ReadCredentials reads the current serverless credentials from the appropriate 'creds' directory
 func (s *serverlessService) ReadCredentials() (ServerlessCredentials, error) {
 	creds := ServerlessCredentials{}
 	credsPath := filepath.Join(s.credsDir, CredentialsFile)

--- a/internal/apps/builder/builder.go
+++ b/internal/apps/builder/builder.go
@@ -266,7 +266,7 @@ func (f *DefaultComponentBuilderFactory) NewComponentBuilder(cli DockerEngineCli
 		return nil, fmt.Errorf("component %s does not exist", opts.Component)
 	}
 
-	// NOTE(ntate); We don't provide this as a configureable argument today.
+	// NOTE(ntate); We don't provide this as a configurable argument today.
 	// We always assume we want copy-on-write. Caching occurs through re-use of the built OCI image.
 	// This may change in the future so we provide as an argument to the baseComponentBuilder.
 	copyOnWriteSemantics := true

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -78,10 +78,10 @@ func setUpTarGz(t *testing.T, tmpDir string, files []string) string {
 			ModTime: info.ModTime(),
 		}
 		err = tarWriter.WriteHeader(header)
-		require.NoError(t, err, "error writting header")
+		require.NoError(t, err, "error writing header")
 
 		_, err = io.Copy(tarWriter, file)
-		require.NoError(t, err, "error writting tar")
+		require.NoError(t, err, "error writing tar")
 	}
 
 	return tarballPath
@@ -116,11 +116,11 @@ func setUpZip(t *testing.T, tmpDir string, files []string) string {
 		header.Name = f
 
 		writer, err := zipWriter.CreateHeader(header)
-		require.NoError(t, err, "error writting zip")
+		require.NoError(t, err, "error writing zip")
 
 		_, err = io.Copy(writer, file)
 
-		require.NoError(t, err, "error writting file to zip")
+		require.NoError(t, err, "error writing file to zip")
 	}
 
 	return zipPath


### PR DESCRIPTION
This PR fixes spelling mistakes and removes duplicated words.