### PR TITLE
Docs audit: Regions and Sizes

### DIFF
--- a/commands/regions.go
+++ b/commands/regions.go
@@ -32,9 +32,9 @@ func Region() *Command {
 
 Use the slugs displayed by this command to specify regions in other commands.
 `
-	CmdBuilder(cmd, RunRegionList, "list", "List datacenter regions", regionDesc,
+	cmdRegionList := CmdBuilder(cmd, RunRegionList, "list", "Retrieves a list of datacenter regions", regionDesc,
 		Writer, aliasOpt("ls"), displayerType(&displayers.Region{}))
-
+	cmdRegionList.Example = "The following example retrieves a list of regions and uses the --format flag to return only the slug for each region: doctl compute region list --format Slug"
 	return cmd
 }
 

--- a/commands/sizes.go
+++ b/commands/sizes.go
@@ -35,7 +35,7 @@ Use these slugs to specify the size of Droplet in other commands, such as ` + "`
 	cmdSizeList := CmdBuilder(cmd, RunSizeList, "list", "List available Droplet sizes", sizeDesc,
 		Writer, aliasOpt("ls"), displayerType(&displayers.Size{}))
 	cmdSizeList.Example = "The following example retrieves a list of Droplet sizes and uses the --format flag to return only the slug for each size and its monthly price: doctl compute size list --format Slug,PriceMonthly"
-≈	return cmd
+	return cmd
 }
 
 // RunSizeList all sizes.

--- a/commands/sizes.go
+++ b/commands/sizes.go
@@ -28,14 +28,14 @@ func Size() *Command {
 		},
 	}
 
-	sizeDesc := `List the slug identifier, RAM, VCPU count, disk size, and pricing details for each Droplet size.
+	sizeDesc := `Retrieves a list of slug identifiers, RAM amounts, vCPU counts, disk sizes, and pricing details for each Droplet size.
 
-Use the slugs displayed by this command to specify the type of Droplet in other commands.
+Use these slugs to specify the size of Droplet in other commands, such as ` + "`" + `doctl compute droplet create <droplet-name> --size <size-slug>` + "`" + `.
 `
-	CmdBuilder(cmd, RunSizeList, "list", "List available Droplet sizes", sizeDesc,
+	cmdSizeList := CmdBuilder(cmd, RunSizeList, "list", "List available Droplet sizes", sizeDesc,
 		Writer, aliasOpt("ls"), displayerType(&displayers.Size{}))
-
-	return cmd
+	cmdSizeList.Example = "The following example retrieves a list of Droplet sizes and uses the --format flag to return only the slug for each size and its monthly price: doctl compute size list --format Slug,PriceMonthly"
+≈	return cmd
 }
 
 // RunSizeList all sizes.


### PR DESCRIPTION
This updates the doc string for the region and size commands, and adds an example for each.