### PR TITLE
APPS-10741: Get stack run image from CNB Builder Image

### DIFF
--- a/internal/apps/builder/cnb.go
+++ b/internal/apps/builder/cnb.go
@@ -26,7 +26,7 @@ import (
 const (
 	// CNBBuilderImage represents the local cnb builder.
 	CNBBuilderImage_Heroku18 = "digitaloceanapps/cnb-local-builder:heroku-18_v0.73.1"
-	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_v0.79.0"
+	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_v0.81.1"
 
 	appVarAllowListKey = "APP_VARS"
 	appVarPrefix       = "APP_VAR_"


### PR DESCRIPTION
## Details

For every new builder image release, we have to manually update the `CNBBuilderImage_Heroku22` and `apps-run` images.
If this combination is not correct, user will encounter error similar to  https://github.com/digitalocean/doctl/pull/1573

This PR tries to fix this by getting `apps-run` image from `CNBBuilderImage`'s metadata.