### PR TITLE
droplet-actions: add necessary scopes to doctl description (poc)

### DIFF
--- a/commands/droplet_actions.go
+++ b/commands/droplet_actions.go
@@ -109,7 +109,7 @@ Droplets that are powered off are still billable. To stop incurring charges on a
   A `+"`"+`power_off`+"`"+` event is a hard shutdown and should only be used if the shutdown action is not successful.
   It is similar to cutting the power on a server and could lead to complications.
 
-  Droplets that are powered off are still billable. To stop incurring charges on a Droplet, destroy it.`+"\n\nScopes:"+"\n"+"  actions:read, droplet:update", Writer,
+  Droplets that are powered off are still billable. To stop incurring charges on a Droplet, destroy it.`+"\n\nCustom Scopes:"+"\n"+"  actions:read, droplet:update", Writer,
 		displayerType(&displayers.Action{}))
 	AddBoolFlag(cmdDropletActionPowerOff, doctl.ArgCommandWait, "", false, "Instruct the terminal to wait for the action to complete before returning access to the user")
 	cmdDropletActionPowerOff.Example = `The following example powers off a Droplet with the ID ` + "`" + `386734086` + "`" + `: doctl compute droplet-action power-off 386734086`


### PR DESCRIPTION
POC for changing pattern of doctl descriptions by adding scopes and adding more sections (Description and Scopes and Examples) for better readability. 

Goes from this:
```
x@x doctl % doctl compute droplet-action power-off --help
Use this command to power off a Droplet.

A `power_off` event is a hard shutdown and should only be used if the shutdown action is not successful. It is similar to cutting the power on a server and could lead to complications.

Droplets that are powered off are still billable. To stop incurring charges on a Droplet, destroy it.

Usage:
  doctl compute droplet-action power-off <droplet-id> [flags]

Examples:
The following example powers off a Droplet with the ID `386734086`: doctl compute droplet-action power-off 386734086

Flags:
      --format ID   Columns for output in a comma-separated list. Possible values: ID, `Status`, `Type`, `StartedAt`, `CompletedAt`, `ResourceID`, `ResourceType`, `Region`.
  -h, --help        help for power-off
      --no-header   Return raw data with no headers
      --wait        Instruct the terminal to wait for the action to complete before returning access to the user

Global Flags:
  -t, --access-token string   API V2 access token
  -u, --api-url string        Override default API endpoint
  -c, --config string         Specify a custom config file (default "/Users/danaelhertani/Library/Application Support/doctl/config.yaml")
      --context string        Specify a custom authentication context name
      --http-retry-max int    Set maximum number of retries for requests that fail with a 429 or 500-level error (default 5)
      --interactive           Enable interactive behavior. Defaults to true if the terminal supports it (default true)
  -o, --output string         Desired output format [text|json] (default "text")
      --trace                 Show a log of network activity while performing a command
  -v, --verbose               Enable verbose output
```

To this:

```
x@x doctl % go run cmd/doctl/main.go compute droplet-action power-off --help

Description:
  Use this command to power off a Droplet.

  A `power_off` event is a hard shutdown and should only be used if the shutdown action is not successful.
  It is similar to cutting the power on a server and could lead to complications.

  Droplets that are powered off are still billable. To stop incurring charges on a Droplet, destroy it.

Custom Scopes:
  actions:read, droplet:update

Usage:
  doctl compute droplet-action power-off <droplet-id> [flags]

Examples:
The following example powers off a Droplet with the ID `386734086`: doctl compute droplet-action power-off 386734086

Flags:
      --format ID   Columns for output in a comma-separated list. Possible values: ID, `Status`, `Type`, `StartedAt`, `CompletedAt`, `ResourceID`, `ResourceType`, `Region`.
  -h, --help        help for power-off
      --no-header   Return raw data with no headers
      --wait        Instruct the terminal to wait for the action to complete before returning access to the user

Global Flags:
  -t, --access-token string   API V2 access token
  -u, --api-url string        Override default API endpoint
  -c, --config string         Specify a custom config file (default "/Users/danaelhertani/Library/Application Support/doctl/config.yaml")
      --context string        Specify a custom authentication context name
      --http-retry-max int    Set maximum number of retries for requests that fail with a 429 or 500-level error (default 5)
      --interactive           Enable interactive behavior. Defaults to true if the terminal supports it (default true)
  -o, --output string         Desired output format [text|json] (default "text")
      --trace                 Show a log of network activity while performing a command
  -v, --verbose               Enable verbose output
```

Could add a helper function to help format descriptions and scopes sections so less fiddling with spaces and new lines. Doing this to all the commands will be tedious but could slowly work towards it. 