### PR TITLE
domain records: Support displaying flags and tag.

### DIFF
--- a/commands/displayers/domain.go
+++ b/commands/displayers/domain.go
@@ -54,6 +54,7 @@ func (d *Domain) KV() []map[string]interface{} {
 
 type DomainRecord struct {
 	DomainRecords do.DomainRecords
+	Short         bool
 }
 
 func (dr *DomainRecord) JSON(out io.Writer) error {
@@ -61,16 +62,31 @@ func (dr *DomainRecord) JSON(out io.Writer) error {
 }
 
 func (dr *DomainRecord) Cols() []string {
-	return []string{
+	defaultCols := []string{
 		"ID", "Type", "Name", "Data", "Priority", "Port", "TTL", "Weight",
 	}
+
+	if dr.Short {
+		return defaultCols
+	}
+
+	return append(defaultCols, "Flags", "Tag")
 }
 
 func (dr *DomainRecord) ColMap() map[string]string {
-	return map[string]string{
+	defaultColMap := map[string]string{
 		"ID": "ID", "Type": "Type", "Name": "Name", "Data": "Data",
 		"Priority": "Priority", "Port": "Port", "TTL": "TTL", "Weight": "Weight",
 	}
+
+	if dr.Short {
+		return defaultColMap
+	}
+
+	defaultColMap["Flags"] = "Flags"
+	defaultColMap["Tag"] = "Tag"
+
+	return defaultColMap
 }
 
 func (dr *DomainRecord) KV() []map[string]interface{} {
@@ -81,6 +97,7 @@ func (dr *DomainRecord) KV() []map[string]interface{} {
 			"ID": d.ID, "Type": d.Type, "Name": d.Name,
 			"Data": d.Data, "Priority": d.Priority,
 			"Port": d.Port, "TTL": d.TTL, "Weight": d.Weight,
+			"Flags": d.Flags, "Tag": d.Tag,
 		}
 		out = append(out, o)
 	}

--- a/commands/domains.go
+++ b/commands/domains.go
@@ -203,9 +203,7 @@ func RunRecordList(c *CmdConfig) error {
 		return err
 	}
 
-	items := &displayers.DomainRecord{DomainRecords: list}
-	return c.Display(items)
-
+	return displayDomainRecords(c, list...)
 }
 
 // RunRecordCreate creates a domain record.
@@ -284,8 +282,7 @@ func RunRecordCreate(c *CmdConfig) error {
 		return err
 	}
 
-	item := &displayers.DomainRecord{DomainRecords: do.DomainRecords{*r}}
-	return c.Display(item)
+	return displayDomainRecords(c, *r)
 
 }
 
@@ -404,6 +401,22 @@ func RunRecordUpdate(c *CmdConfig) error {
 		return err
 	}
 
-	item := &displayers.DomainRecord{DomainRecords: do.DomainRecords{*r}}
+	return displayDomainRecords(c, *r)
+}
+
+func displayDomainRecords(c *CmdConfig, records ...do.DomainRecord) error {
+	// Check the format flag to determine if the displayer should use the short
+	// layout of the record display.The short version is used by default, but to format
+	// output that includes columns not in the short layout we need the full version.
+	var short = true
+	format, err := c.Doit.GetStringSlice(c.NS, doctl.ArgFormat)
+	if err != nil {
+		return err
+	}
+	if len(format) > 0 {
+		short = false
+	}
+
+	item := &displayers.DomainRecord{DomainRecords: do.DomainRecords(records), Short: short}
 	return c.Display(item)
 }

--- a/integration/domain_records_list_test.go
+++ b/integration/domain_records_list_test.go
@@ -1,0 +1,132 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = suite("compute/domain/records/list", func(t *testing.T, when spec.G, it spec.S) {
+	var (
+		expect *require.Assertions
+		server *httptest.Server
+	)
+
+	it.Before(func() {
+		expect = require.New(t)
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/domains/example.com/records":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				if req.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				w.Write([]byte(domainRecordsListResponse))
+
+			default:
+				dump, err := httputil.DumpRequest(req, true)
+				if err != nil {
+					t.Fatal("failed to dump request")
+				}
+
+				t.Fatalf("received unknown request: %s", dump)
+			}
+		}))
+	})
+
+	when("command is list", func() {
+		it("lists domain records", func() {
+			aliases := []string{"list", "ls"}
+
+			for _, alias := range aliases {
+				cmd := exec.Command(builtBinaryPath,
+					"-t", "some-magic-token",
+					"-u", server.URL,
+					"compute",
+					"domain",
+					"records",
+					alias,
+					"example.com",
+				)
+
+				output, err := cmd.CombinedOutput()
+				expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+				expect.Equal(strings.TrimSpace(domainRecordsListOutput), strings.TrimSpace(string(output)))
+			}
+		})
+	})
+
+	when("format flag is passed", func() {
+		it("flags and tag can be displayed", func() {
+			aliases := []string{"list", "ls"}
+
+			for _, alias := range aliases {
+				cmd := exec.Command(builtBinaryPath,
+					"-t", "some-magic-token",
+					"-u", server.URL,
+					"compute",
+					"domain",
+					"records",
+					alias,
+					"example.com",
+					"--format", "ID,Type,Name,Flags,Tag",
+				)
+
+				output, err := cmd.CombinedOutput()
+				expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+				expect.Equal(strings.TrimSpace(domainRecordsListFormattedOutput), strings.TrimSpace(string(output)))
+			}
+		})
+	})
+})
+
+const (
+	domainRecordsListOutput = `
+ID       Type    Name    Data               Priority    Port    TTL     Weight
+123      A       foo     127.0.0.1          0           0       3600    0
+12345    CAA     @       letsencrypt.org    0           0       3600    0
+`
+
+	domainRecordsListFormattedOutput = `
+ID       Type    Name    Flags    Tag
+123      A       foo     0        
+12345    CAA     @       1        issuewild
+`
+
+	domainRecordsListResponse = `
+{
+  "domain_records": [
+	{
+	  "id": 123,
+	  "type": "A",
+	  "name": "foo",
+      "data": "127.0.0.1",
+	  "ttl": 3600
+    },
+	{
+		"id": 12345,
+		"type": "CAA",
+		"name": "@",
+		"data": "letsencrypt.org",
+		"flags": 1,
+		"tag": "issuewild",
+		"ttl": 3600
+	}
+  ]
+}
+`
+)


### PR DESCRIPTION
Domain records can have `flags` and `tag` attributes. We do not currently display those in command output. The adds support for optionally displaying those fields using the `--format` flag as needed.

Fixes: https://github.com/digitalocean/doctl/issues/1436