### PR TITLE
[databases]: add support for MongoDB advanced configuration

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -2439,6 +2439,7 @@ func databaseConfiguration() *Command {
 		displayerType(&displayers.MySQLConfiguration{}),
 		displayerType(&displayers.PostgreSQLConfiguration{}),
 		displayerType(&displayers.RedisConfiguration{}),
+		displayerType(&displayers.MongoDBConfiguration{}),
 	)
 	AddStringFlag(
 		getDatabaseCfgCommand,
@@ -2496,9 +2497,10 @@ func RunDatabaseConfigurationGet(c *CmdConfig) error {
 		"mysql": nil,
 		"pg":    nil,
 		"redis": nil,
+		"mongo": nil,
 	}
 	if _, ok := allowedEngines[engine]; !ok {
-		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'mysql', 'redis'", c.NS)
+		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'mysql', 'redis', 'mongo'", c.NS)
 	}
 
 	dbId := args[0]
@@ -2532,7 +2534,18 @@ func RunDatabaseConfigurationGet(c *CmdConfig) error {
 			RedisConfig: *config,
 		}
 		return c.Display(&displayer)
+	} else if engine == "mongo" {
+		config, err := c.Databases().GetMongoDBConfiguration(dbId)
+		if err != nil {
+			return err
+		}
+
+		displayer := displayers.MongoDBConfiguration{
+			MongoDBConfig: *config,
+		}
+		return c.Display(&displayer)
 	}
+
 	return nil
 }
 
@@ -2554,9 +2567,10 @@ func RunDatabaseConfigurationUpdate(c *CmdConfig) error {
 		"mysql": nil,
 		"pg":    nil,
 		"redis": nil,
+		"mongo": nil,
 	}
 	if _, ok := allowedEngines[engine]; !ok {
-		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'mysql', 'redis'", c.NS)
+		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'mysql', 'redis', 'mongo'", c.NS)
 	}
 
 	configJson, err := c.Doit.GetString(c.NS, doctl.ArgDatabaseConfigJson)
@@ -2580,7 +2594,13 @@ func RunDatabaseConfigurationUpdate(c *CmdConfig) error {
 		if err != nil {
 			return err
 		}
+	} else if engine == "mongo" {
+		err := c.Databases().UpdateMongoDBConfiguration(dbId, configJson)
+		if err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -211,6 +211,10 @@ var (
 		RedisConfig: &godo.RedisConfig{},
 	}
 
+	testMongoDBConfiguration = do.MongoDBConfig{
+		MongoDBConfig: &godo.MongoDBConfig{},
+	}
+
 	topicReplicationFactor = uint32(3)
 	testKafkaTopic         = do.DatabaseTopic{
 		DatabaseTopic: &godo.DatabaseTopic{
@@ -1653,6 +1657,16 @@ func TestDatabaseConfigurationGet(t *testing.T) {
 	})
 
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.databases.EXPECT().GetMongoDBConfiguration(testDBCluster.ID).Return(&testMongoDBConfiguration, nil)
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "mongo")
+
+		err := RunDatabaseConfigurationGet(config)
+
+		assert.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		err := RunDatabaseConfigurationGet(config)
 
 		assert.Equal(t, err, doctl.NewMissingArgsErr(config.NS))
@@ -1670,6 +1684,70 @@ func TestDatabaseConfigurationGet(t *testing.T) {
 		config.Args = append(config.Args, testDBCluster.ID)
 
 		err := RunDatabaseConfigurationGet(config)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestDatabaseConfigurationUpdate(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.databases.EXPECT().UpdateMySQLConfiguration(testDBCluster.ID, "").Return(nil)
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "mysql")
+
+		err := RunDatabaseConfigurationUpdate(config)
+
+		assert.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.databases.EXPECT().UpdatePostgreSQLConfiguration(testDBCluster.ID, "").Return(nil)
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "pg")
+
+		err := RunDatabaseConfigurationUpdate(config)
+
+		assert.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.databases.EXPECT().UpdateRedisConfiguration(testDBCluster.ID, "").Return(nil)
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "redis")
+
+		err := RunDatabaseConfigurationUpdate(config)
+
+		assert.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.databases.EXPECT().UpdateMongoDBConfiguration(testDBCluster.ID, "").Return(nil)
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "mongo")
+
+		err := RunDatabaseConfigurationUpdate(config)
+
+		assert.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		err := RunDatabaseConfigurationUpdate(config)
+
+		assert.Equal(t, err, doctl.NewMissingArgsErr(config.NS))
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		config.Args = append(config.Args, testDBCluster.ID, "extra arg")
+
+		err := RunDatabaseConfigurationUpdate(config)
+
+		assert.Equal(t, err, doctl.NewTooManyArgsErr(config.NS))
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		config.Args = append(config.Args, testDBCluster.ID)
+
+		err := RunDatabaseConfigurationUpdate(config)
 
 		assert.Error(t, err)
 	})

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -1678,6 +1678,67 @@ func (dc *RedisConfiguration) KV() []map[string]any {
 	return o
 }
 
