### PR TITLE
add option to enable/disable routing-agent plugin

### DIFF
--- a/args.go
+++ b/args.go
@@ -126,6 +126,8 @@ const (
 	ArgClusterAutoscalerScaleDownUtilizationThreshold = "scale-down-utilization-threshold"
 	// ArgClusterAutoscalerScaleDownUnneededTime is the cluster autoscaler scale down unneeded time
 	ArgClusterAutoscalerScaleDownUnneededTime = "scale-down-unneeded-time"
+	// ArgEnableRoutingAgent enables the routing-agent cluster plugin.
+	ArgEnableRoutingAgent = "enable-routing-agent"
 	// ArgSurgeUpgrade is a cluster's surge-upgrade argument.
 	ArgSurgeUpgrade = "surge-upgrade"
 	// ArgCommandUpsert is an upsert for a resource to be created or updated argument.

--- a/commands/displayers/kubernetes.go
+++ b/commands/displayers/kubernetes.go
@@ -50,6 +50,7 @@ func (clusters *KubernetesClusters) Cols() []string {
 		"NodePools",
 		"Autoscaler.UtilizationThreshold",
 		"Autoscaler.UnneededTime",
+		"RoutingAgent",
 	}
 }
 
@@ -83,6 +84,7 @@ func (clusters *KubernetesClusters) ColMap() map[string]string {
 		"NodePools":                       "Node Pools",
 		"Autoscaler.UtilizationThreshold": "Autoscaler Scale Down Utilization",
 		"Autoscaler.UnneededTime":         "Autoscaler Scale Down Unneeded Time",
+		"RoutingAgent":                    "Routing Agent",
 	}
 }
 
@@ -117,6 +119,7 @@ func (clusters *KubernetesClusters) KV() []map[string]any {
 			"NodePools":                       strings.Join(nodePools, " "),
 			"Autoscaler.UtilizationThreshold": "",
 			"Autoscaler.UnneededTime":         "",
+			"RoutingAgent":                    cluster.RoutingAgent != nil && *cluster.RoutingAgent.Enabled,
 		}
 
 		if cfg := cluster.ClusterAutoscalerConfiguration; cfg != nil {

--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -295,6 +295,8 @@ After creating a cluster, a configuration context is added to kubectl and made a
 		"The threshold value for the cluster autoscaler's scale-down-utilization-threshold. It is the maximum value between the sum of CPU requests and sum of memory requests of all pods running on the node divided by node's corresponding allocatable resource, below which a node can be considered for scale down. To set the scale-down-utilization-threshold to 50%, pass the floating point value 0.5.")
 	AddStringFlag(cmdKubeClusterCreate, doctl.ArgClusterAutoscalerScaleDownUnneededTime, "", "",
 		"The unneed time for the cluster autoscaler's scale-down-unneeded-time. It defines how long a node should be unneeded before it is eligible for scale down. To set the scale-down-unneeded-time to a minute and 30 seconds for example, pass the string '1m30s'.")
+	AddBoolFlag(cmdKubeClusterCreate, doctl.ArgEnableRoutingAgent, "", false,
+		"Creates the cluster with routing-agent enabled. Defaults to false. To enable routing-agent, supply --routing-agent=true.")
 	AddStringSliceFlag(cmdKubeClusterCreate, doctl.ArgTag, "", nil,
 		"A comma-separated list of `tags` to apply to the cluster, in addition to the default tags of `k8s` and `k8s:$K8S_CLUSTER_ID`.")
 	AddStringFlag(cmdKubeClusterCreate, doctl.ArgSizeSlug, "",
@@ -343,6 +345,8 @@ Updates the configuration values for a Kubernetes cluster. The cluster must be r
 		"Enables the highly-available control plane for the cluster")
 	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgEnableControlPlaneFirewall, "", false,
 		"Creates the cluster with control plane firewall enabled. Defaults to false. To enable the control plane firewall, supply --enable-control-plane-firewall=true.")
+	AddBoolFlag(cmdKubeClusterUpdate, doctl.ArgEnableRoutingAgent, "", false,
+		"Creates the cluster with routing-agent enabled. Defaults to false. To enable routing-agent, supply --routing-agent=true.")
 	AddStringFlag(cmdKubeClusterUpdate, doctl.ArgClusterAutoscalerScaleDownUtilizationThreshold, "", "",
 		"The threshold value for the cluster autoscaler's scale-down-utilization-threshold. It is the maximum value between the sum of CPU requests and sum of memory requests of all pods running on the node divided by node's corresponding allocatable resource, below which a node can be considered for scale down. To set the scale-down-utilization-threshold to 50%, pass the floating point value 0.5.")
 	AddStringFlag(cmdKubeClusterUpdate, doctl.ArgClusterAutoscalerScaleDownUnneededTime, "", "",
@@ -1698,6 +1702,16 @@ func buildClusterCreateRequestFromArgs(c *CmdConfig, r *godo.KubernetesClusterCr
 		}
 	}
 
