### PR TITLE
doks: fix panic during create

### DIFF
--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -764,6 +764,9 @@ func (s *KubernetesCommandService) RunKubernetesClusterCreate(defaultNodeSize st
 			if err != nil {
 				warn("Cluster couldn't enter `running` state: %v", err)
 			}
+			if cluster == nil {
+				return errors.New("cluster vanished while waiting for creation")
+			}
 		}
 
 		if update {


### PR DESCRIPTION
If a user creates a DOKS cluster through doctl and deletes it through some other means while doctl is waiting for the creation the command panics. This fixes the panic and returns an appropriate error.