### PR TITLE
Add support for database events in Doctl

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -155,6 +155,7 @@ For PostgreSQL and MySQL clusters, you can also provide a disk size in MiB to sc
 	cmd.AddCommand(databaseOptions())
 	cmd.AddCommand(databaseConfiguration())
 	cmd.AddCommand(databaseTopic())
+	cmd.AddCommand(databaseEvents())
 
 	return cmd
 }
@@ -2440,4 +2441,41 @@ func RunDatabaseConfigurationUpdate(c *CmdConfig) error {
 		}
 	}
 	return nil
+}
+
+func databaseEvents() *Command {
+	listDatabaseEvents := `
+
+You can get a list of database events by calling:
+
+	doctl databases events list <cluster-id>`
+	cmd := &Command{
+		Command: &cobra.Command{
+			Use:   "events",
+			Short: "Display commands for listing database cluster events",
+			Long:  `The subcommands under ` + "`" + `doctl databases events` + "`" + ` are for listing database cluster events.` + listDatabaseEvents,
+		},
+	}
+	cmdDatabaseEventsList := CmdBuilder(cmd, RunDatabaseEvents, "list <database-cluster-id>", "List your database cluster events", `Retrieves a list of database clusters events:`+listDatabaseEvents, Writer, aliasOpt("ls"), displayerType(&displayers.DatabaseEvents{}))
+
+	cmdDatabaseEventsList.Example = `The following example retrieves a list of databases events in a database cluster with the ID ` + "`" + `ca9f591d-f38h-5555-a0ef-1c02d1d1e35` + "`" + `: doctl databases events list ca9f591d-f38h-5555-a0ef-1c02d1d1e35`
+
+	return cmd
+}
+
+// RunDatabaseDBList retrieves a list of databases for specific database cluster
+func RunDatabaseEvents(c *CmdConfig) error {
+	if len(c.Args) == 0 {
+		return doctl.NewMissingArgsErr(c.NS)
+	}
+
+	id := c.Args[0]
+
+	dbEvents, err := c.Databases().ListDatabaseEvents(id)
+	if err != nil {
+		return err
+	}
+
+	item := &displayers.DatabaseEvents{DatabaseEvents: dbEvents}
+	return c.Display(item)
 }

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -249,6 +249,7 @@ func TestDatabasesCommand(t *testing.T) {
 		"connection",
 		"migrate",
 		"resize",
+		"events",
 		"firewalls",
 		"fork",
 		"backups",

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -1647,3 +1647,47 @@ func (dc *RedisConfiguration) KV() []map[string]any {
 
 	return o
 }
+
+type DatabaseEvents struct {
+	DatabaseEvents do.DatabaseEvents
+}
+
+var _ Displayable = &DatabaseEvents{}
+
+func (dr *DatabaseEvents) JSON(out io.Writer) error {
+	return writeJSON(dr.DatabaseEvents, out)
+}
+
+func (dr *DatabaseEvents) Cols() []string {
+	return []string{
+		"ID",
+		"ServiceName",
+		"EventType",
+		"CreateTime",
+	}
+}
+
+func (dr *DatabaseEvents) ColMap() map[string]string {
+
+	return map[string]string{
+		"ID":          "ID",
+		"ServiceName": "Cluster Name",
+		"EventType":   "Type of Event",
+		"CreateTime":  "Create Time",
+	}
+}
+
+func (dr *DatabaseEvents) KV() []map[string]any {
+	out := make([]map[string]any, 0, len(dr.DatabaseEvents))
+
+	for _, r := range dr.DatabaseEvents {
+		o := map[string]any{
+			"ID":          r.ID,
+			"ServiceName": r.ServiceName,
+			"EventType":   r.EventType,
+			"CreateTime":  r.CreateTime,
+		}
+		out = append(out, o)
+	}
+	return out
+}

--- a/do/mocks/DatabasesService.go
+++ b/do/mocks/DatabasesService.go
@@ -469,6 +469,21 @@ func (mr *MockDatabasesServiceMockRecorder) ListDBs(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDBs", reflect.TypeOf((*MockDatabasesService)(nil).ListDBs), arg0)
 }
 
+// ListDatabaseEvents mocks base method.
+func (m *MockDatabasesService) ListDatabaseEvents(arg0 string) (do.DatabaseEvents, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDatabaseEvents", arg0)
+	ret0, _ := ret[0].(do.DatabaseEvents)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDatabaseEvents indicates an expected call of ListDatabaseEvents.
+func (mr *MockDatabasesServiceMockRecorder) ListDatabaseEvents(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDatabaseEvents", reflect.TypeOf((*MockDatabasesService)(nil).ListDatabaseEvents), arg0)
+}
+
 // ListOptions mocks base method.
 func (m *MockDatabasesService) ListOptions() (*do.DatabaseOptions, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR aims at adding support for database events in Doctl. 

#### Command Details

```
Retrieves a list of database clusters events:

You can get a list of database events by calling:

	doctl databases events list <cluster-id>

Usage:
  doctl databases events list <database-cluster-id> [flags]

Aliases:
  list, ls

Examples:
The following example retrieves a list of databases events in a database cluster with the ID `ca9f591d-f38h-5555-a0ef-1c02d1d1e35`: doctl databases events list ca9f591d-f38h-5555-a0ef-1c02d1d1e35

Flags:
      --format ID   Columns for output in a comma-separated list. Possible values: ID, `ServiceName`, `EventType`, `CreateTime`.
  -h, --help        help for list
      --no-header   Return raw data with no headers

Global Flags:
  -t, --access-token string   API V2 access token
  -u, --api-url string        Override default API endpoint
  -c, --config string         Specify a custom config file (default "/home/user/.config/doctl/config.yaml")
      --context string        Specify a custom authentication context name
      --http-retry-max int    Set maximum number of retries for requests that fail with a 429 or 500-level error (default 5)
      --interactive           Enable interactive behavior. Defaults to true if the terminal supports it (default true)
  -o, --output string         Desired output format [text|json] (default "text")
      --trace                 Show a log of network activity while performing a command
  -v, --verbose               Enable verbose output
  
```

#### Command Usage

`doctl -t $token databases events list 46f972cf-c41b-433e-96f6-8fad9cbd7119`

#### Ouput

```
ID               Cluster Name           Type of Event     Create Time
pe49fdf5c6275    db-kafka-nyc3-22258    cluster_create    2024-03-21T11:01:16Z
```