### PR TITLE
fix: Pull RunImage only if cnb-builder image exists

### DIFF
--- a/commands/apps_dev.go
+++ b/commands/apps_dev.go
@@ -553,27 +553,29 @@ func appDevPrepareEnvironment(ctx context.Context, ws *workspace.AppDev, cli bui
 		return err
 	}
 
-	// Get stack run image from CNBBuilderImage_Heroku22.
-	builderImage, err := builder.GetImage(ctx, cli, builder.CNBBuilderImage_Heroku22)
-	if err != nil {
-		return err
-	}
-	metadataLabel := builderImage.Labels["io.buildpacks.builder.metadata"]
-
-	var metadata Metadata
-	err = json.Unmarshal([]byte(metadataLabel), &metadata)
-	if err != nil {
-		return err
-	}
-
-	exists, err := builder.ImageExists(ctx, cli, metadata.Stack.RunImage.Image)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		err := pullDockerImages(ctx, cli, []string{metadata.Stack.RunImage.Image})
+	if exist, _ := builder.ImageExists(ctx, cli, builder.CNBBuilderImage_Heroku22); exist {
+		// Get stack run image from CNBBuilderImage_Heroku22.
+		builderImage, err := builder.GetImage(ctx, cli, builder.CNBBuilderImage_Heroku22)
 		if err != nil {
 			return err
+		}
+		metadataLabel := builderImage.Labels["io.buildpacks.builder.metadata"]
+
+		var metadata Metadata
+		err = json.Unmarshal([]byte(metadataLabel), &metadata)
+		if err != nil {
+			return err
+		}
+
+		exists, err := builder.ImageExists(ctx, cli, metadata.Stack.RunImage.Image)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			err := pullDockerImages(ctx, cli, []string{metadata.Stack.RunImage.Image})
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/commands/apps_dev_test.go
+++ b/commands/apps_dev_test.go
@@ -52,7 +52,7 @@ func TestRunAppsDevBuild(t *testing.T) {
 
 			tm.appBuilder.EXPECT().Build(gomock.Any()).Return(builder.ComponentBuilderResult{}, nil)
 			tm.appBuilderFactory.EXPECT().NewComponentBuilder(gomock.Any(), ws.Context(), sampleSpec, gomock.Any()).Return(tm.appBuilder, nil)
-			tm.appDockerEngineClient.EXPECT().ImageList(gomock.Any(), gomock.Any()).Return(imageList, nil).Times(2)
+			tm.appDockerEngineClient.EXPECT().ImageList(gomock.Any(), gomock.Any()).Return(imageList, nil).Times(3)
 
 			err = RunAppsDevBuild(config)
 			require.NoError(t, err)
@@ -67,7 +67,7 @@ func TestRunAppsDevBuild(t *testing.T) {
 			require.NoError(t, err, "getting workspace")
 			tm.appBuilderFactory.EXPECT().NewComponentBuilder(gomock.Any(), ws.Context(), sampleSpec, gomock.Any()).Return(tm.appBuilder, nil)
 			tm.appBuilder.EXPECT().Build(gomock.Any()).Return(builder.ComponentBuilderResult{}, nil)
-			tm.appDockerEngineClient.EXPECT().ImageList(gomock.Any(), gomock.Any()).Return(imageList, nil).Times(2)
+			tm.appDockerEngineClient.EXPECT().ImageList(gomock.Any(), gomock.Any()).Return(imageList, nil).Times(3)
 
 			tm.apps.EXPECT().Get(appID).Times(1).Return(&godo.App{
 				Spec: sampleSpec,

--- a/integration/kubernetes_clusters_create_test.go
+++ b/integration/kubernetes_clusters_create_test.go
@@ -233,7 +233,7 @@ some-cluster-id    some-cluster-name    mars      some-kube-version    false    
   },
   "node_pools": [
     {
-      "size": "s-1vcpu-2gb",
+      "size": "s-1vcpu-2gb-intel",
       "count": 3,
       "name": "some-cluster-name-default-pool"
     }
@@ -260,7 +260,7 @@ some-cluster-id    some-cluster-name    mars      some-kube-version    false    
       "count": 2,
       "auto_scale": true,
       "name": "default",
-      "size": "s-1vcpu-2gb"
+      "size": "s-1vcpu-2gb-intel"
     }
   ]
 }


### PR DESCRIPTION
## Details

The images `CNBBuilderImage_Heroku22` and `RunImage` are required only for buildpack-based builds.
For Dockerfile-based builds, we don't need these, as the local Dockerfile is used to build the image.

This PR adds a check to pull `RunImage` only if the `BuilderImage` exists i.e. its a buildpack-based build.


This PR also fixes k8s integration tests by updating the NodePool slug as per the PR #1694 