### PR TITLE
Document App Platform crash log value

### DIFF
--- a/commands/apps.go
+++ b/commands/apps.go
@@ -174,7 +174,8 @@ Only basic information is included with the text output format. For complete app
 Three types of logs are supported and can be specified with the --`+doctl.ArgAppLogType+` flag:
 - build
 - deploy
-- run 
+- run
+- run_restarted 
 
 For more information about logs, see [How to View Logs](https://www.digitalocean.com/docs/app-platform/how-to/view-logs/).
 `,


### PR DESCRIPTION
Resolves PDOCS-2445. Documents the `run_restarted` value for `doctl apps logs $app_id --type`.