### PR TITLE
Add check to prevent focused tests being committed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,31 @@ jobs:
       matrix:
         go-version: [ 1.20.x, 1.21.x ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+
     runs-on: ${{ matrix.os }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
+
     - name: Ensure code is formatted with gofmt
       run: make gofmt_check
       if: matrix.os == 'ubuntu-latest'
+
     - name: Install and run shellcheck
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install shellcheck && make shellcheck
+
     - name: Run unit tests
       run: make test_unit
+
+    - name: Ensure integration test not focused
+      run: make check_focused
+
     - name: Run integration tests
       run: make test_integration

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,10 @@ gofmt_check:
 		echo "gofmt checking failed:\n"; echo "$${GOFMT} \n"; exit 1; \
 	fi
 
+.PHONY: check_focused
+check_focused:
+	@scripts/check_focused_test.sh
+
 .PHONY: snap_image
 snap_image:
 	@echo "==> build docker image for releasing snap"

--- a/scripts/check_focused_test.sh
+++ b/scripts/check_focused_test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# When an integration test is focused, no other test is run.
+# This can be useful in development, but allowing a test to be
+# checked in to main while focused means other tests are not
+# actually run in CI.
+
+set -o pipefail
+
+FOCUSED=$(grep -rn "\.Focus" integration/)
+if [ -n "${FOCUSED}" ]; then
+    echo -e "Focused tests should not be checked in:\n\n${FOCUSED}"
+    exit 1
+fi


### PR DESCRIPTION
This helps to prevent merging branches with tests that have been marked `Focused`. Marking a test `Focused` can be useful in development, but allowing a test to be checked in to main while focused means other tests are not actually run in CI.