### PR TITLE
all: replace 'interface{}' with 'any'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DOCS_OUT = $(shell echo $${DOCS_OUT:-$(my_d)/builds/docs/yaml})
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 
-GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+GOFILES_NOVENDOR_NOMOCK = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "*_mock.go")
 
 GOOS = linux
 ifeq ($(UNAME_S),Darwin)
@@ -113,7 +113,7 @@ shellcheck:
 gofmt_check:
 	@echo "==> ensure code adheres to gofmt (with vendor directory excluded)"
 	@echo ""
-	@GOFMT=$$(gofmt -l ${GOFILES_NOVENDOR}); \
+	@GOFMT=$$(gofmt -w -r 'interface{} -> any' -l ${GOFILES_NOVENDOR_NOMOCK}); \
 	if [ -n "$${GOFMT}" ]; then \
 		echo "gofmt checking failed:\n"; echo "$${GOFMT} \n"; exit 1; \
 	fi

--- a/commands/activations_test.go
+++ b/commands/activations_test.go
@@ -39,15 +39,15 @@ func TestActivationsCommand(t *testing.T) {
 	assert.ElementsMatch(t, expected, names)
 }
 
-var hello1Result = whisk.Result(map[string]interface{}{
+var hello1Result = whisk.Result(map[string]any{
 	"body": "Hello stranger!",
 })
 
-var hello2Result = whisk.Result(map[string]interface{}{
+var hello2Result = whisk.Result(map[string]any{
 	"body": "Hello Archie!",
 })
 
-var hello3Result = whisk.Result(map[string]interface{}{
+var hello3Result = whisk.Result(map[string]any{
 	"error": "Missing main/no code to execute.",
 })
 
@@ -354,10 +354,10 @@ func TestActivationsList(t *testing.T) {
 				}
 
 				count := false
-				var limit interface{}
-				var since interface{}
-				var upto interface{}
-				var skip interface{}
+				var limit any
+				var since any
+				var upto any
+				var skip any
 
 				if tt.doctlFlags != nil {
 					for k, v := range tt.doctlFlags {
@@ -466,8 +466,8 @@ func TestActivationsLogs(t *testing.T) {
 					activationId = config.Args[0]
 				}
 
-				var limit interface{}
-				var funcName interface{}
+				var limit any
+				var funcName any
 
 				if tt.doctlFlags != nil {
 					for k, v := range tt.doctlFlags {

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -222,7 +222,7 @@ func RunAuthList(c *CmdConfig) error {
 	return nil
 }
 
-func displayAuthContexts(out io.Writer, currentContext string, contexts map[string]interface{}) {
+func displayAuthContexts(out io.Writer, currentContext string, contexts map[string]any) {
 	// Because the default context isn't present on the auth-contexts field,
 	// we add it manually so that it's always included in the output, and so
 	// we can check if it's the current context.

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -90,11 +90,11 @@ func TestAuthInitConfig(t *testing.T) {
 		// Ensure that the dev.config.set.dev-config setting is correct to prevent
 		// a conflict with the base config setting.
 		devConfig := configFile["dev"]
-		devConfigSetting := devConfig.(map[interface{}]interface{})["config"]
-		expectedConfigSetting := map[interface{}]interface{}(
-			map[interface{}]interface{}{
-				"set":   map[interface{}]interface{}{"dev-config": ""},
-				"unset": map[interface{}]interface{}{"dev-config": ""},
+		devConfigSetting := devConfig.(map[any]any)["config"]
+		expectedConfigSetting := map[any]any(
+			map[any]any{
+				"set":   map[any]any{"dev-config": ""},
+				"unset": map[any]any{"dev-config": ""},
 			},
 		)
 		assert.Equal(t, expectedConfigSetting, devConfigSetting, "unexpected setting for 'dev.config'")
@@ -140,7 +140,7 @@ func TestAuthForcesLowercase(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.oauth.EXPECT().TokenInfo(gomock.Any()).Return(&do.OAuthTokenInfo{}, nil)
 
-		contexts := map[string]interface{}{doctl.ArgDefaultContext: true, "TestCapitalCase": true}
+		contexts := map[string]any{doctl.ArgDefaultContext: true, "TestCapitalCase": true}
 		context := "TestCapitalCase"
 		viper.Set("auth-contexts", contexts)
 		viper.Set("context", context)
@@ -148,7 +148,7 @@ func TestAuthForcesLowercase(t *testing.T) {
 		err := RunAuthInit(retrieveUserTokenFunc)(config)
 		assert.NoError(t, err)
 
-		contexts = map[string]interface{}{doctl.ArgDefaultContext: true, "TestCapitalCase": true}
+		contexts = map[string]any{doctl.ArgDefaultContext: true, "TestCapitalCase": true}
 		viper.Set("auth-contexts", contexts)
 		viper.Set("context", "contextDoesntExist")
 		err = RunAuthSwitch(config)
@@ -175,14 +175,14 @@ func Test_displayAuthContexts(t *testing.T) {
 		Name     string
 		Out      *bytes.Buffer
 		Context  string
-		Contexts map[string]interface{}
+		Contexts map[string]any
 		Expected string
 	}{
 		{
 			Name:    "default context only",
 			Out:     &bytes.Buffer{},
 			Context: doctl.ArgDefaultContext,
-			Contexts: map[string]interface{}{
+			Contexts: map[string]any{
 				doctl.ArgDefaultContext: true,
 			},
 			Expected: "default (current)\n",
@@ -191,7 +191,7 @@ func Test_displayAuthContexts(t *testing.T) {
 			Name:    "default context and additional context",
 			Out:     &bytes.Buffer{},
 			Context: doctl.ArgDefaultContext,
-			Contexts: map[string]interface{}{
+			Contexts: map[string]any{
 				doctl.ArgDefaultContext: true,
 				"test":                  true,
 			},
@@ -201,7 +201,7 @@ func Test_displayAuthContexts(t *testing.T) {
 			Name:    "default context and additional context set to additional context",
 			Out:     &bytes.Buffer{},
 			Context: "test",
-			Contexts: map[string]interface{}{
+			Contexts: map[string]any{
 				doctl.ArgDefaultContext: true,
 				"test":                  true,
 			},
@@ -211,7 +211,7 @@ func Test_displayAuthContexts(t *testing.T) {
 			Name:    "unset context",
 			Out:     &bytes.Buffer{},
 			Context: "missing",
-			Contexts: map[string]interface{}{
+			Contexts: map[string]any{
 				doctl.ArgDefaultContext: true,
 				"test":                  true,
 			},
@@ -284,7 +284,7 @@ func TestTokenInputValidator(t *testing.T) {
 	}
 }
 
-type testConfig map[string]interface{}
+type testConfig map[string]any
 
 type nopWriteCloser struct {
 	io.Writer

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -1415,7 +1415,7 @@ func TestDatabaseGetSQLModes(t *testing.T) {
 }
 
 func TestDatabaseSetSQLModes(t *testing.T) {
-	testSQLModesInterface := make([]interface{}, 0, len(testSQLModes))
+	testSQLModesInterface := make([]any, 0, len(testSQLModes))
 	for _, sqlMode := range testSQLModes {
 		testSQLModesInterface = append(testSQLModesInterface, sqlMode)
 	}

--- a/commands/displayers/1_click.go
+++ b/commands/displayers/1_click.go
@@ -48,11 +48,11 @@ func (oc *OneClick) ColMap() map[string]string {
 }
 
 // KV maps the values of a 1-click to an output
-func (oc *OneClick) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(oc.OneClicks))
+func (oc *OneClick) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(oc.OneClicks))
 
 	for _, oneClick := range oc.OneClicks {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"SLUG": oneClick.Slug,
 			"TYPE": oneClick.Type,
 		}

--- a/commands/displayers/account.go
+++ b/commands/displayers/account.go
@@ -42,8 +42,8 @@ func (a *Account) ColMap() map[string]string {
 	}
 }
 
-func (a *Account) KV() []map[string]interface{} {
-	x := map[string]interface{}{
+func (a *Account) KV() []map[string]any {
+	x := map[string]any{
 		"Email": a.Email, "DropletLimit": a.DropletLimit,
 		"EmailVerified": a.EmailVerified, "UUID": a.UUID,
 		"Status": a.Status,
@@ -53,5 +53,5 @@ func (a *Account) KV() []map[string]interface{} {
 		x["TeamUUID"] = a.Team.UUID
 	}
 
-	return []map[string]interface{}{x}
+	return []map[string]any{x}
 }

--- a/commands/displayers/action.go
+++ b/commands/displayers/action.go
@@ -43,15 +43,15 @@ func (a *Action) ColMap() map[string]string {
 	}
 }
 
-func (a *Action) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(a.Actions))
+func (a *Action) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(a.Actions))
 
 	for _, x := range a.Actions {
 		region := ""
 		if x.Region != nil {
 			region = x.Region.Slug
 		}
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID": x.ID, "Status": x.Status, "Type": x.Type,
 			"StartedAt": x.StartedAt, "CompletedAt": x.CompletedAt,
 			"ResourceID": x.ResourceID, "ResourceType": x.ResourceType,

--- a/commands/displayers/activations.go
+++ b/commands/displayers/activations.go
@@ -51,11 +51,11 @@ func (a *Activation) JSON(out io.Writer) error {
 }
 
 // KV implements Displayable
-func (a *Activation) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(a.Activations))
+func (a *Activation) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(a.Activations))
 
 	for _, actv := range a.Activations {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Datetime":     time.UnixMilli(actv.Start).Format("01/02 03:04:05"),
 			"Status":       GetActivationStatus(actv.StatusCode),
 			"Kind":         getActivationAnnotationValue(actv, "kind"),
@@ -117,7 +117,7 @@ func GetActivationPackageName(a whisk.Activation) string {
 
 	return ""
 }
-func getActivationAnnotationValue(a whisk.Activation, key string) interface{} {
+func getActivationAnnotationValue(a whisk.Activation, key string) any {
 	if a.Annotations == nil {
 		return nil
 	}

--- a/commands/displayers/apps.go
+++ b/commands/displayers/apps.go
@@ -38,8 +38,8 @@ func (a Apps) ColMap() map[string]string {
 	}
 }
 
-func (a Apps) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, len(a))
+func (a Apps) KV() []map[string]any {
+	out := make([]map[string]any, len(a))
 
 	for i, app := range a {
 		var (
@@ -55,7 +55,7 @@ func (a Apps) KV() []map[string]interface{} {
 			inProgressDeploymentID = app.InProgressDeployment.ID
 		}
 
-		out[i] = map[string]interface{}{
+		out[i] = map[string]any{
 			"ID":                      app.ID,
 			"Spec.Name":               app.Spec.Name,
 			"DefaultIngress":          app.DefaultIngress,
@@ -98,8 +98,8 @@ func (d Deployments) ColMap() map[string]string {
 	}
 }
 
-func (d Deployments) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, len(d))
+func (d Deployments) KV() []map[string]any {
+	out := make([]map[string]any, len(d))
 
 	for i, deployment := range d {
 		var progress string
@@ -111,7 +111,7 @@ func (d Deployments) KV() []map[string]interface{} {
 			}
 		}
 
-		out[i] = map[string]interface{}{
+		out[i] = map[string]any{
 			"ID":       deployment.ID,
 			"Cause":    deployment.Cause,
 			"Progress": progress,
@@ -156,11 +156,11 @@ func (r AppRegions) ColMap() map[string]string {
 	}
 }
 
-func (r AppRegions) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, len(r))
+func (r AppRegions) KV() []map[string]any {
+	out := make([]map[string]any, len(r))
 
 	for i, region := range r {
-		out[i] = map[string]interface{}{
+		out[i] = map[string]any{
 			"Slug":        region.Slug,
 			"Label":       region.Label,
 			"Continent":   region.Continent,
@@ -201,12 +201,12 @@ func (t AppTiers) ColMap() map[string]string {
 	}
 }
 
-func (t AppTiers) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, len(t))
+func (t AppTiers) KV() []map[string]any {
+	out := make([]map[string]any, len(t))
 
 	for i, tier := range t {
 		egressBandwidth, _ := strconv.ParseUint(tier.EgressBandwidthBytes, 10, 64)
-		out[i] = map[string]interface{}{
+		out[i] = map[string]any{
 			"Name":                 tier.Name,
 			"Slug":                 tier.Slug,
 			"EgressBandwidthBytes": BytesToHumanReadableUnitBinary(egressBandwidth),
@@ -252,8 +252,8 @@ func (is AppInstanceSizes) ColMap() map[string]string {
 	}
 }
 
-func (is AppInstanceSizes) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, len(is))
+func (is AppInstanceSizes) KV() []map[string]any {
+	out := make([]map[string]any, len(is))
 
 	for i, instanceSize := range is {
 		memory, _ := strconv.ParseUint(instanceSize.MemoryBytes, 10, 64)
@@ -269,7 +269,7 @@ func (is AppInstanceSizes) KV() []map[string]interface{} {
 			upgradeDowngradePath = upgradeDowngradePath + " -> " + instanceSize.TierUpgradeTo
 		}
 
-		out[i] = map[string]interface{}{
+		out[i] = map[string]any{
 			"Name":                     instanceSize.Name,
 			"Slug":                     instanceSize.Slug,
 			"CPUs":                     cpus,
@@ -327,7 +327,7 @@ func (r AppProposeResponse) ColMap() map[string]string {
 	}
 }
 
-func (r AppProposeResponse) KV() []map[string]interface{} {
+func (r AppProposeResponse) KV() []map[string]any {
 	existingStatic, _ := strconv.ParseInt(r.Res.ExistingStaticApps, 10, 64)
 	maxFreeStatic, _ := strconv.ParseInt(r.Res.MaxFreeStaticApps, 10, 64)
 	var paidStatic int64
@@ -352,7 +352,7 @@ func (r AppProposeResponse) KV() []map[string]interface{} {
 		upgradeCost = fmt.Sprintf("%0.2f", r.Res.AppTierUpgradeCost)
 	}
 
-	out := map[string]interface{}{
+	out := map[string]any{
 		"AppNameAvailable":     boolToYesNo(r.Res.AppNameAvailable),
 		"AppIsStatic":          boolToYesNo(r.Res.AppIsStatic),
 		"StaticApps":           staticApps,
@@ -365,7 +365,7 @@ func (r AppProposeResponse) KV() []map[string]interface{} {
 		out["AppNameSuggestion"] = r.Res.AppNameSuggestion
 	}
 
-	return []map[string]interface{}{out}
+	return []map[string]any{out}
 }
 
 func (r AppProposeResponse) JSON(w io.Writer) error {
@@ -402,8 +402,8 @@ func (a AppAlerts) ColMap() map[string]string {
 	}
 }
 
-func (a AppAlerts) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, len(a))
+func (a AppAlerts) KV() []map[string]any {
+	out := make([]map[string]any, len(a))
 
 	for i, alert := range a {
 		var trigger string
@@ -439,7 +439,7 @@ func (a AppAlerts) KV() []map[string]interface{} {
 			trigger = "Unknown"
 		}
 
-		out[i] = map[string]interface{}{
+		out[i] = map[string]any{
 			"ID":            alert.ID,
 			"Spec.Rule":     alert.Spec.Rule,
 			"Trigger":       trigger,
@@ -480,11 +480,11 @@ func (b Buildpacks) ColMap() map[string]string {
 	}
 }
 
-func (b Buildpacks) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, len(b))
+func (b Buildpacks) KV() []map[string]any {
+	out := make([]map[string]any, len(b))
 
 	for i, bp := range b {
-		out[i] = map[string]interface{}{
+		out[i] = map[string]any{
 			"Name":          bp.Name,
 			"ID":            bp.ID,
 			"Version":       bp.Version,

--- a/commands/displayers/balance.go
+++ b/commands/displayers/balance.go
@@ -45,13 +45,13 @@ func (a *Balance) ColMap() map[string]string {
 	}
 }
 
-func (a *Balance) KV() []map[string]interface{} {
-	x := map[string]interface{}{
+func (a *Balance) KV() []map[string]any {
+	x := map[string]any{
 		"MonthToDateBalance": a.MonthToDateBalance,
 		"AccountBalance":     a.AccountBalance,
 		"MonthToDateUsage":   a.MonthToDateUsage,
 		"GeneratedAt":        a.GeneratedAt.Format(time.RFC3339),
 	}
 
-	return []map[string]interface{}{x}
+	return []map[string]any{x}
 }

--- a/commands/displayers/billing_history.go
+++ b/commands/displayers/billing_history.go
@@ -47,7 +47,7 @@ func (i *BillingHistory) ColMap() map[string]string {
 	}
 }
 
-func (i *BillingHistory) KV() []map[string]interface{} {
+func (i *BillingHistory) KV() []map[string]any {
 	fromStringP := func(s *string) string {
 		if s == nil {
 			return ""
@@ -55,9 +55,9 @@ func (i *BillingHistory) KV() []map[string]interface{} {
 		return *s
 	}
 	history := i.BillingHistory.BillingHistory.BillingHistory
-	out := make([]map[string]interface{}, 0, len(history))
+	out := make([]map[string]any, 0, len(history))
 	for _, ii := range history {
-		x := map[string]interface{}{
+		x := map[string]any{
 			"Date":        ii.Date.Format(time.RFC3339),
 			"Type":        ii.Type,
 			"Description": ii.Description,

--- a/commands/displayers/cdn.go
+++ b/commands/displayers/cdn.go
@@ -47,11 +47,11 @@ func (c *CDN) ColMap() map[string]string {
 	}
 }
 
-func (c *CDN) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(c.CDNs))
+func (c *CDN) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(c.CDNs))
 
 	for _, cdn := range c.CDNs {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"ID":            cdn.ID,
 			"Origin":        cdn.Origin,
 			"Endpoint":      cdn.Endpoint,

--- a/commands/displayers/certificate.go
+++ b/commands/displayers/certificate.go
@@ -56,11 +56,11 @@ func (c *Certificate) ColMap() map[string]string {
 	}
 }
 
-func (c *Certificate) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(c.Certificates))
+func (c *Certificate) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(c.Certificates))
 
 	for _, c := range c.Certificates {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID":              c.ID,
 			"Name":            c.Name,
 			"DNSNames":        strings.Join(c.DNSNames, ","),

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -94,11 +94,11 @@ func (d *Databases) ColMap() map[string]string {
 	}
 }
 
-func (d *Databases) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(d.Databases))
+func (d *Databases) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(d.Databases))
 
 	for _, db := range d.Databases {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID":         db.ID,
 			"Name":       db.Name,
 			"Engine":     db.EngineSlug,
@@ -141,11 +141,11 @@ func (db *DatabaseBackups) ColMap() map[string]string {
 	}
 }
 
-func (db *DatabaseBackups) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(db.DatabaseBackups))
+func (db *DatabaseBackups) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(db.DatabaseBackups))
 
 	for _, b := range db.DatabaseBackups {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Size":    b.SizeGigabytes,
 			"Created": b.CreatedAt,
 		}
@@ -181,11 +181,11 @@ func (du *DatabaseUsers) ColMap() map[string]string {
 	}
 }
 
-func (du *DatabaseUsers) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(du.DatabaseUsers))
+func (du *DatabaseUsers) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(du.DatabaseUsers))
 
 	for _, u := range du.DatabaseUsers {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Role":     u.Role,
 			"Name":     u.Name,
 			"Password": u.Password,
@@ -230,9 +230,9 @@ func (dc *DatabaseConnection) ColMap() map[string]string {
 	}
 }
 
-func (dc *DatabaseConnection) KV() []map[string]interface{} {
+func (dc *DatabaseConnection) KV() []map[string]any {
 	c := dc.DatabaseConnection
-	o := map[string]interface{}{
+	o := map[string]any{
 		"URI":      c.URI,
 		"Database": c.Database,
 		"Host":     c.Host,
@@ -242,7 +242,7 @@ func (dc *DatabaseConnection) KV() []map[string]interface{} {
 		"SSL":      c.SSL,
 	}
 
-	return []map[string]interface{}{o}
+	return []map[string]any{o}
 }
 
 type DatabaseReplicas struct {
@@ -296,11 +296,11 @@ func (dr *DatabaseReplicas) ColMap() map[string]string {
 	}
 }
 
-func (dr *DatabaseReplicas) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(dr.DatabaseReplicas))
+func (dr *DatabaseReplicas) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(dr.DatabaseReplicas))
 
 	for _, r := range dr.DatabaseReplicas {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Name":    r.Name,
 			"ID":      r.ID,
 			"Region":  r.Region,
@@ -336,7 +336,7 @@ func (do *DatabaseOptions) ColMap() map[string]string {
 	}
 }
 
-func (do *DatabaseOptions) KV() []map[string]interface{} {
+func (do *DatabaseOptions) KV() []map[string]any {
 	engines := make([]string, 0)
 	nonEmptyOptionsFn := func(opt godo.DatabaseEngineOptions) bool {
 		return len(opt.Layouts) > 0 || len(opt.Regions) > 0 || len(opt.Versions) > 0
@@ -357,9 +357,9 @@ func (do *DatabaseOptions) KV() []map[string]interface{} {
 		engines = append(engines, "kafka")
 	}
 
-	out := make([]map[string]interface{}, 0, len(engines))
+	out := make([]map[string]any, 0, len(engines))
 	for _, eng := range engines {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Engine": eng,
 		}
 		out = append(out, o)
@@ -391,8 +391,8 @@ func (dbr *DatabaseRegionOptions) ColMap() map[string]string {
 	}
 }
 
-func (dbr *DatabaseRegionOptions) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0)
+func (dbr *DatabaseRegionOptions) KV() []map[string]any {
+	out := make([]map[string]any, 0)
 	regionEngineMap := make(map[string][]string, 0)
 	for eng, regions := range dbr.RegionMap {
 		for _, r := range regions {
@@ -400,7 +400,7 @@ func (dbr *DatabaseRegionOptions) KV() []map[string]interface{} {
 		}
 	}
 	for r, engines := range regionEngineMap {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Region":  r,
 			"Engines": "[" + strings.Join(engines, ",") + "]",
 		}
@@ -433,10 +433,10 @@ func (dbv *DatabaseVersionOptions) ColMap() map[string]string {
 	}
 }
 
-func (dbv *DatabaseVersionOptions) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0)
+func (dbv *DatabaseVersionOptions) KV() []map[string]any {
+	out := make([]map[string]any, 0)
 	for eng, versions := range dbv.VersionMap {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Engine":   eng,
 			"Versions": "[" + strings.Join(versions, ",") + "]",
 		}
@@ -469,8 +469,8 @@ func (dbl *DatabaseLayoutOptions) ColMap() map[string]string {
 	}
 }
 
-func (dbl *DatabaseLayoutOptions) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0)
+func (dbl *DatabaseLayoutOptions) KV() []map[string]any {
+	out := make([]map[string]any, 0)
 	slugNodeMap := make(map[string][]string, 0)
 	for _, layout := range dbl.Layouts {
 		for _, s := range layout.Sizes {
@@ -485,7 +485,7 @@ func (dbl *DatabaseLayoutOptions) KV() []map[string]interface{} {
 	sort.Strings(keys)
 
 	for _, k := range keys {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Slug":     k,
 			"NodeNums": "[" + strings.Join(slugNodeMap[k], ",") + "]",
 		}
@@ -526,11 +526,11 @@ func (dp *DatabasePools) ColMap() map[string]string {
 	}
 }
 
-func (dp *DatabasePools) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(dp.DatabasePools))
+func (dp *DatabasePools) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(dp.DatabasePools))
 
 	for _, p := range dp.DatabasePools {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"User":     p.User,
 			"Name":     p.Name,
 			"Size":     p.Size,
@@ -570,15 +570,15 @@ func (dmw *DatabaseMaintenanceWindow) ColMap() map[string]string {
 	}
 }
 
-func (dmw *DatabaseMaintenanceWindow) KV() []map[string]interface{} {
+func (dmw *DatabaseMaintenanceWindow) KV() []map[string]any {
 	mw := dmw.DatabaseMaintenanceWindow
-	o := map[string]interface{}{
+	o := map[string]any{
 		"Day":     mw.Day,
 		"Hour":    mw.Hour,
 		"Pending": mw.Pending,
 	}
 
-	return []map[string]interface{}{o}
+	return []map[string]any{o}
 }
 
 type DatabaseDBs struct {
@@ -603,11 +603,11 @@ func (db *DatabaseDBs) ColMap() map[string]string {
 	}
 }
 
-func (db *DatabaseDBs) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(db.DatabaseDBs))
+func (db *DatabaseDBs) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(db.DatabaseDBs))
 
 	for _, p := range db.DatabaseDBs {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Name": p.Name,
 		}
 		out = append(out, o)
@@ -638,11 +638,11 @@ func (dsm *DatabaseSQLModes) ColMap() map[string]string {
 	}
 }
 
-func (dsm *DatabaseSQLModes) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(dsm.DatabaseSQLModes))
+func (dsm *DatabaseSQLModes) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(dsm.DatabaseSQLModes))
 
 	for _, p := range dsm.DatabaseSQLModes {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Name": p,
 		}
 		out = append(out, o)
@@ -680,11 +680,11 @@ func (dr *DatabaseFirewallRules) ColMap() map[string]string {
 	}
 }
 
-func (dr *DatabaseFirewallRules) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(dr.DatabaseFirewallRules))
+func (dr *DatabaseFirewallRules) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(dr.DatabaseFirewallRules))
 
 	for _, r := range dr.DatabaseFirewallRules {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"UUID":        r.UUID,
 			"ClusterUUID": r.ClusterUUID,
 			"Type":        r.Type,
@@ -723,11 +723,11 @@ func (dt *DatabaseKafkaTopics) ColMap() map[string]string {
 	}
 }
 
-func (dt *DatabaseKafkaTopics) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(dt.DatabaseTopics))
+func (dt *DatabaseKafkaTopics) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(dt.DatabaseTopics))
 
 	for _, t := range dt.DatabaseTopics {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Name":              t.Name,
 			"State":             t.State,
 			"ReplicationFactor": *t.ReplicationFactor,
@@ -767,11 +767,11 @@ func (dp *DatabaseKafkaTopicPartitions) ColMap() map[string]string {
 	}
 }
 
-func (dp *DatabaseKafkaTopicPartitions) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(dp.DatabaseTopicPartitions))
+func (dp *DatabaseKafkaTopicPartitions) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(dp.DatabaseTopicPartitions))
 
 	for _, p := range dp.DatabaseTopicPartitions {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Id":             p.Id,
 			"InSyncReplicas": p.InSyncReplicas,
 			"EarliestOffset": p.EarliestOffset,
@@ -808,9 +808,9 @@ func (dt *DatabaseKafkaTopic) ColMap() map[string]string {
 	}
 }
 
-func (dt *DatabaseKafkaTopic) KV() []map[string]interface{} {
+func (dt *DatabaseKafkaTopic) KV() []map[string]any {
 	t := dt.DatabaseTopic
-	o := []map[string]interface{}{
+	o := []map[string]any{
 		{
 			"key":   "Name",
 			"value": t.Name,
@@ -830,135 +830,135 @@ func (dt *DatabaseKafkaTopic) KV() []map[string]interface{} {
 	}
 
 	if t.Config != nil {
-		cfg := make([]map[string]interface{}, 0)
+		cfg := make([]map[string]any, 0)
 		if t.Config.CleanupPolicy != "" {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "CleanupPolicy",
 				"value": t.Config.CleanupPolicy,
 			})
 		}
 		if t.Config.CompressionType != "" {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "CompressionType",
 				"value": t.Config.CompressionType,
 			})
 		}
 		if t.Config.DeleteRetentionMS != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "DeleteRetentionMS",
 				"value": *t.Config.DeleteRetentionMS,
 			})
 		}
 		if t.Config.FileDeleteDelayMS != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "FileDeleteDelayMS",
 				"value": *t.Config.FileDeleteDelayMS,
 			})
 		}
 		if t.Config.FlushMessages != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "FlushMessages",
 				"value": *t.Config.FlushMessages,
 			})
 		}
 		if t.Config.FlushMS != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "FlushMS",
 				"value": *t.Config.FlushMS,
 			})
 		}
 		if t.Config.IndexIntervalBytes != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "IndexIntervalBytes",
 				"value": *t.Config.IndexIntervalBytes,
 			})
 		}
 		if t.Config.MaxCompactionLagMS != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "MaxCompactionLagMS",
 				"value": *t.Config.MaxCompactionLagMS,
 			})
 		}
 		if t.Config.MessageDownConversionEnable != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "MessageDownConversionEnable",
 				"value": *t.Config.MessageDownConversionEnable,
 			})
 		}
 		if t.Config.MessageFormatVersion != "" {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "MessageFormatVersion",
 				"value": t.Config.MessageFormatVersion,
 			})
 		}
 		if t.Config.MessageTimestampDifferenceMaxMS != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "MessageTimestampDifferentMaxMS",
 				"value": *t.Config.MessageTimestampDifferenceMaxMS,
 			})
 		}
 		if t.Config.MessageTimestampType != "" {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "MessageTimestampType",
 				"value": t.Config.MessageTimestampType,
 			})
 		}
 		if t.Config.MinCleanableDirtyRatio != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "MinCleanableDirtyRatio",
 				"value": *t.Config.MinCleanableDirtyRatio,
 			})
 		}
 		if t.Config.MinCompactionLagMS != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "MinCompactionLagMS",
 				"value": *t.Config.MinCompactionLagMS,
 			})
 		}
 		if t.Config.MinInsyncReplicas != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "MinInsyncReplicas",
 				"value": *t.Config.MinInsyncReplicas,
 			})
 		}
 		if t.Config.Preallocate != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "Preallocate",
 				"value": *t.Config.Preallocate,
 			})
 		}
 		if t.Config.RetentionBytes != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "RetentionBytes",
 				"value": *t.Config.RetentionBytes,
 			})
 		}
 		if t.Config.RetentionMS != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "RetentionMS",
 				"value": *t.Config.RetentionMS,
 			})
 		}
 		if t.Config.SegmentBytes != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "SegmentBytes",
 				"value": *t.Config.SegmentBytes,
 			})
 		}
 		if t.Config.SegmentIndexBytes != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "SegmentIndexBytes",
 				"value": *t.Config.SegmentIndexBytes,
 			})
 		}
 		if t.Config.SegmentJitterMS != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "SegmentJitterMS",
 				"value": *t.Config.SegmentJitterMS,
 			})
 		}
 		if t.Config.SegmentMS != nil {
-			cfg = append(cfg, map[string]interface{}{
+			cfg = append(cfg, map[string]any{
 				"key":   "SegmentMS",
 				"value": *t.Config.SegmentMS,
 			})
@@ -993,167 +993,167 @@ func (dc *MySQLConfiguration) ColMap() map[string]string {
 	}
 }
 
-func (dc *MySQLConfiguration) KV() []map[string]interface{} {
+func (dc *MySQLConfiguration) KV() []map[string]any {
 	c := dc.MySQLConfiguration
-	o := []map[string]interface{}{}
+	o := []map[string]any{}
 	if c.ConnectTimeout != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "ConnectTimeout",
 			"value": *c.ConnectTimeout,
 		})
 	}
 	if c.DefaultTimeZone != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "DefaultTimeZone",
 			"value": *c.DefaultTimeZone,
 		})
 	}
 	if c.InnodbLogBufferSize != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "InnodbLogBufferSize",
 			"value": *c.InnodbLogBufferSize,
 		})
 	}
 	if c.InnodbOnlineAlterLogMaxSize != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "InnodbOnlineAlterLogMaxSize",
 			"value": *c.InnodbOnlineAlterLogMaxSize,
 		})
 	}
 	if c.InnodbLockWaitTimeout != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "InnodbLockWaitTimeout",
 			"value": *c.InnodbLockWaitTimeout,
 		})
 	}
 	if c.InteractiveTimeout != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "InteractiveTimeout",
 			"value": *c.InteractiveTimeout,
 		})
 	}
 	if c.MaxAllowedPacket != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxAllowedPacket",
 			"value": *c.MaxAllowedPacket,
 		})
 	}
 	if c.NetReadTimeout != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "NetReadTimeout",
 			"value": *c.NetReadTimeout,
 		})
 	}
 	if c.SortBufferSize != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "SortBufferSize",
 			"value": *c.SortBufferSize,
 		})
 	}
 	if c.SQLMode != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "SQLMode",
 			"value": *c.SQLMode,
 		})
 	}
 	if c.SQLRequirePrimaryKey != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "SQLRequirePrimaryKey",
 			"value": *c.SQLRequirePrimaryKey,
 		})
 	}
 	if c.WaitTimeout != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "WaitTimeout",
 			"value": *c.WaitTimeout,
 		})
 	}
 	if c.NetWriteTimeout != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "NetWriteTimeout",
 			"value": *c.NetWriteTimeout,
 		})
 	}
 	if c.GroupConcatMaxLen != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "GroupConcatMaxLen",
 			"value": *c.GroupConcatMaxLen,
 		})
 	}
 	if c.InformationSchemaStatsExpiry != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "InformationSchemaStatsExpiry",
 			"value": *c.InformationSchemaStatsExpiry,
 		})
 	}
 	if c.InnodbFtMinTokenSize != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "InnodbFtMinTokenSize",
 			"value": *c.InnodbFtMinTokenSize,
 		})
 	}
 	if c.InnodbFtServerStopwordTable != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "InnodbFtServerStopwordTable",
 			"value": *c.InnodbFtServerStopwordTable,
 		})
 	}
 	if c.InnodbPrintAllDeadlocks != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "InnodbPrintAllDeadlocks",
 			"value": *c.InnodbPrintAllDeadlocks,
 		})
 	}
 	if c.InnodbRollbackOnTimeout != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "InnodbRollbackOnTimeout",
 			"value": *c.InnodbRollbackOnTimeout,
 		})
 	}
 	if c.InternalTmpMemStorageEngine != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "InternalTmpMemStorageEngine",
 			"value": *c.InternalTmpMemStorageEngine,
 		})
 	}
 	if c.MaxHeapTableSize != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxHeapTableSize",
 			"value": *c.MaxHeapTableSize,
 		})
 	}
 	if c.TmpTableSize != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "TmpTableSize",
 			"value": *c.TmpTableSize,
 		})
 	}
 	if c.SlowQueryLog != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "SlowQueryLog",
 			"value": *c.SlowQueryLog,
 		})
 	}
 	if c.LongQueryTime != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "LongQueryTime",
 			"value": *c.LongQueryTime,
 		})
 	}
 	if c.BackupHour != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "BackupHour",
 			"value": *c.BackupHour,
 		})
 	}
 	if c.BackupMinute != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "BackupMinute",
 			"value": *c.BackupMinute,
 		})
 	}
 	if c.BinlogRetentionPeriod != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "BinlogRetentionPeriod",
 			"value": *c.BinlogRetentionPeriod,
 		})
