### PR TITLE
droplets: support listing GPU Droplets.

### DIFF
--- a/args.go
+++ b/args.go
@@ -565,4 +565,7 @@ const (
 
 	// ArgTokenValidationServer is the server used to validate an OAuth token
 	ArgTokenValidationServer = "token-validation-server"
+
+	// ArgGPUs specifies to list GPU Droplets
+	ArgGPUs = "gpus"
 )

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -398,6 +398,16 @@ func TestDropletsListByTag(t *testing.T) {
 	})
 }
 
+func TestDropletsListGPUs(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.droplets.EXPECT().ListWithGPUs().Return(testDropletList, nil)
+
+		config.Doit.Set(config.NS, doctl.ArgGPUs, true)
+		err := RunDropletList(config)
+		assert.NoError(t, err)
+	})
+}
+
 func TestDropletsTag(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		trr := &godo.TagResourcesRequest{
@@ -412,6 +422,15 @@ func TestDropletsTag(t *testing.T) {
 
 		err := RunDropletTag(config)
 		assert.NoError(t, err)
+	})
+}
+
+func TestDropletsListGPUsAndTagsExclusive(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		config.Doit.Set(config.NS, doctl.ArgGPUs, true)
+		config.Doit.Set(config.NS, doctl.ArgTagName, "my-tag")
+		err := RunDropletList(config)
+		assert.Error(t, err)
 	})
 }
 

