### PR TITLE
Fixing positional resource id descriptions

### DIFF
--- a/commands/firewalls.go
+++ b/commands/firewalls.go
@@ -70,7 +70,7 @@ Use a quoted string of space-separated values for multiple rules.`
 	dropletIDRulesTxt := "A comma-separated list of Droplet IDs to place behind the cloud firewall, for example: `386734086,391669331`"
 	tagNameRulesTxt := "A comma-separated list of existing tags, for example: `frontend,backend`. Droplets with these tags will be placed behind the cloud firewall"
 
-	cmdFirewallGet := CmdBuilder(cmd, RunFirewallGet, "get <id>", "Retrieve information about a cloud firewall", `Retrieves information about an existing cloud firewall, including:`+fwDetail, Writer, aliasOpt("g"), displayerType(&displayers.Firewall{}))
+	cmdFirewallGet := CmdBuilder(cmd, RunFirewallGet, "get <firewall-id>", "Retrieve information about a cloud firewall", `Retrieves information about an existing cloud firewall, including:`+fwDetail, Writer, aliasOpt("g"), displayerType(&displayers.Firewall{}))
 	cmdFirewallGet.Example = `The following example retrieves information about the cloud firewall with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute firewall get f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
 
 	cmdFirewallCreate := CmdBuilder(cmd, RunFirewallCreate, "create", "Create a new cloud firewall", `Creates a cloud firewall. This command must contain at least one inbound or outbound access rule.`, Writer, aliasOpt("c"), displayerType(&displayers.Firewall{}))
@@ -81,7 +81,7 @@ Use a quoted string of space-separated values for multiple rules.`
 	AddStringSliceFlag(cmdFirewallCreate, doctl.ArgTagNames, "", []string{}, tagNameRulesTxt)
 	cmdFirewallCreate.Example = `The following example creates a cloud firewall named ` + "`" + `example-firewall` + "`" + ` that contains an inbound rule and an outbound rule and applies them to the specified Droplet: doctl compute firewall create --name "example-firewall" --inbound-rules "protocol:tcp,ports:22,droplet_id:386734086" --outbound-rules "protocol:tcp,ports:22,address:0.0.0.0/0" --droplet-ids "386734086,391669331"`
 
-	cmdFirewallUpdate := CmdBuilder(cmd, RunFirewallUpdate, "update <id>", "Update a cloud firewall's configuration", `Updates the configuration of an existing cloud firewall. The request should contain a full representation of the firewall, including existing attributes. Any attributes that are not provided are reset to their default values.`, Writer, aliasOpt("u"), displayerType(&displayers.Firewall{}))
+	cmdFirewallUpdate := CmdBuilder(cmd, RunFirewallUpdate, "update <firewall-id>", "Update a cloud firewall's configuration", `Updates the configuration of an existing cloud firewall. The request should contain a full representation of the firewall, including existing attributes. Any attributes that are not provided are reset to their default values.`, Writer, aliasOpt("u"), displayerType(&displayers.Firewall{}))
 	AddStringFlag(cmdFirewallUpdate, doctl.ArgFirewallName, "", "", "The firewall's name", requiredOpt())
 	AddStringFlag(cmdFirewallUpdate, doctl.ArgInboundRules, "", "", inboundRulesTxt)
 	AddStringFlag(cmdFirewallUpdate, doctl.ArgOutboundRules, "", "", outboundRulesTxt)
@@ -95,32 +95,32 @@ Use a quoted string of space-separated values for multiple rules.`
 	cmdirewallListByDroplet := CmdBuilder(cmd, RunFirewallListByDroplet, "list-by-droplet <droplet_id>", "List firewalls by Droplet", `Lists the cloud firewalls assigned to a Droplet.`, Writer, displayerType(&displayers.Firewall{}))
 	cmdirewallListByDroplet.Example = `The following example lists all cloud firewalls assigned to the Droplet with the ID ` + "`" + `386734086` + "`" + `: doctl compute firewall list-by-droplet 386734086`
 