@@ -1186,361 +1186,361 @@ func (dc *PostgreSQLConfiguration) ColMap() map[string]string {
 	}
 }
 
-func (dc *PostgreSQLConfiguration) KV() []map[string]interface{} {
+func (dc *PostgreSQLConfiguration) KV() []map[string]any {
 	c := dc.PostgreSQLConfig
-	o := []map[string]interface{}{}
+	o := []map[string]any{}
 	if c.AutovacuumFreezeMaxAge != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "AutovacuumFreezeMaxAge",
 			"value": *c.AutovacuumFreezeMaxAge,
 		})
 	}
 	if c.AutovacuumMaxWorkers != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "AutovacuumMaxWorkers",
 			"value": *c.AutovacuumMaxWorkers,
 		})
 	}
 	if c.AutovacuumNaptime != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "AutovacuumNaptime",
 			"value": *c.AutovacuumNaptime,
 		})
 	}
 	if c.AutovacuumVacuumThreshold != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "AutovacuumVacuumThreshold",
 			"value": *c.AutovacuumVacuumThreshold,
 		})
 	}
 	if c.AutovacuumAnalyzeThreshold != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "AutovacuumAnalyzeThreshold",
 			"value": *c.AutovacuumAnalyzeThreshold,
 		})
 	}
 	if c.AutovacuumVacuumScaleFactor != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "AutovacuumVacuumScaleFactor",
 			"value": *c.AutovacuumVacuumScaleFactor,
 		})
 	}
 	if c.AutovacuumAnalyzeScaleFactor != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "AutovacuumAnalyzeScaleFactor",
 			"value": *c.AutovacuumAnalyzeScaleFactor,
 		})
 	}
 	if c.AutovacuumVacuumCostDelay != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "AutovacuumVacuumCostDelay",
 			"value": *c.AutovacuumVacuumCostDelay,
 		})
 	}
 	if c.AutovacuumVacuumCostLimit != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "AutovacuumVacuumCostLimit",
 			"value": *c.AutovacuumVacuumCostLimit,
 		})
 	}
 	if c.BGWriterDelay != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "BGWriterDelay",
 			"value": *c.BGWriterDelay,
 		})
 	}
 	if c.BGWriterFlushAfter != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "BGWriterFlushAfter",
 			"value": *c.BGWriterFlushAfter,
 		})
 	}
 	if c.BGWriterLRUMaxpages != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "BGWriterLRUMaxpages",
 			"value": *c.BGWriterLRUMaxpages,
 		})
 	}
 	if c.BGWriterLRUMultiplier != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "BGWriterLRUMultiplier",
 			"value": *c.BGWriterLRUMultiplier,
 		})
 	}
 	if c.DeadlockTimeoutMillis != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "DeadlockTimeoutMillis",
 			"value": *c.DeadlockTimeoutMillis,
 		})
 	}
 	if c.DefaultToastCompression != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "DefaultToastCompression",
 			"value": *c.DefaultToastCompression,
 		})
 	}
 	if c.IdleInTransactionSessionTimeout != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "IdleInTransactionSessionTimeout",
 			"value": *c.IdleInTransactionSessionTimeout,
 		})
 	}
 	if c.JIT != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "JIT",
 			"value": *c.JIT,
 		})
 	}
 	if c.LogAutovacuumMinDuration != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "LogAutovacuumMinDuration",
 			"value": *c.LogAutovacuumMinDuration,
 		})
 	}
 	if c.LogErrorVerbosity != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "LogErrorVerbosity",
 			"value": *c.LogErrorVerbosity,
 		})
 	}
 	if c.LogLinePrefix != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "LogLinePrefix",
 			"value": *c.LogLinePrefix,
 		})
 	}
 	if c.LogMinDurationStatement != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "LogMinDurationStatement",
 			"value": *c.LogMinDurationStatement,
 		})
 	}
 	if c.MaxFilesPerProcess != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxFilesPerProcess",
 			"value": *c.MaxFilesPerProcess,
 		})
 	}
 	if c.MaxPreparedTransactions != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxPreparedTransactions",
 			"value": *c.MaxPreparedTransactions,
 		})
 	}
 	if c.MaxPredLocksPerTransaction != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxPredLocksPerTransaction",
 			"value": *c.MaxPredLocksPerTransaction,
 		})
 	}
 	if c.MaxLocksPerTransaction != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxLocksPerTransaction",
 			"value": *c.MaxLocksPerTransaction,
 		})
 	}
 	if c.MaxStackDepth != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxStackDepth",
 			"value": *c.MaxStackDepth,
 		})
 	}
 	if c.MaxStandbyArchiveDelay != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxStandbyArchiveDelay",
 			"value": *c.MaxStandbyArchiveDelay,
 		})
 	}
 	if c.MaxStandbyStreamingDelay != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxStandbyStreamingDelay",
 			"value": *c.MaxStandbyStreamingDelay,
 		})
 	}
 	if c.MaxReplicationSlots != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxReplicationSlots",
 			"value": *c.MaxReplicationSlots,
 		})
 	}
 	if c.MaxLogicalReplicationWorkers != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxLogicalReplicationWorkers",
 			"value": *c.MaxLogicalReplicationWorkers,
 		})
 	}
 	if c.MaxParallelWorkers != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxParallelWorkers",
 			"value": *c.MaxParallelWorkers,
 		})
 	}
 	if c.MaxParallelWorkersPerGather != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxParallelWorkersPerGather",
 			"value": *c.MaxParallelWorkersPerGather,
 		})
 	}
 	if c.MaxWorkerProcesses != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxWorkerProcesses",
 			"value": *c.MaxWorkerProcesses,
 		})
 	}
 	if c.PGPartmanBGWRole != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "PGPartmanBGWRole",
 			"value": *c.PGPartmanBGWRole,
 		})
 	}
 	if c.PGPartmanBGWInterval != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "PGPartmanBGWInterval",
 			"value": *c.PGPartmanBGWInterval,
 		})
 	}
 	if c.PGStatStatementsTrack != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "PGStatStatementsTrack",
 			"value": *c.PGStatStatementsTrack,
 		})
 	}
 	if c.TempFileLimit != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "TempFileLimit",
 			"value": *c.TempFileLimit,
 		})
 	}
 	if c.Timezone != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "Timezone",
 			"value": *c.Timezone,
 		})
 	}
 	if c.TrackActivityQuerySize != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "TrackActivityQuerySize",
 			"value": *c.TrackActivityQuerySize,
 		})
 	}
 	if c.TrackCommitTimestamp != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "TrackCommitTimestamp",
 			"value": *c.TrackCommitTimestamp,
 		})
 	}
 	if c.TrackFunctions != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "TrackFunctions",
 			"value": *c.TrackFunctions,
 		})
 	}
 	if c.TrackIOTiming != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "TrackIOTiming",
 			"value": *c.TrackIOTiming,
 		})
 	}
 	if c.MaxWalSenders != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "MaxWalSenders",
 			"value": *c.MaxWalSenders,
 		})
 	}
 	if c.WalSenderTimeout != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "WalSenderTimeout",
 			"value": *c.WalSenderTimeout,
 		})
 	}
 	if c.WalWriterDelay != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "WalWriterDelay",
 			"value": *c.WalWriterDelay,
 		})
 	}
 	if c.SharedBuffersPercentage != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "SharedBuffersPercentage",
 			"value": *c.SharedBuffersPercentage,
 		})
 	}
 	if c.PgBouncer != nil {
 		if c.PgBouncer.ServerResetQueryAlways != nil {
-			o = append(o, map[string]interface{}{
+			o = append(o, map[string]any{
 				"key":   "PgBouncer.ServerResetQueryAlways",
 				"value": *c.PgBouncer.ServerResetQueryAlways,
 			})
 		}
 		if c.PgBouncer.IgnoreStartupParameters != nil {
-			o = append(o, map[string]interface{}{
+			o = append(o, map[string]any{
 				"key":   "PgBouncer.IgnoreStartupParameters",
 				"value": strings.Join(*c.PgBouncer.IgnoreStartupParameters, ","),
 			})
 		}
 		if c.PgBouncer.MinPoolSize != nil {
-			o = append(o, map[string]interface{}{
+			o = append(o, map[string]any{
 				"key":   "PgBouncer.MinPoolSize",
 				"value": *c.PgBouncer.MinPoolSize,
 			})
 		}
 		if c.PgBouncer.ServerLifetime != nil {
-			o = append(o, map[string]interface{}{
+			o = append(o, map[string]any{
 				"key":   "PgBouncer.ServerLifetime",
 				"value": *c.PgBouncer.ServerLifetime,
 			})
 		}
 		if c.PgBouncer.ServerIdleTimeout != nil {
-			o = append(o, map[string]interface{}{
+			o = append(o, map[string]any{
 				"key":   "PgBouncer.ServerIdleTimeout",
 				"value": *c.PgBouncer.ServerIdleTimeout,
 			})
 		}
 		if c.PgBouncer.AutodbPoolSize != nil {
-			o = append(o, map[string]interface{}{
+			o = append(o, map[string]any{
 				"key":   "PgBouncer.AutodbPoolSize",
 				"value": *c.PgBouncer.AutodbPoolSize,
 			})
 		}
 		if c.PgBouncer.AutodbPoolMode != nil {
-			o = append(o, map[string]interface{}{
+			o = append(o, map[string]any{
 				"key":   "PgBouncer.AutodbPoolMode",
 				"value": *c.PgBouncer.AutodbPoolMode,
 			})
 		}
 		if c.PgBouncer.AutodbMaxDbConnections != nil {
-			o = append(o, map[string]interface{}{
+			o = append(o, map[string]any{
 				"key":   "PgBouncer.AutodbMaxDbConnections",
 				"value": *c.PgBouncer.AutodbMaxDbConnections,
 			})
 		}
 		if c.PgBouncer.AutodbIdleTimeout != nil {
-			o = append(o, map[string]interface{}{
+			o = append(o, map[string]any{
 				"key":   "PgBouncer.AutodbIdleTimeout",
 				"value": *c.PgBouncer.AutodbIdleTimeout,
 			})
 		}
 	}
 	if c.BackupHour != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "BackupHour",
 			"value": *c.BackupHour,
 		})
 	}
 	if c.BackupMinute != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "BackupMinute",
 			"value": *c.BackupMinute,
 		})
 	}
 	if c.WorkMem != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "WorkMem",
 			"value": *c.WorkMem,
 		})
 	}
 	if c.TimeScaleDB != nil && c.TimeScaleDB.MaxBackgroundWorkers != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "TimeScaleDB.MaxBackgroundWorkers",
 			"value": *c.TimeScaleDB.MaxBackgroundWorkers,
 		})
@@ -1572,71 +1572,71 @@ func (dc *RedisConfiguration) ColMap() map[string]string {
 	}
 }
 
-func (dc *RedisConfiguration) KV() []map[string]interface{} {
+func (dc *RedisConfiguration) KV() []map[string]any {
 	c := dc.RedisConfig
-	o := []map[string]interface{}{}
+	o := []map[string]any{}
 	if c.RedisMaxmemoryPolicy != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "RedisMaxmemoryPolicy",
 			"value": *c.RedisMaxmemoryPolicy,
 		})
 	}
 	if c.RedisPubsubClientOutputBufferLimit != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "RedisPubsubClientOutputBufferLimit",
 			"value": *c.RedisPubsubClientOutputBufferLimit,
 		})
 	}
 	if c.RedisNumberOfDatabases != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "RedisNumberOfDatabases",
 			"value": *c.RedisNumberOfDatabases,
 		})
 	}
 	if c.RedisIOThreads != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "RedisIOThreads",
 			"value": *c.RedisIOThreads,
 		})
 	}
 	if c.RedisLFULogFactor != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "RedisLFULogFactor",
 			"value": *c.RedisLFULogFactor,
 		})
 	}
 	if c.RedisLFUDecayTime != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "RedisLFUDecayTime",
 			"value": *c.RedisLFUDecayTime,
 		})
 	}
 	if c.RedisSSL != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "RedisSSL",
 			"value": *c.RedisSSL,
 		})
 	}
 	if c.RedisTimeout != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "RedisTimeout",
 			"value": *c.RedisTimeout,
 		})
 	}
 	if c.RedisNotifyKeyspaceEvents != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "RedisNotifyKeyspaceEvents",
 			"value": *c.RedisNotifyKeyspaceEvents,
 		})
 	}
 	if c.RedisPersistence != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "RedisPersistence",
 			"value": *c.RedisPersistence,
 		})
 	}
 	if c.RedisACLChannelsDefault != nil {
-		o = append(o, map[string]interface{}{
+		o = append(o, map[string]any{
 			"key":   "RedisACLChannelsDefault",
 			"value": *c.RedisACLChannelsDefault,
 		})

--- a/commands/displayers/domain.go
+++ b/commands/displayers/domain.go
@@ -39,11 +39,11 @@ func (d *Domain) ColMap() map[string]string {
 	}
 }
 
-func (d *Domain) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(d.Domains))
+func (d *Domain) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(d.Domains))
 
 	for _, do := range d.Domains {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Domain": do.Name, "TTL": do.TTL,
 		}
 		out = append(out, o)
