### PR TITLE
Bump godo to v1.128.0.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/creack/pty v1.1.21
-	github.com/digitalocean/godo v1.126.1-0.20241002131132-fb61c333ae26
+	github.com/digitalocean/godo v1.128.0
 	github.com/docker/cli v24.0.5+incompatible
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.126.1-0.20241002131132-fb61c333ae26 h1:Bqg9D5DoRi1UzBL9wdQmcqsPDzEDupY6eLE3gBpDy4Q=
-github.com/digitalocean/godo v1.126.1-0.20241002131132-fb61c333ae26/go.mod h1:PU8JB6I1XYkQIdHFop8lLAY9ojp6M0XcU0TWaQSxbrc=
+github.com/digitalocean/godo v1.128.0 h1:cGn/ibMSRZ9+8etbzMv2MnnCEPTTGlEnx3HHTPwdk1U=
+github.com/digitalocean/godo v1.128.0/go.mod h1:PU8JB6I1XYkQIdHFop8lLAY9ojp6M0XcU0TWaQSxbrc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v24.0.5+incompatible h1:WeBimjvS0eKdH4Ygx+ihVq1Q++xg36M/rMi4aXAvodc=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [v1.128.0] - 2024-10-24
+
+- #746 - @blesswinsamuel - Add archive field to AppSpec to archive/restore apps
+- #745 - @asaha2 - Add load balancer monitoring endpoints
+- #744 - @asaha2 - Adjust delete dangerous
+- #743 - @asaha2 - Introduce droplet autoscale godo methods
+- #740 - @blesswinsamuel - Add maintenance field to AppSpec to enable/disable maintenance mode
+- #739 - @markusthoemmes - Add protocol to AppSpec and pending to detect responses
+
+## [v1.127.0] - 2024-10-18
+
+- #737 - @loosla - [databases]: change Opensearch ism_history_max_docs type to int64 to …
+- #735 - @loosla - [databases]: add a missing field to Opensearch advanced configuration
+- #729 - @loosla - [databases]: add support for Opensearch advanced configuration
+
 ## [v1.126.0] - 2024-09-25
 
 - #732 - @gottwald - DOKS: add custom CIDR fields

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -462,6 +462,15 @@ type AppLogDestinationSpecPapertrail struct {
 	Endpoint string `json:"endpoint"`
 }
 
