### PR TITLE
load-balancers: make network-stack flag consistent

### DIFF
--- a/args.go
+++ b/args.go
@@ -386,7 +386,7 @@ const (
 	// ArgLoadBalancerNetwork is the type of network the load balancer is accessible from.
 	ArgLoadBalancerNetwork = "network"
 	// ArgLoadBalancerNetworkStack is the network stack type the load balancer will be configured with (e.g IPv4, Dual Stack: IPv4 and IPv6).
-	ArgLoadBalancerNetworkStack = "network_stack"
+	ArgLoadBalancerNetworkStack = "network-stack"
 
 	// ArgFirewallName is a name of the firewall.
 	ArgFirewallName = "name"


### PR DESCRIPTION
Happened to notice this and wanted to get it in before a release. Changes `network_stack` to `network-stack` to be consistent with other flags. 