### PR TITLE
commands: strconv.Atoi instead of strconv.ParseInt for ints

### DIFF
--- a/commands/activations_test.go
+++ b/commands/activations_test.go
@@ -366,7 +366,7 @@ func TestActivationsList(t *testing.T) {
 						}
 
 						if k == "limit" {
-							limit, _ = strconv.ParseInt(v, 0, 64)
+							limit, _ = strconv.Atoi(v)
 						}
 
 						if k == "since" {
@@ -378,7 +378,7 @@ func TestActivationsList(t *testing.T) {
 						}
 
 						if k == "skip" {
-							skip, _ = strconv.ParseInt(v, 0, 64)
+							skip, _ = strconv.Atoi(v)
 						}
 
 						if v == "" {
@@ -414,11 +414,11 @@ func TestActivationsList(t *testing.T) {
 						expectedListOptions.Name = config.Args[0]
 					}
 					if limit != nil {
-						expectedListOptions.Limit = int(limit.(int64))
+						expectedListOptions.Limit = limit.(int)
 					}
 
 					if skip != nil {
-						expectedListOptions.Skip = int(skip.(int64))
+						expectedListOptions.Skip = skip.(int)
 					}
 					tm.serverless.EXPECT().ListActivations(expectedListOptions).Return(theActivations, nil)
 				}
@@ -472,7 +472,7 @@ func TestActivationsLogs(t *testing.T) {
 				if tt.doctlFlags != nil {
 					for k, v := range tt.doctlFlags {
 						if k == "limit" {
-							limit, _ = strconv.ParseInt(v, 0, 64)
+							limit, _ = strconv.Atoi(v)
 						}
 
 						if k == "follow" {
@@ -504,7 +504,7 @@ func TestActivationsLogs(t *testing.T) {
 				} else {
 					expectedListOptions := whisk.ActivationListOptions{Docs: true}
 					if limit != nil {
-						expectedListOptions.Limit = int(limit.(int64))
+						expectedListOptions.Limit = limit.(int)
 					}
 
 					if funcName != nil {

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1778,11 +1778,11 @@ func parseNodePoolString(nodePool, defaultName, defaultSize string, defaultCount
 		case "size":
 			out.Size = value
 		case "count":
-			count, err := strconv.ParseInt(value, 10, 64)
+			count, err := strconv.Atoi(value)
 			if err != nil {
 				return nil, errors.New("Node pool count must be a valid integer.")
 			}
-			out.Count = int(count)
+			out.Count = count
 		case "tag":
 			out.Tags = append(out.Tags, value)
 		case "label":
@@ -1806,17 +1806,17 @@ func parseNodePoolString(nodePool, defaultName, defaultSize string, defaultCount
 			}
 			out.AutoScale = autoScale
 		case "min-nodes":
-			minNodes, err := strconv.ParseInt(value, 10, 64)
+			minNodes, err := strconv.Atoi(value)
 			if err != nil {
 				return nil, errors.New("Node pool min-nodes must be a valid integer.")
 			}
-			out.MinNodes = int(minNodes)
+			out.MinNodes = minNodes
 		case "max-nodes":
-			maxNodes, err := strconv.ParseInt(value, 10, 64)
+			maxNodes, err := strconv.Atoi(value)
 			if err != nil {
 				return nil, errors.New("Node pool max-nodes must be a valid integer.")
 			}
-			out.MaxNodes = int(maxNodes)
+			out.MaxNodes = maxNodes
 		default:
 			return nil, fmt.Errorf("Unsupported node pool argument %q", key)
 		}


### PR DESCRIPTION
This PR refactors code to use `strconv.Atoi` instead of `strconv.ParseInt`+`int` type casting.