--- a/do/mocks/DropletsService.go
+++ b/do/mocks/DropletsService.go
@@ -21,6 +21,7 @@ import (
 type MockDropletsService struct {
 	ctrl     *gomock.Controller
 	recorder *MockDropletsServiceMockRecorder
+	isgomock struct{}
 }
 
 // MockDropletsServiceMockRecorder is the mock recorder for MockDropletsService.
@@ -186,6 +187,21 @@ func (m *MockDropletsService) ListByTag(arg0 string) (do.Droplets, error) {
 func (mr *MockDropletsServiceMockRecorder) ListByTag(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByTag", reflect.TypeOf((*MockDropletsService)(nil).ListByTag), arg0)
+}
+
+// ListWithGPUs mocks base method.
+func (m *MockDropletsService) ListWithGPUs() (do.Droplets, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWithGPUs")
+	ret0, _ := ret[0].(do.Droplets)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWithGPUs indicates an expected call of ListWithGPUs.
+func (mr *MockDropletsServiceMockRecorder) ListWithGPUs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWithGPUs", reflect.TypeOf((*MockDropletsService)(nil).ListWithGPUs))
 }
 
 // Neighbors mocks base method.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/creack/pty v1.1.21
-	github.com/digitalocean/godo v1.128.0
+	github.com/digitalocean/godo v1.128.1-0.20241025145008-2654a9d1e887
 	github.com/docker/cli v24.0.5+incompatible
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.128.0 h1:cGn/ibMSRZ9+8etbzMv2MnnCEPTTGlEnx3HHTPwdk1U=
-github.com/digitalocean/godo v1.128.0/go.mod h1:PU8JB6I1XYkQIdHFop8lLAY9ojp6M0XcU0TWaQSxbrc=
+github.com/digitalocean/godo v1.128.1-0.20241025145008-2654a9d1e887 h1:kdXNbMfHEDbQilcqllKkNrJ85ftyJSvSDpsQvzrhHbg=
+github.com/digitalocean/godo v1.128.1-0.20241025145008-2654a9d1e887/go.mod h1:PU8JB6I1XYkQIdHFop8lLAY9ojp6M0XcU0TWaQSxbrc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v24.0.5+incompatible h1:WeBimjvS0eKdH4Ygx+ihVq1Q++xg36M/rMi4aXAvodc=

--- a/vendor/github.com/digitalocean/godo/droplets.go
+++ b/vendor/github.com/digitalocean/godo/droplets.go
@@ -17,6 +17,7 @@ var errNoNetworks = errors.New("no networks have been defined")
 // See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Droplets
 type DropletsService interface {
 	List(context.Context, *ListOptions) ([]Droplet, *Response, error)
+	ListWithGPUs(context.Context, *ListOptions) ([]Droplet, *Response, error)
 	ListByName(context.Context, string, *ListOptions) ([]Droplet, *Response, error)
 	ListByTag(context.Context, string, *ListOptions) ([]Droplet, *Response, error)
 	Get(context.Context, int) (*Droplet, *Response, error)
@@ -313,6 +314,17 @@ func (s *DropletsServiceOp) list(ctx context.Context, path string) ([]Droplet, *
 // List all Droplets.
 func (s *DropletsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Droplet, *Response, error) {
 	path := dropletBasePath
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s.list(ctx, path)
+}
+
+// ListWithGPUs lists all Droplets with GPUs.
+func (s *DropletsServiceOp) ListWithGPUs(ctx context.Context, opt *ListOptions) ([]Droplet, *Response, error) {
+	path := fmt.Sprintf("%s?type=gpus", dropletBasePath)
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err

--- a/vendor/github.com/digitalocean/godo/sizes.go
+++ b/vendor/github.com/digitalocean/godo/sizes.go
@@ -22,16 +22,44 @@ var _ SizesService = &SizesServiceOp{}
 
 // Size represents a DigitalOcean Size
 type Size struct {
-	Slug         string   `json:"slug,omitempty"`
-	Memory       int      `json:"memory,omitempty"`
-	Vcpus        int      `json:"vcpus,omitempty"`
-	Disk         int      `json:"disk,omitempty"`
-	PriceMonthly float64  `json:"price_monthly,omitempty"`
-	PriceHourly  float64  `json:"price_hourly,omitempty"`
-	Regions      []string `json:"regions,omitempty"`
-	Available    bool     `json:"available,omitempty"`
-	Transfer     float64  `json:"transfer,omitempty"`
-	Description  string   `json:"description,omitempty"`
+	Slug         string     `json:"slug,omitempty"`
+	Memory       int        `json:"memory,omitempty"`
+	Vcpus        int        `json:"vcpus,omitempty"`
+	Disk         int        `json:"disk,omitempty"`
+	PriceMonthly float64    `json:"price_monthly,omitempty"`
+	PriceHourly  float64    `json:"price_hourly,omitempty"`
+	Regions      []string   `json:"regions,omitempty"`
+	Available    bool       `json:"available,omitempty"`
+	Transfer     float64    `json:"transfer,omitempty"`
+	Description  string     `json:"description,omitempty"`
+	GPUInfo      *GPUInfo   `json:"gpu_info,omitempty"`
+	DiskInfo     []DiskInfo `json:"disk_info,omitempty"`
+}
+
+// DiskInfo containing information about the disks available to Droplets created
+// with this size.
+type DiskInfo struct {
+	Type string    `json:"type,omitempty"`
+	Size *DiskSize `json:"size,omitempty"`
+}
+
+// DiskSize provides information about the size of a disk.
+type DiskSize struct {
+	Amount int    `json:"amount,omitempty"`
+	Unit   string `json:"unit,omitempty"`
+}
+
+// GPUInfo provides information about the GPU available to Droplets created with this size.
+type GPUInfo struct {
+	Count int    `json:"count,omitempty"`
+	VRAM  *VRAM  `json:"vram,omitempty"`
+	Model string `json:"model,omitempty"`
+}
+
+// VRAM provides information about the amount of VRAM available to the GPU.
+type VRAM struct {
+	Amount int    `json:"amount,omitempty"`
+	Unit   string `json:"unit,omitempty"`
 }
 
 func (s Size) String() string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.128.0
+# github.com/digitalocean/godo v1.128.1-0.20241025145008-2654a9d1e887
 ## explicit; go 1.22
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
Adds a `--gpus` flag to the `doctl compute droplets list` command.