@@ -89,11 +89,11 @@ func (dr *DomainRecord) ColMap() map[string]string {
 	return defaultColMap
 }
 
-func (dr *DomainRecord) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(dr.DomainRecords))
+func (dr *DomainRecord) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(dr.DomainRecords))
 
 	for _, d := range dr.DomainRecords {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID": d.ID, "Type": d.Type, "Name": d.Name,
 			"Data": d.Data, "Priority": d.Priority,
 			"Port": d.Port, "TTL": d.TTL, "Weight": d.Weight,

--- a/commands/displayers/droplet.go
+++ b/commands/displayers/droplet.go
@@ -49,8 +49,8 @@ func (d *Droplet) ColMap() map[string]string {
 	}
 }
 
-func (d *Droplet) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(d.Droplets))
+func (d *Droplet) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(d.Droplets))
 	for _, d := range d.Droplets {
 		sort.Strings(d.Tags)
 		tags := strings.Join(d.Tags, ",")
@@ -60,7 +60,7 @@ func (d *Droplet) KV() []map[string]interface{} {
 		ip6, _ := d.PublicIPv6()
 		features := strings.Join(d.Features, ",")
 		volumes := strings.Join(d.VolumeIDs, ",")
-		m := map[string]interface{}{
+		m := map[string]any{
 			"ID": d.ID, "Name": d.Name, "PublicIPv4": ip, "PrivateIPv4": privIP, "PublicIPv6": ip6,
 			"Memory": d.Memory, "VCPUs": d.Vcpus, "Disk": d.Disk,
 			"Region": d.Region.Slug, "Image": image, "VPCUUID": d.VPCUUID, "Status": d.Status,

--- a/commands/displayers/firewall.go
+++ b/commands/displayers/firewall.go
@@ -60,12 +60,12 @@ func (f *Firewall) ColMap() map[string]string {
 	}
 }
 
-func (f *Firewall) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(f.Firewalls))
+func (f *Firewall) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(f.Firewalls))
 
 	for _, fw := range f.Firewalls {
 		irs, ors := firewallRulesPrintHelper(fw)
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID":             fw.ID,
 			"Name":           fw.Name,
 			"Status":         fw.Status,

--- a/commands/displayers/functions.go
+++ b/commands/displayers/functions.go
@@ -51,10 +51,10 @@ func (i *Functions) ColMap() map[string]string {
 }
 
 // KV is the displayer KV method specialized for functions list
-func (i *Functions) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(i.Info))
+func (i *Functions) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(i.Info))
 	for _, ii := range i.Info {
-		x := map[string]interface{}{
+		x := map[string]any{
 			"Update":   time.UnixMilli(ii.Updated).Format("01/02 03:04:05"),
 			"Runtime":  findRuntime(ii.Annotations),
 			"Version":  ii.Version,

--- a/commands/displayers/image.go
+++ b/commands/displayers/image.go
@@ -42,8 +42,8 @@ func (gi *Image) ColMap() map[string]string {
 	}
 }
 
-func (gi *Image) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(gi.Images))
+func (gi *Image) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(gi.Images))
 
 	for _, i := range gi.Images {
 		publicStatus := false
@@ -51,7 +51,7 @@ func (gi *Image) KV() []map[string]interface{} {
 			publicStatus = true
 		}
 
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID": i.ID, "Name": i.Name, "Type": i.Type, "Distribution": i.Distribution,
 			"Slug": i.Slug, "Public": publicStatus, "MinDisk": i.MinDiskSize,
 		}

