### PR TITLE
fix(app): #1536 fix logging format to work with pino-pretty

### DIFF
--- a/args.go
+++ b/args.go
@@ -54,6 +54,8 @@ const (
 	ArgAppLogFollow = "follow"
 	// ArgAppLogTail tail logs.
 	ArgAppLogTail = "tail"
+	// ArgNoPrefix no prefix to json logs
+	ArgNoPrefix = "no-prefix"
 	// ArgAppForceRebuild forces a deployment rebuild
 	ArgAppForceRebuild = "force-rebuild"
 	// ArgAppAlertDestinations is a path to an app alert destination file.

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -187,6 +187,8 @@ For more information about logs, see [How to View Logs](https://www.digitalocean
 	AddStringFlag(logs, doctl.ArgAppLogType, "", strings.ToLower(string(godo.AppLogTypeRun)), "Retrieves logs for a specific log type. Defaults to run logs.")
 	AddBoolFlag(logs, doctl.ArgAppLogFollow, "f", false, "Returns logs as they are emitted by the app.")
 	AddIntFlag(logs, doctl.ArgAppLogTail, "", -1, "Specifies the number of lines to show from the end of the log.")
+	AddBoolFlag(logs, doctl.ArgNoPrefix, "", false, "Removes the prefix from JSON logs. Useful for JSON structured logs")
+
 	logs.Example = `The following example retrieves the build logs for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + ` and the component ` + "`" + `web` + "`" + `: doctl apps logs f81d4fae-7dec-11d0-a765-00a0c91e6bf6 web --type build`
 
 	listRegions := CmdBuilder(
@@ -611,7 +613,7 @@ func RunAppsGetLogs(c *CmdConfig) error {
 		return err
 	}
 
-	outputJSON, err := c.Doit.GetBool(c.NS, "output-json")
+	noPrefixFlag, err := c.Doit.GetBool(c.NS, doctl.ArgNoPrefix)
 	if err != nil {
 		return err
 	}
@@ -637,7 +639,7 @@ func RunAppsGetLogs(c *CmdConfig) error {
 			}
 			r := strings.NewReader(data.Data)
 
-			if outputJSON {
+			if noPrefixFlag {
 				content, err := io.ReadAll(r)
 				if err != nil {
 					return nil, err
@@ -675,7 +677,7 @@ func RunAppsGetLogs(c *CmdConfig) error {
 		scanner := bufio.NewScanner(resp.Body)
 		for scanner.Scan() {
 			logLine := scanner.Text()
-			if outputJSON {
+			if noPrefixFlag {
 				logParts := strings.SplitN(logLine, " ", 3)
 				if len(logParts) > 2 {
 					logLine = logParts[2]

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -187,7 +187,7 @@ For more information about logs, see [How to View Logs](https://www.digitalocean
 	AddStringFlag(logs, doctl.ArgAppLogType, "", strings.ToLower(string(godo.AppLogTypeRun)), "Retrieves logs for a specific log type. Defaults to run logs.")
 	AddBoolFlag(logs, doctl.ArgAppLogFollow, "f", false, "Returns logs as they are emitted by the app.")
 	AddIntFlag(logs, doctl.ArgAppLogTail, "", -1, "Specifies the number of lines to show from the end of the log.")
-	AddBoolFlag(logs, doctl.ArgNoPrefix, "", false, "Removes the prefix from JSON logs. Useful for JSON structured logs")
+	AddBoolFlag(logs, doctl.ArgNoPrefix, "", false, "Removes the prefix from logs. Useful for JSON structured logs")
 
 	logs.Example = `The following example retrieves the build logs for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + ` and the component ` + "`" + `web` + "`" + `: doctl apps logs f81d4fae-7dec-11d0-a765-00a0c91e6bf6 web --type build`
 


### PR DESCRIPTION
## Summary
This PR introduces a new --output-json flag for the RunAppsGetLogs function in the DigitalOcean CLI (doctl). When this flag is used, the logs are outputted in JSON format without the service name and timestamp prefix.

### Changes Made
- Added --output-json flag to the RunAppsGetLogs function.
- Modified the log processing logic to remove the service name and timestamp prefix when the --output-json flag is used.

Closes #1536 
