### PR TITLE
Update cnb run-image tag

### DIFF
--- a/commands/apps_dev.go
+++ b/commands/apps_dev.go
@@ -516,8 +516,8 @@ func appDevPrepareEnvironment(ctx context.Context, ws *workspace.AppDev, cli bui
 		}
 
 		// TODO: get stack run image from builder image md after we pull it, see below
-		images = append(images, "digitaloceanapps/apps-run:heroku-18_db5978a")
-		images = append(images, "digitaloceanapps/apps-run:heroku-22_db5978a")
+		images = append(images, "digitaloceanapps/apps-run:heroku-18_df7e351")
+		images = append(images, "digitaloceanapps/apps-run:heroku-22_df7e351")
 	}
 
 	if componentSpec.GetType() == godo.AppComponentTypeStaticSite {


### PR DESCRIPTION
https://do-internal.atlassian.net/browse/APPS-8465

The run-image being used in `doctl apps dev build` is outdated.
Local builds are failing with: `failed to export: get run image top layer SHA: image <image-1> has no layers`
This PR updates the tag to fix the issue.