### PR TITLE
SERVERLESS-3399: update minimum serverless version to 5.0.21

### DIFF
--- a/do/serverless.go
+++ b/do/serverless.go
@@ -259,7 +259,7 @@ type serverlessService struct {
 
 const (
 	// Minimum required version of the functions deployer plugin code.
-	minServerlessVersion = "5.0.19"
+	minServerlessVersion = "5.0.21"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v18.17.1"


### PR DESCRIPTION
Updating the min `functions-deployer` version to `5.0.21`