+// AppMaintenanceSpec struct for AppMaintenanceSpec
+type AppMaintenanceSpec struct {
+	// Indicates whether maintenance mode should be enabled for the app.
+	Enabled bool `json:"enabled,omitempty"`
+	// Indicates whether the app should be archived. Setting this to true implies that enabled is set to true.
+	// Note that this feature is currently in closed beta.
+	Archive bool `json:"archive,omitempty"`
+}
+
 // AppRouteSpec struct for AppRouteSpec
 type AppRouteSpec struct {
 	// (Deprecated) An HTTP path prefix. Paths must start with / and must be unique across all components within an app.
@@ -495,7 +504,8 @@ type AppServiceSpec struct {
 	InstanceCount int64               `json:"instance_count,omitempty"`
 	Autoscaling   *AppAutoscalingSpec `json:"autoscaling,omitempty"`
 	// The internal port on which this service's run command will listen. Default: 8080 If there is not an environment variable with the name `PORT`, one will be automatically added with its value set to the value of this field.
-	HTTPPort int64 `json:"http_port,omitempty"`
+	HTTPPort int64           `json:"http_port,omitempty"`
+	Protocol ServingProtocol `json:"protocol,omitempty"`
 	// (Deprecated) A list of HTTP routes that should be routed to this component.
 	Routes      []*AppRouteSpec            `json:"routes,omitempty"`
 	HealthCheck *AppServiceSpecHealthCheck `json:"health_check,omitempty"`
@@ -559,10 +569,11 @@ type AppSpec struct {
 	// A list of environment variables made available to all components in the app.
 	Envs []*AppVariableDefinition `json:"envs,omitempty"`
 	// A list of alerts which apply to the app.
-	Alerts   []*AppAlertSpec `json:"alerts,omitempty"`
-	Ingress  *AppIngressSpec `json:"ingress,omitempty"`
-	Egress   *AppEgressSpec  `json:"egress,omitempty"`
-	Features []string        `json:"features,omitempty"`
+	Alerts      []*AppAlertSpec     `json:"alerts,omitempty"`
+	Ingress     *AppIngressSpec     `json:"ingress,omitempty"`
+	Egress      *AppEgressSpec      `json:"egress,omitempty"`
+	Features    []string            `json:"features,omitempty"`
+	Maintenance *AppMaintenanceSpec `json:"maintenance,omitempty"`
 }
 
 // AppStaticSiteSpec struct for AppStaticSiteSpec
@@ -917,6 +928,8 @@ type DetectResponse struct {
 	TemplateFound bool                       `json:"template_found,omitempty"`
 	TemplateValid bool                       `json:"template_valid,omitempty"`
 	TemplateError string                     `json:"template_error,omitempty"`
+	// Whether or not the underlying detection is still pending. If true, the request can be retried as-is until this field is false and the response contains the detection result.
+	Pending bool `json:"pending,omitempty"`
 }
 
 // DetectResponseComponent struct for DetectResponseComponent
@@ -1251,6 +1264,15 @@ type ResetDatabasePasswordRequest struct {
 type ResetDatabasePasswordResponse struct {
 	Deployment *Deployment `json:"deployment,omitempty"`
 }
+
+// ServingProtocol  - HTTP: The app is serving the HTTP protocol. Default.  - HTTP2: The app is serving the HTTP/2 protocol. Currently, this needs to be implemented in the service by serving HTTP/2 with prior knowledge.
+type ServingProtocol string
+
+// List of ServingProtocol
+const (
+	SERVINGPROTOCOL_HTTP  ServingProtocol = "HTTP"
+	SERVINGPROTOCOL_HTTP2 ServingProtocol = "HTTP2"
+)
 
 // AppStringMatch struct for AppStringMatch
 type AppStringMatch struct {

--- a/vendor/github.com/digitalocean/godo/apps_accessors.go
+++ b/vendor/github.com/digitalocean/godo/apps_accessors.go
@@ -1421,6 +1421,22 @@ func (a *AppLogDestinationSpecPapertrail) GetEndpoint() string {
 	return a.Endpoint
 }
 
+// GetArchive returns the Archive field.
+func (a *AppMaintenanceSpec) GetArchive() bool {
+	if a == nil {
+		return false
+	}
+	return a.Archive
+}
+
+// GetEnabled returns the Enabled field.
+func (a *AppMaintenanceSpec) GetEnabled() bool {
+	if a == nil {
+		return false
+	}
+	return a.Enabled
+}
+
 // GetAppID returns the AppID field.
 func (a *AppProposeRequest) GetAppID() string {
 	if a == nil {
@@ -1757,6 +1773,14 @@ func (a *AppServiceSpec) GetName() string {
 	return a.Name
 }
 
+// GetProtocol returns the Protocol field.
+func (a *AppServiceSpec) GetProtocol() ServingProtocol {
+	if a == nil {
+		return ""
+	}
+	return a.Protocol
+}
+
 // GetRoutes returns the Routes field.
 func (a *AppServiceSpec) GetRoutes() []*AppRouteSpec {
 	if a == nil {
@@ -1939,6 +1963,14 @@ func (a *AppSpec) GetJobs() []*AppJobSpec {
 		return nil
 	}
 	return a.Jobs
+}
+
+// GetMaintenance returns the Maintenance field.
+func (a *AppSpec) GetMaintenance() *AppMaintenanceSpec {
+	if a == nil {
+		return nil
+	}
+	return a.Maintenance
 }
 
 // GetName returns the Name field.
@@ -3091,6 +3123,14 @@ func (d *DetectResponse) GetComponents() []*DetectResponseComponent {
 		return nil
 	}
 	return d.Components
+}
+
+// GetPending returns the Pending field.
+func (d *DetectResponse) GetPending() bool {
+	if d == nil {
+		return false
+	}
+	return d.Pending
 }
 
 // GetTemplate returns the Template field.

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -712,7 +712,7 @@ type OpensearchConfig struct {
 	IsmEnabled                                       *bool    `json:"ism_enabled,omitempty"`
 	IsmHistoryEnabled                                *bool    `json:"ism_history_enabled,omitempty"`
 	IsmHistoryMaxAgeHours                            *int     `json:"ism_history_max_age_hours,omitempty"`
-	IsmHistoryMaxDocs                                *uint64  `json:"ism_history_max_docs,omitempty"`
+	IsmHistoryMaxDocs                                *int64   `json:"ism_history_max_docs,omitempty"`
 	IsmHistoryRolloverCheckPeriodHours               *int     `json:"ism_history_rollover_check_period_hours,omitempty"`
 	IsmHistoryRolloverRetentionPeriodDays            *int     `json:"ism_history_rollover_retention_period_days,omitempty"`
 	SearchMaxBuckets                                 *int     `json:"search_max_buckets,omitempty"`

--- a/vendor/github.com/digitalocean/godo/droplet_autoscale.go
+++ b/vendor/github.com/digitalocean/godo/droplet_autoscale.go
@@ -1,0 +1,258 @@
+package godo
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	dropletAutoscaleBasePath = "/v2/droplets/autoscale"
+)
+
+// DropletAutoscaleService defines an interface for managing droplet autoscale pools through DigitalOcean API
+type DropletAutoscaleService interface {
+	Create(context.Context, *DropletAutoscalePoolRequest) (*DropletAutoscalePool, *Response, error)
+	Get(context.Context, string) (*DropletAutoscalePool, *Response, error)
+	List(context.Context, *ListOptions) ([]*DropletAutoscalePool, *Response, error)
+	ListMembers(context.Context, string, *ListOptions) ([]*DropletAutoscaleResource, *Response, error)
+	ListHistory(context.Context, string, *ListOptions) ([]*DropletAutoscaleHistoryEvent, *Response, error)
+	Update(context.Context, string, *DropletAutoscalePoolRequest) (*DropletAutoscalePool, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+	DeleteDangerous(context.Context, string) (*Response, error)
+}
+
+// DropletAutoscalePool represents a DigitalOcean droplet autoscale pool
+type DropletAutoscalePool struct {
+	ID                 string                               `json:"id"`
+	Name               string                               `json:"name"`
+	Config             *DropletAutoscaleConfiguration       `json:"config"`
+	DropletTemplate    *DropletAutoscaleResourceTemplate    `json:"droplet_template"`
+	CreatedAt          time.Time                            `json:"created_at"`
+	UpdatedAt          time.Time                            `json:"updated_at"`
+	CurrentUtilization *DropletAutoscaleResourceUtilization `json:"current_utilization,omitempty"`
+	Status             string                               `json:"status"`
+}
+
+// DropletAutoscaleConfiguration represents a DigitalOcean droplet autoscale pool configuration
+type DropletAutoscaleConfiguration struct {
+	MinInstances            uint64  `json:"min_instances,omitempty"`
+	MaxInstances            uint64  `json:"max_instances,omitempty"`
+	TargetCPUUtilization    float64 `json:"target_cpu_utilization,omitempty"`
+	TargetMemoryUtilization float64 `json:"target_memory_utilization,omitempty"`
+	CooldownMinutes         uint32  `json:"cooldown_minutes,omitempty"`
+	TargetNumberInstances   uint64  `json:"target_number_instances,omitempty"`
+}
+
+// DropletAutoscaleResourceTemplate represents a DigitalOcean droplet autoscale pool resource template
+type DropletAutoscaleResourceTemplate struct {
+	Size             string   `json:"size"`
+	Region           string   `json:"region"`
+	Image            string   `json:"image"`
+	Tags             []string `json:"tags"`
+	SSHKeys          []string `json:"ssh_keys"`
+	VpcUUID          string   `json:"vpc_uuid"`
+	WithDropletAgent bool     `json:"with_droplet_agent"`
+	ProjectID        string   `json:"project_id"`
+	IPV6             bool     `json:"ipv6"`
+	UserData         string   `json:"user_data"`
+}
+
+// DropletAutoscaleResourceUtilization represents a DigitalOcean droplet autoscale pool resource utilization
+type DropletAutoscaleResourceUtilization struct {
+	Memory float64 `json:"memory,omitempty"`
+	CPU    float64 `json:"cpu,omitempty"`
+}
+
+// DropletAutoscaleResource represents a DigitalOcean droplet autoscale pool resource
+type DropletAutoscaleResource struct {
+	DropletID          uint64                               `json:"droplet_id"`
+	CreatedAt          time.Time                            `json:"created_at"`
+	UpdatedAt          time.Time                            `json:"updated_at"`
+	HealthStatus       string                               `json:"health_status"`
+	UnhealthyReason    string                               `json:"unhealthy_reason,omitempty"`
+	Status             string                               `json:"status"`
+	CurrentUtilization *DropletAutoscaleResourceUtilization `json:"current_utilization,omitempty"`
+}
+
+// DropletAutoscaleHistoryEvent represents a DigitalOcean droplet autoscale pool history event
+type DropletAutoscaleHistoryEvent struct {
+	HistoryEventID       string    `json:"history_event_id"`
+	CurrentInstanceCount uint64    `json:"current_instance_count"`
+	DesiredInstanceCount uint64    `json:"desired_instance_count"`
+	Reason               string    `json:"reason"`
+	Status               string    `json:"status"`
+	ErrorReason          string    `json:"error_reason,omitempty"`
+	CreatedAt            time.Time `json:"created_at"`
+	UpdatedAt            time.Time `json:"updated_at"`
+}
+
+// DropletAutoscalePoolRequest represents a DigitalOcean droplet autoscale pool create/update request
+type DropletAutoscalePoolRequest struct {
+	Name            string                            `json:"name"`
+	Config          *DropletAutoscaleConfiguration    `json:"config"`
+	DropletTemplate *DropletAutoscaleResourceTemplate `json:"droplet_template"`
+}
+
+type dropletAutoscalePoolRoot struct {
+	AutoscalePool *DropletAutoscalePool `json:"autoscale_pool"`
+}
+
+type dropletAutoscalePoolsRoot struct {
+	AutoscalePools []*DropletAutoscalePool `json:"autoscale_pools"`
+	Links          *Links                  `json:"links"`
+	Meta           *Meta                   `json:"meta"`
+}
+
+type dropletAutoscaleMembersRoot struct {
+	Droplets []*DropletAutoscaleResource `json:"droplets"`
+	Links    *Links                      `json:"links"`
+	Meta     *Meta                       `json:"meta"`
+}
+
+type dropletAutoscaleHistoryEventsRoot struct {
+	History []*DropletAutoscaleHistoryEvent `json:"history"`
+	Links   *Links                          `json:"links"`
+	Meta    *Meta                           `json:"meta"`
+}
+
+// DropletAutoscaleServiceOp handles communication with droplet autoscale-related methods of the DigitalOcean API
+type DropletAutoscaleServiceOp struct {
+	client *Client
+}
+
+var _ DropletAutoscaleService = &DropletAutoscaleServiceOp{}
+
+// Create a new droplet autoscale pool
+func (d *DropletAutoscaleServiceOp) Create(ctx context.Context, createReq *DropletAutoscalePoolRequest) (*DropletAutoscalePool, *Response, error) {
+	req, err := d.client.NewRequest(ctx, http.MethodPost, dropletAutoscaleBasePath, createReq)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(dropletAutoscalePoolRoot)
+	resp, err := d.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return root.AutoscalePool, resp, nil
+}
+
+// Get an existing droplet autoscale pool
+func (d *DropletAutoscaleServiceOp) Get(ctx context.Context, id string) (*DropletAutoscalePool, *Response, error) {
+	req, err := d.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", dropletAutoscaleBasePath, id), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(dropletAutoscalePoolRoot)
+	resp, err := d.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return root.AutoscalePool, resp, err
+}
+
+// List all existing droplet autoscale pools
+func (d *DropletAutoscaleServiceOp) List(ctx context.Context, opts *ListOptions) ([]*DropletAutoscalePool, *Response, error) {
+	path, err := addOptions(dropletAutoscaleBasePath, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := d.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(dropletAutoscalePoolsRoot)
+	resp, err := d.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	if root.Links != nil {
+		resp.Links = root.Links
+	}
+	if root.Meta != nil {
+		resp.Meta = root.Meta
+	}
+	return root.AutoscalePools, resp, err
+}
+
+// ListMembers all members for an existing droplet autoscale pool
+func (d *DropletAutoscaleServiceOp) ListMembers(ctx context.Context, id string, opts *ListOptions) ([]*DropletAutoscaleResource, *Response, error) {
+	path, err := addOptions(fmt.Sprintf("%s/%s/members", dropletAutoscaleBasePath, id), opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := d.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(dropletAutoscaleMembersRoot)
+	resp, err := d.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	if root.Links != nil {
+		resp.Links = root.Links
+	}
+	if root.Meta != nil {
+		resp.Meta = root.Meta
+	}
+	return root.Droplets, resp, err
+}
+
+// ListHistory all history events for an existing droplet autoscale pool
+func (d *DropletAutoscaleServiceOp) ListHistory(ctx context.Context, id string, opts *ListOptions) ([]*DropletAutoscaleHistoryEvent, *Response, error) {
+	path, err := addOptions(fmt.Sprintf("%s/%s/history", dropletAutoscaleBasePath, id), opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := d.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(dropletAutoscaleHistoryEventsRoot)
+	resp, err := d.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	if root.Links != nil {
+		resp.Links = root.Links
+	}
+	if root.Meta != nil {
+		resp.Meta = root.Meta
+	}
+	return root.History, resp, err
+}
+
+// Update an existing autoscale pool
+func (d *DropletAutoscaleServiceOp) Update(ctx context.Context, id string, updateReq *DropletAutoscalePoolRequest) (*DropletAutoscalePool, *Response, error) {
+	req, err := d.client.NewRequest(ctx, http.MethodPut, fmt.Sprintf("%s/%s", dropletAutoscaleBasePath, id), updateReq)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(dropletAutoscalePoolRoot)
+	resp, err := d.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return root.AutoscalePool, resp, nil
+}
+
+// Delete an existing autoscale pool
+func (d *DropletAutoscaleServiceOp) Delete(ctx context.Context, id string) (*Response, error) {
+	req, err := d.client.NewRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", dropletAutoscaleBasePath, id), nil)
+	if err != nil {
+		return nil, err
+	}
+	return d.client.Do(ctx, req, nil)
+}
+
+// DeleteDangerous deletes an existing autoscale pool with all underlying resources
+func (d *DropletAutoscaleServiceOp) DeleteDangerous(ctx context.Context, id string) (*Response, error) {
+	req, err := d.client.NewRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s/dangerous", dropletAutoscaleBasePath, id), nil)
+	req.Header.Set("X-Dangerous", "true")
+	if err != nil {
+		return nil, err
+	}
+	return d.client.Do(ctx, req, nil)
+}

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.126.0"
+	libraryVersion = "1.128.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -65,6 +65,7 @@ type Client struct {
 	Domains           DomainsService
 	Droplets          DropletsService
 	DropletActions    DropletActionsService
+	DropletAutoscale  DropletAutoscaleService
 	Firewalls         FirewallsService
 	FloatingIPs       FloatingIPsService
 	FloatingIPActions FloatingIPActionsService
@@ -275,6 +276,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Domains = &DomainsServiceOp{client: c}
 	c.Droplets = &DropletsServiceOp{client: c}
 	c.DropletActions = &DropletActionsServiceOp{client: c}
+	c.DropletAutoscale = &DropletAutoscaleServiceOp{client: c}
 	c.Firewalls = &FirewallsServiceOp{client: c}
 	c.FloatingIPs = &FloatingIPsServiceOp{client: c}
 	c.FloatingIPActions = &FloatingIPActionsServiceOp{client: c}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.126.1-0.20241002131132-fb61c333ae26
+# github.com/digitalocean/godo v1.128.0
 ## explicit; go 1.22
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
Bumps godo to v1.128.0 in order to pull in various App Spec changes allowing doctl to unmarshal files with the new fields.