### PR TITLE
Docs audit: Volumes and Volume Actions

### DIFF
--- a/commands/volume_actions.go
+++ b/commands/volume_actions.go
@@ -61,47 +61,52 @@ func VolumeAction() *Command {
 
 	actionDetail := `
 
-	- The unique numeric ID used to identify and reference a volume action.
-	- The status of the volume action. This will be either ` + "`" + `in-progress` + "`" + `, ` + "`" + `completed` + "`" + `, or ` + "`" + `errored` + "`" + `.
-	- A time value given in ISO8601 combined date and time format that represents when the action was initiated.
-	- A time value given in ISO8601 combined date and time format that represents when the action was completed.
-	- The resource ID, which is a unique identifier for the resource that the action is associated with.
-	- The type of resource that the action is associated with.
-	- The region where the action occurred.
-	- The slug for the region where the action occurred.
+- The unique numeric ID used to identify and reference a volume action.
+- The status of the volume action. Possible values: ` + "`" + `in-progress` + "`" + `, ` + "`" + `completed` + "`" + `, ` + "`" + `errored` + "`" + `.
+- When the action was initiated, in ISO8601 combined date and time format
+- When the action was completed, in ISO8601 combined date and time format
+- The resource ID, which is a unique identifier for the resource that the action is associated with.
+- The type of resource that the action is associated with.
+- The region where the action occurred.
+- The slug for the region where the action occurred.
 	`
 
-	cmdVolumeActionsGet := CmdBuilder(cmd, RunVolumeActionsGet, "get <volume-id>", "Retrieve the status of a volume action", `Use this command to retrieve the status of a volume action, including the following details:`+actionDetail, Writer,
+	cmdVolumeActionsGet := CmdBuilder(cmd, RunVolumeActionsGet, "get <volume-id>", "Retrieve the status of a volume action", `Retrieves the status of a volume action, including the following details:`+actionDetail, Writer,
 		displayerType(&displayers.Action{}))
 	AddIntFlag(cmdVolumeActionsGet, doctl.ArgActionID, "", 0, "action id", requiredOpt())
+	cmdVolumeActionsGet.Example = `The following example retrieves the status of an action taken on a volume with the UUID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute volume-action get f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --action-id 191669331`
 
-	CmdBuilder(cmd, RunVolumeActionsList, "list <volume-id>", "Retrieve a list of actions taken on a volume", `This command retrieves a list of actions taken on a volume. The following details are provided:`+actionDetail, Writer,
+	cmdVolumeActionsList := CmdBuilder(cmd, RunVolumeActionsList, "list <volume-id>", "Retrieve a list of actions taken on a volume", `Retrieves a list of actions taken on a volume. The following details are provided:`+actionDetail, Writer,
 		aliasOpt("ls"), displayerType(&displayers.Action{}))
+	cmdVolumeActionsList.Example = `The following example retrieves a list of actions taken on a volume with the UUID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `. The command also uses the ` + "`" + `--format` + "`" + ` flag to return ony the resource ID and status for each action listed: doctl compute volume-action list f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --format ResourceID,Status`
 
-	cmdRunVolumeAttach := CmdBuilder(cmd, RunVolumeAttach, "attach <volume-id> <droplet-id>", "Attach a volume to a Droplet", `Use this command to attach a block storage volume to a Droplet.
+	cmdRunVolumeAttach := CmdBuilder(cmd, RunVolumeAttach, "attach <volume-id> <droplet-id>", "Attach a volume to a Droplet", `Attaches a block storage volume to a Droplet.
 
-Each volume can be attached to only one Droplet at a time. However, up to five volumes may be attached to a single Droplet.
+You can only attach one Droplet to a volume at a time. However, you can attach up to five different volumes to a Droplet at a time.
 
 When you attach a pre-formatted volume to Ubuntu, Debian, Fedora, Fedora Atomic, and CentOS Droplets created on or after April 26, 2018, the volume automatically mounts. On older Droplets, additional configuration is required. Visit https://docs.digitalocean.com/products/volumes/how-to/mount/ for details`, Writer,
 		aliasOpt("a"))
-	AddBoolFlag(cmdRunVolumeAttach, doctl.ArgCommandWait, "", false, "Wait for volume to attach")
+	AddBoolFlag(cmdRunVolumeAttach, doctl.ArgCommandWait, "", false, "Instructs the terminal to wait for the volume to attach before returning control to the user")
+	cmdRunVolumeAttach.Example = `The following example attaches a volume with the UUID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + ` to a Droplet with the ID ` + "`" + `386734086` + "`" + `: doctl compute volume-action attach f81d4fae-7dec-11d0-a765-00a0c91e6bf6 386734086`
 
-	cmdRunVolumeDetach := CmdBuilder(cmd, RunVolumeDetach, "detach <volume-id> <droplet-id>", "Detach a volume from a Droplet", `Use this command to detach a block storage volume from a Droplet.`, Writer,
+	cmdRunVolumeDetach := CmdBuilder(cmd, RunVolumeDetach, "detach <volume-id> <droplet-id>", "Detach a volume from a Droplet", `Detaches a block storage volume from a Droplet.`, Writer,
 		aliasOpt("d"))
-	AddBoolFlag(cmdRunVolumeDetach, doctl.ArgCommandWait, "", false, "Wait for volume to detach")
+	AddBoolFlag(cmdRunVolumeDetach, doctl.ArgCommandWait, "", false, "Instructs the terminal to wait for the volume to detach before returning control to the user")
+	cmdRunVolumeDetach.Example = `The following example detaches a volume with the UUID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + ` from a Droplet with the ID ` + "`" + `386734086` + "`" + `: doctl compute volume-action detach f81d4fae-7dec-11d0-a765-00a0c91e6bf6 386734086`
 
 	CmdBuilder(cmd, RunVolumeDetach, "detach-by-droplet-id <volume-id> <droplet-id>", "(Deprecated) Detach a volume. Use `detach` instead.", "This command detaches a volume. This command is deprecated. Use `doctl compute volume-action detach` instead.",
 		Writer)
 
-	cmdRunVolumeResize := CmdBuilder(cmd, RunVolumeResize, "resize <volume-id>", "Resize the disk of a volume", `Use this command to resize a block storage volume.
+	cmdRunVolumeResize := CmdBuilder(cmd, RunVolumeResize, "resize <volume-id>", "Resize the disk of a volume", `Resizes a block storage volume.
 
 Volumes may only be resized upwards. The maximum size for a volume is 16TiB.`, Writer,
 		aliasOpt("r"))
-	AddIntFlag(cmdRunVolumeResize, doctl.ArgSizeSlug, "", 0, "New size in GiB",
+	AddIntFlag(cmdRunVolumeResize, doctl.ArgSizeSlug, "", 0, "The volume's new size, in GiB",
 		requiredOpt())
-	AddStringFlag(cmdRunVolumeResize, doctl.ArgRegionSlug, "", "", "Volume region",
+	AddStringFlag(cmdRunVolumeResize, doctl.ArgRegionSlug, "", "", "The volume's current region",
 		requiredOpt())
-	AddBoolFlag(cmdRunVolumeResize, doctl.ArgCommandWait, "", false, "Wait for volume to resize")
+	AddBoolFlag(cmdRunVolumeResize, doctl.ArgCommandWait, "", false, "Instructs the terminal to wait for the volume to complete resizing before returning control to the user")
+	cmdRunVolumeResize.Example = `The following example resizes a volume with the UUID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + ` to 120 GiB in the ` + "`" + `nyc1` + "`" + ` region: doctl compute volume-action resize f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --size 120 --region nyc1`
 
 	return cmd
 

--- a/commands/volumes.go
+++ b/commands/volumes.go
@@ -39,37 +39,44 @@ Volumes function as raw block devices, meaning they appear to the operating syst
 		},
 	}
 
-	cmdRunVolumeList := CmdBuilder(cmd, RunVolumeList, "list", "List block storage volumes by ID", `Use this command to list all of the block storage volumes on your account.`, Writer,
+	cmdRunVolumeList := CmdBuilder(cmd, RunVolumeList, "list", "List block storage volumes by ID", `Lists all of the block storage volumes on your account.`, Writer,
 		aliasOpt("ls"), displayerType(&displayers.Volume{}))
-	AddStringFlag(cmdRunVolumeList, doctl.ArgRegionSlug, "", "", "Volume region")
+	AddStringFlag(cmdRunVolumeList, doctl.ArgRegionSlug, "", "", "Filter's volumes by the specified region")
+	cmdRunVolumeList.Example = `The following example retrieves a list of volumes on your account in the ` + "`" + `nyc1` + "`" + ` region. The command also uses the ` + "`" + `--format` + "`" + ` flag to return only the name and size of each volume: doctl compute volume list --region nyc1 --format Name,Size`
 
-	cmdVolumeCreate := CmdBuilder(cmd, RunVolumeCreate, "create <volume-name>", "Create a block storage volume", `Use this command to create a block storage volume on your account.
+	cmdVolumeCreate := CmdBuilder(cmd, RunVolumeCreate, "create <volume-name>", "Create a block storage volume", `Creates a block storage volume on your account.
 
-You can use flags to specify the volume size, region, description, filesystem type, tags, and to create a volume from an existing volume snapshot.`, Writer,
+You can use flags to specify the volume size, region, description, filesystem type, tags, and to create a volume from an existing volume snapshot.
+
+Use the `+"`"+`doctl compute volume-action attach <volume-id> <droplet-id>`+"`"+` command to attach a new volume to a Droplet.`, Writer,
 		aliasOpt("c"), displayerType(&displayers.Volume{}))
 	AddStringFlag(cmdVolumeCreate, doctl.ArgVolumeSize, "", "4TiB", "Volume size",
 		requiredOpt())
-	AddStringFlag(cmdVolumeCreate, doctl.ArgVolumeDesc, "", "", "Volume description")
-	AddStringFlag(cmdVolumeCreate, doctl.ArgVolumeRegion, "", "", "Volume region; should not be specified with a snapshot")
-	AddStringFlag(cmdVolumeCreate, doctl.ArgVolumeSnapshot, "", "", "Volume snapshot; should not be specified with a region")
-	AddStringFlag(cmdVolumeCreate, doctl.ArgVolumeFilesystemType, "", "", "Volume filesystem type (ext4 or xfs)")
-	AddStringFlag(cmdVolumeCreate, doctl.ArgVolumeFilesystemLabel, "", "", "Volume filesystem label")
-	AddStringSliceFlag(cmdVolumeCreate, doctl.ArgTag, "", []string{}, "Tags to apply to the volume; comma separate or repeat `--tag` to add multiple tags at once")
+	AddStringFlag(cmdVolumeCreate, doctl.ArgVolumeDesc, "", "", "A description of the volume")
+	AddStringFlag(cmdVolumeCreate, doctl.ArgVolumeRegion, "", "", "The volume's region. Not compatible with the `--snapshot` flag")
+	AddStringFlag(cmdVolumeCreate, doctl.ArgVolumeSnapshot, "", "", "Creates a volume from the specified snapshot ID. Not compatible with the `--region` flag")
+	AddStringFlag(cmdVolumeCreate, doctl.ArgVolumeFilesystemType, "", "", "The volume's filesystem type: ext4 or xfs. If not specified, the volume is left unformatted")
+	AddStringFlag(cmdVolumeCreate, doctl.ArgVolumeFilesystemLabel, "", "", "The volume's filesystem label")
+	AddStringSliceFlag(cmdVolumeCreate, doctl.ArgTag, "", []string{}, "A comma-separated list of tags to apply to the volume. For example, `--tag frontend` or `--tag frontend,backend`")
+	cmdVolumeCreate.Example = `The following example creates a 4TiB volume named ` + "`" + `example-volume` + "`" + ` in the ` + "`" + `nyc1` + "`" + ` region. The command also applies two tags to the volume: doctl compute volume create example-volume --region nyc1 --size 4TiB --tag frontend,backend`
 
-	cmdRunVolumeDelete := CmdBuilder(cmd, RunVolumeDelete, "delete <volume-id>", "Delete a block storage volume", `Use this command to delete a block storage volume by ID, destroying all of its data and removing it from your account.`, Writer,
+	cmdRunVolumeDelete := CmdBuilder(cmd, RunVolumeDelete, "delete <volume-id>", "Delete a block storage volume", `Deletes a block storage volume by ID, destroying all of its data and removing it from your account. This is irreversible.`, Writer,
 		aliasOpt("d", "rm"))
-	AddBoolFlag(cmdRunVolumeDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Force volume delete")
+	AddBoolFlag(cmdRunVolumeDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Delete the volume without prompting for confirmation")
+	cmdRunVolumeDelete.Example = `The following example deletes a volume with the UUID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute volume delete f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
 
-	CmdBuilder(cmd, RunVolumeGet, "get <volume-id>", "Retrieve an existing block storage volume", `Use this command to retrieve information about a block storage volume using its ID.`, Writer, aliasOpt("g"),
+	cmdVolumeGet := CmdBuilder(cmd, RunVolumeGet, "get <volume-id>", "Retrieve an existing block storage volume", `Retrieves information about a block storage volume.`, Writer, aliasOpt("g"),
 		displayerType(&displayers.Volume{}))
+	cmdVolumeGet.Example = `The following example retrieves information about a volume with the UUID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute volume get f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
 
-	cmdRunVolumeSnapshot := CmdBuilder(cmd, RunVolumeSnapshot, "snapshot <volume-id>", "Create a block storage volume snapshot", `Use this command to create a snapshot of a block storage volume by ID.
+	cmdRunVolumeSnapshot := CmdBuilder(cmd, RunVolumeSnapshot, "snapshot <volume-id>", "Create a block storage volume snapshot", `Creates a snapshot of a block storage volume by ID.
 
 You can use a block storage volume snapshot ID as a flag with `+"`"+`doctl volume create`+"`"+` to create a new block storage volume with the same data as the volume the snapshot was taken from.`, Writer,
 		aliasOpt("s"), displayerType(&displayers.Volume{}))
-	AddStringFlag(cmdRunVolumeSnapshot, doctl.ArgSnapshotName, "", "", "Snapshot name", requiredOpt())
-	AddStringFlag(cmdRunVolumeSnapshot, doctl.ArgSnapshotDesc, "", "", "Snapshot description")
-	AddStringSliceFlag(cmdRunVolumeSnapshot, doctl.ArgTag, "", []string{}, "Tags to apply to the snapshot; comma separate or repeat `--tag` to add multiple tags at once")
+	AddStringFlag(cmdRunVolumeSnapshot, doctl.ArgSnapshotName, "", "", "The snapshot name", requiredOpt())
+	AddStringFlag(cmdRunVolumeSnapshot, doctl.ArgSnapshotDesc, "", "", "A description of the snapshot")
+	AddStringSliceFlag(cmdRunVolumeSnapshot, doctl.ArgTag, "", []string{}, "A comma-separate list of tags to apply to the snapshot. For example, `--tag frontend` or `--tag frontend,backend`")
+	cmdRunVolumeSnapshot.Example = `The following example creates a snapshot of a volume with the UUID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute volume snapshot f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --snapshot-name example-snapshot --tag frontend,backend`
 
 	return cmd
 


### PR DESCRIPTION
Updates and clarifies doc strings for the Volume and Volume Actions commands. Also add examples for each command.