### PR TITLE
snap: use snapcore/action-build for release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,17 +48,9 @@ jobs:
           # fetch-depth: 0 fetches all history for all branches and tags
           fetch-depth: 0
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build snap
+        uses: snapcore/action-build@v1
         id: build
-        run: |
-          make _build_snap && \
-          find doctl_v*.snap -exec echo "snap={}" >> "$GITHUB_OUTPUT" \;
 
       - uses: snapcore/action-publish@master
         env:


### PR DESCRIPTION
Follow up on https://github.com/digitalocean/doctl/pull/1566 Candidate build was successful: 

https://github.com/digitalocean/doctl/actions/runs/10359332118/job/28675519869

```
$ snap info doctl | grep candidate
  latest/candidate: v1.110.0+git50ad7727 2024-08-12 (1718) 45MB -
```

I've installed the candidate build and validated it is working as expected, including the Docker and K8s integrations as well as the serverless plugin.