### PR TITLE
Update tag for CNBBuilderImage

### DIFF
--- a/internal/apps/builder/cnb.go
+++ b/internal/apps/builder/cnb.go
@@ -25,8 +25,8 @@ import (
 
 const (
 	// CNBBuilderImage represents the local cnb builder.
-	CNBBuilderImage_Heroku18 = "digitaloceanapps/cnb-local-builder:heroku-18_da24158"
-	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_da24158"
+	CNBBuilderImage_Heroku18 = "digitaloceanapps/cnb-local-builder:heroku-18_v0.64.0"
+	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_v0.64.0"
 
 	appVarAllowListKey = "APP_VARS"
 	appVarPrefix       = "APP_VAR_"


### PR DESCRIPTION
### Details

This PR updates CNBBuilderImage tag to `v0.64.0` (current stable version)

### Issue

This fixes the following error:
```
ERROR: failed to export: get run image top layer SHA: image "<image-0>" has no layers
```