### PR TITLE
Add /app to $PATH in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --update --no-cache \
         openssh
 
 WORKDIR /app
+ENV PATH="/app:$PATH"
 COPY --from=build /out/doctl /app/doctl
 
 RUN adduser -D user


### PR DESCRIPTION
Add `/app` to `$PATH` in the Dockerfile to ensure that the `/app` directory is included in the container's executable search path.

### Why:

For example, when you define `cmd` in a Kubernetes manifest, you need to specify the full path to the binary.

```bash
command = [
 "/app/doctl", # <- THIS
 "registry",
 "garbage-collection",
 "start",
 "-f",
 "--include-untagged-manifests",
 "registry-name",
]
```