### PR TITLE
Update for goreleaser 2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
           go-version: 1.21.x
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,5 @@
 project_name: doctl
-
+version: 2
 builds:
 - main: ./cmd/doctl/main.go
   env:
@@ -50,4 +50,4 @@ release:
     name: doctl
 
 changelog:
-  skip: false
+  disable: false


### PR DESCRIPTION
Another update for goreleaser 2.0. 

- `changelog.skip` was replaced by `changelog.disable`
- configures the action to use 2.x to prevent future breakage

https://goreleaser.com/blog/goreleaser-v2/#upgrading