### PR TITLE
misc: clean up additional typos found in CI.

### DIFF
--- a/commands/functions.go
+++ b/commands/functions.go
@@ -92,7 +92,7 @@ func RunFunctionsGet(c *CmdConfig) error {
 	fetchCode := codeFlag || saveFlag || saveAsFlag != ""
 
 	sls := c.Serverless()
-	action, parms, err := sls.GetFunction(c.Args[0], fetchCode)
+	action, params, err := sls.GetFunction(c.Args[0], fetchCode)
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func RunFunctionsGet(c *CmdConfig) error {
 	}
 
 	if saveEnvFlag != "" || saveEnvJSONFlag != "" {
-		return doSaveFunctionEnvironment(saveEnvFlag, saveEnvJSONFlag, parms)
+		return doSaveFunctionEnvironment(saveEnvFlag, saveEnvJSONFlag, params)
 	}
 
 	if codeFlag {
@@ -156,14 +156,14 @@ func doSaveFunctionCode(action whisk.Action, save bool, saveAs string) error {
 
 // doSaveFunctionEnvironment saves the environment variables for a function to file,
 // either as key-value pairs or JSON.  Could do both if both are specified.
-func doSaveFunctionEnvironment(saveEnv string, saveEnvJSON string, parms []do.FunctionParameter) error {
+func doSaveFunctionEnvironment(saveEnv string, saveEnvJSON string, params []do.FunctionParameter) error {
 	keyVals := []string{}
 	envMap := map[string]string{}
-	for _, parm := range parms {
-		if parm.Init {
-			keyVal := parm.Key + "=" + parm.Value
+	for _, p := range params {
+		if p.Init {
+			keyVal := p.Key + "=" + p.Value
 			keyVals = append(keyVals, keyVal)
-			envMap[parm.Key] = parm.Value
+			envMap[p.Key] = p.Value
 		}
 	}
 

--- a/commands/volume_actions.go
+++ b/commands/volume_actions.go
@@ -78,7 +78,7 @@ func VolumeAction() *Command {
 
 	cmdVolumeActionsList := CmdBuilder(cmd, RunVolumeActionsList, "list <volume-id>", "Retrieve a list of actions taken on a volume", `Retrieves a list of actions taken on a volume. The following details are provided:`+actionDetail, Writer,
 		aliasOpt("ls"), displayerType(&displayers.Action{}))
-	cmdVolumeActionsList.Example = `The following example retrieves a list of actions taken on a volume with the UUID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `. The command also uses the ` + "`" + `--format` + "`" + ` flag to return ony the resource ID and status for each action listed: doctl compute volume-action list f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --format ResourceID,Status`
+	cmdVolumeActionsList.Example = `The following example retrieves a list of actions taken on a volume with the UUID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `. The command also uses the ` + "`" + `--format` + "`" + ` flag to return only the resource ID and status for each action listed: doctl compute volume-action list f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --format ResourceID,Status`
 
 	cmdRunVolumeAttach := CmdBuilder(cmd, RunVolumeAttach, "attach <volume-id> <droplet-id>", "Attach a volume to a Droplet", `Attaches a block storage volume to a Droplet.
 


### PR DESCRIPTION
This one is a bit pedantic:

    error: `parm` should be `param`, `pram`, `parma`

But there is a real one in the help output for for `volume-actions ls`.