### PR TITLE
commands: Use godo.PtrTo instead of deprecated godo.Int, godo.String

### DIFF
--- a/commands/billing_history_test.go
+++ b/commands/billing_history_test.go
@@ -28,8 +28,8 @@ var testBillingHistoryList = &do.BillingHistory{
 			{
 				Description: "Invoice for May 2018",
 				Amount:      "12.34",
-				InvoiceID:   godo.String("123"),
-				InvoiceUUID: godo.String("example-uuid"),
+				InvoiceID:   godo.PtrTo("123"),
+				InvoiceUUID: godo.PtrTo("example-uuid"),
 				Date:        time.Date(2018, 6, 1, 8, 44, 38, 0, time.UTC),
 				Type:        "Invoice",
 			},

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -405,10 +405,10 @@ func RunRegistryLogin(c *CmdConfig) error {
 
 	regCredReq := godo.RegistryDockerCredentialsRequest{
 		ReadWrite:     !readOnly,
-		ExpirySeconds: godo.Int(defaultRegistryAPITokenExpirySeconds),
+		ExpirySeconds: godo.PtrTo(defaultRegistryAPITokenExpirySeconds),
 	}
 	if expirySeconds != 0 {
-		regCredReq.ExpirySeconds = godo.Int(expirySeconds)
+		regCredReq.ExpirySeconds = godo.PtrTo(expirySeconds)
 	}
 	if neverExpire {
 		regCredReq.ExpirySeconds = nil
@@ -548,7 +548,7 @@ func RunDockerConfig(c *CmdConfig) error {
 		ReadWrite: readWrite,
 	}
 	if expirySeconds != 0 {
-		regCredReq.ExpirySeconds = godo.Int(expirySeconds)
+		regCredReq.ExpirySeconds = godo.PtrTo(expirySeconds)
 	}
 
 	dockerCreds, err := c.Registry().DockerCredentials(&regCredReq)

--- a/commands/registry_test.go
+++ b/commands/registry_test.go
@@ -247,7 +247,7 @@ func TestDockerConfig(t *testing.T) {
 			expect: func(m *mocks.MockRegistryService) {
 				m.EXPECT().DockerCredentials(&godo.RegistryDockerCredentialsRequest{
 					ReadWrite:     false,
-					ExpirySeconds: godo.Int(3600),
+					ExpirySeconds: godo.PtrTo(3600),
 				}).Return(testDockerCredentials, nil)
 			},
 		},
@@ -258,7 +258,7 @@ func TestDockerConfig(t *testing.T) {
 			expect: func(m *mocks.MockRegistryService) {
 				m.EXPECT().DockerCredentials(&godo.RegistryDockerCredentialsRequest{
 					ReadWrite:     true,
-					ExpirySeconds: godo.Int(3600),
+					ExpirySeconds: godo.PtrTo(3600),
 				}).Return(testDockerCredentials, nil)
 			},
 		},
@@ -662,7 +662,7 @@ func TestRegistryLogin(t *testing.T) {
 				m.EXPECT().Endpoint().Return(do.RegistryHostname)
 				m.EXPECT().DockerCredentials(&godo.RegistryDockerCredentialsRequest{
 					ReadWrite:     true,
-					ExpirySeconds: godo.Int(3600),
+					ExpirySeconds: godo.PtrTo(3600),
 				}).Return(testDockerCredentials, nil)
 			},
 		},
@@ -674,7 +674,7 @@ func TestRegistryLogin(t *testing.T) {
 				m.EXPECT().Endpoint().Return(do.RegistryHostname)
 				m.EXPECT().DockerCredentials(&godo.RegistryDockerCredentialsRequest{
 					ReadWrite:     false,
-					ExpirySeconds: godo.Int(defaultRegistryAPITokenExpirySeconds),
+					ExpirySeconds: godo.PtrTo(defaultRegistryAPITokenExpirySeconds),
 				}).Return(testDockerCredentials, nil)
 			},
 		},


### PR DESCRIPTION
This PR replaces deprecated functions `godo.Int, godo.String` with `godo.PtrTo`.