### PR TITLE
Check for --project-id before droplet creation

### DIFF
--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -27,6 +27,7 @@ import (
 	"github.com/digitalocean/doctl/do"
 	"github.com/digitalocean/godo"
 	"github.com/gobwas/glob"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
@@ -364,6 +365,9 @@ func RunDropletCreate(c *CmdConfig) error {
 
 // ValidateProjectUUID checks if the given projectUUID exists
 func ValidateProjectUUID(c *CmdConfig, projectUUID string) error {
+	if _, err := uuid.Parse(projectUUID); err != nil {
+		return err
+	}
 	ps := c.Projects()
 	_, err := ps.Get(projectUUID)
 	return err

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -366,7 +366,7 @@ func RunDropletCreate(c *CmdConfig) error {
 // ValidateProjectUUID checks if the given projectUUID exists
 func ValidateProjectUUID(c *CmdConfig, projectUUID string) error {
 	if _, err := uuid.Parse(projectUUID); err != nil {
-		return err
+		return fmt.Errorf("Invalid Project UUID - %w", err)
 	}
 	ps := c.Projects()
 	_, err := ps.Get(projectUUID)

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -246,6 +246,13 @@ func RunDropletCreate(c *CmdConfig) error {
 		return err
 	}
 
+	if projectUUID != "" {
+		err := ValidateProjectUUID(c, projectUUID)
+		if err != nil {
+			return err
+		}
+	}
+
 	tagNames, err := c.Doit.GetStringSlice(c.NS, doctl.ArgTagNames)
 	if err != nil {
 		return err
@@ -353,6 +360,16 @@ func RunDropletCreate(c *CmdConfig) error {
 	}
 
 	return c.Display(item)
+}
+
+// ValidateProjectUUID checks if the given projectUUID exists
+func ValidateProjectUUID(c *CmdConfig, projectUUID string) error {
+	ps := c.Projects()
+	_, err := ps.Get(projectUUID)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // RunDropletTag adds a tag to a droplet.

--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -366,10 +366,7 @@ func RunDropletCreate(c *CmdConfig) error {
 func ValidateProjectUUID(c *CmdConfig, projectUUID string) error {
 	ps := c.Projects()
 	_, err := ps.Get(projectUUID)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // RunDropletTag adds a tag to a droplet.

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -285,7 +285,7 @@ func TestProjectsValidOrInvalidUUID(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		err := ValidateProjectUUID(config, "ab06e011-6dd1-4034-9293-201f71-ba299")
+		err := ValidateProjectUUID(config, "ab06e011-6dd1-4034-9293-201f71-by299")
 		assert.Error(t, err)
 	})
 }

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -277,12 +277,16 @@ func TestDropletCreateWithProjectID(t *testing.T) {
 	})
 }
 
-func TestProjectsValidUUID(t *testing.T) {
+func TestProjectsValidOrInvalidUUID(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		projectUUID := "ab06e011-6dd1-4034-9293-201f71aba299"
 		tm.projects.EXPECT().Get(projectUUID).Return(&testProject, nil)
 		err := ValidateProjectUUID(config, "ab06e011-6dd1-4034-9293-201f71aba299")
 		assert.NoError(t, err)
+	})
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		err := ValidateProjectUUID(config, "ab06e011-6dd1-4034-9293-201f71-ba299")
+		assert.Error(t, err)
 	})
 }
 

--- a/commands/droplets_test.go
+++ b/commands/droplets_test.go
@@ -261,6 +261,7 @@ func TestDropletCreateWithProjectID(t *testing.T) {
 			SSHKeys: []godo.DropletCreateSSHKey{},
 		}
 		tm.droplets.EXPECT().Create(dcr, false).Return(&testDroplet, nil)
+		tm.projects.EXPECT().Get(projectUUID).Return(&testProject, nil)
 		tm.projects.EXPECT().
 			AssignResources(projectUUID, []string{testDroplet.URN()}).
 			Return(do.ProjectResources{}, nil)
@@ -272,6 +273,15 @@ func TestDropletCreateWithProjectID(t *testing.T) {
 		config.Doit.Set(config.NS, doctl.ArgProjectID, projectUUID)
 
 		err := RunDropletCreate(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestProjectsValidUUID(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		projectUUID := "ab06e011-6dd1-4034-9293-201f71aba299"
+		tm.projects.EXPECT().Get(projectUUID).Return(&testProject, nil)
+		err := ValidateProjectUUID(config, "ab06e011-6dd1-4034-9293-201f71aba299")
 		assert.NoError(t, err)
 	})
 }

--- a/integration/droplet_create_test.go
+++ b/integration/droplet_create_test.go
@@ -332,12 +332,12 @@ const (
 `
 	getProjectResponse = `{
 		"project": {
-			"id": "4e1bfbc3-dc3e-41f2-a18f-1b4d7ba71679",
-			"owner_uuid": "99525febec065ca37b2ffe4f852fd2b2581895e7",
+			"id": "00000000-0000-4000-8000-000000000000",
+			"owner_uuid": "00000000-0000-4000-8000-000000000000",
 			"owner_id": 258992,
-			"name": "my-web-api",
-			"description": "My website API",
-			"purpose": "Service or API",
+			"name": "some-project-name",
+			"description": "some-description",
+			"purpose": "some-purpose",
 			"environment": "Production",
 			"created_at": "2018-09-27T20:10:35Z",
 			"updated_at": "2018-09-27T20:10:35Z",

--- a/integration/droplet_create_test.go
+++ b/integration/droplet_create_test.go
@@ -69,6 +69,9 @@ var _ = suite("compute/droplet/create", func(t *testing.T, when spec.G, it spec.
 				// since we've successfully tested all the behavior
 				// at this point
 				w.Write([]byte(dropletCreateResponse))
+			case "/v2/projects/00000000-0000-4000-8000-000000000000":
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(getProjectResponse))
 			case "/v2/projects/00000000-0000-4000-8000-000000000000/resources":
 				auth := req.Header.Get("Authorization")
 				if auth != "Bearer some-magic-token" {
@@ -327,7 +330,20 @@ const (
   ]
 }
 `
-
+	getProjectResponse = `{
+		"project": {
+			"id": "4e1bfbc3-dc3e-41f2-a18f-1b4d7ba71679",
+			"owner_uuid": "99525febec065ca37b2ffe4f852fd2b2581895e7",
+			"owner_id": 258992,
+			"name": "my-web-api",
+			"description": "My website API",
+			"purpose": "Service or API",
+			"environment": "Production",
+			"created_at": "2018-09-27T20:10:35Z",
+			"updated_at": "2018-09-27T20:10:35Z",
+			"is_default": false
+		}
+	}`
 	dropletCreateOutput = `
 ID      Name                 Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region              Image                          VPC UUID                                Status    Tags    Features    Volumes
 1111    some-droplet-name    1.2.3.4        7.7.7.7                        12        13       15      some-region-slug    some-distro some-image-name    00000000-0000-4000-8000-000000000000    active    yes     remotes     some-volume-id


### PR DESCRIPTION
Earlier on giving a random name or UUID for --project-id `Error: 404 Not Found` is thrown but still a droplet gets created in default project. 

```
`
doctl % doctl compute droplet create demo --image ubuntu-20-04-x64 --size s-1vcpu-1gb --region nyc1 --project-id first-project
Error: POST https://api.digitalocean.com/v2/projects/first-project/resources: 404 (request "9f376d2ade") not found

doctl % doctl compute droplet create demo --image ubuntu-20-04-x64 --size s-1vcpu-1gb --region nyc1 --project-id 8d22f3 
Error: POST https://api.digitalocean.com/v2/projects/8d2710122f3/resources: 404 (request "07b307e2a") not found`
```


Added a check to validate if project-id exist or not.

Following execution shows examples with correct, incorrect and no --project-id.

```
doctl % docker run --rm -it doctl_local compute droplet create demo --image ubuntu-20-04-x64 --size s-1vcpu-1gb --region nyc1 --project-id 8d27e2f339 --access-token 74
ID           Name    Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region    Image                     VPC UUID    Status    Tags    Features         Volumes
488725106    demo                                                  1024      1        25      nyc1      Ubuntu 20.04 (LTS) x64                new               droplet_agent    

doctl % docker run --rm -it doctl_local compute droplet create demo --image ubuntu-20-04-x64 --size s-1vcpu-1gb --region nyc1 --project-id 810122 --access-token 34
Error: GET https://api.digitalocean.com/v2/projects/8d2710122: 404 (request "830ada579") project not found

doctl % docker run --rm -it doctl_local compute droplet create demo --image ubuntu-20-04-x64 --size s-1vcpu-1gb --region nyc1 --project-id first-project --access-token 34                          
Error: GET https://api.digitalocean.com/v2/projects/first-project: 404 (request "0fddda99a4c42") project not found

doctl % docker run --rm -it doctl_local compute droplet create demo --image ubuntu-20-04-x64 --size s-1vcpu-1gb --region nyc1 --access-token 34 
ID           Name    Public IPv4    Private IPv4    Public IPv6    Memory    VCPUs    Disk    Region    Image                     VPC UUID    Status    Tags    Features         Volumes
488725238    demo                                                  1024      1        25      nyc1      Ubuntu 20.04 (LTS) x64                new               droplet_agent    

```