--- a/commands/displayers/invoice.go
+++ b/commands/displayers/invoice.go
@@ -53,10 +53,10 @@ func (i *Invoice) ColMap() map[string]string {
 	}
 }
 
-func (i *Invoice) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(i.Invoice.Invoice.InvoiceItems))
+func (i *Invoice) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(i.Invoice.Invoice.InvoiceItems))
 	for _, ii := range i.Invoice.Invoice.InvoiceItems {
-		x := map[string]interface{}{
+		x := map[string]any{
 			"ResourceID":       ii.ResourceID,
 			"ResourceUUID":     ii.ResourceUUID,
 			"Product":          ii.Product,

--- a/commands/displayers/invoice_list.go
+++ b/commands/displayers/invoice_list.go
@@ -43,17 +43,17 @@ func (i *InvoiceList) ColMap() map[string]string {
 	}
 }
 
-func (i *InvoiceList) KV() []map[string]interface{} {
+func (i *InvoiceList) KV() []map[string]any {
 	invoices := i.InvoiceList.Invoices
-	out := make([]map[string]interface{}, 0, len(invoices)+1)
-	x := map[string]interface{}{
+	out := make([]map[string]any, 0, len(invoices)+1)
+	x := map[string]any{
 		"InvoiceUUID":   "preview",
 		"Amount":        i.InvoicePreview.Amount,
 		"InvoicePeriod": i.InvoicePreview.InvoicePeriod,
 	}
 	out = append(out, x)
 	for _, ii := range invoices {
-		x := map[string]interface{}{
+		x := map[string]any{
 			"InvoiceUUID":   ii.InvoiceUUID,
 			"Amount":        ii.Amount,
 			"InvoicePeriod": ii.InvoicePeriod,

--- a/commands/displayers/invoice_summary.go
+++ b/commands/displayers/invoice_summary.go
@@ -59,8 +59,8 @@ func (i *InvoiceSummary) ColMap() map[string]string {
 	}
 }
 
-func (i *InvoiceSummary) KV() []map[string]interface{} {
-	x := map[string]interface{}{
+func (i *InvoiceSummary) KV() []map[string]any {
+	x := map[string]any{
 		"InvoiceUUID":           i.InvoiceSummary.InvoiceUUID,
 		"BillingPeriod":         i.InvoiceSummary.BillingPeriod,
 		"Amount":                i.InvoiceSummary.Amount,
@@ -73,5 +73,5 @@ func (i *InvoiceSummary) KV() []map[string]interface{} {
 		"CreditsAndAdjustments": i.InvoiceSummary.CreditsAndAdjustments.Amount,
 	}
 
-	return []map[string]interface{}{x}
+	return []map[string]any{x}
 }

--- a/commands/displayers/kernel.go
+++ b/commands/displayers/kernel.go
@@ -41,11 +41,11 @@ func (ke *Kernel) ColMap() map[string]string {
 	}
 }
 
-func (ke *Kernel) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(ke.Kernels))
+func (ke *Kernel) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(ke.Kernels))
 
 	for _, k := range ke.Kernels {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID": k.ID, "Name": k.Name, "Version": k.Version,
 		}
 

--- a/commands/displayers/key.go
+++ b/commands/displayers/key.go
@@ -42,11 +42,11 @@ func (ke *Key) ColMap() map[string]string {
 	}
 }
 
-func (ke *Key) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(ke.Keys))
+func (ke *Key) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(ke.Keys))
 
 	for _, k := range ke.Keys {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID": k.ID, "Name": k.Name, "FingerPrint": k.Fingerprint,
 		}
 
@@ -81,11 +81,11 @@ func (ke *KeyGet) ColMap() map[string]string {
 	}
 }
 
-func (ke *KeyGet) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(ke.Keys))
+func (ke *KeyGet) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(ke.Keys))
 
 	for _, k := range ke.Keys {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID": k.ID, "Name": k.Name, "FingerPrint": k.Fingerprint, "PublicKey": k.PublicKey,
 		}
 

--- a/commands/displayers/kubernetes.go
+++ b/commands/displayers/kubernetes.go
@@ -81,8 +81,8 @@ func (clusters *KubernetesClusters) ColMap() map[string]string {
 	}
 }
 
-func (clusters *KubernetesClusters) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(clusters.KubernetesClusters))
+func (clusters *KubernetesClusters) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(clusters.KubernetesClusters))
 
 	for _, cluster := range clusters.KubernetesClusters {
 		tags := strings.Join(cluster.Tags, ",")
@@ -94,7 +94,7 @@ func (clusters *KubernetesClusters) KV() []map[string]interface{} {
 			cluster.Status = new(godo.KubernetesClusterStatus)
 		}
 
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID":             cluster.ID,
 			"Name":           cluster.Name,
 			"Region":         cluster.RegionSlug,
@@ -153,8 +153,8 @@ func (nodePools *KubernetesNodePools) ColMap() map[string]string {
 	}
 }
 
-func (nodePools *KubernetesNodePools) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(nodePools.KubernetesNodePools))
+func (nodePools *KubernetesNodePools) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(nodePools.KubernetesNodePools))
 
 	for _, nodePools := range nodePools.KubernetesNodePools {
 		tags := strings.Join(nodePools.Tags, ",")
@@ -163,7 +163,7 @@ func (nodePools *KubernetesNodePools) KV() []map[string]interface{} {
 			nodes = append(nodes, node.Name)
 		}
 
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID":     nodePools.ID,
 			"Name":   nodePools.Name,
 			"Size":   nodePools.Size,
@@ -205,12 +205,12 @@ func (versions *KubernetesVersions) ColMap() map[string]string {
 	}
 }
 
-func (versions *KubernetesVersions) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(versions.KubernetesVersions))
+func (versions *KubernetesVersions) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(versions.KubernetesVersions))
 
 	for _, version := range versions.KubernetesVersions {
 
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Slug":              version.KubernetesVersion.Slug,
 			"KubernetesVersion": version.KubernetesVersion.KubernetesVersion,
 			"SupportedFeatures": strings.Join(version.KubernetesVersion.SupportedFeatures, ", "),
@@ -245,12 +245,12 @@ func (regions *KubernetesRegions) ColMap() map[string]string {
 	}
 }
 
-func (regions *KubernetesRegions) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(regions.KubernetesRegions))
+func (regions *KubernetesRegions) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(regions.KubernetesRegions))
 
 	for _, region := range regions.KubernetesRegions {
 
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Slug": region.KubernetesRegion.Slug,
 			"Name": region.KubernetesRegion.Name,
 		}
@@ -284,12 +284,12 @@ func (nodeSizes *KubernetesNodeSizes) ColMap() map[string]string {
 	}
 }
 
-func (nodeSizes *KubernetesNodeSizes) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(nodeSizes.KubernetesNodeSizes))
+func (nodeSizes *KubernetesNodeSizes) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(nodeSizes.KubernetesNodeSizes))
 
 	for _, size := range nodeSizes.KubernetesNodeSizes {
 
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Slug": size.KubernetesNodeSize.Slug,
 			"Name": size.KubernetesNodeSize.Name,
 		}
@@ -325,13 +325,13 @@ func (ar *KubernetesAssociatedResources) ColMap() map[string]string {
 	}
 }
 
