### PR TITLE
Enable droplet-autoscaler commands

### DIFF
--- a/commands/droplet_autoscale.go
+++ b/commands/droplet_autoscale.go
@@ -25,13 +25,12 @@ import (
 func DropletAutoscale() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
-			Hidden:  true,
 			Use:     "droplet-autoscale",
 			Aliases: []string{"das"},
 			Short:   "Display commands to manage Droplet autoscale pools",
 			Long: `Use the subcommands of ` + "`" + `doctl compute droplet-autoscale` + "`" + ` to perform actions on Droplet Autoscale Pools.
 
-You can use droplet-autoscale to perform CRUD operations on a Droplet Autoscale Pools.`,
+You can use droplet-autoscale to perform CRUD operations on a Droplet Autoscale Pool.`,
 		},
 	}
 	cmdDropletAutoscaleCreate := CmdBuilder(cmd, RunDropletAutoscaleCreate, "create", "Create a new Droplet autoscale pool", "", Writer, displayerType(&displayers.DropletAutoscalePools{}))


### PR DESCRIPTION
Remove option to hide the autoscaler commands now that it is publicly GA'd. 