### PR TITLE
apps: Set default apps dev build image to `CNBBuilderImage_Heroku22`.

### DIFF
--- a/internal/apps/builder/cnb.go
+++ b/internal/apps/builder/cnb.go
@@ -379,11 +379,6 @@ func (b *CNBComponentBuilder) builderImage() string {
 	if b.builderImageOverride != "" {
 		return b.builderImageOverride
 	}
-	for _, f := range b.spec.Features {
-		if strings.EqualFold(f, "buildpack-stack=ubuntu-22") {
-			return CNBBuilderImage_Heroku22
-		}
-	}
 
-	return CNBBuilderImage_Heroku18
+	return CNBBuilderImage_Heroku22
 }

--- a/internal/apps/builder/cnb.go
+++ b/internal/apps/builder/cnb.go
@@ -379,6 +379,11 @@ func (b *CNBComponentBuilder) builderImage() string {
 	if b.builderImageOverride != "" {
 		return b.builderImageOverride
 	}
+	for _, f := range b.spec.Features {
+		if strings.EqualFold(f, "buildpack-stack=ubuntu-18") {
+			return CNBBuilderImage_Heroku18
+		}
+	}
 
 	return CNBBuilderImage_Heroku22
 }


### PR DESCRIPTION
App Platform's default build image in the Online Service is `CNBBuilderImage_Heroku18`. This change makes `CNBBuilderImage_Heroku22` the default to bring parity to local dev tooling.