-func (ar *KubernetesAssociatedResources) KV() []map[string]interface{} {
-	o := map[string]interface{}{
+func (ar *KubernetesAssociatedResources) KV() []map[string]any {
+	o := map[string]any{
 		"Volumes":         flattenAssociatedResourceIDs(ar.KubernetesAssociatedResources.Volumes),
 		"VolumeSnapshots": flattenAssociatedResourceIDs(ar.KubernetesAssociatedResources.VolumeSnapshots),
 		"LoadBalancers":   flattenAssociatedResourceIDs(ar.KubernetesAssociatedResources.LoadBalancers),
 	}
-	return []map[string]interface{}{o}
+	return []map[string]any{o}
 }
 
 func flattenAssociatedResourceIDs(resources []*godo.AssociatedResource) (out []string) {

--- a/commands/displayers/load_balancer.go
+++ b/commands/displayers/load_balancer.go
@@ -74,8 +74,8 @@ func (lb *LoadBalancer) ColMap() map[string]string {
 	}
 }
 
-func (lb *LoadBalancer) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(lb.LoadBalancers))
+func (lb *LoadBalancer) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(lb.LoadBalancers))
 
 	for _, l := range lb.LoadBalancers {
 		forwardingRules := make([]string, 0, len(l.ForwardingRules))
@@ -83,7 +83,7 @@ func (lb *LoadBalancer) KV() []map[string]interface{} {
 			forwardingRules = append(forwardingRules, prettyPrintStruct(r))
 		}
 
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID":                           l.ID,
 			"IP":                           l.IP,
 			"Name":                         l.Name,
@@ -118,7 +118,7 @@ func toBool(b *bool) bool {
 	return *b
 }
 
-func prettyPrintStruct(obj interface{}) string {
+func prettyPrintStruct(obj any) string {
 	defer func() {
 		if err := recover(); err != nil {
 			fmt.Printf("Recovered from %v", err)

--- a/commands/displayers/monitoring.go
+++ b/commands/displayers/monitoring.go
@@ -51,8 +51,8 @@ func (a *AlertPolicy) ColMap() map[string]string {
 	}
 }
 
-func (a *AlertPolicy) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(a.AlertPolicies))
+func (a *AlertPolicy) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(a.AlertPolicies))
 
 	for _, x := range a.AlertPolicies {
 		emails := ""
@@ -67,7 +67,7 @@ func (a *AlertPolicy) KV() []map[string]interface{} {
 		}
 		slacks := strings.Join(slackChannels, ",")
 
-		o := map[string]interface{}{
+		o := map[string]any{
 			"UUID":           x.UUID,
 			"Type":           x.Type,
 			"Description":    x.Description,

--- a/commands/displayers/namespaces.go
+++ b/commands/displayers/namespaces.go
@@ -49,10 +49,10 @@ func (i *Namespaces) ColMap() map[string]string {
 }
 
 // KV is the displayer KV method specialized for namespaces list
-func (i *Namespaces) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(i.Info))
+func (i *Namespaces) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(i.Info))
 	for _, ii := range i.Info {
-		x := map[string]interface{}{
+		x := map[string]any{
 			"Label":  ii.Label,
 			"Region": ii.Region,
 			"ID":     ii.Namespace,

--- a/commands/displayers/output.go
+++ b/commands/displayers/output.go
@@ -27,7 +27,7 @@ import (
 type Displayable interface {
 	Cols() []string
 	ColMap() map[string]string
-	KV() []map[string]interface{}
+	KV() []map[string]any
 	JSON(io.Writer) error
 }
 
@@ -89,7 +89,7 @@ func DisplayText(item Displayable, out io.Writer, noHeaders bool, includeCols []
 	}
 
 	for _, r := range item.KV() {
-		values := make([]interface{}, 0, len(cols))
+		values := make([]any, 0, len(cols))
 		formats := make([]string, 0, len(cols))
 
 		for _, col := range cols {
@@ -117,7 +117,7 @@ func DisplayText(item Displayable, out io.Writer, noHeaders bool, includeCols []
 	return w.Flush()
 }
 
-func writeJSON(item interface{}, w io.Writer) error {
+func writeJSON(item any, w io.Writer) error {
 	b, err := json.Marshal(item)
 	if err != nil {
 		return err
@@ -135,7 +135,7 @@ func writeJSON(item interface{}, w io.Writer) error {
 
 // containsOnlyNiSlice returns true if the given interface's concrete type is
 // a pointer to a struct that contains a single nil slice field.
-func containsOnlyNilSlice(i interface{}) bool {
+func containsOnlyNilSlice(i any) bool {
 	if reflect.TypeOf(i).Kind() != reflect.Ptr {
 		return false
 	}

--- a/commands/displayers/plugin.go
+++ b/commands/displayers/plugin.go
@@ -42,11 +42,11 @@ func (p *Plugin) ColMap() map[string]string {
 	}
 }
 
-func (p *Plugin) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(p.Plugins))
+func (p *Plugin) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(p.Plugins))
 
 	for _, plug := range p.Plugins {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Name": plug.Name,
 		}
 

--- a/commands/displayers/project.go
+++ b/commands/displayers/project.go
@@ -59,11 +59,11 @@ func (p *Project) ColMap() map[string]string {
 	}
 }
 
-func (p *Project) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(p.Projects))
+func (p *Project) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(p.Projects))
 
 	for _, pr := range p.Projects {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID":          pr.ID,
 			"OwnerUUID":   pr.OwnerUUID,
 			"OwnerID":     pr.OwnerID,
@@ -107,8 +107,8 @@ func (p *ProjectResource) ColMap() map[string]string {
 	}
 }
 
-func (p *ProjectResource) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(p.ProjectResources))
+func (p *ProjectResource) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(p.ProjectResources))
 
 	for _, pr := range p.ProjectResources {
 		assignedAt := pr.AssignedAt
@@ -116,7 +116,7 @@ func (p *ProjectResource) KV() []map[string]interface{} {
 			assignedAt = "N/A"
 		}
 
-		o := map[string]interface{}{
+		o := map[string]any{
 			"URN":        pr.URN,
 			"AssignedAt": assignedAt,
 			"Status":     pr.Status,

--- a/commands/displayers/rate_limit.go
+++ b/commands/displayers/rate_limit.go
@@ -41,10 +41,10 @@ func (rl *RateLimit) ColMap() map[string]string {
 	}
 }
 
-func (rl *RateLimit) KV() []map[string]interface{} {
-	x := map[string]interface{}{
+func (rl *RateLimit) KV() []map[string]any {
+	x := map[string]any{
 		"Limit": rl.Limit, "Remaining": rl.Remaining, "Reset": rl.Reset,
 	}
 
-	return []map[string]interface{}{x}
+	return []map[string]any{x}
 }

--- a/commands/displayers/region.go
+++ b/commands/displayers/region.go
@@ -41,11 +41,11 @@ func (re *Region) ColMap() map[string]string {
 	}
 }
 
-func (re *Region) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(re.Regions))
+func (re *Region) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(re.Regions))
 
 	for _, r := range re.Regions {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Slug": r.Slug, "Name": r.Name, "Available": r.Available,
 		}
 

--- a/commands/displayers/registry.go
+++ b/commands/displayers/registry.go
@@ -47,11 +47,11 @@ func (r *Registry) ColMap() map[string]string {
 	}
 }
 
-func (r *Registry) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(r.Registries))
+func (r *Registry) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(r.Registries))
 
 	for _, reg := range r.Registries {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"Name":     reg.Name,
 			"Endpoint": reg.Endpoint(),
 			"Region":   reg.Region,
@@ -91,11 +91,11 @@ func (r *Repository) ColMap() map[string]string {
 	}
 }
 
-func (r *Repository) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(r.Repositories))
+func (r *Repository) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(r.Repositories))
 
 	for _, reg := range r.Repositories {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"Name":      reg.Name,
 			"LatestTag": reg.LatestTag.Tag,
 			"TagCount":  reg.TagCount,
@@ -140,8 +140,8 @@ func (r *RepositoryV2) ColMap() map[string]string {
 	}
 }
 
-func (r *RepositoryV2) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(r.Repositories))
+func (r *RepositoryV2) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(r.Repositories))
 
 	for _, reg := range r.Repositories {
 		var latestManifest string
@@ -156,7 +156,7 @@ func (r *RepositoryV2) KV() []map[string]interface{} {
 			latestUpdate = &reg.LatestManifest.UpdatedAt
 		}
 
-		m := map[string]interface{}{
+		m := map[string]any{
 			"Name":           reg.Name,
 			"LatestManifest": latestManifest,
 			"LatestTag":      latestTag,
@@ -199,11 +199,11 @@ func (r *RepositoryTag) ColMap() map[string]string {
 	}
 }
 
-func (r *RepositoryTag) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(r.Tags))
+func (r *RepositoryTag) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(r.Tags))
 
 	for _, tag := range r.Tags {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"Tag":                 tag.Tag,
 			"CompressedSizeBytes": BytesToHumanReadableUnit(tag.CompressedSizeBytes),
 			"UpdatedAt":           tag.UpdatedAt,
@@ -246,11 +246,11 @@ func (r *RepositoryManifest) ColMap() map[string]string {
 	}
 }
 
-func (r *RepositoryManifest) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(r.Manifests))
+func (r *RepositoryManifest) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(r.Manifests))
 
 	for _, manifest := range r.Manifests {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"Digest":              manifest.Digest,
 			"CompressedSizeBytes": BytesToHumanReadableUnit(manifest.CompressedSizeBytes),
 			"SizeBytes":           BytesToHumanReadableUnit(manifest.SizeBytes),
@@ -298,11 +298,11 @@ func (g *GarbageCollection) ColMap() map[string]string {
 	}
 }
 
-func (g *GarbageCollection) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(g.GarbageCollections))
+func (g *GarbageCollection) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(g.GarbageCollections))
 
 	for _, gc := range g.GarbageCollections {
-		out = append(out, map[string]interface{}{
+		out = append(out, map[string]any{
 			"UUID":         gc.UUID,
 			"RegistryName": gc.RegistryName,
 			"Status":       gc.Status,
@@ -352,11 +352,11 @@ func (t *RegistrySubscriptionTiers) ColMap() map[string]string {
 	}
 }
 
-func (t *RegistrySubscriptionTiers) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(t.SubscriptionTiers))
+func (t *RegistrySubscriptionTiers) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(t.SubscriptionTiers))
 
 	for _, tier := range t.SubscriptionTiers {
-		out = append(out, map[string]interface{}{
+		out = append(out, map[string]any{
 			"Name":                   tier.Name,
 			"Slug":                   tier.Slug,
 			"IncludedRepositories":   tier.IncludedRepositories,
@@ -392,11 +392,11 @@ func (t *RegistryAvailableRegions) ColMap() map[string]string {
 	}
 }
 
-func (t *RegistryAvailableRegions) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(t.Regions))
+func (t *RegistryAvailableRegions) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(t.Regions))
 
 	for _, region := range t.Regions {
-		out = append(out, map[string]interface{}{
+		out = append(out, map[string]any{
 			"Slug": region,
 		})
 	}

--- a/commands/displayers/reserved_ip.go
+++ b/commands/displayers/reserved_ip.go
@@ -42,8 +42,8 @@ func (rip *ReservedIP) ColMap() map[string]string {
 	}
 }
 
-func (rip *ReservedIP) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(rip.ReservedIPs))
+func (rip *ReservedIP) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(rip.ReservedIPs))
 
 	for _, f := range rip.ReservedIPs {
 		var dropletID, dropletName string
@@ -52,7 +52,7 @@ func (rip *ReservedIP) KV() []map[string]interface{} {
 			dropletName = f.Droplet.Name
 		}
 
-		o := map[string]interface{}{
+		o := map[string]any{
 			"IP": f.IP, "Region": f.Region.Slug,
 			"DropletID": dropletID, "DropletName": dropletName,
 			"ProjectID": f.ProjectID,

--- a/commands/displayers/size.go
+++ b/commands/displayers/size.go
@@ -45,11 +45,11 @@ func (si *Size) ColMap() map[string]string {
 	}
 }
 
-func (si *Size) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(si.Sizes))
+func (si *Size) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(si.Sizes))
 
 	for _, s := range si.Sizes {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Slug": s.Slug, "Description": s.Description,
 			"Memory": s.Memory, "VCPUs": s.Vcpus,
 			"Disk": s.Disk, "PriceMonthly": fmt.Sprintf("%0.2f", s.PriceMonthly),

--- a/commands/displayers/snapshot.go
+++ b/commands/displayers/snapshot.go
@@ -42,11 +42,11 @@ func (s *Snapshot) ColMap() map[string]string {
 		"ResourceId": "Resource ID", "ResourceType": "Resource Type", "MinDiskSize": "Min Disk Size", "Size": "Size", "Tags": "Tags"}
 }
 
-func (s *Snapshot) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(s.Snapshots))
+func (s *Snapshot) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(s.Snapshots))
 
 	for _, ss := range s.Snapshots {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID": ss.ID, "Name": ss.Name, "ResourceId": ss.ResourceID,
 			"ResourceType": ss.ResourceType, "Regions": ss.Regions, "MinDiskSize": ss.MinDiskSize,
 			"Size": strconv.FormatFloat(ss.SizeGigaBytes, 'f', 2, 64) + " GiB", "CreatedAt": ss.Created,

--- a/commands/displayers/tag.go
+++ b/commands/displayers/tag.go
@@ -40,12 +40,12 @@ func (t *Tag) ColMap() map[string]string {
 	}
 }
 
-func (t *Tag) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(t.Tags))
+func (t *Tag) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(t.Tags))
 
 	for _, x := range t.Tags {
 		dropletCount := x.Resources.Droplets.Count
-		o := map[string]interface{}{
+		o := map[string]any{
 			"Name":         x.Name,
 			"DropletCount": dropletCount,
 		}

--- a/commands/displayers/triggers.go
+++ b/commands/displayers/triggers.go
@@ -48,15 +48,15 @@ func (i *Triggers) ColMap() map[string]string {
 }
 
 // KV is the displayer KV method specialized for triggers list
-func (i *Triggers) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(i.List))
+func (i *Triggers) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(i.List))
 	for _, ii := range i.List {
 		lastRun := "_"
 		if ii.ScheduledRuns != nil && ii.ScheduledRuns.LastRunAt != nil && !ii.ScheduledRuns.LastRunAt.IsZero() {
 			lastRun = ii.ScheduledRuns.LastRunAt.String()
 		}
 
-		x := map[string]interface{}{
+		x := map[string]any{
 			"Name":     ii.Name,
 			"Cron":     ii.ScheduledDetails.Cron,
 			"Function": ii.Function,

--- a/commands/displayers/uptime_alert.go
+++ b/commands/displayers/uptime_alert.go
@@ -47,8 +47,8 @@ func (ua *UptimeAlert) ColMap() map[string]string {
 	}
 }
 
-func (ua *UptimeAlert) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(ua.UptimeAlerts))
+func (ua *UptimeAlert) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(ua.UptimeAlerts))
 	for _, uptimeAlert := range ua.UptimeAlerts {
 		emails := ""
 		if uptimeAlert.Notifications.Email != nil {
@@ -62,7 +62,7 @@ func (ua *UptimeAlert) KV() []map[string]interface{} {
 		}
 		slacks := strings.Join(slackChannels, ",")
 
-		m := map[string]interface{}{
+		m := map[string]any{
 			"ID":             uptimeAlert.ID,
 			"Name":           uptimeAlert.Name,
 			"Type":           uptimeAlert.Type,

--- a/commands/displayers/uptime_check.go
+++ b/commands/displayers/uptime_check.go
@@ -48,10 +48,10 @@ func (uc *UptimeCheck) ColMap() map[string]string {
 	}
 }
 
-func (uc *UptimeCheck) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(uc.UptimeChecks))
+func (uc *UptimeCheck) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(uc.UptimeChecks))
 	for _, uptimeCheck := range uc.UptimeChecks {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"ID":      uptimeCheck.ID,
 			"Name":    uptimeCheck.Name,
 			"Type":    uptimeCheck.Type,

--- a/commands/displayers/volume.go
+++ b/commands/displayers/volume.go
@@ -53,10 +53,10 @@ func (a *Volume) ColMap() map[string]string {
 
 }
 
-func (a *Volume) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(a.Volumes))
+func (a *Volume) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(a.Volumes))
 	for _, volume := range a.Volumes {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"ID":               volume.ID,
 			"Name":             volume.Name,
 			"Size":             strconv.FormatInt(volume.SizeGigaBytes, 10) + " GiB",

--- a/commands/displayers/vpc.go
+++ b/commands/displayers/vpc.go
@@ -55,11 +55,11 @@ func (v *VPC) ColMap() map[string]string {
 	}
 }
 
