### PR TITLE
LBAAS-2899: doctl not removing LB firewall rules on update

### DIFF
--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -125,9 +125,9 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 		"disable automatic DNS record creation for Let's Encrypt certificates that are added to the load balancer")
 	AddStringFlag(cmdRecordUpdate, doctl.ArgProjectID, "", "",
 		"Indicates which project to associate the Load Balancer with. If not specified, the Load Balancer will be placed in your default project.")
-	AddStringSliceFlag(cmdRecordUpdate, doctl.ArgAllowList, "", []string{},
+	AddStringSliceFlag(cmdRecordUpdate, doctl.ArgAllowList, "", nil,
 		"A comma-separated list of ALLOW rules for the load balancer, e.g.: `ip:1.2.3.4,cidr:1.2.0.0/16`")
-	AddStringSliceFlag(cmdRecordUpdate, doctl.ArgDenyList, "", []string{},
+	AddStringSliceFlag(cmdRecordUpdate, doctl.ArgDenyList, "", nil,
 		"A comma-separated list of DENY rules for the load balancer, e.g.: `ip:1.2.3.4,cidr:1.2.0.0/16`")
 
 	CmdBuilder(cmd, RunLoadBalancerList, "list", "List load balancers", "Use this command to get a list of the load balancers on your account, including the following information for each:\n\n"+lbDetail, Writer,
@@ -557,17 +557,17 @@ func buildRequestFromArgs(c *CmdConfig, r *godo.LoadBalancerRequest) error {
 		r.HTTPIdleTimeoutSeconds = &t
 	}
 
-	allowRules, err := c.Doit.GetStringSlice(c.NS, doctl.ArgAllowList)
+	allowRules, allowflagSet, err := c.Doit.GetStringSliceIsFlagSet(c.NS, doctl.ArgAllowList)
 	if err != nil {
 		return err
 	}
 
-	denyRules, err := c.Doit.GetStringSlice(c.NS, doctl.ArgDenyList)
+	denyRules, denyFlagSet, err := c.Doit.GetStringSliceIsFlagSet(c.NS, doctl.ArgDenyList)
 	if err != nil {
 		return err
 	}
 
-	if len(allowRules) > 0 || len(denyRules) > 0 {
+	if allowflagSet || denyFlagSet {
 		firewall := new(godo.LBFirewall)
 		firewall.Allow = allowRules
 		firewall.Deny = denyRules

--- a/doit.go
+++ b/doit.go
@@ -219,6 +219,7 @@ type Config interface {
 	GetInt(ns, key string) (int, error)
 	GetIntPtr(ns, key string) (*int, error)
 	GetStringSlice(ns, key string) ([]string, error)
+	GetStringSliceIsFlagSet(ns, key string) ([]string, bool, error)
 	GetStringMapString(ns, key string) (map[string]string, error)
 	GetDuration(ns, key string) (time.Duration, error)
 }
@@ -426,6 +427,15 @@ func (c *LiveConfig) GetStringSlice(ns, key string) ([]string, error) {
 	return out, nil
 }
 
+// GetStringSliceIsFlagSet returns a config value as a string slice and a bool representing the existence of the flag.
+func (c *LiveConfig) GetStringSliceIsFlagSet(ns, key string) ([]string, bool, error) {
+	if !c.IsSet(key) {
+		return nil, false, nil
+	}
+	strSlice, err := c.GetStringSlice(ns, key)
+	return strSlice, true, err
+}
+
 // GetStringMapString returns a config value as a string to string map.
 func (c *LiveConfig) GetStringMapString(ns, key string) (map[string]string, error) {
 	nskey := nskey(ns, key)
@@ -560,6 +570,17 @@ func (c *TestConfig) GetIntPtr(ns, key string) (*int, error) {
 func (c *TestConfig) GetStringSlice(ns, key string) ([]string, error) {
 	nskey := nskey(ns, key)
 	return c.v.GetStringSlice(nskey), nil
+}
+
+// GetStringSliceIsFlagSet returns the string slice value for the key in the given
+// namespace and a bool representing the existence of the flag. Because this is a mock implementation,
+// and error will never be returned.
+func (c *TestConfig) GetStringSliceIsFlagSet(ns, key string) ([]string, bool, error) {
+	nskey := nskey(ns, key)
+	if !c.v.IsSet(nskey) {
+		return nil, false, nil
+	}
+	return c.v.GetStringSlice(nskey), true, nil
 }
 
 // GetStringMapString returns the string-to-string value for the key in the


### PR DESCRIPTION
Currently, when you pass an empty value to the the load balancer allow/deny rules flag we are not updating the LB firewall rules. To match the behavior of our public API we should allow an empty flag allow/deny rules flag to remove the firewall rules from the LB.

At current passing an empty flag does not populates the LB firewall field. We should be separating the behavior of the allow/deny rules flag not being specified and the flag being specified but empty

This change allows an empty value in the fw rules flags to update the LB firewall to empty.
When not specifying the fw rules flags the LB firewall will not be updated.