### PR TITLE
dbaas: Fix typo and add additional detail in config update help.

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -2424,8 +2424,11 @@ func databaseConfiguration() *Command {
 			Long:    "The subcommands of `doctl databases configuration` are used to view a database cluster's configuration.",
 		},
 	}
-	getConfigurationLongDesc := "Retrieves the configuration for the specified cluster, including its backup settings, temporary file limit, and session timeout values."
-	updateConfigurationLongDesc := "Updates the specified database cluster's configuration. Using this command, you can update varioous settings like backup times, temporary file limits, and session timeouts."
+	getConfigurationLongDesc := "Retrieves the advanced configuration for the specified cluster, including its backup settings, temporary file limit, and session timeout values."
+	updateConfigurationLongDesc := `Updates the specified database cluster's advanced configuration. Using this command, you can update various settings like backup times, temporary file limits, and session timeouts. Available settings vary by database engine.
+
+This command functions as a PATCH request, meaning that only the specified fields are updated. If a field is not specified, it will not be changed. The settings are passed using the ` + "`" + `--config-json` + "`" + ` flag, which takes a JSON object as its value.
+`
 
 	getDatabaseCfgCommand := CmdBuilder(
 


### PR DESCRIPTION
Reviewing https://github.com/digitalocean/doctl/pull/1582, I noticed a type outside of the scope of that PR. While fixing that, I've also added some additional detail to the help output.