-	cmdRunRecordDelete := CmdBuilder(cmd, RunFirewallDelete, "delete <id>...", "Permanently delete a cloud firewall", `Permanently deletes a cloud firewall. This is irreversible, but does not delete any Droplets assigned to the cloud firewall.`, Writer, aliasOpt("d", "rm"))
+	cmdRunRecordDelete := CmdBuilder(cmd, RunFirewallDelete, "delete <firewall-id>...", "Permanently delete a cloud firewall", `Permanently deletes a cloud firewall. This is irreversible, but does not delete any Droplets assigned to the cloud firewall.`, Writer, aliasOpt("d", "rm"))
 	AddBoolFlag(cmdRunRecordDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Deletes the firewall without a confirmation prompt")
 	cmdRunRecordDelete.Example = `The following example deletes a cloud firewall with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute firewall delete f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
 
-	cmdAddDroplets := CmdBuilder(cmd, RunFirewallAddDroplets, "add-droplets <id>", "Add Droplets to a cloud firewall", `Assigns Droplets to a cloud firewall on your account.`, Writer)
+	cmdAddDroplets := CmdBuilder(cmd, RunFirewallAddDroplets, "add-droplets <firewall-id>", "Add Droplets to a cloud firewall", `Assigns Droplets to a cloud firewall on your account.`, Writer)
 	AddStringSliceFlag(cmdAddDroplets, doctl.ArgDropletIDs, "", []string{}, dropletIDRulesTxt)
 	cmdAddDroplets.Example = `The following example assigns two Droplets to the cloud firewall with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute firewall add-droplets f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --droplet-ids "386734086,391669331"`
 
-	cmdRemoveDroplets := CmdBuilder(cmd, RunFirewallRemoveDroplets, "remove-droplets <id>", "Remove Droplets from a cloud firewall", `Removes Droplets from a cloud firewall.`, Writer)
+	cmdRemoveDroplets := CmdBuilder(cmd, RunFirewallRemoveDroplets, "remove-droplets <firewall-id>", "Remove Droplets from a cloud firewall", `Removes Droplets from a cloud firewall.`, Writer)
 	AddStringSliceFlag(cmdRemoveDroplets, doctl.ArgDropletIDs, "", []string{}, dropletIDRulesTxt)
 	cmdRemoveDroplets.Example = `The following example removes two Droplets from a cloud firewall with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute firewall remove-droplets f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --droplet-ids "386734086,391669331"`
 
-	cmdAddTags := CmdBuilder(cmd, RunFirewallAddTags, "add-tags <id>", "Add tags to a cloud firewall", `Add tags to a cloud firewall. This adds all assets using that tag to the firewall.`, Writer)
+	cmdAddTags := CmdBuilder(cmd, RunFirewallAddTags, "add-tags <firewall-id>", "Add tags to a cloud firewall", `Add tags to a cloud firewall. This adds all assets using that tag to the firewall.`, Writer)
 	AddStringSliceFlag(cmdAddTags, doctl.ArgTagNames, "", []string{}, tagNameRulesTxt)
 	cmdAddTags.Example = `The following example adds two tags to a cloud firewall with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute firewall add-tags f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --tag-names "frontend,backend"`
 
-	cmdRemoveTags := CmdBuilder(cmd, RunFirewallRemoveTags, "remove-tags <id>", "Remove tags from a cloud firewall", `Removes tags from a cloud firewall. This removes all assets using that tag from the firewall.`, Writer)
+	cmdRemoveTags := CmdBuilder(cmd, RunFirewallRemoveTags, "remove-tags <firewall-id>", "Remove tags from a cloud firewall", `Removes tags from a cloud firewall. This removes all assets using that tag from the firewall.`, Writer)
 	AddStringSliceFlag(cmdRemoveTags, doctl.ArgTagNames, "", []string{}, tagNameRulesTxt)
 	cmdRemoveTags.Example = `The following example removes two tags from a cloud firewall with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute firewall remove-tags f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --tag-names "frontend,backend"`
 
-	cmdAddRules := CmdBuilder(cmd, RunFirewallAddRules, "add-rules <id>", "Add inbound or outbound rules to a cloud firewall", `Add inbound or outbound rules to a cloud firewall.`, Writer)
+	cmdAddRules := CmdBuilder(cmd, RunFirewallAddRules, "add-rules <firewall-id>", "Add inbound or outbound rules to a cloud firewall", `Add inbound or outbound rules to a cloud firewall.`, Writer)
 	AddStringFlag(cmdAddRules, doctl.ArgInboundRules, "", "", inboundRulesTxt)
 	AddStringFlag(cmdAddRules, doctl.ArgOutboundRules, "", "", outboundRulesTxt)
 	cmdAddRules.Example = `The following example adds an inbound rule and an outbound rule to a cloud firewall with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute firewall add-rules f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --inbound-rules "protocol:tcp,ports:22,droplet_id:386734086" --outbound-rules "protocol:tcp,ports:22,address:0.0.0.0/0"`
 
-	cmdRemoveRules := CmdBuilder(cmd, RunFirewallRemoveRules, "remove-rules <id>", "Remove inbound or outbound rules from a cloud firewall", `Remove inbound or outbound rules from a cloud firewall.`, Writer)
+	cmdRemoveRules := CmdBuilder(cmd, RunFirewallRemoveRules, "remove-rules <firewall-id>", "Remove inbound or outbound rules from a cloud firewall", `Remove inbound or outbound rules from a cloud firewall.`, Writer)
 	AddStringFlag(cmdRemoveRules, doctl.ArgInboundRules, "", "", inboundRulesTxt)
 	AddStringFlag(cmdRemoveRules, doctl.ArgOutboundRules, "", "", outboundRulesTxt)
 	cmdRemoveRules.Example = `The following example removes an inbound rule and an outbound rule from a cloud firewall with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl compute firewall remove-rules f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --inbound-rules "protocol:tcp,ports:22,droplet_id:386734086" --outbound-rules "protocol:tcp,ports:22,address:0.0.0.0/0"`

--- a/commands/load_balancers.go
+++ b/commands/load_balancers.go
@@ -51,7 +51,7 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 	}
 
 	forwardingRulesTxt := "A comma-separated list of key-value pairs representing forwarding rules, which define how traffic is routed, e.g.: `entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306`."
-	CmdBuilder(cmd, RunLoadBalancerGet, "get <id>", "Retrieve a load balancer", "Use this command to retrieve information about a load balancer instance, including:\n\n"+lbDetail, Writer,
+	CmdBuilder(cmd, RunLoadBalancerGet, "get <load-balancer-id>", "Retrieve a load balancer", "Use this command to retrieve information about a load balancer instance, including:\n\n"+lbDetail, Writer,
 		aliasOpt("g"), displayerType(&displayers.LoadBalancer{}))
 
 	cmdLoadBalancerCreate := CmdBuilder(cmd, RunLoadBalancerCreate, "create",
@@ -109,7 +109,7 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 	cmdLoadBalancerCreate.Flags().MarkHidden(doctl.ArgLoadBalancerType)
 	cmdLoadBalancerCreate.Flags().MarkHidden(doctl.ArgLoadBalancerNetwork)
 
-	cmdRecordUpdate := CmdBuilder(cmd, RunLoadBalancerUpdate, "update <id>",
+	cmdRecordUpdate := CmdBuilder(cmd, RunLoadBalancerUpdate, "update <load-balancer-id>",
 		"Update a load balancer's configuration", `Use this command to update the configuration of a specified load balancer. Using all applicable flags, the command should contain a full representation of the load balancer including existing attributes, such as the load balancer's name, region, forwarding rules, and Droplet IDs. Any attribute that is not provided is reset to its default value.`, Writer, aliasOpt("u"))
 	AddStringFlag(cmdRecordUpdate, doctl.ArgLoadBalancerName, "", "",
 		"The load balancer's name")
@@ -160,30 +160,30 @@ With the load-balancer command, you can list, create, or delete load balancers, 
 	CmdBuilder(cmd, RunLoadBalancerList, "list", "List load balancers", "Use this command to get a list of the load balancers on your account, including the following information for each:\n\n"+lbDetail, Writer,
 		aliasOpt("ls"), displayerType(&displayers.LoadBalancer{}))
 
-	cmdRunRecordDelete := CmdBuilder(cmd, RunLoadBalancerDelete, "delete <id>",
+	cmdRunRecordDelete := CmdBuilder(cmd, RunLoadBalancerDelete, "delete <load-balancer-id>",
 		"Permanently delete a load balancer", `Use this command to permanently delete the specified load balancer. This is irreversible.`, Writer, aliasOpt("d", "rm"))
 	AddBoolFlag(cmdRunRecordDelete, doctl.ArgForce, doctl.ArgShortForce, false,
 		"Delete the load balancer without a confirmation prompt")
 
-	cmdAddDroplets := CmdBuilder(cmd, RunLoadBalancerAddDroplets, "add-droplets <id>",
+	cmdAddDroplets := CmdBuilder(cmd, RunLoadBalancerAddDroplets, "add-droplets <load-balancer-id>",
 		"Add Droplets to a load balancer", `Use this command to add Droplets to a load balancer.`, Writer)
 	AddStringSliceFlag(cmdAddDroplets, doctl.ArgDropletIDs, "", []string{},
 		"A comma-separated list of IDs of Droplet to add to the load balancer, example value: `12,33`")
 
 	cmdRemoveDroplets := CmdBuilder(cmd, RunLoadBalancerRemoveDroplets,
-		"remove-droplets <id>", "Remove Droplets from a load balancer", `Use this command to remove Droplets from a load balancer. This command does not destroy any Droplets.`, Writer)
+		"remove-droplets <load-balancer-id>", "Remove Droplets from a load balancer", `Use this command to remove Droplets from a load balancer. This command does not destroy any Droplets.`, Writer)
 	AddStringSliceFlag(cmdRemoveDroplets, doctl.ArgDropletIDs, "", []string{},
 		"A comma-separated list of IDs of Droplets to remove from the load balancer, example value: `12,33`")
 
 	cmdAddForwardingRules := CmdBuilder(cmd, RunLoadBalancerAddForwardingRules,
-		"add-forwarding-rules <id>", "Add forwarding rules to a load balancer", "Use this command to add forwarding rules to a load balancer, specified with the `--forwarding-rules` flag. Valid rules include:\n"+forwardingDetail, Writer)
+		"add-forwarding-rules <load-balancer-id>", "Add forwarding rules to a load balancer", "Use this command to add forwarding rules to a load balancer, specified with the `--forwarding-rules` flag. Valid rules include:\n"+forwardingDetail, Writer)
 	AddStringFlag(cmdAddForwardingRules, doctl.ArgForwardingRules, "", "", forwardingRulesTxt)
 
 	cmdRemoveForwardingRules := CmdBuilder(cmd, RunLoadBalancerRemoveForwardingRules,
-		"remove-forwarding-rules <id>", "Remove forwarding rules from a load balancer", "Use this command to remove forwarding rules from a load balancer, specified with the `--forwarding-rules` flag. Valid rules include:\n"+forwardingDetail, Writer)
+		"remove-forwarding-rules <load-balancer-id>", "Remove forwarding rules from a load balancer", "Use this command to remove forwarding rules from a load balancer, specified with the `--forwarding-rules` flag. Valid rules include:\n"+forwardingDetail, Writer)
 	AddStringFlag(cmdRemoveForwardingRules, doctl.ArgForwardingRules, "", "", forwardingRulesTxt)
 
