### PR TITLE
APP-Platform: Update CNB builder image

### DIFF
--- a/commands/apps_dev.go
+++ b/commands/apps_dev.go
@@ -516,8 +516,8 @@ func appDevPrepareEnvironment(ctx context.Context, ws *workspace.AppDev, cli bui
 		}
 
 		// TODO: get stack run image from builder image md after we pull it, see below
-		images = append(images, "digitaloceanapps/apps-run:heroku-18_1b6264d")
-		images = append(images, "digitaloceanapps/apps-run:heroku-22_1b6264d")
+		images = append(images, "digitaloceanapps/apps-run:heroku-18_db5978a")
+		images = append(images, "digitaloceanapps/apps-run:heroku-22_db5978a")
 	}
 
 	if componentSpec.GetType() == godo.AppComponentTypeStaticSite {

--- a/internal/apps/builder/cnb.go
+++ b/internal/apps/builder/cnb.go
@@ -25,8 +25,8 @@ import (
 
 const (
 	// CNBBuilderImage represents the local cnb builder.
-	CNBBuilderImage_Heroku18 = "digitaloceanapps/cnb-local-builder:heroku-18_63b9615"
-	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_63b9615"
+	CNBBuilderImage_Heroku18 = "digitaloceanapps/cnb-local-builder:heroku-18_da24158"
+	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_da24158"
 
 	appVarAllowListKey = "APP_VARS"
 	appVarPrefix       = "APP_VAR_"


### PR DESCRIPTION
[APPS-7962](https://do-internal.atlassian.net/browse/APPS-7962 )
This change updates the CNB builder image to our latest for apps that use Ubuntu-18 and Ubuntu-22 for local builds.

[APPS-7962]: https://do-internal.atlassian.net/browse/APPS-7962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