### PR TITLE
projects: Add support for retrieving floating IPv6 from URN

### DIFF
--- a/commands/projects.go
+++ b/commands/projects.go
@@ -280,6 +280,8 @@ func RunProjectResourcesGet(c *CmdConfig) error {
 		return k8sCmdService.RunKubernetesClusterGet(c)
 	case "app":
 		return RunAppsGet(c)
+	case "floatingipv6":
+		return RunReservedIPv6Get(c)
 	default:
 		return fmt.Errorf("%q is an invalid resource type, consult the documentation", parts[1])
 	}


### PR DESCRIPTION
This minor change allow searching `floatingipv6` URNs searchable from `projects resources get` command