### PR TITLE
Fix useless error check in extractTarGz

### DIFF
--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -88,7 +88,7 @@ func extractTarGz(source, target string) error {
 				return err
 			}
 
-			f.Chmod(info.Mode())
+			err = f.Chmod(info.Mode())
 			if err != nil {
 				return err
 			}
@@ -142,7 +142,7 @@ func extractZip(source, target string) error {
 			return err
 		}
 
-		f.Chmod(zf.Mode())
+		err = f.Chmod(zf.Mode())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR fixes impossible condition `nil != nil`.

Consider the following code:
```go
f, err := os.Create(path)
if err != nil {
	return err
}

f.Chmod(info.Mode())
if err != nil {
	return err
}
```

The second `if err != nil` effectively becomes `if nil != nil` due to the preceding `if err != nil` check.

There are two ways to fix this: the first is to simply delete the second `if err != nil`, and the second is to handle an error from `f.Chmod`, which is the option I have chosen.