### PR TITLE
fix suspicious characters in a regular expression

### DIFF
--- a/doit.go
+++ b/doit.go
@@ -344,7 +344,7 @@ func (c *LiveConfig) Set(ns, key string, val any) {
 
 // IsSet checks if a config is set
 func (c *LiveConfig) IsSet(key string) bool {
-	matches := regexp.MustCompile("\b*--([a-z-_]+)").FindAllStringSubmatch(strings.Join(os.Args, " "), -1)
+	matches := regexp.MustCompile(`\b--([a-z-_]+)`).FindAllStringSubmatch(strings.Join(os.Args, " "), -1)
 	if len(matches) == 0 {
 		return false
 	}


### PR DESCRIPTION
https://github.com/digitalocean/doctl/blob/b9ebaacade312d03d9f16582d9b8c5a83f71c332/doit.go#L347-L347

Fix the issue need to replace the literal backspace `\b` with the correct escape sequence for a word boundary, `\\b`. This ensures that the regular expression behaves as intended, matching command-line arguments that start with `--` and contain valid option names. Additionally, we should use a raw string literal (enclosed in backticks) to avoid confusion with escape sequences and improve readability.

The specific change will be made on line 347, replacing `"\b*--([a-z-_]+)"` with `` `\b--([a-z-_]+)` ``. The `*` after `\b` is unnecessary and will be removed, as it does not contribute meaningfully to the pattern.

---

When a character in a string literal or regular expression literal is preceded by a backslash, it is interpreted as part of an escape sequence. the escape sequence `\n` in a string literal corresponds to a single newline character, and not the `\` and n characters. There are two Go escape sequences that could produce surprising results. First, `regexp.Compile("\a")` matches the bell character, whereas `regexp.Compile("\\A")` matches the start of text and `regexp.Compile("\\a")` is a Vim (but not Go) regular expression matching any alphabetic character. Second, `regexp.Compile("\b")` matches a backspace, whereas `regexp.Compile("\\b")` matches the start of a word. Confusing one for the other could lead to a regular expression passing or failing much more often than expected, with potential security consequences. Note this is less of a problem than in some other languages because in Go, only valid escape sequences are accepted, both in an ordinary string (`s := "\k"` will not compile as there is no such escape sequence) and in regular expressions (`regexp.MustCompile("\\k")` will panic as `\k` does not refer to a character class or other special token according to Go's regular expression grammar).

**References**
- [Overview of the Regexp package](https://golang.org/pkg/regexp/)
- [Syntax of regular expressions accepted by RE2](https://github.com/google/re2/wiki/Syntax)
- [CWE-20](https://cwe.mitre.org/data/definitions/20.html)