+type MongoDBConfiguration struct {
+	MongoDBConfig do.MongoDBConfig
+}
+
+var _ Displayable = &MongoDBConfiguration{}
+
+func (dc *MongoDBConfiguration) JSON(out io.Writer) error {
+	return writeJSON(dc.MongoDBConfig, out)
+}
+
+func (dc *MongoDBConfiguration) Cols() []string {
+	return []string{
+		"key",
+		"value",
+	}
+}
+
+func (dc *MongoDBConfiguration) ColMap() map[string]string {
+	return map[string]string{
+		"key":   "key",
+		"value": "value",
+	}
+}
+
+func (dc *MongoDBConfiguration) KV() []map[string]any {
+	c := dc.MongoDBConfig
+	o := []map[string]any{}
+	if c.DefaultReadConcern != nil {
+		o = append(o, map[string]any{
+			"key":   "DefaultReadConcern",
+			"value": *c.DefaultReadConcern,
+		})
+	}
+	if c.DefaultWriteConcern != nil {
+		o = append(o, map[string]any{
+			"key":   "DefaultWriteConcern",
+			"value": *c.DefaultWriteConcern,
+		})
+	}
+	if c.SlowOpThresholdMs != nil {
+		o = append(o, map[string]any{
+			"key":   "SlowOpThresholdMs",
+			"value": *c.SlowOpThresholdMs,
+		})
+	}
+	if c.TransactionLifetimeLimitSeconds != nil {
+		o = append(o, map[string]any{
+			"key":   "TransactionLifetimeLimitSeconds",
+			"value": *c.TransactionLifetimeLimitSeconds,
+		})
+	}
+	if c.Verbosity != nil {
+		o = append(o, map[string]any{
+			"key":   "Verbosity",
+			"value": *c.Verbosity,
+		})
+	}
+
+	return o
+}
+
 type DatabaseEvents struct {
 	DatabaseEvents do.DatabaseEvents
 }

--- a/do/databases.go
+++ b/do/databases.go
@@ -120,6 +120,11 @@ type RedisConfig struct {
 	*godo.RedisConfig
 }
 
+// MongoDBConfig is a wrapper for godo.MongoDBConfig
+type MongoDBConfig struct {
+	*godo.MongoDBConfig
+}
+
 // DatabaseTopics is a slice of DatabaseTopic
 type DatabaseTopics []DatabaseTopic
 
@@ -200,10 +205,12 @@ type DatabasesService interface {
 	GetMySQLConfiguration(databaseID string) (*MySQLConfig, error)
 	GetPostgreSQLConfiguration(databaseID string) (*PostgreSQLConfig, error)
 	GetRedisConfiguration(databaseID string) (*RedisConfig, error)
+	GetMongoDBConfiguration(databaseID string) (*MongoDBConfig, error)
 
 	UpdateMySQLConfiguration(databaseID string, confString string) error
 	UpdatePostgreSQLConfiguration(databaseID string, confString string) error
 	UpdateRedisConfiguration(databaseID string, confString string) error
+	UpdateMongoDBConfiguration(databaseID string, confString string) error
 
 	ListTopics(string) (DatabaseTopics, error)
 	GetTopic(string, string) (*DatabaseTopic, error)
@@ -695,6 +702,17 @@ func (ds *databasesService) GetRedisConfiguration(databaseID string) (*RedisConf
 	}, nil
 }
 
