### PR TITLE
Feat: Add command to get current running instance of an app

### DIFF
--- a/args.go
+++ b/args.go
@@ -44,8 +44,8 @@ const (
 	ArgAppLogType = "type"
 	// ArgAppDeployment is the deployment ID.
 	ArgAppDeployment = "deployment"
-	// ArgAppDeployment is the deployment ID.
-	ArgAppInstanceID = "instance-id"
+	// ArgAppInstanceName is the instance name of currently running instances (optional).
+	ArgAppInstanceName = "instance-name"
 	// ArgAppDevConfig is the path to the app dev link config.
 	ArgAppDevConfig = "dev-config"
 	// ArgBuildCommand is an optional build command to set for local development.

--- a/args.go
+++ b/args.go
@@ -44,6 +44,8 @@ const (
 	ArgAppLogType = "type"
 	// ArgAppDeployment is the deployment ID.
 	ArgAppDeployment = "deployment"
+	// ArgAppDeployment is the deployment ID.
+	ArgAppInstanceID = "instance-id"
 	// ArgAppDevConfig is the path to the app dev link config.
 	ArgAppDevConfig = "dev-config"
 	// ArgBuildCommand is an optional build command to set for local development.

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -238,7 +238,7 @@ For more information about logs, see [How to View Logs](https://www.digitalocean
 		aliasOpt("i"),
 	)
 
-	appInstances.Example = `The following examples retrives the currently running, emphemeral compute instances for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl apps instances f81d4fae-7dec-11d0-a765-00a0c91e6bf6 web`
+	appInstances.Example = `The following examples retrieves the currently running, emphemeral compute instances for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl apps instances f81d4fae-7dec-11d0-a765-00a0c91e6bf6 web`
 
 	listRegions := CmdBuilder(
 		cmd,

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -1320,7 +1320,8 @@ func RunGetAppInstances(c *CmdConfig) error {
 	}
 	appID := c.Args[0]
 
-	instances, err := c.Apps().GetAppInstances(appID, nil)
+	opts := &godo.GetAppInstancesOpts{}
+	instances, err := c.Apps().GetAppInstances(appID, opts)
 	if err != nil {
 		return err
 	}

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -150,7 +150,7 @@ This permanently deletes the app and all of its associated deployments.`,
 		RunAppsCreateDeployment,
 		"create-deployment <app id>",
 		"Creates a deployment",
-		`Creates an app using the provided app spec. To redeploy an existing app using its latest image or source code changes, use the --update-sources flag. To update an existing app’s spec configuration without pulling its latest changes or image, use the `+"`"+`--upsert`+"`"+` flag or `+"`"+`doctl apps update`+"`"+` command. 
+		`Creates an app using the provided app spec. To redeploy an existing app using its latest image or source code changes, use the --update-sources flag. To update an existing app’s spec configuration without pulling its latest changes or image, use the `+"`"+`--upsert`+"`"+` flag or `+"`"+`doctl apps update`+"`"+` command.
 `,
 		Writer,
 		aliasOpt("cd"),
@@ -199,7 +199,7 @@ Three types of logs are supported and can be specified with the --`+doctl.ArgApp
 - build
 - deploy
 - run
-- run_restarted 
+- run_restarted
 
 For more information about logs, see [How to View Logs](https://www.digitalocean.com/docs/app-platform/how-to/view-logs/).
 `,
@@ -217,13 +217,14 @@ For more information about logs, see [How to View Logs](https://www.digitalocean
 	console := CmdBuilder(
 		cmd,
 		RunAppsConsole,
-		"console <app id> <component name>",
+		"console <app id> <component name> <instance id (optional)>",
 		"Starts a console session",
 		`Instantiates a console session for a component of an app.`,
 		Writer,
 		aliasOpt("cs"),
 	)
 	AddStringFlag(console, doctl.ArgAppDeployment, "", "", "Starts a console session for a specific deployment ID. Defaults to current deployment.")
+	AddStringFlag(console, doctl.ArgAppInstanceID, "", "", "Starts a console session for a specific instance ID. Optional, defaults to the first available pod.")
 
 	console.Example = `The following example initiates a console session for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + ` and the component ` + "`" + `web` + "`" + `: doctl apps console f81d4fae-7dec-11d0-a765-00a0c91e6bf6 web`
 
@@ -799,13 +800,17 @@ func RunAppsConsole(c *CmdConfig) error {
 	}
 	appID := c.Args[0]
 	component := c.Args[1]
+	var instanceID string
+	if len(c.Args) >= 3 {
+		instanceID = c.Args[2]
+	}
 
 	deploymentID, err := c.Doit.GetString(c.NS, doctl.ArgAppDeployment)
 	if err != nil {
 		return err
 	}
 
-	execResp, err := c.Apps().GetExec(appID, deploymentID, component)
+	execResp, err := c.Apps().GetExec(appID, deploymentID, component, instanceID)
 	if err != nil {
 		return err
 	}

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -228,6 +228,18 @@ For more information about logs, see [How to View Logs](https://www.digitalocean
 
 	console.Example = `The following example initiates a console session for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + ` and the component ` + "`" + `web` + "`" + `: doctl apps console f81d4fae-7dec-11d0-a765-00a0c91e6bf6 web`
 
+	appInstances := CmdBuilder(
+		cmd,
+		RunGetAppInstances,
+		"instances <app id> ",
+		"Get app instances",
+		`Returns an app's currently running emphemeral compute instances.`,
+		Writer,
+		aliasOpt("i"),
+	)
+
+	appInstances.Example = `The following examples retrives the currently running, emphemeral compute instances for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl apps instances f81d4fae-7dec-11d0-a765-00a0c91e6bf6 web`
+
 	listRegions := CmdBuilder(
 		cmd,
 		RunAppsListRegions,
@@ -1296,6 +1308,7 @@ func getIDByName(apps []*godo.App, name string) (string, error) {
 	return "", fmt.Errorf("app not found")
 }
 
+// RunGetAppInstances gets currently running emphemera compute instances for an app
 func RunGetAppInstances(c *CmdConfig) error {
 	if len(c.Args) < 1 {
 		return doctl.NewMissingArgsErr(c.NS)

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -233,12 +233,12 @@ For more information about logs, see [How to View Logs](https://www.digitalocean
 		RunGetAppInstances,
 		"instances <app id> ",
 		"Get app instances",
-		`Returns an app's currently running emphemeral compute instances.`,
+		`Returns an app's currently running ephemeral compute instances.`,
 		Writer,
 		aliasOpt("i"),
 	)
 
-	appInstances.Example = `The following examples retrieves the currently running, emphemeral compute instances for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl apps instances f81d4fae-7dec-11d0-a765-00a0c91e6bf6 web`
+	appInstances.Example = `The following examples retrieves the currently running, ephemeral compute instances for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl apps instances f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
 
 	listRegions := CmdBuilder(
 		cmd,

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -1295,3 +1295,17 @@ func getIDByName(apps []*godo.App, name string) (string, error) {
 
 	return "", fmt.Errorf("app not found")
 }
+
+func RunGetAppInstances(c *CmdConfig) error {
+	if len(c.Args) < 1 {
+		return doctl.NewMissingArgsErr(c.NS)
+	}
+	appID := c.Args[0]
+
+	instances, err := c.Apps().GetAppInstances(appID, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.Display(displayers.Apps(instances))
+}

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -1307,5 +1307,5 @@ func RunGetAppInstances(c *CmdConfig) error {
 		return err
 	}
 
-	return c.Display(displayers.Apps(instances))
+	return c.Display(displayers.AppInstances(instances))
 }

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -228,6 +228,18 @@ For more information about logs, see [How to View Logs](https://www.digitalocean
 
 	console.Example = `The following example initiates a console session for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + ` and the component ` + "`" + `web` + "`" + `: doctl apps console f81d4fae-7dec-11d0-a765-00a0c91e6bf6 web. To initiate a console session to a specific instance, append the instance id: doctl apps console f81d4fae-7dec-11d0-a765-00a0c91e6bf6 web sample-golang-5d9f95556c-5f58g`
 
+	appInstances := CmdBuilder(
+		cmd,
+		RunGetAppInstances,
+		"instances <app id> ",
+		"Get app instances",
+		`Returns an app's currently running emphemeral compute instances.`,
+		Writer,
+		aliasOpt("i"),
+	)
+
+	appInstances.Example = `The following examples retrives the currently running, emphemeral compute instances for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl apps instances f81d4fae-7dec-11d0-a765-00a0c91e6bf6 web`
+
 	listRegions := CmdBuilder(
 		cmd,
 		RunAppsListRegions,
@@ -1299,4 +1311,19 @@ func getIDByName(apps []*godo.App, name string) (string, error) {
 	}
 
 	return "", fmt.Errorf("app not found")
+}
+
+// RunGetAppInstances gets currently running emphemera compute instances for an app
+func RunGetAppInstances(c *CmdConfig) error {
+	if len(c.Args) < 1 {
+		return doctl.NewMissingArgsErr(c.NS)
+	}
+	appID := c.Args[0]
+
+	instances, err := c.Apps().GetAppInstances(appID, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.Display(displayers.AppInstances(instances))
 }

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -1313,7 +1313,7 @@ func getIDByName(apps []*godo.App, name string) (string, error) {
 	return "", fmt.Errorf("app not found")
 }
 
-// RunGetAppInstances gets currently running emphemera compute instances for an app
+// RunGetAppInstances gets currently running ephemeral compute instances for an app
 func RunGetAppInstances(c *CmdConfig) error {
 	if len(c.Args) < 1 {
 		return doctl.NewMissingArgsErr(c.NS)

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -231,14 +231,14 @@ For more information about logs, see [How to View Logs](https://www.digitalocean
 	appInstances := CmdBuilder(
 		cmd,
 		RunGetAppInstances,
-		"instances <app id> ",
+		"list-instances <app id>",
 		"Get app instances",
 		`Returns an app's currently running ephemeral compute instances.`,
 		Writer,
 		aliasOpt("i"),
 	)
 
-	appInstances.Example = `The following examples retrieves the currently running, ephemeral compute instances for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl apps instances f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
+	appInstances.Example = `The following examples retrieves the currently running, ephemeral compute instances for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl apps list-instances f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
 
 	listRegions := CmdBuilder(
 		cmd,

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -652,9 +652,10 @@ func TestRunAppsConsole(t *testing.T) {
 	appID := uuid.New().String()
 	deploymentID := uuid.New().String()
 	component := "service"
+	instanceID := ""
 
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.apps.EXPECT().GetExec(appID, deploymentID, component).Times(1).Return(&godo.AppExec{URL: "wss://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=aa-bb-11-cc-33"}, nil)
+		tm.apps.EXPECT().GetExec(appID, deploymentID, component, instanceID).Times(1).Return(&godo.AppExec{URL: "wss://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=aa-bb-11-cc-33"}, nil)
 		tm.listen.EXPECT().Listen(gomock.Any()).Times(1).Return(nil)
 		tm.terminal.EXPECT().ReadRawStdin(gomock.Any(), gomock.Any()).Times(1).Return(func() {}, nil)
 		tm.terminal.EXPECT().MonitorResizeEvents(gomock.Any(), gomock.Any()).Times(1).Return(nil)

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -24,6 +24,7 @@ func TestAppsCommand(t *testing.T) {
 	require.NotNil(t, cmd)
 	assertCommandNames(t, cmd,
 		"console",
+		"instances",
 		"create",
 		"get",
 		"list",

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -1070,3 +1070,22 @@ func TestRunAppsUpgradeBuildpack(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestRunAppsGetInstances(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		appID := uuid.New().String()
+
+		opts := &godo.GetAppInstancesOpts{}
+
+		tm.apps.EXPECT().GetAppInstances(appID, opts).Times(1).Return([]*godo.AppInstance{{
+			InstanceName:  "service-instance-1d34fg678-45f6",
+			ComponentType: "service",
+			ComponentName: "service-instance",
+		}}, nil)
+
+		config.Args = append(config.Args, appID)
+
+		err := RunGetAppInstances(config)
+		require.NoError(t, err)
+	})
+}

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -24,7 +24,7 @@ func TestAppsCommand(t *testing.T) {
 	require.NotNil(t, cmd)
 	assertCommandNames(t, cmd,
 		"console",
-		"instances",
+		"list-instances",
 		"create",
 		"get",
 		"list",

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -651,11 +651,14 @@ func TestRunAppsGetLogsWithAppNameAndDeploymentID(t *testing.T) {
 func TestRunAppsConsole(t *testing.T) {
 	appID := uuid.New().String()
 	deploymentID := uuid.New().String()
-	component := "service"
-	instanceID := ""
+	componentName := "service"
+	instanceName := "app-instance-1d34fg678-45f6"
 
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.apps.EXPECT().GetExec(appID, deploymentID, component, instanceID).Times(1).Return(&godo.AppExec{URL: "wss://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=aa-bb-11-cc-33"}, nil)
+		opts := &godo.AppGetExecOptions{
+			DeploymentID: deploymentID,
+		}
+		tm.apps.EXPECT().GetExecWithOpts(appID, componentName, opts).Times(1).Return(&godo.AppExec{URL: "wss://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=aa-bb-11-cc-33"}, nil)
 		tm.listen.EXPECT().Listen(gomock.Any()).Times(1).Return(nil)
 		tm.terminal.EXPECT().ReadRawStdin(gomock.Any(), gomock.Any()).Times(1).Return(func() {}, nil)
 		tm.terminal.EXPECT().MonitorResizeEvents(gomock.Any(), gomock.Any()).Times(1).Return(nil)
@@ -670,7 +673,34 @@ func TestRunAppsConsole(t *testing.T) {
 			return tm.terminal
 		}
 
-		config.Args = append(config.Args, appID, component)
+		config.Args = append(config.Args, appID, componentName)
+		config.Doit.Set(config.NS, doctl.ArgAppDeployment, deploymentID)
+
+		err := RunAppsConsole(config)
+		require.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		opts := &godo.AppGetExecOptions{
+			DeploymentID: deploymentID,
+			InstanceName: instanceName,
+		}
+		tm.apps.EXPECT().GetExecWithOpts(appID, componentName, opts).Times(1).Return(&godo.AppExec{URL: "wss://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=aa-bb-11-cc-33"}, nil)
+		tm.listen.EXPECT().Listen(gomock.Any()).Times(1).Return(nil)
+		tm.terminal.EXPECT().ReadRawStdin(gomock.Any(), gomock.Any()).Times(1).Return(func() {}, nil)
+		tm.terminal.EXPECT().MonitorResizeEvents(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
+		tc := config.Doit.(*doctl.TestConfig)
+		tc.ListenFn = func(url *url.URL, token string, schemaFunc listen.SchemaFunc, out io.Writer, in <-chan []byte) listen.ListenerService {
+			assert.Equal(t, "aa-bb-11-cc-33", token)
+			assert.Equal(t, "wss://proxy-apps-prod-ams3-001.ondigitalocean.app/?token=aa-bb-11-cc-33", url.String())
+			return tm.listen
+		}
+		tc.TerminalFn = func() terminal.Terminal {
+			return tm.terminal
+		}
+
+		config.Args = append(config.Args, appID, componentName, instanceName)
 		config.Doit.Set(config.NS, doctl.ArgAppDeployment, deploymentID)
 
 		err := RunAppsConsole(config)

--- a/commands/displayers/apps.go
+++ b/commands/displayers/apps.go
@@ -509,17 +509,17 @@ var _ Displayable = (*AppInstances)(nil)
 
 func (a AppInstances) Cols() []string {
 	return []string{
+		"Name",
 		"ComponentName",
 		"ComponentType",
-		"InstanceName",
 	}
 }
 
 func (a AppInstances) ColMap() map[string]string {
 	return map[string]string{
+		"Name":          "Name",
 		"ComponentName": "ComponentName",
 		"ComponentType": "ComponentType",
-		"InstanceName":  "InstanceName",
 	}
 }
 
@@ -528,9 +528,9 @@ func (a AppInstances) KV() []map[string]any {
 
 	for i, appInstance := range a {
 		out[i] = map[string]any{
+			"Name":          appInstance.InstanceName,
 			"ComponentName": appInstance.ComponentName,
 			"ComponentType": appInstance.ComponentType,
-			"InstanceName":  appInstance.InstanceName,
 		}
 	}
 	return out

--- a/commands/displayers/apps.go
+++ b/commands/displayers/apps.go
@@ -502,3 +502,42 @@ func (b Buildpacks) JSON(w io.Writer) error {
 	e.SetIndent("", "  ")
 	return e.Encode(b)
 }
+
+type AppInstances []*godo.AppInstance
+
+var _ Displayable = (*AppInstances)(nil)
+
+func (b AppInstances) Cols() []string {
+	return []string{
+		"ComponentName",
+		"ComponentType",
+		"InstanceName",
+	}
+}
+
+func (b AppInstances) ColMap() map[string]string {
+	return map[string]string{
+		"ComponentName": "ComponentName",
+		"ComponentType": "ComponentType",
+		"InstanceName": "InstanceName",
+	
+}
+
+func (a AppInstances) KV() []map[string]any {
+	out := make([]map[string]any, len(a))
+
+	for i, instance := range a {
+		out[i] = map[string]any{
+			"ComponentName":  instance.ComponentName,
+			"ComponentType":  instance.ComponentType,
+			"InstanceName":   instance.InstanceName,
+		}
+	}
+	return out
+}
+
+func (b AppInstances) JSON(w io.Writer) error {
+	e := json.NewEncoder(w)
+	e.SetIndent("", "  ")
+	return e.Encode(b)
+}

--- a/commands/displayers/apps.go
+++ b/commands/displayers/apps.go
@@ -507,7 +507,7 @@ type AppInstances []*godo.AppInstance
 
 var _ Displayable = (*AppInstances)(nil)
 
-func (b AppInstances) Cols() []string {
+func (a AppInstances) Cols() []string {
 	return []string{
 		"ComponentName",
 		"ComponentType",
@@ -515,29 +515,29 @@ func (b AppInstances) Cols() []string {
 	}
 }
 
-func (b AppInstances) ColMap() map[string]string {
+func (a AppInstances) ColMap() map[string]string {
 	return map[string]string{
 		"ComponentName": "ComponentName",
 		"ComponentType": "ComponentType",
-		"InstanceName": "InstanceName",
-	
+		"InstanceName":  "InstanceName",
+	}
 }
 
 func (a AppInstances) KV() []map[string]any {
 	out := make([]map[string]any, len(a))
 
-	for i, instance := range a {
+	for i, appInstance := range a {
 		out[i] = map[string]any{
-			"ComponentName":  instance.ComponentName,
-			"ComponentType":  instance.ComponentType,
-			"InstanceName":   instance.InstanceName,
+			"ComponentName": appInstance.ComponentName,
+			"ComponentType": appInstance.ComponentType,
+			"InstanceName":  appInstance.InstanceName,
 		}
 	}
 	return out
 }
 
-func (b AppInstances) JSON(w io.Writer) error {
+func (a AppInstances) JSON(w io.Writer) error {
 	e := json.NewEncoder(w)
 	e.SetIndent("", "  ")
-	return e.Encode(b)
+	return e.Encode(a)
 }

--- a/do/apps.go
+++ b/do/apps.go
@@ -54,6 +54,8 @@ type AppsService interface {
 
 	ListBuildpacks() ([]*godo.Buildpack, error)
 	UpgradeBuildpack(appID string, options godo.UpgradeBuildpackOptions) (affectedComponents []string, deployment *godo.Deployment, err error)
+
+	GetAppInstances(appID string, opts *godo.GetAppInstancesOpts) ([]*godo.AppInstance, error)
 }
 
 type appsService struct {
@@ -311,4 +313,12 @@ func (s *appsService) UpgradeBuildpack(appID string, options godo.UpgradeBuildpa
 		return nil, nil, err
 	}
 	return res.AffectedComponents, res.Deployment, nil
+}
+
+func (s *appsService) GetAppInstances(appID string, opts *godo.GetAppInstancesOpts) ([]*godo.AppInstance, error) {
+	instances, _, err := s.client.Apps.GetAppInstances(s.ctx, appID, opts)
+	if err != nil {
+		return nil, err
+	}
+	return instances, nil
 }

--- a/do/apps.go
+++ b/do/apps.go
@@ -53,7 +53,7 @@ type AppsService interface {
 	ListBuildpacks() ([]*godo.Buildpack, error)
 	UpgradeBuildpack(appID string, options godo.UpgradeBuildpackOptions) (affectedComponents []string, deployment *godo.Deployment, err error)
 
-	GetAppInstances(appID string, opts godo.GetAppInstancesOptions)([]*godo.AppInstance, error)
+	GetAppInstances(appID string, opts *godo.GetAppInstancesOpts) ([]*godo.AppInstance, error)
 }
 
 type appsService struct {
@@ -304,7 +304,7 @@ func (s *appsService) UpgradeBuildpack(appID string, options godo.UpgradeBuildpa
 	return res.AffectedComponents, res.Deployment, nil
 }
 
-func (s *appsService) GetAppInstances(appID string, opts godo.GetAppInstancesOptions) ([]*godo.AppInstance, error) {
+func (s *appsService) GetAppInstances(appID string, opts *godo.GetAppInstancesOpts) ([]*godo.AppInstance, error) {
 	instances, _, err := s.client.Apps.GetAppInstances(s.ctx, appID, opts)
 	if err != nil {
 		return nil, err

--- a/do/apps.go
+++ b/do/apps.go
@@ -52,6 +52,8 @@ type AppsService interface {
 
 	ListBuildpacks() ([]*godo.Buildpack, error)
 	UpgradeBuildpack(appID string, options godo.UpgradeBuildpackOptions) (affectedComponents []string, deployment *godo.Deployment, err error)
+
+	GetAppInstances(appID string, opts godo.GetAppInstancesOptions)([]*godo.AppInstance, error)
 }
 
 type appsService struct {
@@ -300,4 +302,12 @@ func (s *appsService) UpgradeBuildpack(appID string, options godo.UpgradeBuildpa
 		return nil, nil, err
 	}
 	return res.AffectedComponents, res.Deployment, nil
+}
+
+func (s *appsService) GetAppInstances(appID string, opts godo.GetAppInstancesOptions) ([]*godo.AppInstance, error) {
+	instances, _, err := s.client.Apps.GetAppInstances(s.ctx, appID, opts)
+	if err != nil {
+		return nil, err
+	}
+	return instances, nil
 }

--- a/do/apps.go
+++ b/do/apps.go
@@ -37,7 +37,7 @@ type AppsService interface {
 	ListDeployments(appID string) ([]*godo.Deployment, error)
 
 	GetLogs(appID, deploymentID, component string, logType godo.AppLogType, follow bool, tail int) (*godo.AppLogs, error)
-	GetExec(appID, deploymentID, component string) (*godo.AppExec, error)
+	GetExec(appID, deploymentID, component, instanceID string) (*godo.AppExec, error)
 
 	ListRegions() ([]*godo.AppRegion, error)
 
@@ -222,8 +222,8 @@ func (s *appsService) GetLogs(appID, deploymentID, component string, logType god
 	return logs, nil
 }
 
-func (s *appsService) GetExec(appID, deploymentID, component string) (*godo.AppExec, error) {
-	exec, _, err := s.client.Apps.GetExec(s.ctx, appID, deploymentID, component)
+func (s *appsService) GetExec(appID, deploymentID, component, instanceID string) (*godo.AppExec, error) {
+	exec, _, err := s.client.Apps.GetExec(s.ctx, appID, deploymentID, component, instanceID)
 	if err != nil {
 		return nil, err
 	}

--- a/do/mocks/AppsService.go
+++ b/do/mocks/AppsService.go
@@ -130,18 +130,33 @@ func (mr *MockAppsServiceMockRecorder) GetDeployment(appID, deploymentID any) *g
 }
 
 // GetExec mocks base method.
-func (m *MockAppsService) GetExec(appID, deploymentID, component, instanceID string) (*godo.AppExec, error) {
+func (m *MockAppsService) GetExec(appID, deploymentID, componentName string) (*godo.AppExec, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetExec", appID, deploymentID, component, instanceID)
+	ret := m.ctrl.Call(m, "GetExec", appID, deploymentID, componentName)
 	ret0, _ := ret[0].(*godo.AppExec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetExec indicates an expected call of GetExec.
-func (mr *MockAppsServiceMockRecorder) GetExec(appID, deploymentID, component, instanceID any) *gomock.Call {
+func (mr *MockAppsServiceMockRecorder) GetExec(appID, deploymentID, componentName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExec", reflect.TypeOf((*MockAppsService)(nil).GetExec), appID, deploymentID, component, instanceID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExec", reflect.TypeOf((*MockAppsService)(nil).GetExec), appID, deploymentID, componentName)
+}
+
+// GetExecWithOpts mocks base method.
+func (m *MockAppsService) GetExecWithOpts(appID, componentName string, opts *godo.AppGetExecOptions) (*godo.AppExec, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExecWithOpts", appID, componentName, opts)
+	ret0, _ := ret[0].(*godo.AppExec)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetExecWithOpts indicates an expected call of GetExecWithOpts.
+func (mr *MockAppsServiceMockRecorder) GetExecWithOpts(appID, componentName, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExecWithOpts", reflect.TypeOf((*MockAppsService)(nil).GetExecWithOpts), appID, componentName, opts)
 }
 
 // GetInstanceSize mocks base method.

--- a/do/mocks/AppsService.go
+++ b/do/mocks/AppsService.go
@@ -130,18 +130,18 @@ func (mr *MockAppsServiceMockRecorder) GetDeployment(appID, deploymentID any) *g
 }
 
 // GetExec mocks base method.
-func (m *MockAppsService) GetExec(appID, deploymentID, component string) (*godo.AppExec, error) {
+func (m *MockAppsService) GetExec(appID, deploymentID, component, instanceID string) (*godo.AppExec, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetExec", appID, deploymentID, component)
+	ret := m.ctrl.Call(m, "GetExec", appID, deploymentID, component, instanceID)
 	ret0, _ := ret[0].(*godo.AppExec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetExec indicates an expected call of GetExec.
-func (mr *MockAppsServiceMockRecorder) GetExec(appID, deploymentID, component any) *gomock.Call {
+func (mr *MockAppsServiceMockRecorder) GetExec(appID, deploymentID, component, instanceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExec", reflect.TypeOf((*MockAppsService)(nil).GetExec), appID, deploymentID, component)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExec", reflect.TypeOf((*MockAppsService)(nil).GetExec), appID, deploymentID, component, instanceID)
 }
 
 // GetInstanceSize mocks base method.

--- a/do/mocks/AppsService.go
+++ b/do/mocks/AppsService.go
@@ -114,6 +114,21 @@ func (mr *MockAppsServiceMockRecorder) Get(appID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockAppsService)(nil).Get), appID)
 }
 
+// GetAppInstances mocks base method.
+func (m *MockAppsService) GetAppInstances(appID string, opts *godo.GetAppInstancesOpts) ([]*godo.AppInstance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAppInstances", appID, opts)
+	ret0, _ := ret[0].([]*godo.AppInstance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAppInstances indicates an expected call of GetAppInstances.
+func (mr *MockAppsServiceMockRecorder) GetAppInstances(appID, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppInstances", reflect.TypeOf((*MockAppsService)(nil).GetAppInstances), appID, opts)
+}
+
 // GetDeployment mocks base method.
 func (m *MockAppsService) GetDeployment(appID, deploymentID string) (*godo.Deployment, error) {
 	m.ctrl.T.Helper()

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/creack/pty v1.1.21
-	github.com/digitalocean/godo v1.146.1
+	github.com/digitalocean/godo v1.147.0
 	github.com/docker/cli v24.0.5+incompatible
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/creack/pty v1.1.21
-	github.com/digitalocean/godo v1.147.0
+	github.com/digitalocean/godo v1.148.0
 	github.com/docker/cli v24.0.5+incompatible
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/creack/pty v1.1.21
-	github.com/digitalocean/godo v1.146.0
+	github.com/digitalocean/godo v1.146.1
 	github.com/docker/cli v24.0.5+incompatible
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.146.0 h1:0CDU1/vxvlvMFjIOk1UfC8Ku6pwfZFOM1Uf/ZEke4oc=
-github.com/digitalocean/godo v1.146.0/go.mod h1:tYeiWY5ZXVpU48YaFv0M5irUFHXGorZpDNm7zzdWMzM=
+github.com/digitalocean/godo v1.146.1 h1:kO4bnJsj9pYzD105QEFbUeUa7EnfFhnhVHM6cuVyTYw=
+github.com/digitalocean/godo v1.146.1/go.mod h1:tYeiWY5ZXVpU48YaFv0M5irUFHXGorZpDNm7zzdWMzM=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v24.0.5+incompatible h1:WeBimjvS0eKdH4Ygx+ihVq1Q++xg36M/rMi4aXAvodc=

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.146.1 h1:kO4bnJsj9pYzD105QEFbUeUa7EnfFhnhVHM6cuVyTYw=
-github.com/digitalocean/godo v1.146.1/go.mod h1:tYeiWY5ZXVpU48YaFv0M5irUFHXGorZpDNm7zzdWMzM=
+github.com/digitalocean/godo v1.147.0 h1:cTsh91i1A1YygYIdAYzvW2p1MDvXxs7Ay15MarEIkL0=
+github.com/digitalocean/godo v1.147.0/go.mod h1:tYeiWY5ZXVpU48YaFv0M5irUFHXGorZpDNm7zzdWMzM=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v24.0.5+incompatible h1:WeBimjvS0eKdH4Ygx+ihVq1Q++xg36M/rMi4aXAvodc=

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.147.0 h1:cTsh91i1A1YygYIdAYzvW2p1MDvXxs7Ay15MarEIkL0=
-github.com/digitalocean/godo v1.147.0/go.mod h1:tYeiWY5ZXVpU48YaFv0M5irUFHXGorZpDNm7zzdWMzM=
+github.com/digitalocean/godo v1.148.0 h1:th91q+6bZY+Slgs9eZxBupa2+aUUYn1qT7gPICFmtPA=
+github.com/digitalocean/godo v1.148.0/go.mod h1:tYeiWY5ZXVpU48YaFv0M5irUFHXGorZpDNm7zzdWMzM=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v24.0.5+incompatible h1:WeBimjvS0eKdH4Ygx+ihVq1Q++xg36M/rMi4aXAvodc=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [v1.147.0] - 2025-05-14
+
+- #831 - @thearyanahmed - Implement GetAppInstances - allowing users to list currently running compute instances
 
 ## [v1.146.1] - 2025-05-09
 

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.148.0] - 2025-05-14
+
+- #824 - @asaha2 - Introduce egress-gateway service api
+
 ## [v1.147.0] - 2025-05-14
 
 - #831 - @thearyanahmed - Implement GetAppInstances - allowing users to list currently running compute instances

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+
+## [v1.146.1] - 2025-05-09
+
+- #828 - @thearyanahmed - Pass GetExec() request params as query params
+
 ## [v1.146.0] - 2025-05-09
 
 - #826 - @ssaengs - APPS-5889: add liveness health check, update comment

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -367,6 +367,24 @@ type AppIngressSpecRuleStringMatch struct {
 	Exact  string `json:"exact,omitempty"`
 }
 
+// AppInstance struct for AppInstance
+type AppInstance struct {
+	ComponentName string                   `json:"component_name,omitempty"`
+	InstanceName  string                   `json:"instance_name,omitempty"`
+	ComponentType AppInstanceComponentType `json:"component_type,omitempty"`
+}
+
+// AppInstanceComponentType the model 'AppInstanceComponentType'
+type AppInstanceComponentType string
+
+// List of AppInstanceComponentType
+const (
+	APPINSTANCECOMPONENTTYPE_Unknown AppInstanceComponentType = "UNKNOWN"
+	APPINSTANCECOMPONENTTYPE_Service AppInstanceComponentType = "SERVICE"
+	APPINSTANCECOMPONENTTYPE_Worker  AppInstanceComponentType = "WORKER"
+	APPINSTANCECOMPONENTTYPE_Job     AppInstanceComponentType = "JOB"
+)
+
 // AppJobSpec struct for AppJobSpec
 type AppJobSpec struct {
 	// The name. Must be unique across all components within the same app.
@@ -539,9 +557,9 @@ type AppServiceSpecHealthCheck struct {
 	PeriodSeconds int32 `json:"period_seconds,omitempty"`
 	// The number of seconds after which the check times out. Default: 1 second, Minimum 1, Maximum 120.
 	TimeoutSeconds int32 `json:"timeout_seconds,omitempty"`
-	// The number of successful health checks before considered healthy. Default: 1 second, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 1 second, Minimum 1, Maximum 1.
+	// The number of successful health checks before considered healthy. Default: 1, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 1, Minimum 1, Maximum 1.
 	SuccessThreshold int32 `json:"success_threshold,omitempty"`
-	// The number of failed health checks before considered unhealthy. Default: 9 seconds, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 18 seconds, Minimum 1, Maximum 50.
+	// The number of failed health checks before considered unhealthy. Default: 9, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 18, Minimum 1, Maximum 50.
 	FailureThreshold int32 `json:"failure_threshold,omitempty"`
 	// The route path used for the HTTP health check ping. If not set, the HTTP health check will be disabled and a TCP health check used instead.
 	HTTPPath string `json:"http_path,omitempty"`
@@ -693,7 +711,6 @@ type Buildpack struct {
 
 // DeploymentCauseDetailsAutoscalerAction struct for DeploymentCauseDetailsAutoscalerAction
 type DeploymentCauseDetailsAutoscalerAction struct {
-	// Marker for the deployment being autoscaled. Necessary because the generation tooling can't handle empty messages.
 	Autoscaled bool `json:"autoscaled,omitempty"`
 }
 
@@ -1096,6 +1113,11 @@ type AppDomainValidation struct {
 // GetAppDatabaseConnectionDetailsResponse struct for GetAppDatabaseConnectionDetailsResponse
 type GetAppDatabaseConnectionDetailsResponse struct {
 	ConnectionDetails []*GetDatabaseConnectionDetailsResponse `json:"connection_details,omitempty"`
+}
+
+// GetAppInstancesResponse struct for GetAppInstancesResponse
+type GetAppInstancesResponse struct {
+	Instances []*AppInstance `json:"instances,omitempty"`
 }
 
 // GetDatabaseConnectionDetailsResponse struct for GetDatabaseConnectionDetailsResponse

--- a/vendor/github.com/digitalocean/godo/apps.go
+++ b/vendor/github.com/digitalocean/godo/apps.go
@@ -74,6 +74,8 @@ type AppsService interface {
 		*Response,
 		error,
 	)
+
+	GetAppInstances(ctx context.Context, appID string, opts *GetAppInstancesOpts) ([]*AppInstance, *Response, error)
 }
 
 // AppLogs represent app logs.
@@ -189,6 +191,10 @@ type buildpacksRoot struct {
 // AppsServiceOp handles communication with Apps methods of the DigitalOcean API.
 type AppsServiceOp struct {
 	client *Client
+}
+
+type GetAppInstancesOpts struct {
+	// reserved for future use.
 }
 
 // URN returns a URN identifier for the app
@@ -663,6 +669,23 @@ func (s *AppsServiceOp) ToggleDatabaseTrustedSource(
 		return nil, resp, err
 	}
 	return root, resp, nil
+}
+
+// GetAppInstances returns a list of emphemeral compute instances of the current deployment for an app.
+// opts is reserved for future use.
+func (s *AppsServiceOp) GetAppInstances(ctx context.Context, appID string, opts *GetAppInstancesOpts) ([]*AppInstance, *Response, error) {
+	path := fmt.Sprintf("%s/%s/instances", appsBasePath, appID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(GetAppInstancesResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Instances, resp, nil
 }
 
 // AppComponentType is an app component type.

--- a/vendor/github.com/digitalocean/godo/apps.go
+++ b/vendor/github.com/digitalocean/godo/apps.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	netURL "net/url"
 )
 
 const (
@@ -423,13 +424,25 @@ func (s *AppsServiceOp) GetExecWithOpts(ctx context.Context, appID, componentNam
 		url = fmt.Sprintf("%s/%s/deployments/%s/components/%s/exec", appsBasePath, appID, opts.DeploymentID, componentName)
 	}
 
-	type ExecRequestParams struct {
-		InstanceName string `json:"instance_name"`
+	params := map[string]string{
+		"instance_name": opts.InstanceName,
 	}
 
-	params := ExecRequestParams{InstanceName: opts.InstanceName}
+	urlValues := netURL.Values{}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, url, params)
+	for k, v := range params {
+		if v == "" {
+			continue
+		}
+
+		urlValues.Add(k, v)
+	}
+
+	if len(urlValues) > 0 {
+		url = fmt.Sprintf("%s?%s", url, urlValues.Encode())
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/apps_accessors.go
+++ b/vendor/github.com/digitalocean/godo/apps_accessors.go
@@ -1037,6 +1037,30 @@ func (a *AppIngressSpecRuleStringMatch) GetPrefix() string {
 	return a.Prefix
 }
 
+// GetComponentName returns the ComponentName field.
+func (a *AppInstance) GetComponentName() string {
+	if a == nil {
+		return ""
+	}
+	return a.ComponentName
+}
+
+// GetComponentType returns the ComponentType field.
+func (a *AppInstance) GetComponentType() AppInstanceComponentType {
+	if a == nil {
+		return ""
+	}
+	return a.ComponentType
+}
+
+// GetInstanceName returns the InstanceName field.
+func (a *AppInstance) GetInstanceName() string {
+	if a == nil {
+		return ""
+	}
+	return a.InstanceName
+}
+
 // GetBandwidthAllowanceGib returns the BandwidthAllowanceGib field.
 func (a *AppInstanceSize) GetBandwidthAllowanceGib() string {
 	if a == nil {

--- a/vendor/github.com/digitalocean/godo/egress_gateways.go
+++ b/vendor/github.com/digitalocean/godo/egress_gateways.go
@@ -1,0 +1,166 @@
+package godo
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	egressGatewaysBasePath = "/v2/egress_gateways"
+)
+
+// EgressGatewaysService defines an interface for managing Egress Gateways through the DigitalOcean API
+type EgressGatewaysService interface {
+	Create(context.Context, *EgressGatewayRequest) (*EgressGateway, *Response, error)
+	Get(context.Context, string) (*EgressGateway, *Response, error)
+	List(context.Context, *EgressGatewaysListOptions) ([]*EgressGateway, *Response, error)
+	Update(context.Context, string, *EgressGatewayRequest) (*EgressGateway, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+}
+
+// EgressGatewayRequest represents a DigitalOcean Egress Gateway create/update request
+type EgressGatewayRequest struct {
+	Name               string        `json:"name"`
+	Type               string        `json:"type"`
+	Region             string        `json:"region"`
+	VPCs               []*IngressVPC `json:"vpcs"`
+	UDPTimeoutSeconds  uint32        `json:"udp_timeout_seconds,omitempty"`
+	ICMPTimeoutSeconds uint32        `json:"icmp_timeout_seconds,omitempty"`
+	TCPTimeoutSeconds  uint32        `json:"tcp_timeout_seconds,omitempty"`
+}
+
+// EgressGateway represents a DigitalOcean Egress Gateway resource
+type EgressGateway struct {
+	ID                 string        `json:"id"`
+	Name               string        `json:"name"`
+	Type               string        `json:"type"`
+	State              string        `json:"state"`
+	Region             string        `json:"region"`
+	VPCs               []*IngressVPC `json:"vpcs"`
+	Egresses           *Egresses     `json:"egresses,omitempty"`
+	UDPTimeoutSeconds  uint32        `json:"udp_timeout_seconds,omitempty"`
+	ICMPTimeoutSeconds uint32        `json:"icmp_timeout_seconds,omitempty"`
+	TCPTimeoutSeconds  uint32        `json:"tcp_timeout_seconds,omitempty"`
+	CreatedAt          time.Time     `json:"created_at"`
+	UpdatedAt          time.Time     `json:"updated_at"`
+}
+
+// IngressVPC defines the ingress configs supported by an Egress Gateway
+type IngressVPC struct {
+	VpcUUID              string `json:"vpc_uuid"`
+	GatewayIP            string `json:"gateway_ip,omitempty"`
+	DefaultEgressGateway bool   `json:"default_egress_gateway,omitempty"`
+}
+
+// Egresses define egress routes supported by an Egress Gateway
+type Egresses struct {
+	PublicGateways []*PublicGateway `json:"public_gateways,omitempty"`
+}
+
+// PublicGateway defines the public egress supported by an Egress Gateway
+type PublicGateway struct {
+	IPv4 string `json:"ipv4"`
+}
+
+// EgressGatewaysListOptions define custom options for listing Egress Gateways
+type EgressGatewaysListOptions struct {
+	ListOptions
+	State  []string `json:"state,omitempty"`
+	Region []string `json:"region,omitempty"`
+	Type   []string `json:"type,omitempty"`
+	Name   []string `json:"name,omitempty"`
+}
+
+type egressGatewayRoot struct {
+	EgressGateway *EgressGateway `json:"egress_gateway"`
+}
+
+type egressGatewaysRoot struct {
+	EgressGateways []*EgressGateway `json:"egress_gateways"`
+	Links          *Links           `json:"links"`
+	Meta           *Meta            `json:"meta"`
+}
+
+// EgressGatewaysServiceOp handles communication with Egress Gateway methods of the DigitalOcean API
+type EgressGatewaysServiceOp struct {
+	client *Client
+}
+
+var _ EgressGatewaysService = &EgressGatewaysServiceOp{}
+
+// Create a new Egress Gateway
+func (n *EgressGatewaysServiceOp) Create(ctx context.Context, createReq *EgressGatewayRequest) (*EgressGateway, *Response, error) {
+	req, err := n.client.NewRequest(ctx, http.MethodPost, egressGatewaysBasePath, createReq)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(egressGatewayRoot)
+	resp, err := n.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return root.EgressGateway, resp, nil
+}
+
+// Get an existing Egress Gateway
+func (n *EgressGatewaysServiceOp) Get(ctx context.Context, id string) (*EgressGateway, *Response, error) {
+	req, err := n.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", egressGatewaysBasePath, id), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(egressGatewayRoot)
+	resp, err := n.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return root.EgressGateway, resp, nil
+}
+
+// List all active Egress Gateways
+func (n *EgressGatewaysServiceOp) List(ctx context.Context, opts *EgressGatewaysListOptions) ([]*EgressGateway, *Response, error) {
+	path, err := addOptions(egressGatewaysBasePath, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := n.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(egressGatewaysRoot)
+	resp, err := n.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	if root.Links != nil {
+		resp.Links = root.Links
+	}
+	if root.Meta != nil {
+		resp.Meta = root.Meta
+	}
+	return root.EgressGateways, resp, nil
+}
+
+// Update an existing Egress Gateway
+func (n *EgressGatewaysServiceOp) Update(ctx context.Context, id string, updateReq *EgressGatewayRequest) (*EgressGateway, *Response, error) {
+	req, err := n.client.NewRequest(ctx, http.MethodPut, fmt.Sprintf("%s/%s", egressGatewaysBasePath, id), updateReq)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(egressGatewayRoot)
+	resp, err := n.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return root.EgressGateway, resp, nil
+}
+
+// Delete an existing Egress Gateway
+func (n *EgressGatewaysServiceOp) Delete(ctx context.Context, id string) (*Response, error) {
+	req, err := n.client.NewRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", egressGatewaysBasePath, id), nil)
+	if err != nil {
+		return nil, err
+	}
+	return n.client.Do(ctx, req, nil)
+}

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.146.1"
+	libraryVersion = "1.147.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.146.0"
+	libraryVersion = "1.146.1"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.147.0"
+	libraryVersion = "1.148.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -66,6 +66,7 @@ type Client struct {
 	Droplets            DropletsService
 	DropletActions      DropletActionsService
 	DropletAutoscale    DropletAutoscaleService
+	EgressGateways      EgressGatewaysService
 	Firewalls           FirewallsService
 	FloatingIPs         FloatingIPsService
 	FloatingIPActions   FloatingIPActionsService
@@ -293,6 +294,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Kubernetes = &KubernetesServiceOp{client: c}
 	c.LoadBalancers = &LoadBalancersServiceOp{client: c}
 	c.Monitoring = &MonitoringServiceOp{client: c}
+	c.EgressGateways = &EgressGatewaysServiceOp{client: c}
 	c.OneClick = &OneClickServiceOp{client: c}
 	c.Projects = &ProjectsServiceOp{client: c}
 	c.Regions = &RegionsServiceOp{client: c}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.146.1
+# github.com/digitalocean/godo v1.147.0
 ## explicit; go 1.23
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.147.0
+# github.com/digitalocean/godo v1.148.0
 ## explicit; go 1.23
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.146.0
+# github.com/digitalocean/godo v1.146.1
 ## explicit; go 1.23
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
This PR adds a new command to list an app's currently running instances. Using godo's `GetAppInstances()`. Doctl's implementation also follows godo's `GetAppInstancesOpts` to keep it future proof and aligned.  

This PR depends on https://github.com/digitalocean/godo/pull/831 to be merged and released. 

Usage will be
- ~`doctl apps instances $app_id`~
- `doctl apps list-instances $app_id`


Expected result

![image](https://github.com/user-attachments/assets/264f111f-cb66-44b8-9c79-cea7d47e2d19)
