### PR TITLE
Added support getting logs for an app by name.

### DIFF
--- a/do/mocks/AppsService.go
+++ b/do/mocks/AppsService.go
@@ -84,6 +84,21 @@ func (mr *MockAppsServiceMockRecorder) Delete(appID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockAppsService)(nil).Delete), appID)
 }
 
+// Find mocks base method.
+func (m *MockAppsService) Find(appRef string) (*godo.App, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Find", appRef)
+	ret0, _ := ret[0].(*godo.App)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Find indicates an expected call of Find.
+func (mr *MockAppsServiceMockRecorder) Find(appRef any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockAppsService)(nil).Find), appRef)
+}
+
 // Get mocks base method.
 func (m *MockAppsService) Get(appID string) (*godo.App, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
I host [a bunch of apps](https://www.vestris.com/) on DO which is working really great. 

Trying to use the UX less. This change lists apps if you specify anything other than a UUID, I use this as `doctl apps logs slack-strava` vs. `doctl apps logs 4bf2666d-8fa9-4edd-8013-298ce3a8d52a` that I always have to get from the command line or UI.

Closes https://github.com/digitalocean/doctl/issues/1615.
