### PR TITLE
add Created field to images command

### DIFF
--- a/args.go
+++ b/args.go
@@ -386,7 +386,7 @@ const (
 	// ArgLoadBalancerNetwork is the type of network the load balancer is accessible from.
 	ArgLoadBalancerNetwork = "network"
 	// ArgLoadBalancerNetworkStack is the network stack type the load balancer will be configured with (e.g IPv4, Dual Stack: IPv4 and IPv6).
-	ArgLoadBalancerNetworkStack = "network_stack"
+	ArgLoadBalancerNetworkStack = "network-stack"
 
 	// ArgFirewallName is a name of the firewall.
 	ArgFirewallName = "name"

--- a/commands/displayers/image.go
+++ b/commands/displayers/image.go
@@ -31,14 +31,14 @@ func (gi *Image) JSON(out io.Writer) error {
 
 func (gi *Image) Cols() []string {
 	return []string{
-		"ID", "Name", "Type", "Distribution", "Slug", "Public", "MinDisk",
+		"ID", "Name", "Type", "Distribution", "Slug", "Public", "MinDisk", "Created",
 	}
 }
 
 func (gi *Image) ColMap() map[string]string {
 	return map[string]string{
 		"ID": "ID", "Name": "Name", "Type": "Type", "Distribution": "Distribution",
-		"Slug": "Slug", "Public": "Public", "MinDisk": "Min Disk",
+		"Slug": "Slug", "Public": "Public", "MinDisk": "Min Disk", "Created": "Created",
 	}
 }
 
@@ -53,7 +53,7 @@ func (gi *Image) KV() []map[string]any {
 
 		o := map[string]any{
 			"ID": i.ID, "Name": i.Name, "Type": i.Type, "Distribution": i.Distribution,
-			"Slug": i.Slug, "Public": publicStatus, "MinDisk": i.MinDiskSize,
+			"Slug": i.Slug, "Public": publicStatus, "MinDisk": i.MinDiskSize, "Created": i.Created,
 		}
 
 		out = append(out, o)

--- a/commands/images.go
+++ b/commands/images.go
@@ -54,7 +54,7 @@ Currently, there are five types of images: snapshots, backups, custom images, di
 	cmdImagesList := CmdBuilder(cmd, RunImagesList, "list", "List images on your account", `Lists all private images on your account. To list public images, use the `+"`"+`--public`+"`"+` flag. This command returns the following information about each image:`+imageDetail, Writer,
 		aliasOpt("ls"), displayerType(&displayers.Image{}))
 	AddBoolFlag(cmdImagesList, doctl.ArgImagePublic, "", false, "Lists public images")
-	cmdImagesList.Example = `The following example lists all private images on your account and uses the ` + "`" + `--format` + "`" + ` flag to return only the ID, distribution, and slug for each image: doctl compute image list --format ID,Distribution,Slug`
+	cmdImagesList.Example = `The following example lists all private images on your account and uses the ` + "`" + `--format` + "`" + ` flag to return only the ID, distribution, slug and created for each image: doctl compute image list --format ID,Distribution,Slug,Created`
 
 	cmdImagesListDistribution := CmdBuilder(cmd, RunImagesListDistribution,
 		"list-distribution", "List available distribution images", `Lists the distribution images available from DigitalOcean. This command returns the following information about each image:`+imageDetail, Writer,

--- a/integration/droplet_backups_test.go
+++ b/integration/droplet_backups_test.go
@@ -68,8 +68,8 @@ var _ = suite("compute/droplet/backups", func(t *testing.T, when spec.G, it spec
 
 const (
 	dropletBackupsOutput = `
-ID      Name     Type        Distribution    Slug      Public    Min Disk
-4444    magic    snapshot    Fedora          slimey    false     25
+ID      Name     Type        Distribution    Slug      Public    Min Disk    Created
+4444    magic    snapshot    Fedora          slimey    false     25          2018-09-20T19:28:00Z
 `
 	dropletBackupsResponse = `
 {"backups": [
@@ -79,7 +79,8 @@ ID      Name     Type        Distribution    Slug      Public    Min Disk
      "distribution": "Fedora",
      "type": "snapshot",
      "slug": "slimey",
-     "min_disk_size": 25
+     "min_disk_size": 25,
+	 "created_at": "2018-09-20T19:28:00Z"
     }
   ]
 }`

--- a/integration/droplet_backups_test.go
+++ b/integration/droplet_backups_test.go
@@ -80,7 +80,7 @@ ID      Name     Type        Distribution    Slug      Public    Min Disk    Cre
      "type": "snapshot",
      "slug": "slimey",
      "min_disk_size": 25,
-	 "created_at": "2018-09-20T19:28:00Z"
+     "created_at": "2018-09-20T19:28:00Z"
     }
   ]
 }`

--- a/integration/droplet_snapshots_test.go
+++ b/integration/droplet_snapshots_test.go
@@ -81,7 +81,7 @@ ID      Name           Type        Distribution    Slug      Public    Min Disk 
     "type": "snapshot",
     "slug": "slimey",
     "min_disk_size": 25,
-	"created_at": "2018-09-20T19:28:00Z"
+    "created_at": "2018-09-20T19:28:00Z"
   },
   {
     "id": 2222,
@@ -90,7 +90,7 @@ ID      Name           Type        Distribution    Slug      Public    Min Disk 
     "type": "snapshot",
     "slug": "slimey",
     "min_disk_size": 25,
-	"created_at": "2018-09-20T19:28:00Z"
+    "created_at": "2018-09-20T19:28:00Z"
   }
 ]}
 `

--- a/integration/droplet_snapshots_test.go
+++ b/integration/droplet_snapshots_test.go
@@ -68,9 +68,9 @@ var _ = suite("compute/droplet/snapshots", func(t *testing.T, when spec.G, it sp
 
 const (
 	dropletSnapshotsOutput = `
-ID      Name           Type        Distribution    Slug      Public    Min Disk
-4444    magic          snapshot    Fedora          slimey    false     25
-2222    other-magic    snapshot    Ubuntu          slimey    false     25
+ID      Name           Type        Distribution    Slug      Public    Min Disk    Created
+4444    magic          snapshot    Fedora          slimey    false     25          2018-09-20T19:28:00Z
+2222    other-magic    snapshot    Ubuntu          slimey    false     25          2018-09-20T19:28:00Z
 `
 	dropletSnapshotsResponse = `
 {"snapshots": [
@@ -80,7 +80,8 @@ ID      Name           Type        Distribution    Slug      Public    Min Disk
     "distribution": "Fedora",
     "type": "snapshot",
     "slug": "slimey",
-    "min_disk_size": 25
+    "min_disk_size": 25,
+	"created_at": "2018-09-20T19:28:00Z"
   },
   {
     "id": 2222,
@@ -88,7 +89,8 @@ ID      Name           Type        Distribution    Slug      Public    Min Disk
     "distribution": "Ubuntu",
     "type": "snapshot",
     "slug": "slimey",
-    "min_disk_size": 25
+    "min_disk_size": 25,
+	"created_at": "2018-09-20T19:28:00Z"
   }
 ]}
 `

--- a/integration/image_create_test.go
+++ b/integration/image_create_test.go
@@ -149,6 +149,6 @@ const imageCreateResponse = `{
   }`
 
 const imageCreateOutput = `
-ID          Name                    Type      Distribution    Slug    Public    Min Disk
-38413969    ubuntu-18.04-minimal    custom    Ubuntu                  false     0
+ID          Name                    Type      Distribution    Slug    Public    Min Disk    Created
+38413969    ubuntu-18.04-minimal    custom    Ubuntu                  false     0           2018-09-20T19:28:00Z
 `

--- a/integration/image_get_test.go
+++ b/integration/image_get_test.go
@@ -71,8 +71,9 @@ var _ = suite("compute/image/get", func(t *testing.T, when spec.G, it spec.S) {
 
 const (
 	imageGetOutput = `
-ID         Name         Type    Distribution    Slug                Public    Min Disk
-6918990    14.04 x64            Ubuntu          ubuntu-16-04-x64    true      20`
+ID         Name         Type    Distribution    Slug                Public    Min Disk    Created
+6918990    14.04 x64            Ubuntu          ubuntu-16-04-x64    true      20          2014-10-17T20:24:33Z
+`
 	imageGetResponse = `{
   "image": {
     "id": 6918990,

--- a/integration/image_list_application_test.go
+++ b/integration/image_list_application_test.go
@@ -73,10 +73,10 @@ var _ = suite("compute/image/list-application", func(t *testing.T, when spec.G, 
 
 const (
 	imageListApplicationOutput = `
-ID         Name                                        Type    Distribution    Slug             Public    Min Disk
-6376601    Ruby on Rails on 14.04 (Nginx + Unicorn)            Ubuntu          ruby-on-rails    true      20
-6376602    Ruby on Rails on 14.04 (Nginx + Unicorn)            Ubuntu          ruby-on-rails    false     20
-	`
+ID         Name                                        Type    Distribution    Slug             Public    Min Disk    Created
+6376601    Ruby on Rails on 14.04 (Nginx + Unicorn)            Ubuntu          ruby-on-rails    true      20          2014-09-26T20:20:24Z
+6376602    Ruby on Rails on 14.04 (Nginx + Unicorn)            Ubuntu          ruby-on-rails    false     20          2014-09-26T20:20:24Z
+`
 	imageListApplicationResponse = `{
   "images": [
     {

--- a/integration/image_list_test.go
+++ b/integration/image_list_test.go
@@ -151,12 +151,12 @@ var _ = suite("compute/image/list", func(t *testing.T, when spec.G, it spec.S) {
 
 const (
 	imageListPrivateOutput = `
-ID         Name                                        Type    Distribution    Slug             Public    Min Disk
-6376602    Ruby on Rails on 14.04 (Nginx + Unicorn)            Ubuntu          ruby-on-rails    false     20
-	`
+ID         Name                                        Type    Distribution    Slug             Public    Min Disk    Created
+6376602    Ruby on Rails on 14.04 (Nginx + Unicorn)            Ubuntu          ruby-on-rails    false     20          2014-09-26T20:20:24Z
+`
 	imageListNoticeWithHeader = `
 Notice: Listing private images. Use '--public' to include all images.
-ID    Name    Type    Distribution    Slug    Public    Min Disk
+ID    Name    Type    Distribution    Slug    Public    Min Disk    Created
 `
 	imageListNotice = `
 Notice: Listing private images. Use '--public' to include all images.


### PR DESCRIPTION
In this PR we are adding the field `Created` to doctl images command. This is useful for us to manage our images/snapshots available for the autoscale group. Once this field is available in godo and DO API.