### PR TITLE
Apps: Display "phase" for apps get-deployments

### DIFF
--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -248,6 +248,7 @@ func TestRunAppsCreateDeployment(t *testing.T) {
 				SourceCommitHash: "commit",
 			}},
 			Cause: "Manual",
+			Phase: godo.DeploymentPhase_PendingDeploy,
 			Progress: &godo.DeploymentProgress{
 				PendingSteps: 1,
 				RunningSteps: 0,
@@ -351,6 +352,7 @@ func TestRunAppsGetDeployment(t *testing.T) {
 				SourceCommitHash: "commit",
 			}},
 			Cause: "Manual",
+			Phase: godo.DeploymentPhase_PendingDeploy,
 			Progress: &godo.DeploymentProgress{
 				PendingSteps: 1,
 				RunningSteps: 0,
@@ -388,6 +390,7 @@ func TestRunAppsListDeployments(t *testing.T) {
 				SourceCommitHash: "commit",
 			}},
 			Cause: "Manual",
+			Phase: godo.DeploymentPhase_PendingDeploy,
 			Progress: &godo.DeploymentProgress{
 				PendingSteps: 1,
 				RunningSteps: 0,

--- a/commands/displayers/apps.go
+++ b/commands/displayers/apps.go
@@ -83,6 +83,7 @@ func (d Deployments) Cols() []string {
 		"ID",
 		"Cause",
 		"Progress",
+		"Phase",
 		"Created",
 		"Updated",
 	}
@@ -93,6 +94,7 @@ func (d Deployments) ColMap() map[string]string {
 		"ID":       "ID",
 		"Cause":    "Cause",
 		"Progress": "Progress",
+		"Phase":    "Phase",
 		"Created":  "Created At",
 		"Updated":  "Updated At",
 	}
@@ -115,6 +117,7 @@ func (d Deployments) KV() []map[string]any {
 			"ID":       deployment.ID,
 			"Cause":    deployment.Cause,
 			"Progress": progress,
+			"Phase":    deployment.Phase,
 			"Created":  deployment.CreatedAt,
 			"Updated":  deployment.UpdatedAt,
 		}

--- a/integration/apps_test.go
+++ b/integration/apps_test.go
@@ -153,12 +153,13 @@ var (
 			Default:     true,
 		}},
 	}
+
 	testAppsOutput = `ID                                      Spec Name    Default Ingress    Active Deployment ID                    In Progress Deployment ID    Created At                       Updated At
 93a37175-f520-4a12-a7ad-26e63491dbf4    test                            f4e37431-a0f4-458f-8f9f-5c9a61d8562f                                 1970-01-01 00:00:01 +0000 UTC    1970-01-01 00:00:01 +0000 UTC`
-	testDeploymentsOutput = `ID                                      Cause     Progress    Created At                       Updated At
-f4e37431-a0f4-458f-8f9f-5c9a61d8562f    Manual    0/1         1970-01-01 00:00:01 +0000 UTC    1970-01-01 00:00:01 +0000 UTC`
-	testActiveDeploymentOutput = `ID                                      Cause     Progress    Created At                       Updated At
-f4e37431-a0f4-458f-8f9f-5c9a61d8562f    Manual    1/1         1970-01-01 00:00:01 +0000 UTC    1970-01-01 00:00:01 +0000 UTC`
+	testDeploymentsOutput = `ID                                      Cause     Progress    Phase             Created At                       Updated At
+f4e37431-a0f4-458f-8f9f-5c9a61d8562f    Manual    0/1         PENDING_DEPLOY    1970-01-01 00:00:01 +0000 UTC    1970-01-01 00:00:01 +0000 UTC`
+	testActiveDeploymentOutput = `ID                                      Cause     Progress    Phase     Created At                       Updated At
+f4e37431-a0f4-458f-8f9f-5c9a61d8562f    Manual    1/1         ACTIVE    1970-01-01 00:00:01 +0000 UTC    1970-01-01 00:00:01 +0000 UTC`
 	testRegionsOutput = `Region    Label        Continent    Data Centers    Is Disabled?    Reason (if disabled)    Is Default?
 ams       Amsterdam    Europe       [ams3]          false                                   true`
 )
@@ -1339,8 +1340,8 @@ var _ = suite("apps/upgrade-buildpack", func(t *testing.T, when spec.G, it spec.
 			upgraded buildpack digitalocean/go. 2 components were affected: [api www].
 			triggered a new deployment to apply the upgrade:
 			
-			ID                                      Cause     Progress    Created At                       Updated At
-			f4e37431-a0f4-458f-8f9f-5c9a61d8562f    Manual    0/1         1970-01-01 00:00:01 +0000 UTC    1970-01-01 00:00:01 +0000 UTC
+			ID                                      Cause     Progress    Phase             Created At                       Updated At
+			f4e37431-a0f4-458f-8f9f-5c9a61d8562f    Manual    0/1         PENDING_DEPLOY    1970-01-01 00:00:01 +0000 UTC    1970-01-01 00:00:01 +0000 UTC
 		`), string(output))
 		expect.NoError(err)
 	})


### PR DESCRIPTION
Address  #1460 

Adding "Phase" to `apps get-deployment` display so users know if deployment is still in progress, cancelled, or finished etc. Currently there's only a "Progress" display but, for example, a progress field with "6/7" could mean a lot of things (i.e. is the deployment still in progress? is it cancelled and stoped at 6th step? etc.) 

Before:
```
 % doctl apps get-deployment 3785-4bc2  e652-401c-8794
ID                                      Cause               Progress    Created At                       Updated At
e652-401c-8794    app spec updated    6/7         2023-09-12 13:49:39 +0000 UTC    2023-09-12 13:49:50 +0000 UTC
```

After:
```
go run cmd/doctl/main.go  apps get-deployment 3785-4bc2  e652-401c-8794
ID                                      Cause               Progress    Phase     Created At                       Updated At
216b3799-e652-401c-8794-9b1c0ba35238    app spec updated    7/7         ACTIVE    2023-09-12 13:49:39 +0000 UTC    2023-09-12 13:49:50 +0000 UTC
```