### PR TITLE
misc: use 'go install' in _install_github_release_notes make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ clean:
 
 .PHONY: _install_github_release_notes
 _install_github_release_notes:
-	@GO111MODULE=off go get -u github.com/digitalocean/github-changelog-generator
+	go install github.com/digitalocean/github-changelog-generator@latest
 
 .PHONY: _changelog
 _changelog: _install_github_release_notes


### PR DESCRIPTION
Fix for:

```
$ make _install_github_release_notes
go: modules disabled by GO111MODULE=off; see 'go help modules'
make: *** [Makefile:163: _install_github_release_notes] Error 1
```