### PR TITLE
builder,integration: Replace path import with path/filepath

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -35,7 +34,7 @@ func TestMain(m *testing.M) {
 	}
 	defer os.RemoveAll(tmpDir) // yes, this is the best effort only
 
-	builtBinaryPath = filepath.Join(tmpDir, path.Base(packagePath))
+	builtBinaryPath = filepath.Join(tmpDir, filepath.Base(filepath.FromSlash(packagePath)))
 	if runtime.GOOS == "windows" {
 		builtBinaryPath += ".exe"
 	}

--- a/internal/apps/builder/docker.go
+++ b/internal/apps/builder/docker.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -34,14 +33,15 @@ func (b *DockerComponentBuilder) Build(ctx context.Context) (ComponentBuilderRes
 	}
 
 	if c, ok := b.component.(*godo.AppStaticSiteSpec); ok {
-		// NOTE(knasser): we use `path` instead of `filepath` because we want forward slash '/' separated path handling
-		// even on windows as the output_dir will be evaluated within the build container which is always linux-based.
-		outputDir := path.Clean(c.GetOutputDir())
+		// output_dir is evaluated within the build container which is always linux-based.
+		outputDir := filepath.ToSlash(filepath.Clean(filepath.FromSlash(c.GetOutputDir())))
 		if outputDir == "" || outputDir == "." {
 			return ComponentBuilderResult{}, errors.New("output_dir is required for dockerfile-based static site builds")
-		} else if outputDir == "/" {
+		}
+		if outputDir == "/" {
 			return ComponentBuilderResult{}, errors.New("output_dir may not be /")
-		} else if !strings.HasPrefix(outputDir, "/") {
+		}
+		if !strings.HasPrefix(outputDir, "/") {
 			return ComponentBuilderResult{}, errors.New("output_dir must be an absolute path with dockerfile-based static site builds")
 		}
 	}


### PR DESCRIPTION
This PR refactors code by replacing usages of `path` with `filepath`. Because `path/filepath` package is designed for working with operating system paths.