### PR TITLE
Fix: registry login test failing on OSX.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,12 @@ Writing an integration test typically looks like this,
 Rather than providing an example here, please have a look at the [`integration/account_test.go`](/integration/account_test.go)
 file to see what an integration test typically looks like.
 
+Use `make test_integration` to run all integration tests, or run a single integration test as follows.
+
+```
+go test -v -mod=vendor ./integration -run TestRun/doctl/registry/login/all_required_flags_are_passed/writes_a_docker_config.json_file
+```
+
 #### `godo` mocks
 
 To upgrade `godo`, run `make upgrade_godo`. This will:

--- a/integration/registry_login_test.go
+++ b/integration/registry_login_test.go
@@ -86,7 +86,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("DOCKER_CONFIG=%s", tmpDir))
 
 			output, err := cmd.CombinedOutput()
-			expect.NoError(err)
+			expect.NoError(err, string(output))
 
 			fileBytes, err := os.ReadFile(config)
 			expect.NoError(err)
@@ -120,7 +120,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("DOCKER_CONFIG=%s", tmpDir))
 
 			output, err := cmd.CombinedOutput()
-			expect.NoError(err)
+			expect.NoError(err, string(output))
 
 			fileBytes, err := os.ReadFile(config)
 			expect.NoError(err)
@@ -156,7 +156,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("DOCKER_CONFIG=%s", tmpDir))
 
 			output, err := cmd.CombinedOutput()
-			expect.NoError(err)
+			expect.NoError(err, string(output))
 
 			fileBytes, err := os.ReadFile(config)
 			expect.NoError(err)


### PR DESCRIPTION
I am seeing this failure locally on OSX.

```
$ go test -v -mod=vendor ./integration -run TestRun/doctl/registry/login
=== RUN   TestRun
Suite: doctl
Total: 385 | Focused: 0 | Pending: 0
=== RUN   TestRun/doctl
=== RUN   TestRun/doctl/registry/login/all_required_flags_are_passed/writes_a_docker_config.json_file
=== PAUSE TestRun/doctl/registry/login/all_required_flags_are_passed/writes_a_docker_config.json_file
=== RUN   TestRun/doctl/registry/login/expiry-seconds_flag_is_passed/add_the_correct_query_parameter
=== PAUSE TestRun/doctl/registry/login/expiry-seconds_flag_is_passed/add_the_correct_query_parameter
=== RUN   TestRun/doctl/registry/login/read-only_flag_is_passed_and_the_token_doesn't_expire/add_the_correct_query_parameter
=== PAUSE TestRun/doctl/registry/login/read-only_flag_is_passed_and_the_token_doesn't_expire/add_the_correct_query_parameter
=== CONT  TestRun/doctl/registry/login/all_required_flags_are_passed/writes_a_docker_config.json_file
=== CONT  TestRun/doctl/registry/login/read-only_flag_is_passed_and_the_token_doesn't_expire/add_the_correct_query_parameter
=== CONT  TestRun/doctl/registry/login/expiry-seconds_flag_is_passed/add_the_correct_query_parameter
    registry_login_test.go:123: 
        	Error Trace:	/Users/dblock/source/doctl/dblock-doctl/integration/registry_login_test.go:123
        	            				/Users/dblock/source/doctl/dblock-doctl/vendor/github.com/sclevine/spec/spec.go:269
        	            				/Users/dblock/source/doctl/dblock-doctl/vendor/github.com/sclevine/spec/spec.go:262
        	            				/Users/dblock/source/doctl/dblock-doctl/vendor/github.com/sclevine/spec/parser.go:133
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestRun/doctl/registry/login/expiry-seconds_flag_is_passed/add_the_correct_query_parameter
        	Messages:   	Logging Docker in to registry.digitalocean.com
        	            	Error: error storing credentials - err: exit status 1, out: `The specified item already exists in the keychain.`


Passed: 2 | Failed: 1 | Skipped: 0

--- FAIL: TestRun (0.46s)
    --- FAIL: TestRun/doctl (0.00s)
        --- FAIL: TestRun/doctl/registry/login/expiry-seconds_flag_is_passed/add_the_correct_query_parameter (0.45s)
        --- PASS: TestRun/doctl/registry/login/all_required_flags_are_passed/writes_a_docker_config.json_file (0.46s)
        --- PASS: TestRun/doctl/registry/login/read-only_flag_is_passed_and_the_token_doesn't_expire/add_the_correct_query_parameter (0.46s)
FAIL
FAIL	github.com/digitalocean/doctl/integration	1.630s
FAIL
```

This looks like a side-effect of a prior test that successfully stores credentials and doesn't clean up, but I can't make sense of what calls what to store these items in the keychain.

If someone can point me to where this actually happens maybe I can fix this.