### PR TITLE
Update cnb builder tags

### DIFF
--- a/commands/apps_dev.go
+++ b/commands/apps_dev.go
@@ -516,8 +516,8 @@ func appDevPrepareEnvironment(ctx context.Context, ws *workspace.AppDev, cli bui
 		}
 
 		// TODO: get stack run image from builder image md after we pull it, see below
-		images = append(images, "digitaloceanapps/apps-run:heroku-18_df7e351")
-		images = append(images, "digitaloceanapps/apps-run:heroku-22_df7e351")
+		images = append(images, "digitaloceanapps/apps-run:heroku-18_c047ec7")
+		images = append(images, "digitaloceanapps/apps-run:heroku-22_c047ec7")
 	}
 
 	if componentSpec.GetType() == godo.AppComponentTypeStaticSite {

--- a/internal/apps/builder/cnb.go
+++ b/internal/apps/builder/cnb.go
@@ -25,8 +25,8 @@ import (
 
 const (
 	// CNBBuilderImage represents the local cnb builder.
-	CNBBuilderImage_Heroku18 = "digitaloceanapps/cnb-local-builder:heroku-18_v0.71.0"
-	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_v0.71.0"
+	CNBBuilderImage_Heroku18 = "digitaloceanapps/cnb-local-builder:heroku-18_v0.73.1"
+	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_v0.73.1"
 
 	appVarAllowListKey = "APP_VARS"
 	appVarPrefix       = "APP_VAR_"


### PR DESCRIPTION
### Details

This PR updates CNBBuilderImage tag to `v0.73.1` (current stable version) and `apps-run` to `c047ec7`

Fix: #1518 

### Issue

This fixes the following error:
```
ERROR: failed to export: get run image top layer SHA: image "<image-0>" has no layers
```