### PR TITLE
Fix: Ensure constant format strings in fmt and printf calls

### DIFF
--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -635,7 +635,7 @@ func RunKubernetesOneClickInstall(c *CmdConfig) error {
 		return err
 	}
 
-	notice(oneClickInstall)
+	notice("%s", oneClickInstall)
 	return nil
 }
 
@@ -784,7 +784,7 @@ func (s *KubernetesCommandService) RunKubernetesClusterCreate(defaultNodeSize st
 			if err != nil {
 				warn("Failed to kick off 1-Click Application(s) install")
 			} else {
-				notice(messageResponse)
+				notice("%s", messageResponse)
 			}
 		}
 


### PR DESCRIPTION
Go 1.24 introduces stricter checks for format string validation. This commit fixes instances where non-constant format strings were used in calls to functions like `fmt.Errorf`, `fmt.Printf`, and similar.