### PR TITLE
APPS: Add an --update-sources parameter to create and update app

### DIFF
--- a/args.go
+++ b/args.go
@@ -126,6 +126,8 @@ const (
 	ArgSurgeUpgrade = "surge-upgrade"
 	// ArgCommandUpsert is an upsert for a resource to be created or updated argument.
 	ArgCommandUpsert = "upsert"
+	// ArgCommandUpdateSources tells the respective operation to also update the underlying sources.
+	ArgCommandUpdateSources = "update-sources"
 	// ArgCommandWait is a wait for a resource to be created argument.
 	ArgCommandWait = "wait"
 	// ArgSetCurrentContext is a flag to set the new kubeconfig context as current.


### PR DESCRIPTION
This adds a parameter named `--update-sources` to the `apps create` and `apps update` commands. If set, the respective update of the app spec also causes the underlying sources to be reevaluated and their respective latest state to be reflected in the created deployment.

On the `apps create` flow, this only applies to `--upsert` cases.