### PR TITLE
Add kafka acl option to user create

### DIFF
--- a/args.go
+++ b/args.go
@@ -390,6 +390,8 @@ const (
 	ArgDatabaseUserMySQLAuthPlugin = "mysql-auth-plugin"
 	// ArgDatabasePrivateConnectionBool determine if the private connection details should be shown
 	ArgDatabasePrivateConnectionBool = "private"
+	// ArgDatabaseUserKafkaACLs will specify permissions on topics in kafka clsuter
+	ArgDatabaseUserKafkaACLs = "acl"
 
 	// ArgDatabaseTopicReplicationFactor is the replication factor of a kafka topic
 	ArgDatabaseTopicReplicationFactor = "replication-factor"

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -936,6 +936,29 @@ func TestDatabaseUserCreate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	// Successful call with kafka acl set
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		r := &godo.DatabaseCreateUserRequest{
+			Name: testDBUser.Name,
+			Settings: &godo.DatabaseUserSettings{
+				ACL: []*godo.KafkaACL{
+					{
+						Permission: "admin",
+						Topic:      "test",
+					},
+				},
+			},
+		}
+
+		tm.databases.EXPECT().CreateUser(testDBCluster.ID, r).Return(&testDBUser, nil)
+
+		config.Args = append(config.Args, testDBCluster.ID, testDBUser.Name)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseUserKafkaACLs, "test:admin")
+
+		err := RunDatabaseUserCreate(config)
+		assert.NoError(t, err)
+	})
+
 	// Error
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.databases.EXPECT().CreateUser(


### PR DESCRIPTION
This PR aims at adding `kafka ACL option` to `user create` command under `databases` in doctl.
i.e.

Creates a new user for a database. New users are given a role of `normal` and are given an automatically-generated password.

Flag:
     ` --acl topic:permission`                    A comma-separated list of kafka ACL rules, in topic:permission format.

Usage:
 ` doctl databases user create <database-cluster-id> <user-name> --acl <topic>:<permission>,<topic>:<permission>`

Examples:
The following example creates a new user with the username `example-user` for a database cluster with the ID `ca9f591d-f38h-5555-a0ef-1c02d1d1e35`: 

`doctl databases user create ca9f591d-f38h-5555-a0ef-1c02d1d1e35 example-user --acl new_topic:consume,test:admin`


