### PR TITLE
Docs audit: Reserved IPs

### DIFF
--- a/commands/reserved_ip_actions.go
+++ b/commands/reserved_ip_actions.go
@@ -35,26 +35,29 @@ func ReservedIPAction() *Command {
 	}
 	flipActionDetail := `
 
-	- The unique numeric ID used to identify and reference a reserved IP action.
-	- The status of the reserved IP action. This will be either "in-progress", "completed", or "errored".
-	- A time value given in ISO8601 combined date and time format that represents when the action was initiated.
-	- A time value given in ISO8601 combined date and time format that represents when the action was completed.
-	- The resource ID, which is a unique identifier for the resource that the action is associated with.
-	- The type of resource that the action is associated with.
-	- The region where the action occurred.
-	- The slug for the region where the action occurred.
+- The unique numeric ID used to identify and reference a reserved IP action
+- The status of the reserved IP action. Possible values: "in-progress", "completed", "errored"
+- When the action was initiated, in ISO8601 combined date and time format
+- When the action was completed, in ISO8601 combined date and time format
+- The ID of the resource that the action is associated with
+- The type of resource that the action is associated with
+- The region where the action occurred
+- The slug for the region where the action occurred
 `
-	CmdBuilder(cmd, RunReservedIPActionsGet,
-		"get <reserved-ip> <action-id>", "Retrieve the status of a reserved IP action", `Use this command to retrieve the status of a reserved IP action. Outputs the following information:`+flipActionDetail, Writer,
+	cmdReservedIPActionsGet := CmdBuilder(cmd, RunReservedIPActionsGet,
+		"get <reserved-ip> <action-id>", "Retrieve the status of a reserved IP action", `Retrieves the status of a reserved IP action. Outputs the following information:`+flipActionDetail, Writer,
 		displayerType(&displayers.Action{}))
+	cmdReservedIPActionsGet.Example = `The following example retrieves the status of an action, that has the ID ` + "`" + `191669331` + "`" + `, that was taken on the reserved IP address ` + "`" + `203.0.113.25` + "`" + `: doctl compute reserved-ip-action get 203.0.113.25 191669331`
 
-	CmdBuilder(cmd, RunReservedIPActionsAssign,
-		"assign <reserved-ip> <droplet-id>", "Assign a reserved IP address to a Droplet", "Use this command to assign a reserved IP address to a Droplet by specifying the `droplet_id`.", Writer,
+	cmdReservedIPActionsAssign := CmdBuilder(cmd, RunReservedIPActionsAssign,
+		"assign <reserved-ip> <droplet-id>", "Assign a reserved IP address to a Droplet", "Assigns a reserved IP address to the specified Droplet.", Writer,
 		displayerType(&displayers.Action{}))
+	cmdReservedIPActionsAssign.Example = `The following example assigns the reserved IP address ` + "`" + `203.0.113.25` + "`" + ` to a Droplet with the ID ` + "`" + `386734086` + "`" + `: doctl compute reserved-ip-action assign 203.0.113.25 386734086`
 
-	CmdBuilder(cmd, RunReservedIPActionsUnassign,
-		"unassign <reserved-ip>", "Unassign a reserved IP address from a Droplet", `Use this command to unassign a reserved IP address from a Droplet. The reserved IP address will be reserved in the region but not assigned to a Droplet.`, Writer,
+	cmdReservedIPActionsUnassign := CmdBuilder(cmd, RunReservedIPActionsUnassign,
+		"unassign <reserved-ip>", "Unassign a reserved IP address from a Droplet", `Unassigns a reserved IP address from a Droplet. Due to a shortage on IPv4 addresses, unassigned reserved IP addresses remain available on your account but accumulate charges for not being assigned.`, Writer,
 		displayerType(&displayers.Action{}))
+	cmdReservedIPActionsUnassign.Example = `The following example unassigns the reserved IP address ` + "`" + `203.0.113.25` + "`" + ` from a resource: doctl compute reserved-ip-action unassign 203.0.113.25`
 
 	return cmd
 }

--- a/commands/reserved_ips.go
+++ b/commands/reserved_ips.go
@@ -31,34 +31,38 @@ func ReservedIP() *Command {
 			Use:   "reserved-ip",
 			Short: "Display commands to manage reserved IP addresses",
 			Long: `The sub-commands of ` + "`" + `doctl compute reserved-ip` + "`" + ` manage reserved IP addresses.
-Reserved IPs are publicly-accessible static IP addresses that can be mapped to one of your Droplets. They can be used to create highly available setups or other configurations requiring movable addresses. Reserved IPs are bound to a specific region.`,
+Reserved IPs are publicly-accessible static IP addresses that you can to one of your Droplets. They can be used to create highly available setups or other configurations requiring movable addresses. Reserved IPs are bound to the regions they are created in.`,
 			Aliases: []string{"fip", "floating-ip", "floating-ips", "reserved-ips"},
 		},
 	}
 
-	cmdReservedIPCreate := CmdBuilder(cmd, RunReservedIPCreate, "create", "Create a new reserved IP address", `Use this command to create a new reserved IP address.
+	cmdReservedIPCreate := CmdBuilder(cmd, RunReservedIPCreate, "create", "Create a new reserved IP address", `Creates a new reserved IP address.
 
-A reserved IP address must be either assigned to a Droplet or reserved to a region.`, Writer,
+Reserved IP addresses can either be assigned to Droplets or held in the region they were created in on your account, but because of the IPv4 address shortage, unassigned reserved IP addresses incur charges.`, Writer,
 		aliasOpt("c"), displayerType(&displayers.ReservedIP{}))
 	AddStringFlag(cmdReservedIPCreate, doctl.ArgRegionSlug, "", "",
-		fmt.Sprintf("Region where to create the reserved IP address. (mutually exclusive with `--%s`)",
+		fmt.Sprintf("The region where to create the reserved IP address. Cannot be used with the `--%s` flag.",
 			doctl.ArgDropletID))
 	AddStringFlag(cmdReservedIPCreate, doctl.ArgProjectID, "", "",
-		fmt.Sprintf("The ID of the project the reserved IP address will be assigned to. When excluded, it will be assigned to the default project. When using the `--%s` flag, it will be assigned to the project containing the Droplet.",
+		fmt.Sprintf("The ID of the project to assign the IP address. When excluded, the address is assigned to your default project. When using the `--%s` flag, it is assigned to the project containing the Droplet.",
 			doctl.ArgDropletID))
 	AddIntFlag(cmdReservedIPCreate, doctl.ArgDropletID, "", 0,
-		fmt.Sprintf("The ID of the Droplet to assign the reserved IP to (mutually exclusive with `--%s`).",
+		fmt.Sprintf("The ID of the Droplet to assign the reserved IP to. Cannot be used with the `--%s` flag.",
 			doctl.ArgRegionSlug))
+	cmdReservedIPCreate.Example = `The following example creates a reserved IP address in the ` + "`" + `nyc1` + "`" + ` region and assigns it to a Droplet with the ID ` + "`" + `386734086` + "`" + `: doctl compute reserved-ip create --region nyc1 --droplet-id 386734086`
 
-	CmdBuilder(cmd, RunReservedIPGet, "get <reserved-ip>", "Retrieve information about a reserved IP address", "Use this command to retrieve detailed information about a reserved IP address.", Writer,
+	cmdReservedIPGet := CmdBuilder(cmd, RunReservedIPGet, "get <reserved-ip>", "Retrieve information about a reserved IP address", "Retrieves detailed information about a reserved IP address, including its region and the ID of the Droplet its assigned to.", Writer,
 		aliasOpt("g"), displayerType(&displayers.ReservedIP{}))
+	cmdReservedIPGet.Example = `The following example retrieves information about the reserved IP address ` + "`" + `203.0.113.25` + "`" + `: doctl compute reserved-ip get 203.0.113.25`
 
-	cmdRunReservedIPDelete := CmdBuilder(cmd, RunReservedIPDelete, "delete <reserved-ip>", "Permanently delete a reserved IP address", "Use this command to permanently delete a reserved IP address. This is irreversible.", Writer, aliasOpt("d", "rm"))
-	AddBoolFlag(cmdRunReservedIPDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force reserved IP delete")
+	cmdRunReservedIPDelete := CmdBuilder(cmd, RunReservedIPDelete, "delete <reserved-ip>", "Permanently delete a reserved IP address", "Permanently deletes a reserved IP address. This is irreversible.", Writer, aliasOpt("d", "rm"))
+	AddBoolFlag(cmdRunReservedIPDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Deletes the reserved IP address without confirmation")
+	cmdRunReservedIPDelete.Example = `The following example deletes the reserved IP address ` + "`" + `203.0.113.25` + "`" + `: doctl compute reserved-ip delete 203.0.113.25`
 
-	cmdReservedIPList := CmdBuilder(cmd, RunReservedIPList, "list", "List all reserved IP addresses on your account", "Use this command to list all the reserved IP addresses on your account.", Writer,
+	cmdReservedIPList := CmdBuilder(cmd, RunReservedIPList, "list", "List all reserved IP addresses on your account", "Retrieves a list of all the reserved IP addresses on your account.", Writer,
 		aliasOpt("ls"), displayerType(&displayers.ReservedIP{}))
-	AddStringFlag(cmdReservedIPList, doctl.ArgRegionSlug, "", "", "The region the reserved IP address resides in")
+	AddStringFlag(cmdReservedIPList, doctl.ArgRegionSlug, "", "", "Retrieves a list of reserved IP addresses in the specified region")
+	cmdReservedIPList.Example = `The following example lists all reserved IP addresses in the ` + "`" + `nyc1` + "`" + ` region: doctl compute reserved-ip list --region nyc1`
 
 	return cmd
 }


### PR DESCRIPTION
Updates and clarifies doc strings for Reserved IP and Reserved IP Action commands. Also add examples for each command.