-	cmdRunCachePurge := CmdBuilder(cmd, RunLoadBalancerPurgeCache, "purge-cache <id>",
+	cmdRunCachePurge := CmdBuilder(cmd, RunLoadBalancerPurgeCache, "purge-cache <load-balancer-id>",
 		"Purges CDN cache for a global load balancer", `Use this command to purge the CDN cache for specified global load balancer.`, Writer)
 	AddBoolFlag(cmdRunCachePurge, doctl.ArgForce, doctl.ArgShortForce, false,
 		"Purge the global load balancer CDN cache without a confirmation prompt "+

--- a/commands/projects.go
+++ b/commands/projects.go
@@ -58,8 +58,8 @@ Projects allow you to organize your DigitalOcean resources (like Droplets, Space
 		Writer, aliasOpt("ls"), displayerType(&displayers.Project{}))
 	cmdProjectsList.Example = `The following example retrieves a list of projects on your account and uses the ` + "`" + `--format` + "`" + ` flag to return only the ID, name, and purpose of each project: doctl projects list --format ID,Name,Purpose`
 
-	cmdProjectsGet := CmdBuilder(cmd, RunProjectsGet, "get <id>", "Retrieve details for a specific project",
-		"Retrieves the following details for an existing project (use `default` as the <id> to retrieve details about your default project):"+projectDetails,
+	cmdProjectsGet := CmdBuilder(cmd, RunProjectsGet, "get <project-id>", "Retrieve details for a specific project",
+		"Retrieves the following details for an existing project (use `default` as the <project-id> to retrieve details about your default project):"+projectDetails,
 		Writer, aliasOpt("g"), displayerType(&displayers.Project{}))
 	cmdProjectsGet.Example = `The following example retrieves details for a project with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl projects get f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
 
@@ -73,24 +73,24 @@ Projects allow you to organize your DigitalOcean resources (like Droplets, Space
 	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectDescription, "", "",
 		"A description of the project")
 	AddStringFlag(cmdProjectsCreate, doctl.ArgProjectEnvironment, "", "",
-		"The environment in which your project resides. Possible values: `Development`, `Staging`, or `Production`")
+		"The environment in which your project resides. Possible `enum` values: `Development`, `Staging`, `Production`.")
 	cmdProjectsCreate.Example = `The following example creates a project named ` + "`" + `Example Project` + "`" + ` with the purpose "Frontend development": doctl projects create --name "Example Project" --purpose "Frontend development"`
 
-	cmdProjectsUpdate := CmdBuilder(cmd, RunProjectsUpdate, "update <id>",
+	cmdProjectsUpdate := CmdBuilder(cmd, RunProjectsUpdate, "update <project-id>",
 		"Update an existing project",
-		"Updates information about an existing project. Use `default` as the <id> to update your default project.",
+		"Updates information about an existing project. Use `default` as the <project-id> to update your default project.",
 		Writer, aliasOpt("u"), displayerType(&displayers.Project{}))
 	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectName, "", "", "The project's name")
 	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectPurpose, "", "", "The project's purpose")
 	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectDescription, "", "",
 		"A description of the project")
 	AddStringFlag(cmdProjectsUpdate, doctl.ArgProjectEnvironment, "", "",
-		"The environment in which your project resides. Possible values: `Development`, `Staging`, or `Production`")
+		"The environment in which your project resides. Possible `enum` values: `Development`, `Staging`, or `Production`")
 	AddBoolFlag(cmdProjectsUpdate, doctl.ArgProjectIsDefault, "", false,
 		"Sets the specified project as your default project")
 	cmdProjectsUpdate.Example = `The following example updates the project with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + ` to have the name ` + "`" + `API Project` + "`" + ` and the purpose "Backend development": doctl projects update f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --name "API Project" --purpose "Backend development"`
 
-	cmdProjectsDelete := CmdBuilder(cmd, RunProjectsDelete, "delete <id> [<id> ...]",
+	cmdProjectsDelete := CmdBuilder(cmd, RunProjectsDelete, "delete <project-id> [<project-id> ...]",
 		"Delete the specified project", "Deletes a project. To be deleted, a project must not have any resources assigned to it.",
 		Writer, aliasOpt("d", "rm"))
 	AddBoolFlag(cmdProjectsDelete, doctl.ArgForce, doctl.ArgShortForce, false,

--- a/commands/vpc_peerings.go
+++ b/commands/vpc_peerings.go
@@ -33,7 +33,7 @@ With the VPC Peerings commands, you can get, list, create, update, or delete VPC
 - The VPC Peering Status
 - The VPC Peering creation date, in ISO8601 combined date and time format
 `
-	cmdPeeringGet := CmdBuilder(cmd, RunVPCPeeringGet, "get <id>",
+	cmdPeeringGet := CmdBuilder(cmd, RunVPCPeeringGet, "get <peering-id>",
 		"Retrieves a VPC Peering", "Retrieves information about a VPC Peering, including:"+peeringDetails, Writer,
 		aliasOpt("g"), displayerType(&displayers.VPCPeering{}))
 	cmdPeeringGet.Example = `The following example retrieves information about a VPC Peering with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl vpcs peerings get f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
@@ -53,7 +53,7 @@ With the VPC Peerings commands, you can get, list, create, update, or delete VPC
 		"`" + `example-peering-name` + "`" +
 		` : doctl vpcs peerings create example-peering-name --vpc-ids f81d4fae-7dec-11d0-a765-00a0c91e6bf6,3f900b61-30d7-40d8-9711-8c5d6264b268`
 
-	cmdPeeringUpdate := CmdBuilder(cmd, RunVPCPeeringUpdate, "update <id>",
+	cmdPeeringUpdate := CmdBuilder(cmd, RunVPCPeeringUpdate, "update <peering-id>",
 		"Update a VPC Peering's name", `Use this command to update the name of a VPC Peering`, Writer, aliasOpt("u"))
 	AddStringFlag(cmdPeeringUpdate, doctl.ArgVPCPeeringName, "", "",
 		"The VPC Peering's name", requiredOpt())
@@ -61,7 +61,7 @@ With the VPC Peerings commands, you can get, list, create, update, or delete VPC
 		"`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + ` to ` + "`" + `new-name` + "`" +
 		`: doctl vpcs peerings update f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --name new-name`
 
-	cmdPeeringDelete := CmdBuilder(cmd, RunVPCPeeringDelete, "delete <id>",
+	cmdPeeringDelete := CmdBuilder(cmd, RunVPCPeeringDelete, "delete <peering-id>",
 		"Permanently delete a VPC Peering", `Permanently deletes the specified VPC Peering. This is irreversible.`, Writer, aliasOpt("d", "rm"))
 	AddBoolFlag(cmdPeeringDelete, doctl.ArgForce, doctl.ArgShortForce, false,
 		"Delete the VPC Peering without any confirmation prompt")

--- a/commands/vpcs.go
+++ b/commands/vpcs.go
@@ -51,7 +51,7 @@ With the VPC commands, you can list, create, or delete VPCs, and manage their co
 - The VPC network's creation date, in ISO8601 combined date and time format
 `
 
-	cmdVPCGet := CmdBuilder(cmd, RunVPCGet, "get <id>", "Retrieve a VPC network", "Retrieve information about a VPC network, including:"+vpcDetail, Writer,
+	cmdVPCGet := CmdBuilder(cmd, RunVPCGet, "get <vpc-id>", "Retrieve a VPC network", "Retrieve information about a VPC network, including:"+vpcDetail, Writer,
 		aliasOpt("g"), displayerType(&displayers.VPC{}))
 	cmdVPCGet.Example = `The following example retrieves information about a VPC network with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl vpcs get f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
 
@@ -65,7 +65,7 @@ With the VPC commands, you can list, create, or delete VPCs, and manage their co
 	AddStringFlag(cmdRecordCreate, doctl.ArgRegionSlug, "", "", "The VPC network's region slug, such as `nyc1`", requiredOpt())
 	cmdRecordCreate.Example = `The following example creates a VPC network named ` + "`" + `example-vpc` + "`" + ` in the ` + "`" + `nyc1` + "`" + ` region: doctl vpcs create --name example-vpc --region nyc1`
 
-	cmdRecordUpdate := CmdBuilder(cmd, RunVPCUpdate, "update <id>",
+	cmdRecordUpdate := CmdBuilder(cmd, RunVPCUpdate, "update <vpc-id>",
 		"Update a VPC network's configuration", `Updates a VPC network's configuration. You can update its name, description, and default state.`, Writer, aliasOpt("u"))
 	AddStringFlag(cmdRecordUpdate, doctl.ArgVPCName, "", "",
 		"The VPC network's name")
@@ -79,7 +79,7 @@ With the VPC commands, you can list, create, or delete VPCs, and manage their co
 		aliasOpt("ls"), displayerType(&displayers.VPC{}))
 	cmdVPCList.Example = `The following example lists the VPCs on your account and uses the --format flag to return only the name, IP range, and region for each VPC network: doctl vpcs list --format Name,IPRange,Region`
 
-	cmdRunRecordDelete := CmdBuilder(cmd, RunVPCDelete, "delete <id>",
+	cmdRunRecordDelete := CmdBuilder(cmd, RunVPCDelete, "delete <vpc-id>",
 		"Permanently delete a VPC network", `Permanently deletes the specified VPC. This is irreversible.
 		
 		You cannot delete VPCs that are default networks for a region. To delete a default VPC network, make another VPC network the default for the region using the `+"`"+`doctl vpcs update <vpc-network-id> --default=true`+"`"+` command, and then delete the target VPC network.`, Writer, aliasOpt("d", "rm"))


### PR DESCRIPTION
I have fixed some other places and replaced **<id>** with **<resource-id>** in command descriptions as it's more common and descriptive pattern.