-func (v *VPC) KV() []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(v.VPCs))
+func (v *VPC) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(v.VPCs))
 
 	for _, v := range v.VPCs {
-		o := map[string]interface{}{
+		o := map[string]any{
 			"ID":          v.ID,
 			"URN":         v.URN,
 			"Name":        v.Name,

--- a/commands/errors.go
+++ b/commands/errors.go
@@ -97,13 +97,13 @@ func ensureOneArg(c *CmdConfig) error {
 	}
 }
 
-func warn(msg string, args ...interface{}) {
+func warn(msg string, args ...any) {
 	fmt.Fprintf(color.Output, "%s: %s\n", colorWarn, fmt.Sprintf(msg, args...))
 }
-func warnConfirm(msg string, args ...interface{}) {
+func warnConfirm(msg string, args ...any) {
 	fmt.Fprintf(color.Output, "%s: %s", colorWarn, fmt.Sprintf(msg, args...))
 }
 
-func notice(msg string, args ...interface{}) {
+func notice(msg string, args ...any) {
 	fmt.Fprintf(color.Output, "%s: %s\n", colorNotice, fmt.Sprintf(msg, args...))
 }

--- a/commands/firewalls.go
+++ b/commands/firewalls.go
@@ -448,8 +448,8 @@ func extractOutboundRules(s string) (rules []godo.OutboundRule, err error) {
 	return rules, nil
 }
 
-func extractRule(ruleStr string, sd string) (map[string]interface{}, error) {
-	rule := map[string]interface{}{}
+func extractRule(ruleStr string, sd string) (map[string]any, error) {
+	rule := map[string]any{}
 	var dropletIDs []int
 	var addresses, lbUIDs, k8sIDs, tags []string
 
@@ -480,7 +480,7 @@ func extractRule(ruleStr string, sd string) (map[string]interface{}, error) {
 		}
 	}
 
-	rule[sd] = map[string]interface{}{
+	rule[sd] = map[string]any{
 		"addresses":          addresses,
 		"droplet_ids":        dropletIDs,
 		"load_balancer_uids": lbUIDs,

--- a/commands/functions.go
+++ b/commands/functions.go
@@ -240,9 +240,9 @@ func RunFunctionsInvoke(c *CmdConfig) error {
 	}
 	web, _ := c.Doit.GetBool(c.NS, flagWeb)
 	if web {
-		var mapParams map[string]interface{} = nil
+		var mapParams map[string]any = nil
 		if params != nil {
-			p, ok := params.(map[string]interface{})
+			p, ok := params.(map[string]any)
 			if !ok {
 				return fmt.Errorf("cannot invoke via web: parameters do not form a dictionary")
 			}
@@ -258,7 +258,7 @@ func RunFunctionsInvoke(c *CmdConfig) error {
 
 	if err != nil {
 		if response != nil {
-			activationResponse := response.(map[string]interface{})
+			activationResponse := response.(map[string]any)
 			template.Print(`Request accepted, but processing not completed yet. {{nl}}All functions invocation >= 30s will get demoted to an asynchronous invocation. Use {{highlight "--no-wait"}} flag to immediately return the activation id. {{nl}}
 Use this command to view the results.
 {{bold "doctl sls activations result" }} {{bold .}} {{nl 2}}`, activationResponse["activationId"])
@@ -323,8 +323,8 @@ func sortFunctionList(list []whisk.Action) {
 
 // consolidateParams accepts parameters from a file, the command line, or both, and consolidates all
 // such parameters into a simple dictionary.
-func consolidateParams(paramFile string, params []string) (interface{}, error) {
-	consolidated := map[string]interface{}{}
+func consolidateParams(paramFile string, params []string) (any, error) {
+	consolidated := map[string]any{}
 	if len(paramFile) > 0 {
 		contents, err := os.ReadFile(paramFile)
 		if err != nil {

--- a/commands/functions_test.go
+++ b/commands/functions_test.go
@@ -173,9 +173,9 @@ func TestFunctionsInvoke(t *testing.T) {
 	tests := []struct {
 		name          string
 		doctlArgs     string
-		doctlFlags    map[string]interface{}
+		doctlFlags    map[string]any
 		requestResult bool
-		passedParams  interface{}
+		passedParams  any
 	}{
 		{
 			name:          "no flags",
@@ -186,34 +186,34 @@ func TestFunctionsInvoke(t *testing.T) {
 		{
 			name:          "full flag",
 			doctlArgs:     "hello",
-			doctlFlags:    map[string]interface{}{"full": ""},
+			doctlFlags:    map[string]any{"full": ""},
 			requestResult: false,
 			passedParams:  nil,
 		},
 		{
 			name:          "param flag",
 			doctlArgs:     "hello",
-			doctlFlags:    map[string]interface{}{"param": "name:world"},
+			doctlFlags:    map[string]any{"param": "name:world"},
 			requestResult: true,
-			passedParams:  map[string]interface{}{"name": "world"},
+			passedParams:  map[string]any{"name": "world"},
 		},
 		{
 			name:          "param flag list",
 			doctlArgs:     "hello",
-			doctlFlags:    map[string]interface{}{"param": []string{"name:world", "address:everywhere"}},
+			doctlFlags:    map[string]any{"param": []string{"name:world", "address:everywhere"}},
 			requestResult: true,
-			passedParams:  map[string]interface{}{"name": "world", "address": "everywhere"},
+			passedParams:  map[string]any{"name": "world", "address": "everywhere"},
 		},
 		{
 			name:          "param flag colon-value",
 			doctlArgs:     "hello",
-			doctlFlags:    map[string]interface{}{"param": []string{"url:https://example.com"}},
+			doctlFlags:    map[string]any{"param": []string{"url:https://example.com"}},
 			requestResult: true,
-			passedParams:  map[string]interface{}{"url": "https://example.com"},
+			passedParams:  map[string]any{"url": "https://example.com"},
 		},
 	}
 
-	expectedRemoteResult := map[string]interface{}{
+	expectedRemoteResult := map[string]any{
 		"body": "Hello world!",
 	}
 

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -378,7 +378,7 @@ func extractForwardingRules(s string) (forwardingRules []godo.ForwardingRule, er
 	return forwardingRules, err
 }
 
-func fillStructFromStringSliceArgs(obj interface{}, s string) error {
+func fillStructFromStringSliceArgs(obj any, s string) error {
 	if len(s) == 0 {
 		return nil
 	}

--- a/commands/namespaces_test.go
+++ b/commands/namespaces_test.go
@@ -40,7 +40,7 @@ func TestNamespacesCommand(t *testing.T) {
 func TestNamespacesCreate(t *testing.T) {
 	tests := []struct {
 		name           string
-		doctlFlags     map[string]interface{}
+		doctlFlags     map[string]any
 		expectedOutput string
 		expectedError  error
 		expectList     bool
@@ -52,7 +52,7 @@ func TestNamespacesCreate(t *testing.T) {
 		},
 		{
 			name: "invalid region",
-			doctlFlags: map[string]interface{}{
+			doctlFlags: map[string]any{
 				"label":  "my_dog",
 				"region": "dog",
 			},
@@ -60,7 +60,7 @@ func TestNamespacesCreate(t *testing.T) {
 		},
 		{
 			name: "legal flags, with no-connect",
-			doctlFlags: map[string]interface{}{
+			doctlFlags: map[string]any{
 				"label":      "something",
 				"region":     "lon",
 				"no-connect": true,
@@ -70,7 +70,7 @@ func TestNamespacesCreate(t *testing.T) {
 		},
 		{
 			name: "legal flags, with label conflict",
-			doctlFlags: map[string]interface{}{
+			doctlFlags: map[string]any{
 				"label":  "my_dog",
 				"region": "lon",
 			},
@@ -79,7 +79,7 @@ func TestNamespacesCreate(t *testing.T) {
 		},
 		{
 			name: "legal flags, should connect",
-			doctlFlags: map[string]interface{}{
+			doctlFlags: map[string]any{
 				"label":  "something",
 				"region": "lon",
 			},
@@ -184,7 +184,7 @@ func TestNamespacesList(t *testing.T) {
 func TestNamespacesDelete(t *testing.T) {
 	tests := []struct {
 		name               string
-		doctlFlags         map[string]interface{}
+		doctlFlags         map[string]any
 		doctlArg           string
 		expectedOutput     string
 		expectedError      error
@@ -203,7 +203,7 @@ func TestNamespacesDelete(t *testing.T) {
 		{
 			name:       "valid argument with force",
 			doctlArg:   "my_dog",
-			doctlFlags: map[string]interface{}{"force": true},
+			doctlFlags: map[string]any{"force": true},
 		},
 		{
 			name:               "valid argument with prompt",

--- a/commands/serverless_test.go
+++ b/commands/serverless_test.go
@@ -359,7 +359,7 @@ func TestServerlessInit(t *testing.T) {
 		name            string
 		doctlArgs       string
 		doctlFlags      map[string]string
-		out             map[string]interface{}
+		out             map[string]any
 		expectCheck     bool
 		expectOverwrite bool
 	}{
@@ -368,21 +368,21 @@ func TestServerlessInit(t *testing.T) {
 			doctlArgs: "path/to/foo",
 			// The language flag has a default normally applied by cobra
 			doctlFlags: map[string]string{"language": "javascript"},
-			out:        map[string]interface{}{"project": "foo"},
+			out:        map[string]any{"project": "foo"},
 		},
 		{
 			name:      "overwrite",
 			doctlArgs: "path/to/foo",
 			// The language flag has a default normally applied by cobra
 			doctlFlags:      map[string]string{"overwrite": "", "language": "javascript"},
-			out:             map[string]interface{}{"project": "foo"},
+			out:             map[string]any{"project": "foo"},
 			expectOverwrite: true,
 		},
 		{
 			name:        "language flag",
 			doctlArgs:   "path/to/foo",
 			doctlFlags:  map[string]string{"language": "go"},
-			out:         map[string]interface{}{"project": "foo"},
+			out:         map[string]any{"project": "foo"},
 			expectCheck: true,
 		},
 	}

--- a/commands/serverless_util.go
+++ b/commands/serverless_util.go
@@ -129,7 +129,7 @@ func isServerlessConnected(leafCredsDir string, serverlessDir string) bool {
 // Converts something "object-like" but untyped to generic JSON
 // Designed for human eyes; does not provide an explicit error
 // result
-func genericJSON(toFormat interface{}) string {
+func genericJSON(toFormat any) string {
 	bytes, err := json.MarshalIndent(&toFormat, "", "  ")
 	if err != nil {
 		return "<not representable as JSON>"

--- a/commands/triggers_test.go
+++ b/commands/triggers_test.go
@@ -54,7 +54,7 @@ func TestTriggersGet(t *testing.T) {
 			UpdatedAt: time.Date(2022, 10, 17, 18, 41, 30, 0, time.UTC),
 			ScheduledDetails: &do.TriggerScheduledDetails{
 				Cron: "5 * * * *",
-				Body: map[string]interface{}{
+				Body: map[string]any{
 					"foo": "bar",
 				},
 			},
@@ -85,7 +85,7 @@ func TestTriggersList(t *testing.T) {
 			Type:      "SCHEDULED",
 			ScheduledDetails: &do.TriggerScheduledDetails{
 				Cron: "* * * * *",
-				Body: map[string]interface{}{},
+				Body: map[string]any{},
 			},
 			IsEnabled: true,
 			CreatedAt: time.Date(2022, 10, 5, 13, 46, 59, 0, time.UTC),
@@ -115,14 +115,14 @@ func TestTriggersList(t *testing.T) {
 	}
 	tests := []struct {
 		name           string
-		doctlFlags     map[string]interface{}
+		doctlFlags     map[string]any
 		expectedOutput string
 		listArg        string
 		listResult     []do.ServerlessTrigger
 	}{
 		{
 			name: "simple list",
-			doctlFlags: map[string]interface{}{
+			doctlFlags: map[string]any{
 				"no-header": "",
 			},
 			listResult: theList,
@@ -133,7 +133,7 @@ firePoll2    10 * * * *    misc/pollStatus        false    _
 		},
 		{
 			name: "filtered list",
-			doctlFlags: map[string]interface{}{
+			doctlFlags: map[string]any{
 				"function":  "misc/pollStatus",
 				"no-header": "",
 			},

--- a/do/1_clicks.go
+++ b/do/1_clicks.go
@@ -49,13 +49,13 @@ func NewOneClickService(client *godo.Client) OneClickService {
 }
 
 func (ocs *oneClickService) List(oneClickType string) (OneClicks, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ocs.Client.OneClick.List(context.TODO(), oneClickType)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/account_test.go
+++ b/do/account_test.go
@@ -58,7 +58,7 @@ func (m *MockAccountService) Get(arg0 context.Context) (*godo.Account, *godo.Res
 }
 
 // Get indicates an expected call of Get
-func (mr *MockAccountServiceMockRecorder) Get(arg0 interface{}) *gomock.Call {
+func (mr *MockAccountServiceMockRecorder) Get(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockAccountService)(nil).Get), arg0)
 }

--- a/do/actions.go
+++ b/do/actions.go
@@ -47,13 +47,13 @@ func NewActionsService(godoClient *godo.Client) ActionsService {
 }
 
 func (as *actionsService) List() (Actions, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := as.client.Actions.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/apps.go
+++ b/do/apps.go
@@ -81,14 +81,14 @@ func (s *appsService) Get(appID string) (*godo.App, error) {
 }
 
 func (s *appsService) List(withProjects bool) ([]*godo.App, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		opt.WithProjects = withProjects
 		list, resp, err := s.client.Apps.List(s.ctx, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, 0, len(list))
+		si := make([]any, 0, len(list))
 		for _, item := range list {
 			si = append(si, item)
 		}
@@ -150,13 +150,13 @@ func (s *appsService) GetDeployment(appID, deploymentID string) (*godo.Deploymen
 }
 
 func (s *appsService) ListDeployments(appID string) ([]*godo.Deployment, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := s.client.Apps.ListDeployments(s.ctx, appID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, 0, len(list))
+		si := make([]any, 0, len(list))
 		for _, item := range list {
 			si = append(si, item)
 		}

--- a/do/balance_test.go
+++ b/do/balance_test.go
@@ -58,7 +58,7 @@ func (m *MockBalanceService) Get(arg0 context.Context) (*godo.Balance, *godo.Res
 }
 
 // Get indicates an expected call of Get
-func (mr *MockBalanceServiceMockRecorder) Get(arg0 interface{}) *gomock.Call {
+func (mr *MockBalanceServiceMockRecorder) Get(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBalanceService)(nil).Get), arg0)
 }

--- a/do/billing_history.go
+++ b/do/billing_history.go
@@ -43,13 +43,13 @@ func NewBillingHistoryService(client *godo.Client) BillingHistoryService {
 }
 
 func (is *billingHistoryService) List() (*BillingHistory, error) {
-	listFn := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	listFn := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		historyList, resp, err := is.client.BillingHistory.List(context.Background(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(historyList.BillingHistory))
+		si := make([]any, len(historyList.BillingHistory))
 		for i := range historyList.BillingHistory {
 			si[i] = historyList.BillingHistory[i]
 		}

--- a/do/cdns.go
+++ b/do/cdns.go
@@ -34,13 +34,13 @@ func NewCDNsService(godoClient *godo.Client) CDNsService {
 }
 
 func (c *cdnsService) List() ([]CDN, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := c.client.CDNs.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/certificates.go
+++ b/do/certificates.go
@@ -67,13 +67,13 @@ func (cs *certificatesService) Create(cr *godo.CertificateRequest) (*Certificate
 }
 
 func (cs *certificatesService) List() (Certificates, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := cs.client.Certificates.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/databases.go
+++ b/do/databases.go
@@ -199,13 +199,13 @@ func NewDatabasesService(client *godo.Client) DatabasesService {
 }
 
 func (ds *databasesService) List() (Databases, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Databases.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -297,13 +297,13 @@ func (ds *databasesService) UpdateMaintenance(databaseID string, req *godo.Datab
 }
 
 func (ds *databasesService) ListBackups(databaseID string) (DatabaseBackups, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Databases.ListBackups(context.TODO(), databaseID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -334,13 +334,13 @@ func (ds *databasesService) GetUser(databaseID, userName string) (*DatabaseUser,
 }
 
 func (ds *databasesService) ListUsers(databaseID string) (DatabaseUsers, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Databases.ListUsers(context.TODO(), databaseID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -385,13 +385,13 @@ func (ds *databasesService) ResetUserAuth(databaseID, userID string, req *godo.D
 }
 
 func (ds *databasesService) ListDBs(databaseID string) (DatabaseDBs, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Databases.ListDBs(context.TODO(), databaseID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -437,13 +437,13 @@ func (ds *databasesService) DeleteDB(databaseID, dbID string) error {
 }
 
 func (ds *databasesService) ListPools(databaseID string) (DatabasePools, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Databases.ListPools(context.TODO(), databaseID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -498,13 +498,13 @@ func (ds *databasesService) GetReplica(databaseID, replicaID string) (*DatabaseR
 }
 
 func (ds *databasesService) ListReplicas(databaseID string) (DatabaseReplicas, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Databases.ListReplicas(context.TODO(), databaseID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -568,13 +568,13 @@ func (ds *databasesService) SetSQLMode(databaseID string, sqlModes ...string) er
 }
 
 func (ds *databasesService) GetFirewallRules(databaseID string) (DatabaseFirewallRules, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Databases.GetFirewallRules(context.TODO(), databaseID)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -689,13 +689,13 @@ func (ds *databasesService) UpdateRedisConfiguration(databaseID string, confStri
 }
 
 func (ds *databasesService) ListTopics(databaseID string) (DatabaseTopics, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Databases.ListTopics(context.TODO(), databaseID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/domains.go
+++ b/do/domains.go
@@ -85,13 +85,13 @@ func NewDomainsService(client *godo.Client) DomainsService {
 }
 
 func (ds *domainsService) List() (Domains, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Domains.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -137,13 +137,13 @@ func (ds *domainsService) Delete(name string) error {
 }
 
 func (ds *domainsService) Records(name string) (DomainRecords, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Domains.Records(context.TODO(), name, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/droplets.go
+++ b/do/droplets.go
@@ -79,13 +79,13 @@ func NewDropletsService(client *godo.Client) DropletsService {
 }
 
 func (ds *dropletsService) List() (Droplets, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Droplets.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -108,13 +108,13 @@ func (ds *dropletsService) List() (Droplets, error) {
 }
 
 func (ds *dropletsService) ListByTag(tagName string) (Droplets, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Droplets.ListByTag(context.TODO(), tagName, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -198,13 +198,13 @@ func (ds *dropletsService) DeleteByTag(tag string) error {
 }
 
 func (ds *dropletsService) Kernels(id int) (Kernels, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Droplets.Kernels(context.TODO(), id, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -227,13 +227,13 @@ func (ds *dropletsService) Kernels(id int) (Kernels, error) {
 }
 
 func (ds *dropletsService) Snapshots(id int) (Images, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Droplets.Snapshots(context.TODO(), id, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -256,13 +256,13 @@ func (ds *dropletsService) Snapshots(id int) (Images, error) {
 }
 
 func (ds *dropletsService) Backups(id int) (Images, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Droplets.Backups(context.TODO(), id, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -285,13 +285,13 @@ func (ds *dropletsService) Backups(id int) (Images, error) {
 }
 
 func (ds *dropletsService) Actions(id int) (Actions, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ds.client.Droplets.Actions(context.TODO(), id, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/firewalls.go
+++ b/do/firewalls.go
@@ -83,13 +83,13 @@ func (fs *firewallsService) Update(fID string, fr *godo.FirewallRequest) (*Firew
 }
 
 func (fs *firewallsService) List() (Firewalls, error) {
-	listFn := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	listFn := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := fs.client.Firewalls.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -101,13 +101,13 @@ func (fs *firewallsService) List() (Firewalls, error) {
 }
 
 func (fs *firewallsService) ListByDroplet(dID int) (Firewalls, error) {
-	listFn := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	listFn := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := fs.client.Firewalls.ListByDroplet(context.TODO(), dID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -153,7 +153,7 @@ func (fs *firewallsService) RemoveRules(fID string, rr *godo.FirewallRulesReques
 	return err
 }
 
-func paginatedListHelper(listFn func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error)) (Firewalls, error) {
+func paginatedListHelper(listFn func(opt *godo.ListOptions) ([]any, *godo.Response, error)) (Firewalls, error) {
 	si, err := PaginateResp(listFn)
 	if err != nil {
 		return nil, err

--- a/do/images.go
+++ b/do/images.go
@@ -113,13 +113,13 @@ func (is *imagesService) Create(icr *godo.CustomImageCreateRequest) (*Image, err
 type listFn func(context.Context, *godo.ListOptions) ([]godo.Image, *godo.Response, error)
 
 func (is *imagesService) listImages(lFn listFn, public bool) (Images, error) {
-	fn := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	fn := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := lFn(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := []interface{}{}
+		si := []any{}
 		for _, i := range list {
 			if (public && i.Public) || !i.Public {
 				si = append(si, i)

--- a/do/invoices.go
+++ b/do/invoices.go
@@ -64,14 +64,14 @@ func NewInvoicesService(client *godo.Client) InvoicesService {
 func (is *invoicesService) List() (*InvoiceList, error) {
 	var invoicePreview godo.InvoiceListItem
 
-	listFn := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	listFn := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		invoiceList, resp, err := is.client.Invoices.List(context.Background(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 		invoicePreview = invoiceList.InvoicePreview
 
-		si := make([]interface{}, len(invoiceList.Invoices))
+		si := make([]any, len(invoiceList.Invoices))
 		for i := range invoiceList.Invoices {
 			si[i] = invoiceList.Invoices[i]
 		}
@@ -96,12 +96,12 @@ func (is *invoicesService) List() (*InvoiceList, error) {
 }
 
 func (is *invoicesService) Get(uuid string) (*Invoice, error) {
-	listFn := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	listFn := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		invoice, resp, err := is.client.Invoices.Get(context.Background(), uuid, opt)
 		if err != nil {
 			return nil, nil, err
 		}
-		si := make([]interface{}, len(invoice.InvoiceItems))
+		si := make([]any, len(invoice.InvoiceItems))
 		for i := range invoice.InvoiceItems {
 			si[i] = invoice.InvoiceItems[i]
 		}

--- a/do/kubernetes.go
+++ b/do/kubernetes.go
@@ -169,13 +169,13 @@ func (k8s *kubernetesClusterService) GetUpgrades(clusterID string) (KubernetesVe
 }
 
 func (k8s *kubernetesClusterService) List() (KubernetesClusters, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := k8s.client.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, 0, len(list))
+		si := make([]any, 0, len(list))
 		for _, item := range list {
 			si = append(si, item)
 		}
@@ -262,13 +262,13 @@ func (k8s *kubernetesClusterService) GetNodePool(clusterID, poolID string) (*Kub
 }
 
 func (k8s *kubernetesClusterService) ListNodePools(clusterID string) (KubernetesNodePools, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := k8s.client.ListNodePools(context.TODO(), clusterID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, 0, len(list))
+		si := make([]any, 0, len(list))
 		for _, item := range list {
 			si = append(si, item)
 		}

--- a/do/load_balancers.go
+++ b/do/load_balancers.go
@@ -63,13 +63,13 @@ func (lbs *loadBalancersService) Get(lbID string) (*LoadBalancer, error) {
 }
 
 func (lbs *loadBalancersService) List() (LoadBalancers, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := lbs.client.LoadBalancers.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/monitoring.go
+++ b/do/monitoring.go
@@ -50,13 +50,13 @@ func NewMonitoringService(godoClient *godo.Client) MonitoringService {
 }
 
 func (ms *monitoringService) ListAlertPolicies() (AlertPolicies, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ms.client.Monitoring.ListAlertPolicies(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/pagination.go
+++ b/do/pagination.go
@@ -29,12 +29,12 @@ var perPage = 200
 var fetchFn = fetchPage
 
 type paginatedList struct {
-	list  [][]interface{}
+	list  [][]any
 	total int
 	mu    sync.Mutex
 }
 
-func (pl *paginatedList) set(page int, items []interface{}) {
+func (pl *paginatedList) set(page int, items []any) {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 	pl.total += len(items)
@@ -42,10 +42,10 @@ func (pl *paginatedList) set(page int, items []interface{}) {
 }
 
 // Generator is a function that generates the list to be paginated.
-type Generator func(*godo.ListOptions) ([]interface{}, *godo.Response, error)
+type Generator func(*godo.ListOptions) ([]any, *godo.Response, error)
 
 // PaginateResp paginates a Response.
-func PaginateResp(gen Generator) ([]interface{}, error) {
+func PaginateResp(gen Generator) ([]any, error) {
 	opt := &godo.ListOptions{Page: 1, PerPage: perPage}
 
 	// fetch first page to get page count (x)
@@ -61,7 +61,7 @@ func PaginateResp(gen Generator) ([]interface{}, error) {
 	}
 
 	l := paginatedList{
-		list: make([][]interface{}, lp),
+		list: make([][]any, lp),
 	}
 
 	// set results from the first page
@@ -93,7 +93,7 @@ func PaginateResp(gen Generator) ([]interface{}, error) {
 	wg.Wait()
 
 	// flatten paginated list
-	items := make([]interface{}, l.total)[:0]
+	items := make([]any, l.total)[:0]
 	for _, page := range l.list {
 		if page == nil {
 			// must have been an error getting page results
@@ -107,7 +107,7 @@ func PaginateResp(gen Generator) ([]interface{}, error) {
 	return items, nil
 }
 
-func fetchPage(gen Generator, page int) ([]interface{}, error) {
+func fetchPage(gen Generator, page int) ([]any, error) {
 	opt := &godo.ListOptions{Page: page, PerPage: perPage}
 	items, _, err := gen(opt)
 	return items, err

--- a/do/pagination_test.go
+++ b/do/pagination_test.go
@@ -26,11 +26,11 @@ func Test_PaginateResp(t *testing.T) {
 	currentPage := 0
 	resp := &godo.Response{Links: &godo.Links{Pages: &godo.Pages{Last: "http://example.com/?page=5"}}}
 
-	gen := func(*godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	gen := func(*godo.ListOptions) ([]any, *godo.Response, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		currentPage++
-		return []interface{}{currentPage}, resp, nil
+		return []any{currentPage}, resp, nil
 	}
 
 	list, err := PaginateResp(gen)
@@ -40,8 +40,8 @@ func Test_PaginateResp(t *testing.T) {
 }
 
 func Test_Pagination_fetchPage(t *testing.T) {
-	gen := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
-		items := []interface{}{}
+	gen := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
+		items := []any{}
 		resp := &godo.Response{}
 
 		assert.Equal(t, 10, opt.Page)

--- a/do/projects.go
+++ b/do/projects.go
@@ -66,13 +66,13 @@ func NewProjectsService(client *godo.Client) ProjectsService {
 
 // List projects.
 func (ps *projectsService) List() (Projects, error) {
-	listFn := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	listFn := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ps.client.Projects.List(ps.ctx, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -125,13 +125,13 @@ func (ps *projectsService) Delete(projectUUID string) error {
 }
 
 func (ps *projectsService) ListResources(projectUUID string) (ProjectResources, error) {
-	listFn := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	listFn := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ps.client.Projects.ListResources(ps.ctx, projectUUID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -143,7 +143,7 @@ func (ps *projectsService) ListResources(projectUUID string) (ProjectResources, 
 }
 
 func (ps *projectsService) AssignResources(projectUUID string, resources []string) (ProjectResources, error) {
-	assignableResources := make([]interface{}, len(resources))
+	assignableResources := make([]any, len(resources))
 	for i, resource := range resources {
 		assignableResources[i] = resource
 	}
@@ -161,7 +161,7 @@ func (ps *projectsService) AssignResources(projectUUID string, resources []strin
 	return prs, err
 }
 
-func projectsPaginatedListHelper(listFn func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error)) (Projects, error) {
+func projectsPaginatedListHelper(listFn func(opt *godo.ListOptions) ([]any, *godo.Response, error)) (Projects, error) {
 	si, err := PaginateResp(listFn)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func projectsPaginatedListHelper(listFn func(opt *godo.ListOptions) ([]interface
 	return list, nil
 }
 
-func projectResourcesPaginatedListHelper(listFn func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error)) (ProjectResources, error) {
+func projectResourcesPaginatedListHelper(listFn func(opt *godo.ListOptions) ([]any, *godo.Response, error)) (ProjectResources, error) {
 	si, err := PaginateResp(listFn)
 	if err != nil {
 		return nil, err

--- a/do/regions.go
+++ b/do/regions.go
@@ -46,13 +46,13 @@ func NewRegionsService(client *godo.Client) RegionsService {
 }
 
 func (rs *regionsService) List() (Regions, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := rs.client.Regions.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/registry.go
+++ b/do/registry.go
@@ -137,13 +137,13 @@ func (rs *registryService) DockerCredentials(request *godo.RegistryDockerCredent
 }
 
 func (rs *registryService) ListRepositories(registry string) ([]Repository, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := rs.client.Registry.ListRepositories(rs.ctx, registry, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -166,7 +166,7 @@ func (rs *registryService) ListRepositories(registry string) ([]Repository, erro
 }
 
 func (rs *registryService) ListRepositoriesV2(registry string) ([]RepositoryV2, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := rs.client.Registry.ListRepositoriesV2(rs.ctx, registry, &godo.TokenListOptions{
 			Page:    opt.Page,
 			PerPage: opt.PerPage,
@@ -176,7 +176,7 @@ func (rs *registryService) ListRepositoriesV2(registry string) ([]RepositoryV2, 
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -199,13 +199,13 @@ func (rs *registryService) ListRepositoriesV2(registry string) ([]RepositoryV2, 
 }
 
 func (rs *registryService) ListRepositoryTags(registry, repository string) ([]RepositoryTag, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := rs.client.Registry.ListRepositoryTags(rs.ctx, registry, repository, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -228,13 +228,13 @@ func (rs *registryService) ListRepositoryTags(registry, repository string) ([]Re
 }
 
 func (rs *registryService) ListRepositoryManifests(registry, repository string) ([]RepositoryManifest, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := rs.client.Registry.ListRepositoryManifests(rs.ctx, registry, repository, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -285,13 +285,13 @@ func (rs *registryService) GetGarbageCollection(registry string) (*GarbageCollec
 }
 
 func (rs *registryService) ListGarbageCollections(registry string) ([]GarbageCollection, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := rs.client.Registry.ListGarbageCollections(rs.ctx, registry, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/reserved_ip_actions.go
+++ b/do/reserved_ip_actions.go
@@ -69,13 +69,13 @@ func (fia *reservedIPActionsService) Get(ip string, actionID int) (*Action, erro
 }
 
 func (fia *reservedIPActionsService) List(ip string, opt *godo.ListOptions) ([]Action, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := fia.client.ReservedIPActions.List(context.TODO(), ip, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/reserved_ips.go
+++ b/do/reserved_ips.go
@@ -49,13 +49,13 @@ func NewReservedIPsService(client *godo.Client) ReservedIPsService {
 }
 
 func (fis *reservedIPsService) List() (ReservedIPs, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := fis.client.ReservedIPs.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/serverless.go
+++ b/do/serverless.go
@@ -129,19 +129,19 @@ type ServerlessProject struct {
 // ServerlessSpec describes a project.yml spec
 // reference: https://docs.nimbella.com/configuration/
 type ServerlessSpec struct {
-	Parameters  map[string]interface{} `json:"parameters,omitempty"`
-	Environment map[string]interface{} `json:"environment,omitempty"`
-	Packages    []*ServerlessPackage   `json:"packages,omitempty"`
+	Parameters  map[string]any       `json:"parameters,omitempty"`
+	Environment map[string]any       `json:"environment,omitempty"`
+	Packages    []*ServerlessPackage `json:"packages,omitempty"`
 }
 
 // ServerlessPackage ...
 type ServerlessPackage struct {
-	Name        string                 `json:"name,omitempty"`
-	Shared      bool                   `json:"shared,omitempty"`
-	Environment map[string]interface{} `json:"environment,omitempty"`
-	Parameters  map[string]interface{} `json:"parameters,omitempty"`
-	Annotations map[string]interface{} `json:"annotations,omitempty"`
-	Functions   []*ServerlessFunction  `json:"functions,omitempty"`
+	Name        string                `json:"name,omitempty"`
+	Shared      bool                  `json:"shared,omitempty"`
+	Environment map[string]any        `json:"environment,omitempty"`
+	Parameters  map[string]any        `json:"parameters,omitempty"`
+	Annotations map[string]any        `json:"annotations,omitempty"`
+	Functions   []*ServerlessFunction `json:"functions,omitempty"`
 }
 
 // ServerlessFunction ...
@@ -152,12 +152,12 @@ type ServerlessFunction struct {
 	Runtime string `json:"runtime,omitempty"`
 	// `web` can be either true or "raw". We use interface{} to support both types. If we start consuming the value we
 	// should probably define a custom type with proper validation.
-	Web         interface{}            `json:"web,omitempty"`
-	WebSecure   interface{}            `json:"webSecure,omitempty" yaml:"webSecure"`
-	Parameters  map[string]interface{} `json:"parameters,omitempty"`
-	Environment map[string]interface{} `json:"environment,omitempty"`
-	Annotations map[string]interface{} `json:"annotations,omitempty"`
-	Limits      map[string]int         `json:"limits,omitempty"`
+	Web         any            `json:"web,omitempty"`
+	WebSecure   any            `json:"webSecure,omitempty" yaml:"webSecure"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+	Environment map[string]any `json:"environment,omitempty"`
+	Annotations map[string]any `json:"annotations,omitempty"`
+	Limits      map[string]int `json:"limits,omitempty"`
 }
 
 // ProjectMetadata describes the nim project:get-metadata output structure.
@@ -195,8 +195,8 @@ type ServerlessTrigger struct {
 }
 
 type TriggerScheduledDetails struct {
-	Cron string                 `json:"cron,omitempty"`
-	Body map[string]interface{} `json:"body,omitempty"`
+	Cron string         `json:"cron,omitempty"`
+	Body map[string]any `json:"body,omitempty"`
 }
 
 type TriggerScheduledRuns struct {
@@ -231,8 +231,8 @@ type ServerlessService interface {
 	GetFunction(string, bool) (whisk.Action, []FunctionParameter, error)
 	ListFunctions(string, int, int) ([]whisk.Action, error)
 	DeleteFunction(string, bool) error
-	InvokeFunction(string, interface{}, bool, bool) (interface{}, error)
-	InvokeFunctionViaWeb(string, interface{}) error
+	InvokeFunction(string, any, bool, bool) (any, error)
+	InvokeFunctionViaWeb(string, any) error
 	ListActivations(whisk.ActivationListOptions) ([]whisk.Activation, error)
 	GetActivationCount(whisk.ActivationCountOptions) (whisk.ActivationCount, error)
 	GetActivation(string) (whisk.Activation, error)
@@ -315,11 +315,11 @@ var (
 
 // ServerlessOutput contains the output returned from calls to the sandbox plugin.
 type ServerlessOutput struct {
-	Table     []map[string]interface{} `json:"table,omitempty"`
-	Captured  []string                 `json:"captured,omitempty"`
-	Formatted []string                 `json:"formatted,omitempty"`
-	Entity    interface{}              `json:"entity,omitempty"`
-	Error     string                   `json:"error,omitempty"`
+	Table     []map[string]any `json:"table,omitempty"`
+	Captured  []string         `json:"captured,omitempty"`
+	Formatted []string         `json:"formatted,omitempty"`
+	Entity    any              `json:"entity,omitempty"`
+	Error     string           `json:"error,omitempty"`
 }
 
 // NewServerlessService returns a configured ServerlessService.
@@ -898,8 +898,8 @@ func (s *serverlessService) DeletePackage(name string, recursive bool) error {
 }
 
 // InvokeFunction invokes a function via POST with authentication
-func (s *serverlessService) InvokeFunction(name string, params interface{}, blocking bool, result bool) (interface{}, error) {
-	var empty map[string]interface{}
+func (s *serverlessService) InvokeFunction(name string, params any, blocking bool, result bool) (any, error) {
+	var empty map[string]any
 	err := initWhisk(s)
 	if err != nil {
 		return empty, err
@@ -909,7 +909,7 @@ func (s *serverlessService) InvokeFunction(name string, params interface{}, bloc
 }
 
 // InvokeFunctionViaWeb invokes a function via GET using its web URL (or error if not a web function)
-func (s *serverlessService) InvokeFunctionViaWeb(name string, params interface{}) error {
+func (s *serverlessService) InvokeFunctionViaWeb(name string, params any) error {
 	// Get the function so we can use its metadata in formulating the request
 	theFunction, _, err := s.GetFunction(name, false)
 	if err != nil {
@@ -941,7 +941,7 @@ func (s *serverlessService) InvokeFunctionViaWeb(name string, params interface{}
 	// Add params, if any
 	if params != nil {
 		encoded := url.Values{}
-		for key, val := range params.(map[string]interface{}) {
+		for key, val := range params.(map[string]any) {
 			stringVal, ok := val.(string)
 			if !ok {
 				return fmt.Errorf("the value of '%s' is not a string; web invocation is not possible", key)

--- a/do/sizes.go
+++ b/do/sizes.go
@@ -46,13 +46,13 @@ func NewSizesService(client *godo.Client) SizesService {
 }
 
 func (rs *sizesService) List() (Sizes, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := rs.client.Sizes.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/snapshots.go
+++ b/do/snapshots.go
@@ -50,13 +50,13 @@ func NewSnapshotsService(client *godo.Client) SnapshotsService {
 }
 
 func (ss *snapshotsService) List() (Snapshots, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ss.client.Snapshots.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -79,13 +79,13 @@ func (ss *snapshotsService) List() (Snapshots, error) {
 }
 
 func (ss *snapshotsService) ListVolume() (Snapshots, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ss.client.Snapshots.ListVolume(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -108,13 +108,13 @@ func (ss *snapshotsService) ListVolume() (Snapshots, error) {
 }
 
 func (ss *snapshotsService) ListDroplet() (Snapshots, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ss.client.Snapshots.ListDroplet(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/sshkeys.go
+++ b/do/sshkeys.go
@@ -52,13 +52,13 @@ func NewKeysService(client *godo.Client) KeysService {
 }
 
 func (ks *keysService) List() (SSHKeys, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ks.client.Keys.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/tags.go
+++ b/do/tags.go
@@ -51,13 +51,13 @@ func NewTagsService(godoClient *godo.Client) TagsService {
 }
 
 func (ts *tagsService) List() (Tags, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ts.client.Tags.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/uptime_checks.go
+++ b/do/uptime_checks.go
@@ -71,13 +71,13 @@ func (ucs *uptimeChecksService) Create(req *godo.CreateUptimeCheckRequest) (*Upt
 }
 
 func (ucs *uptimeChecksService) List() ([]UptimeCheck, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ucs.client.UptimeChecks.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -136,13 +136,13 @@ func (ucs *uptimeChecksService) CreateAlert(id string, req *godo.CreateUptimeAle
 }
 
 func (ucs *uptimeChecksService) ListAlerts(id string) ([]UptimeAlert, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := ucs.client.UptimeChecks.ListAlerts(context.TODO(), id, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/volume_actions.go
+++ b/do/volume_actions.go
@@ -55,13 +55,13 @@ func (vas *volumeActionsService) Get(volumeID string, actionID int) (*Action, er
 }
 
 func (vas *volumeActionsService) List(volumeID string) ([]Action, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := vas.client.StorageActions.List(context.TODO(), volumeID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/volumes.go
+++ b/do/volumes.go
@@ -37,14 +37,14 @@ func NewVolumesService(godoClient *godo.Client) VolumesService {
 }
 
 func (a *volumesService) List() ([]Volume, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		params := &godo.ListVolumeParams{ListOptions: opt}
 		list, resp, err := a.client.Storage.ListVolumes(context.TODO(), params)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}
@@ -111,13 +111,13 @@ func (a *volumesService) DeleteSnapshot(snapshotID string) error {
 }
 
 func (a *volumesService) ListSnapshots(volumeID string, opt *godo.ListOptions) ([]Snapshot, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := a.client.Storage.ListSnapshots(context.TODO(), volumeID, opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/do/vpcs.go
+++ b/do/vpcs.go
@@ -60,13 +60,13 @@ func (v *vpcsService) Get(vpcUUID string) (*VPC, error) {
 }
 
 func (v *vpcsService) List() (VPCs, error) {
-	f := func(opt *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	f := func(opt *godo.ListOptions) ([]any, *godo.Response, error) {
 		list, resp, err := v.client.VPCs.List(context.TODO(), opt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		si := make([]interface{}, len(list))
+		si := make([]any, len(list))
 		for i := range list {
 			si[i] = list[i]
 		}

--- a/doit.go
+++ b/doit.go
@@ -191,7 +191,7 @@ func (glv *GithubLatestVersioner) LatestVersion() (string, error) {
 
 	defer res.Body.Close()
 
-	var m map[string]interface{}
+	var m map[string]any
 	if err = json.NewDecoder(res.Body).Decode(&m); err != nil {
 		return "", err
 	}
@@ -211,7 +211,7 @@ type Config interface {
 	GetDockerEngineClient() (builder.DockerEngineClient, error)
 	SSH(user, host, keyPath string, port int, opts ssh.Options) runner.Runner
 	Listen(url *url.URL, token string, schemaFunc listen.SchemaFunc, out io.Writer) listen.ListenerService
-	Set(ns, key string, val interface{})
+	Set(ns, key string, val any)
 	IsSet(key string) bool
 	GetString(ns, key string) (string, error)
 	GetBool(ns, key string) (bool, error)
@@ -329,7 +329,7 @@ func (c *LiveConfig) Listen(url *url.URL, token string, schemaFunc listen.Schema
 }
 
 // Set sets a config key.
-func (c *LiveConfig) Set(ns, key string, val interface{}) {
+func (c *LiveConfig) Set(ns, key string, val any) {
 	viper.Set(nskey(ns, key), val)
 }
 
@@ -517,7 +517,7 @@ func (c *TestConfig) Listen(url *url.URL, token string, schemaFunc listen.Schema
 }
 
 // Set sets a config key.
-func (c *TestConfig) Set(ns, key string, val interface{}) {
+func (c *TestConfig) Set(ns, key string, val any) {
 	nskey := nskey(ns, key)
 	c.v.Set(nskey, val)
 	c.IsSetMap[key] = true

--- a/integration/database_create_fork_test.go
+++ b/integration/database_create_fork_test.go
@@ -44,12 +44,12 @@ var _ = suite("database/create/fork", func(t *testing.T, when spec.G, it spec.S)
 				expect.NoError(err)
 
 				request := struct {
-					Name          string      `json:"name"`
-					Engine        string      `json:"engine"`
-					Version       string      `json:"version"`
-					Region        string      `json:"region"`
-					Nodes         int         `json:"num_nodes"`
-					BackupRestore interface{} `json:"backup_restore"`
+					Name          string `json:"name"`
+					Engine        string `json:"engine"`
+					Version       string `json:"version"`
+					Region        string `json:"region"`
+					Nodes         int    `json:"num_nodes"`
+					BackupRestore any    `json:"backup_restore"`
 				}{}
 
 				err = json.Unmarshal(reqBody, &request)

--- a/integration/database_create_restore_from_cluster.go
+++ b/integration/database_create_restore_from_cluster.go
@@ -44,12 +44,12 @@ var _ = suite("database/create/backup-restore", func(t *testing.T, when spec.G, 
 				expect.NoError(err)
 
 				request := struct {
-					Name          string      `json:"name"`
-					Engine        string      `json:"engine"`
-					Version       string      `json:"version"`
-					Region        string      `json:"region"`
-					Nodes         int         `json:"num_nodes"`
-					BackupRestore interface{} `json:"backup_restore"`
+					Name          string `json:"name"`
+					Engine        string `json:"engine"`
+					Version       string `json:"version"`
+					Region        string `json:"region"`
+					Nodes         int    `json:"num_nodes"`
+					BackupRestore any    `json:"backup_restore"`
 				}{}
 
 				err = json.Unmarshal(reqBody, &request)

--- a/integration/database_firewall_add_test.go
+++ b/integration/database_firewall_add_test.go
@@ -36,7 +36,7 @@ func (ms *mockServer) Get(t *testing.T, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	data, err := json.Marshal(map[string]interface{}{
+	data, err := json.Marshal(map[string]any{
 		"rules": ms.rules,
 	})
 	if err != nil {

--- a/integration/registry_garbagecollection_test.go
+++ b/integration/registry_garbagecollection_test.go
@@ -265,7 +265,7 @@ var _ = suite("registry/garbage-collection", func(t *testing.T, when spec.G, it 
 	})
 })
 
-func reifyTemplateStr(t *testing.T, tmplStr string, v interface{}) string {
+func reifyTemplateStr(t *testing.T, tmplStr string, v any) string {
 	tmpl, err := template.New("meow").Parse(tmplStr)
 	require.NoError(t, err)
 

--- a/internal/apps/builder/docker_test.go
+++ b/internal/apps/builder/docker_test.go
@@ -342,7 +342,7 @@ type testingT struct {
 	errors []string
 }
 
-func (t *testingT) Errorf(format string, args ...interface{}) {
+func (t *testingT) Errorf(format string, args ...any) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	t.failed = true

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Options is the type used to specify options passed to the SSH command
-type Options map[string]interface{}
+type Options map[string]any
 
 // Runner runs ssh commands.
 type Runner struct {

--- a/pkg/urn/urn.go
+++ b/pkg/urn/urn.go
@@ -36,7 +36,7 @@ func ParseURN(s string) (*URN, error) {
 }
 
 // NewURN constructs an *URN from a namespace, resource type, and identifier.
-func NewURN(namespace string, collection string, id interface{}) *URN {
+func NewURN(namespace string, collection string, id any) *URN {
 	return &URN{
 		namespace:  strings.ToLower(namespace),
 		collection: strings.ToLower(collection),

--- a/pkg/urn/urn_test.go
+++ b/pkg/urn/urn_test.go
@@ -74,7 +74,7 @@ func TestNewURN(t *testing.T) {
 		name       string
 		namespace  string
 		collection string
-		identifier interface{}
+		identifier any
 		expected   *URN
 		asString   string
 	}{


### PR DESCRIPTION
This PR reformats the codebase to use `any` instead of `interface{}` for consistency (by running `gofmt -w -r 'interface{} -> any' .`). Because `any` is already used in the code.
Additionally, modifies the `make` target `gofmt_check` to fail if `interface{}` appeared in all files excluding `vendor` and mocks.