+	enableRoutingAgent, err := c.Doit.GetBoolPtr(c.NS, doctl.ArgEnableRoutingAgent)
+	if err != nil {
+		return err
+	}
+	if enableRoutingAgent != nil {
+		r.RoutingAgent = &godo.KubernetesRoutingAgent{
+			Enabled: enableRoutingAgent,
+		}
+	}
+
 	var clusterAutoscalerConfiguration = &godo.KubernetesClusterAutoscalerConfiguration{}
 	thresholdStr, err := c.Doit.GetString(c.NS, doctl.ArgClusterAutoscalerScaleDownUtilizationThreshold)
 	if err != nil {
@@ -1834,6 +1848,16 @@ func buildClusterUpdateRequestFromArgs(c *CmdConfig, r *godo.KubernetesClusterUp
 	if enableControlPlaneFirewall != nil {
 		r.ControlPlaneFirewall = &godo.KubernetesControlPlaneFirewall{
 			Enabled: enableControlPlaneFirewall,
+		}
+	}
+
+	enableRoutingAgent, err := c.Doit.GetBoolPtr(c.NS, doctl.ArgEnableRoutingAgent)
+	if err != nil {
+		return err
+	}
+	if enableRoutingAgent != nil {
+		r.RoutingAgent = &godo.KubernetesRoutingAgent{
+			Enabled: enableRoutingAgent,
 		}
 	}
 

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -45,6 +45,9 @@ var (
 				ScaleDownUtilizationThreshold: &scaleDownUtilizationThreshold,
 				ScaleDownUnneededTime:         &scaleDownUnneededTime,
 			},
+			RoutingAgent: &godo.KubernetesRoutingAgent{
+				Enabled: boolPtr(true),
+			},
 		},
 	}
 
@@ -523,6 +526,9 @@ func TestKubernetesCreate(t *testing.T) {
 				ScaleDownUtilizationThreshold: &scaleDownUtilizationThreshold,
 				ScaleDownUnneededTime:         &scaleDownUnneededTime,
 			},
+			RoutingAgent: &godo.KubernetesRoutingAgent{
+				Enabled: boolPtr(true),
+			},
 		}
 		tm.kubernetes.EXPECT().Create(&r).Return(&testCluster, nil)
 
@@ -548,6 +554,8 @@ func TestKubernetesCreate(t *testing.T) {
 
 		config.Doit.Set(config.NS, doctl.ArgClusterAutoscalerScaleDownUtilizationThreshold, testCluster.ClusterAutoscalerConfiguration.ScaleDownUtilizationThreshold)
 		config.Doit.Set(config.NS, doctl.ArgClusterAutoscalerScaleDownUnneededTime, testCluster.ClusterAutoscalerConfiguration.ScaleDownUnneededTime)
+
+		config.Doit.Set(config.NS, doctl.ArgEnableRoutingAgent, testCluster.RoutingAgent.Enabled)
 
 		// Test with no vpc-uuid specified
 		err := testK8sCmdService().RunKubernetesClusterCreate("c-8", 3)(config)
@@ -606,6 +614,9 @@ func TestKubernetesUpdate(t *testing.T) {
 				ScaleDownUtilizationThreshold: &scaleDownUtilizationThreshold,
 				ScaleDownUnneededTime:         &scaleDownUnneededTime,
 			},
+			RoutingAgent: &godo.KubernetesRoutingAgent{
+				Enabled: boolPtr(true),
+			},
 		}
 		tm.kubernetes.EXPECT().Update(testCluster.ID, &r).Return(&testCluster, nil)
 
@@ -619,6 +630,7 @@ func TestKubernetesUpdate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgControlPlaneFirewallAllowedAddresses, testCluster.ControlPlaneFirewall.AllowedAddresses)
 		config.Doit.Set(config.NS, doctl.ArgClusterAutoscalerScaleDownUtilizationThreshold, testCluster.ClusterAutoscalerConfiguration.ScaleDownUtilizationThreshold)
 		config.Doit.Set(config.NS, doctl.ArgClusterAutoscalerScaleDownUnneededTime, testCluster.ClusterAutoscalerConfiguration.ScaleDownUnneededTime)