+func (ds *databasesService) GetMongoDBConfiguration(databaseID string) (*MongoDBConfig, error) {
+	cfg, _, err := ds.client.Databases.GetMongoDBConfig(context.TODO(), databaseID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MongoDBConfig{
+		MongoDBConfig: cfg,
+	}, nil
+}
+
 func (ds *databasesService) UpdateMySQLConfiguration(databaseID string, confString string) error {
 	var conf godo.MySQLConfig
 	err := json.Unmarshal([]byte(confString), &conf)
@@ -733,6 +751,21 @@ func (ds *databasesService) UpdateRedisConfiguration(databaseID string, confStri
 	}
 
 	_, err = ds.client.Databases.UpdateRedisConfig(context.TODO(), databaseID, &conf)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ds *databasesService) UpdateMongoDBConfiguration(databaseID string, confString string) error {
+	var conf godo.MongoDBConfig
+	err := json.Unmarshal([]byte(confString), &conf)
+	if err != nil {
+		return err
+	}
+
+	_, err = ds.client.Databases.UpdateMongoDBConfig(context.TODO(), databaseID, &conf)
 	if err != nil {
 		return err
 	}

--- a/do/mocks/DatabasesService.go
+++ b/do/mocks/DatabasesService.go
@@ -318,6 +318,21 @@ func (mr *MockDatabasesServiceMockRecorder) GetMaintenance(arg0 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenance", reflect.TypeOf((*MockDatabasesService)(nil).GetMaintenance), arg0)
 }
 
+// GetMongoDBConfiguration mocks base method.
+func (m *MockDatabasesService) GetMongoDBConfiguration(databaseID string) (*do.MongoDBConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMongoDBConfiguration", databaseID)
+	ret0, _ := ret[0].(*do.MongoDBConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMongoDBConfiguration indicates an expected call of GetMongoDBConfiguration.
+func (mr *MockDatabasesServiceMockRecorder) GetMongoDBConfiguration(databaseID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMongoDBConfiguration", reflect.TypeOf((*MockDatabasesService)(nil).GetMongoDBConfiguration), databaseID)
+}
+
 // GetMySQLConfiguration mocks base method.
 func (m *MockDatabasesService) GetMySQLConfiguration(databaseID string) (*do.MySQLConfig, error) {
 	m.ctrl.T.Helper()
@@ -719,6 +734,20 @@ func (m *MockDatabasesService) UpdateMaintenance(arg0 string, arg1 *godo.Databas
 func (mr *MockDatabasesServiceMockRecorder) UpdateMaintenance(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMaintenance", reflect.TypeOf((*MockDatabasesService)(nil).UpdateMaintenance), arg0, arg1)
+}
+
+// UpdateMongoDBConfiguration mocks base method.
+func (m *MockDatabasesService) UpdateMongoDBConfiguration(databaseID, confString string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMongoDBConfiguration", databaseID, confString)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateMongoDBConfiguration indicates an expected call of UpdateMongoDBConfiguration.
+func (mr *MockDatabasesServiceMockRecorder) UpdateMongoDBConfiguration(databaseID, confString any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMongoDBConfiguration", reflect.TypeOf((*MockDatabasesService)(nil).UpdateMongoDBConfiguration), databaseID, confString)
 }
 
 // UpdateMySQLConfiguration mocks base method.

--- a/integration/database_config_get_test.go
+++ b/integration/database_config_get_test.go
@@ -60,6 +60,18 @@ var _ = suite("database/config/get", func(t *testing.T, when spec.G, it spec.S) 
 				}
 
 				w.Write([]byte(databaseConfigRedisGetResponse))
+			case "/v2/databases/mongo-database-id/config":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusTeapot)
+				}
+
+				if req.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				w.Write([]byte(databaseConfigMongoDBGetResponse))
 			default:
 				dump, err := httputil.DumpRequest(req, true)
 				if err != nil {
@@ -256,6 +268,15 @@ RedisACLChannelsDefault      allchannels
 	  "redis_persistence": "rdb",
 	  "redis_acl_channels_default": "allchannels"
 	}
-  }
-`
+  }`
+
+	databaseConfigMongoDBGetResponse = `{
+	"config": {
+	  "default_read_concern": "local",
+	  "default_write_concern": "majority",
+	  "slow_op_threshold_ms": 100,
+	  "transaction_lifetime_limit_seconds": 60,
+	  "verbosity": 1
+	}
+  }`
 )

--- a/integration/database_config_update_test.go
+++ b/integration/database_config_update_test.go
@@ -85,6 +85,26 @@ var _ = suite("database/config/get", func(t *testing.T, when spec.G, it spec.S) 
 				expect.Equal(expected, strings.TrimSpace(string(b)))
 
 				w.WriteHeader(http.StatusOK)
+			case "/v2/databases/mongo-database-id/config":
+				auth := req.Header.Get("Authorization")
+				if auth != "Bearer some-magic-token" {
+					w.WriteHeader(http.StatusTeapot)
+				}
+
+				if req.Method != http.MethodPatch {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				expected := `{"config":{"verbosity":2}}`
+				b, err := io.ReadAll(req.Body)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				expect.Equal(expected, strings.TrimSpace(string(b)))
+
+				w.WriteHeader(http.StatusOK)
 			default:
 				dump, err := httputil.DumpRequest(req, true)
 				if err != nil {
@@ -145,6 +165,25 @@ var _ = suite("database/config/get", func(t *testing.T, when spec.G, it spec.S) 
 				"--engine", "redis",
 				"redis-database-id",
 				"--config-json", `{"redis_timeout":1200}`,
+			)
+
+			output, err := cmd.CombinedOutput()
+			expect.NoError(err, fmt.Sprintf("received error output: %s", output))
+			expect.Empty(strings.TrimSpace(string(output)))
+		})
+	})
+
+	when("all required flags are passed", func() {
+		it("updates the mongo database config", func() {
+			cmd := exec.Command(builtBinaryPath,
+				"-t", "some-magic-token",
+				"-u", server.URL,
+				"database",
+				"configuration",
+				"update",
+				"--engine", "mongo",
+				"mongo-database-id",
+				"--config-json", `{"verbosity":2}`,
 			)
 
 			output, err := cmd.CombinedOutput()


### PR DESCRIPTION
This PR is adding a support for MongoDB advanced configuration: Get, Update.

#### Command examples to test
```
doctl databases configuration get 5cc032db-562d-4a53-974e-be7b8f8d6102 -e mongo
```
```
doctl databases configuration update 5cc032db-562d-4a53-974e-be7b8f8d6102 -e mongo --config-json '{"verbosity":1}'
```
