### PR TITLE
go: upgrade to 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.20.x, 1.21.x ]
+        go-version: [ 1.21.x, 1.22.x ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/digitalocean/doctl
 
-go 1.21
+go 1.22
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Upgrades the GitHub CI workflows and `go.mod` entry for Go 1.22. Just in time for Go 1.23 to be released 😅 