### PR TITLE
Use cnb builder v0.75.2

### DIFF
--- a/commands/apps_dev.go
+++ b/commands/apps_dev.go
@@ -517,7 +517,7 @@ func appDevPrepareEnvironment(ctx context.Context, ws *workspace.AppDev, cli bui
 
 		// TODO: get stack run image from builder image md after we pull it, see below
 		images = append(images, "digitaloceanapps/apps-run:heroku-18_c047ec7")
-		images = append(images, "digitaloceanapps/apps-run:heroku-22_c047ec7")
+		images = append(images, "digitaloceanapps/apps-run:heroku-22_f7a0bf0")
 	}
 
 	if componentSpec.GetType() == godo.AppComponentTypeStaticSite {

--- a/internal/apps/builder/cnb.go
+++ b/internal/apps/builder/cnb.go
@@ -26,7 +26,7 @@ import (
 const (
 	// CNBBuilderImage represents the local cnb builder.
 	CNBBuilderImage_Heroku18 = "digitaloceanapps/cnb-local-builder:heroku-18_v0.73.1"
-	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_v0.73.1"
+	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_v0.75.2"
 
 	appVarAllowListKey = "APP_VARS"
 	appVarPrefix       = "APP_VAR_"


### PR DESCRIPTION
## Details

This PR updates CNBBuilderImage tag to v0.75.2 (current stable version) and apps-run to `f7a0bf0`

