### PR TITLE
Add missing closing response body

### DIFF
--- a/do/registry.go
+++ b/do/registry.go
@@ -364,9 +364,10 @@ func (rs *registryService) RevokeOAuthToken(token string, endpoint string) error
 	client := http.Client{}
 
 	resp, err := client.Do(req)
-	if resp == nil {
+	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return errors.New("error revoking token: " + http.StatusText(resp.StatusCode))


### PR DESCRIPTION
This PR fixes possible resource leaks by adding a statement that closes a response body.

From the [documentation](https://pkg.go.dev/net/http):
> The caller must close the response body when finished with it

Also, see this [article](https://golang50shad.es/index.html#close_http_resp_body) for a deep dive into the problem.