### PR TITLE
docs(cdn): add examples for `compute cdn flush` command

### DIFF
--- a/commands/cdns.go
+++ b/commands/cdns.go
@@ -87,7 +87,12 @@ Currently, you can only update the custom domain and its certificate ID with thi
 
 This is useful when you need to ensure that files which were recently changed on the origin server are immediately available via the CDN.
 
-To purge specific files, you can use the `+"`"+`--files`+"`"+` flag and supply a path. The path may be for a single file or may contain a wildcard (`+"`"+`*`+"`"+`) to recursively purge all files under a directory. When only a wildcard is provided, or no path is provided, all cached files will be purged.`, Writer,
+To purge specific files, you can use the `+"`"+`--files`+"`"+` flag and supply a path. The path may be for a single file or may contain a wildcard (`+"`"+`*`+"`"+`) to recursively purge all files under a directory. When only a wildcard is provided, or no path is provided, all cached files will be purged.
+Examples:		
+ doctl compute cdn flush <cdn-id>  --files /path/to/assets/*
+ doctl compute cdn flush <cdn-id>  --files "/path/to/file.one, /path/to/file.two"
+ doctl compute cdn flush <cdn-id>  --files /path/to/file.one --files /path/to/file.two
+ doctl compute cdn flush <cdn-id>  --files * `, Writer,
 		aliasOpt("fc"))
 	AddStringSliceFlag(cmdCDNFlushCache, doctl.ArgCDNFiles, "", []string{"*"}, "cdn files")
 


### PR DESCRIPTION
aims to fix #1156 

Before: 
``` 
gor cmd/doctl/main.go compute cdn flush -h
This command flushes the cache of a Content Delivery Network (CDN), which:

- purges all copies of the files in the cache
- re-caches the files
- retrieves files from the origin server for any requests that hit the CDN endpoint until all the files are re-cached

This is useful when you need to ensure that files which were recently changed on the origin server are immediately available via the CDN.

To purge specific files, you can use the `--files` flag and supply a path. The path may be for a single file or may contain a wildcard (`*`) to recursively purge all files under a directory. When only a wildcard is provided, or no path is provided, all cached files will be purged.

Usage:
  doctl compute cdn flush <cdn-id> [flags]

```

After:
```
gor cmd/doctl/main.go compute cdn flush -h
This command flushes the cache of a Content Delivery Network (CDN), which:

- purges all copies of the files in the cache
- re-caches the files
- retrieves files from the origin server for any requests that hit the CDN endpoint until all the files are re-cached

This is useful when you need to ensure that files which were recently changed on the origin server are immediately available via the CDN.

To purge specific files, you can use the `--files` flag and supply a path. The path may be for a single file or may contain a wildcard (`*`) to recursively purge all files under a directory. When only a wildcard is provided, or no path is provided, all cached files will be purged.
Examples:
 doctl compute cdn flush <cdn-id>  --files /path/to/assets/*
 doctl compute cdn flush <cdn-id>  --files "/path/to/file.one, /path/to/file.two"
 doctl compute cdn flush <cdn-id>  --files /path/to/file.one --files /path/to/file.two
 doctl compute cdn flush <cdn-id>  --files *

Usage:
  doctl compute cdn flush <cdn-id> [flags]
```