### PR TITLE
snap: use snapcore/action-build for candidate builds

### DIFF
--- a/.github/workflows/snapcraft-candidate.yml
+++ b/.github/workflows/snapcraft-candidate.yml
@@ -16,17 +16,9 @@ jobs:
           # fetch-depth: 0 fetches all history for all branches and tags
           fetch-depth: 0
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build snap
+        uses: snapcore/action-build@v1
         id: build
-        run: |
-          make _build_snap && \
-          find doctl_v*.snap -exec echo "snap={}" >> "$GITHUB_OUTPUT" \;
 
       - uses: snapcore/action-publish@master
         env:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   clusters, firewalls, load balancers, database clusters, domains, and more.
 license: Apache-2.0
 
-base: core20
+base: core22
 grade: stable
 confinement: strict
 
@@ -24,22 +24,23 @@ parts:
     override-build: |
       cd $SNAPCRAFT_PART_BUILD
       chmod +x doctl-launch
-      snapcraftctl build
+      craftctl default
+
   doctl:
     after: [launcher]
-    source: .
+    source: https://github.com/digitalocean/doctl
+    source-type: git
     plugin: go
+    build-snaps: [go/latest/stable]
     build-environment:
     # Results in installation to /snap/doctl/current/opt/sandbox
     - OVERRIDE_SANDBOX_DIR: "$SNAPCRAFT_PART_INSTALL/opt/sandbox"
     - SNAP_SANDBOX_INSTALL: "true"
     # Override to prevent 'invalid cross-device link' calling doctl
     - XDG_CONFIG_HOME: "$SNAPCRAFT_PART_INSTALL/tmp/.config"
-    override-pull: |
-      git clone https://github.com/digitalocean/doctl.git .
     override-build: |
       version=$(scripts/version.sh --snap)
-      snapcraftctl set-version ${version}
+      craftctl set version=${version}
 
       echo "==> Building doctl ${version} using $(go version)"
 


### PR DESCRIPTION
This switches the snap candidate builds to use the official `snapcore/action-build` GitHub Action rather than our bespoke Docker build.Additionally it updates the snap base to `core22`, 

This built successfully in my fork (note it is red as the upload failed due to the missing credentials, but the build itself succeeded):

https://github.com/andrewsomething/doctl/actions/runs/10359056705/job/28674610325#step:3:98

Once we've successfully built, uploaded, and validated a new candidate snap, I'll follow on with a new PR for the release workflow. Then finally, after successfully cutting a new release, we can rip out the Docker build scripts.