+		config.Doit.Set(config.NS, doctl.ArgEnableRoutingAgent, testCluster.RoutingAgent.Enabled)
 
 		err := testK8sCmdService().RunKubernetesClusterUpdate(config)
 		assert.NoError(t, err)
@@ -645,6 +657,9 @@ func TestKubernetesUpdate(t *testing.T) {
 				ScaleDownUtilizationThreshold: &scaleDownUtilizationThreshold,
 				ScaleDownUnneededTime:         &scaleDownUnneededTime,
 			},
+			RoutingAgent: &godo.KubernetesRoutingAgent{
+				Enabled: boolPtr(true),
+			},
 		}
 		tm.kubernetes.EXPECT().List().Return(testClusterList, nil)
 		tm.kubernetes.EXPECT().Update(testCluster.ID, &r).Return(&testCluster, nil)
@@ -658,6 +673,7 @@ func TestKubernetesUpdate(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgControlPlaneFirewallAllowedAddresses, testCluster.ControlPlaneFirewall.AllowedAddresses)
 		config.Doit.Set(config.NS, doctl.ArgClusterAutoscalerScaleDownUtilizationThreshold, testCluster.ClusterAutoscalerConfiguration.ScaleDownUtilizationThreshold)
 		config.Doit.Set(config.NS, doctl.ArgClusterAutoscalerScaleDownUnneededTime, testCluster.ClusterAutoscalerConfiguration.ScaleDownUnneededTime)
+		config.Doit.Set(config.NS, doctl.ArgEnableRoutingAgent, testCluster.RoutingAgent.Enabled)
 
 		err := testK8sCmdService().RunKubernetesClusterUpdate(config)
 		assert.NoError(t, err)

--- a/integration/kubernetes_clusters_get_test.go
+++ b/integration/kubernetes_clusters_get_test.go
@@ -115,7 +115,7 @@ var (
 }
 `
 
-	k8sGetOutput = `ID                 Name               Region    Version              Auto Upgrade    HA Control Plane    Status     Endpoint    IPv4    Cluster Subnet    Service Subnet    Tags          Created At                       Updated At                       Node Pools       Autoscaler Scale Down Utilization    Autoscaler Scale Down Unneeded Time
-some-cluster-id    some-cluster-id    nyc3      some-kube-version    true            false               running                                                            production    2018-11-15 16:00:11 +0000 UTC    2018-11-15 16:00:11 +0000 UTC    frontend-pool    50%                                  1m30s
+	k8sGetOutput = `ID                 Name               Region    Version              Auto Upgrade    HA Control Plane    Status     Endpoint    IPv4    Cluster Subnet    Service Subnet    Tags          Created At                       Updated At                       Node Pools       Autoscaler Scale Down Utilization    Autoscaler Scale Down Unneeded Time    Routing Agent
+some-cluster-id    some-cluster-id    nyc3      some-kube-version    true            false               running                                                            production    2018-11-15 16:00:11 +0000 UTC    2018-11-15 16:00:11 +0000 UTC    frontend-pool    50%                                  1m30s                                  false
 `
 )

--- a/integration/projects_resources_get_test.go
+++ b/integration/projects_resources_get_test.go
@@ -343,9 +343,10 @@ ID                                      Name       Size      Region    Filesyste
 }
 `
 	projectsResourcesGetKubernetesOutput = `
-ID    Name    Region    Version    Auto Upgrade    HA Control Plane    Status          Endpoint    IPv4    Cluster Subnet    Service Subnet    Tags    Created At                       Updated At                       Node Pools    Autoscaler Scale Down Utilization    Autoscaler Scale Down Unneeded Time
-      1111                         false           false               provisioning                                                            k8s     2021-01-29 16:02:02 +0000 UTC    0001-01-01 00:00:00 +0000 UTC    pool-test
+ID    Name    Region    Version    Auto Upgrade    HA Control Plane    Status          Endpoint    IPv4    Cluster Subnet    Service Subnet    Tags    Created At                       Updated At                       Node Pools    Autoscaler Scale Down Utilization    Autoscaler Scale Down Unneeded Time    Routing Agent
+      1111                         false           false               provisioning                                                            k8s     2021-01-29 16:02:02 +0000 UTC    0001-01-01 00:00:00 +0000 UTC    pool-test                                                                                 false
 `
+
 	projectsResourcesListKubernetesOutput = `
 	{
 		"kubernetes_clusters": [


### PR DESCRIPTION
Includes an up of godo version to `v1.138.0` to use newly introduced `RoutingAgent` flags.

Can be merged now.