### PR TITLE
fix(realease): correct tag regex to strictly match SemVer vX.Y.Z format.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: tagged-release
 on:
   push:
     tags:
-      - 'v[1-9].[0-9]+.[0-9]+'
+      - '^v[0-9]+\.[0-9]+\.[0-9]+$'
 
 jobs:
   github-release:


### PR DESCRIPTION
### 🛠 What this PR fixes

The current `on.push.tags` pattern in the `tagged-release` workflow incorrectly matches some invalid tags and misses valid SemVer tags. Specifically:

- ✅ It **matches invalid tags** like:
  - `v2x3.4` (because `.` matches any character)
  - `v1-2-3` or `v1.2x3`
  - `v10.0.0` is ignored due to `[1-9]` limitation
  
  ####  FInd attached SCREENSHOT BELOW
![issueSEMVER](https://github.com/user-attachments/assets/2ac693d5-dae9-45ac-aed6-fc5c6bf87b86)


- ❌ It **misses valid tags** like:
  - `v0.1.0`
  - `v1.24`
  - `v1.2`

### ✅ Fix

This PR replaces the regex:
```
from: 'v[1-9].[0-9]+.[0-9]+'
to:   '^v[0-9]+\.[0-9]+(\.[0-9]+)+$' 
```

 #### FIND ATTACHED FIXED SemVer SCREENSHOT . 
![semVERfixed](https://github.com/user-attachments/assets/2e3e4d71-447d-4ebc-84b9-81ba28cbef7f)

