### PR TITLE
Enhancement: Pull ubuntu-18 builder image only when the app requires ubuntu-18

### DIFF
--- a/commands/apps_dev.go
+++ b/commands/apps_dev.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/MakeNowJust/heredoc"
@@ -519,13 +520,15 @@ func appDevPrepareEnvironment(ctx context.Context, ws *workspace.AppDev, cli bui
 		if ws.Config.CNBBuilderImage != "" {
 			images = append(images, ws.Config.CNBBuilderImage)
 		} else {
-			images = append(images, builder.CNBBuilderImage_Heroku18)
+			for _, f := range ws.Config.AppSpec.Features {
+				if strings.EqualFold(f, "buildpack-stack=ubuntu-18") {
+					images = append(images, builder.CNBBuilderImage_Heroku18)
+					images = append(images, builder.CNBAppsRunImage_Heroku18)
+				}
+			}
+			// Get stack run image from CNBBuilderImage_Heroku22.
 			images = append(images, builder.CNBBuilderImage_Heroku22)
 		}
-
-		// Get stack run image from CNBBuilderImage_Heroku22.
-		// Stack run-image for CNBBuilderImage_Heroku18 is hardcoded to heroku-18_c047ec7.
-		images = append(images, "digitaloceanapps/apps-run:heroku-18_c047ec7")
 	}
 
 	if componentSpec.GetType() == godo.AppComponentTypeStaticSite {

--- a/internal/apps/builder/cnb.go
+++ b/internal/apps/builder/cnb.go
@@ -28,6 +28,8 @@ const (
 	CNBBuilderImage_Heroku18 = "digitaloceanapps/cnb-local-builder:heroku-18_v0.73.1"
 	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_v0.83.0"
 
+	CNBAppsRunImage_Heroku18 = "digitaloceanapps/apps-run:heroku-18_c047ec7"
+
 	appVarAllowListKey = "APP_VARS"
 	appVarPrefix       = "APP_VAR_"
 	cnbCacheDir        = "/cnb/cache"


### PR DESCRIPTION
## Details

For the command: `doctl apps dev build`, all builder images are pulled before the app is built.
This results in unnecessary bandwidth and storage usage, as it pulls builders for both `ubuntu-22` and `ubuntu-18` stacks, even though only one is actually used during the build.

With this change, doctl will pull the `ubuntu-18` builder image only if the AppSpec explicitly specifies this stack.