### PR TITLE
Updated minServerlessVersion to 5.0.22

### DIFF
--- a/do/serverless.go
+++ b/do/serverless.go
@@ -259,7 +259,7 @@ type serverlessService struct {
 
 const (
 	// Minimum required version of the functions deployer plugin code.
-	minServerlessVersion = "5.0.21"
+	minServerlessVersion = "5.0.22"
 
 	// The version of nodejs to download alongsize the plugin download.
 	nodeVersion = "v18.17.1"


### PR DESCRIPTION
Updated minServerlessVersion to 5.0.22 to get new latest functions-deployer changes.

Doc followed for the changes: https://do-internal.atlassian.net/wiki/spaces/TF/pages/1937670159/doctl+Upgrade+serverless+plugin

Ticket: https://do-internal.atlassian.net/browse/SERVERLESS-3237

Related PR: https://github.com/digitalocean/functions-deployer/pull/52