### PR TITLE
ssh: add retries

### DIFF
--- a/args.go
+++ b/args.go
@@ -190,6 +190,8 @@ const (
 	ArgsSSHPrivateIP = "ssh-private-ip"
 	// ArgSSHCommand is a ssh argument.
 	ArgSSHCommand = "ssh-command"
+	// ArgSSHRetryMax is a ssh argument.
+	ArgSSHRetryMax = "ssh-retry-max"
 	// ArgUserData is a user data argument.
 	ArgUserData = "user-data"
 	// ArgUserDataFile is a user data file location argument.

--- a/args.go
+++ b/args.go
@@ -98,8 +98,6 @@ const (
 	ArgCommandUpsert = "upsert"
 	// ArgCommandWait is a wait for a resource to be created argument.
 	ArgCommandWait = "wait"
-	// ArgCommandRetry is a retry for an action to be successful argument.
-	ArgCommandRetry = "retry"
 	// ArgSetCurrentContext is a flag to set the new kubeconfig context as current.
 	ArgSetCurrentContext = "set-current-context"
 	// ArgDropletID is a droplet id argument.

--- a/args.go
+++ b/args.go
@@ -98,6 +98,8 @@ const (
 	ArgCommandUpsert = "upsert"
 	// ArgCommandWait is a wait for a resource to be created argument.
 	ArgCommandWait = "wait"
+	// ArgCommandRetry is a retry for an action to be successful argument.
+	ArgCommandRetry = "retry"
 	// ArgSetCurrentContext is a flag to set the new kubeconfig context as current.
 	ArgSetCurrentContext = "set-current-context"
 	// ArgDropletID is a droplet id argument.

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -29,8 +29,6 @@ import (
 
 var (
 	sshHostRE = regexp.MustCompile(`^((?P<m1>\w+)@)?(?P<m2>.*?)(:(?P<m3>\d+))?$`)
-	// number of retrys to attempt to successfully SSH into droplet
-	retries = 15
 )
 
 // SSH creates the ssh commands hierarchy

--- a/doit.go
+++ b/doit.go
@@ -320,6 +320,7 @@ func (c *LiveConfig) SSH(user, host, keyPath string, port int, opts ssh.Options)
 		Port:            port,
 		AgentForwarding: opts[ArgsSSHAgentForwarding].(bool),
 		Command:         opts[ArgSSHCommand].(string),
+		RetriesMax:      opts[ArgSSHRetryMax].(int),
 	}
 }
 

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -34,6 +34,7 @@ type Runner struct {
 	Port            int
 	AgentForwarding bool
 	Command         string
+	RetriesMax      int
 }
 
 var _ runner.Runner = &Runner{}
@@ -61,6 +62,11 @@ func (r *Runner) Run() error {
 	args = append(args, sshHost)
 	if r.Command != "" {
 		args = append(args, r.Command)
+	}
+
+	if r.RetriesMax > 0 {
+		connAttemptsOpt := fmt.Sprintf("ConnectionAttempts=%d", r.RetriesMax)
+		args = append(args, "-o", connAttemptsOpt)
 	}
 
 	cmd := exec.Command("ssh", args...)

--- a/testscript.sh
+++ b/testscript.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-DROPLET_ID=$(go run cmd/doctl/main.go compute droplet create --image ubuntu-20-04-x64 --size s-1vcpu-1gb --region nyc1 wb2 --ssh-keys 40563907 --wait -o json | jq '.[] | .id')
-go run cmd/doctl/main.go compute ssh $DROPLET_ID --ssh-retry-max 30  
-doctl compute droplet delete $DROPLET_ID

--- a/testscript.sh
+++ b/testscript.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+DROPLET_ID=$(go run cmd/doctl/main.go compute droplet create --image ubuntu-20-04-x64 --size s-1vcpu-1gb --region nyc1 wb2 --ssh-keys 40563907 --wait -o json | jq '.[] | .id')
+go run cmd/doctl/main.go compute ssh $DROPLET_ID --ssh-retry-max 30  
+doctl compute droplet delete $DROPLET_ID


### PR DESCRIPTION
A work around for #1003

Passing in the `--wait` flag for `doctl compute droplet create` will return to user before the droplet is ready to accept ssh connections. This PR adds a `--ssh-retry-max` flag for `doctl compute ssh` command to retry for a successful connection to the droplet a certain amount of times before returning to user:

An example of what a CI script would look like:
```
#!/bin/bash
DROPLET_ID=$(go run cmd/doctl/main.go compute droplet create --image ubuntu-20-04-x64 --size s-1vcpu-1gb --region nyc1 wb2 --ssh-keys 40563907 --wait -o json | jq '.[] | .id')
go run cmd/doctl/main.go compute ssh $DROPLET_ID --ssh-retry-max 15  
doctl compute droplet delete $DROPLET_ID
```