### PR TITLE
[DO NOT MERGE] fix(DOCR-1637): Fixes the integration tests for registry

### DIFF
--- a/integration/registry_login_test.go
+++ b/integration/registry_login_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -53,13 +52,13 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 					w.Write([]byte(registryDockerCredentialsExpiryResponse))
 				} else if expiryParam == "2592000" {
 					// Default 30-day expiry response for first test
-					w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}` /* gitguardian:ignore */))
+					w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`))
 				} else if expiryParam == "" {
 					if readWriteParam == "false" {
 						w.Write([]byte(registryDockerCredentialsReadOnlyRegistryResponse))
 					} else {
 						// Fallback for empty expiry (shouldn't happen with current doctl logic)
-						w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}` /* gitguardian:ignore */))
+						w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`))
 					}
 				} else {
 					t.Fatalf("received unknown value: %s", expiryParam)
@@ -186,9 +185,9 @@ const (
 )
 
 var (
-	// Test Docker auth token (base64 encoded "testuser:testpass" for testing)
-	testDockerAuthToken = base64.StdEncoding.EncodeToString([]byte("testuser:testpass")) // gitguardian:ignore
+	// Test Docker auth token (valid base64 encoding of "test:data" for testing)
+	testDockerAuthToken = "dGVzdDpkYXRh"
 
-	registryDockerCredentialsExpiryResponse           = `{"auths":{"` + expiringTest2RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}` // gitguardian:ignore
-	registryDockerCredentialsReadOnlyRegistryResponse = `{"auths":{"` + readOnlyTest3RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}` // gitguardian:ignore
+	registryDockerCredentialsExpiryResponse           = `{"auths":{"` + expiringTest2RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`
+	registryDockerCredentialsReadOnlyRegistryResponse = `{"auths":{"` + readOnlyTest3RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`
 )

--- a/integration/registry_login_test.go
+++ b/integration/registry_login_test.go
@@ -48,13 +48,17 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 
 				readWriteParam := req.URL.Query().Get("read_write")
 				expiryParam := req.URL.Query().Get("expiry_seconds")
-				if expiryParam == "3600" || expiryParam == "2592000" {
+				if expiryParam == "3600" {
 					w.Write([]byte(registryDockerCredentialsExpiryResponse))
+				} else if expiryParam == "2592000" {
+					// Default 30-day expiry response for first test
+					w.Write([]byte(`{"auths":{"expiring-test1.registry.com":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`))
 				} else if expiryParam == "" {
 					if readWriteParam == "false" {
 						w.Write([]byte(registryDockerCredentialsReadOnlyRegistryResponse))
 					} else {
-						w.Write([]byte(registryDockerCredentialsResponse))
+						// Fallback for empty expiry (shouldn't happen with current doctl logic)
+						w.Write([]byte(`{"auths":{"expiring-test1.registry.com":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`))
 					}
 				} else {
 					t.Fatalf("received unknown value: %s", expiryParam)
@@ -97,7 +101,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 
 			expect.Equal("Logging Docker in to registry.digitalocean.com\nNotice: Login valid for 30 days. Use the --expiry-seconds flag to set a shorter expiration or --never-expire for no expiration.\n", string(output))
 			for host := range dc.Auths {
-				expect.Equal("expiring.registry.com", host)
+				expect.Equal("expiring-test1.registry.com", host)
 			}
 		})
 	})
@@ -131,7 +135,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 
 			expect.Equal("Logging Docker in to registry.digitalocean.com\n", string(output))
 			for host := range dc.Auths {
-				expect.Equal("expiring.registry.com", host)
+				expect.Equal("expiring-test2.registry.com", host)
 			}
 		})
 	})
@@ -167,13 +171,13 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 
 			expect.Equal("Logging Docker in to registry.digitalocean.com\n", string(output))
 			for host := range dc.Auths {
-				expect.Equal("readonlyregistry.registry.com", host)
+				expect.Equal("readonlyregistry-test3.registry.com", host)
 			}
 		})
 	})
 })
 
 const (
-	registryDockerCredentialsExpiryResponse           = `{"auths":{"expiring.registry.com":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`
-	registryDockerCredentialsReadOnlyRegistryResponse = `{"auths":{"readonlyregistry.registry.com":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`
+	registryDockerCredentialsExpiryResponse           = `{"auths":{"expiring-test2.registry.com":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`
+	registryDockerCredentialsReadOnlyRegistryResponse = `{"auths":{"readonlyregistry-test3.registry.com":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`
 )

--- a/integration/registry_login_test.go
+++ b/integration/registry_login_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -182,9 +183,11 @@ const (
 	expiringTest1RegistryHost = "expiring-test1.registry.com"
 	expiringTest2RegistryHost = "expiring-test2.registry.com"
 	readOnlyTest3RegistryHost = "readonlyregistry-test3.registry.com"
+)
 
-	// Test Docker auth token (base64 encoded "credentials:thatexpire" for testing)
-	testDockerAuthToken = "Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="
+var (
+	// Test Docker auth token (base64 encoded "testuser:testpass" for testing)
+	testDockerAuthToken = base64.StdEncoding.EncodeToString([]byte("testuser:testpass"))
 
 	registryDockerCredentialsExpiryResponse           = `{"auths":{"` + expiringTest2RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`
 	registryDockerCredentialsReadOnlyRegistryResponse = `{"auths":{"` + readOnlyTest3RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`

--- a/integration/registry_login_test.go
+++ b/integration/registry_login_test.go
@@ -52,13 +52,13 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 					w.Write([]byte(registryDockerCredentialsExpiryResponse))
 				} else if expiryParam == "2592000" {
 					// Default 30-day expiry response for first test
-					w.Write([]byte(`{"auths":{"expiring-test1.registry.com":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`))
+					w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`))
 				} else if expiryParam == "" {
 					if readWriteParam == "false" {
 						w.Write([]byte(registryDockerCredentialsReadOnlyRegistryResponse))
 					} else {
 						// Fallback for empty expiry (shouldn't happen with current doctl logic)
-						w.Write([]byte(`{"auths":{"expiring-test1.registry.com":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`))
+						w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`))
 					}
 				} else {
 					t.Fatalf("received unknown value: %s", expiryParam)
@@ -101,7 +101,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 
 			expect.Equal("Logging Docker in to registry.digitalocean.com\nNotice: Login valid for 30 days. Use the --expiry-seconds flag to set a shorter expiration or --never-expire for no expiration.\n", string(output))
 			for host := range dc.Auths {
-				expect.Equal("expiring-test1.registry.com", host)
+				expect.Equal(expiringTest1RegistryHost, host)
 			}
 		})
 	})
@@ -135,7 +135,7 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 
 			expect.Equal("Logging Docker in to registry.digitalocean.com\n", string(output))
 			for host := range dc.Auths {
-				expect.Equal("expiring-test2.registry.com", host)
+				expect.Equal(expiringTest2RegistryHost, host)
 			}
 		})
 	})
@@ -171,13 +171,18 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 
 			expect.Equal("Logging Docker in to registry.digitalocean.com\n", string(output))
 			for host := range dc.Auths {
-				expect.Equal("readonlyregistry-test3.registry.com", host)
+				expect.Equal(readOnlyTest3RegistryHost, host)
 			}
 		})
 	})
 })
 
 const (
-	registryDockerCredentialsExpiryResponse           = `{"auths":{"expiring-test2.registry.com":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`
-	registryDockerCredentialsReadOnlyRegistryResponse = `{"auths":{"readonlyregistry-test3.registry.com":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`
+	// Test hostnames for unique keychain entries
+	expiringTest1RegistryHost = "expiring-test1.registry.com"
+	expiringTest2RegistryHost = "expiring-test2.registry.com"
+	readOnlyTest3RegistryHost = "readonlyregistry-test3.registry.com"
+
+	registryDockerCredentialsExpiryResponse           = `{"auths":{"` + expiringTest2RegistryHost + `":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`
+	registryDockerCredentialsReadOnlyRegistryResponse = `{"auths":{"` + readOnlyTest3RegistryHost + `":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`
 )

--- a/integration/registry_login_test.go
+++ b/integration/registry_login_test.go
@@ -52,13 +52,13 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 					w.Write([]byte(registryDockerCredentialsExpiryResponse))
 				} else if expiryParam == "2592000" {
 					// Default 30-day expiry response for first test
-					w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`))
+					w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`))
 				} else if expiryParam == "" {
 					if readWriteParam == "false" {
 						w.Write([]byte(registryDockerCredentialsReadOnlyRegistryResponse))
 					} else {
 						// Fallback for empty expiry (shouldn't happen with current doctl logic)
-						w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`))
+						w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`))
 					}
 				} else {
 					t.Fatalf("received unknown value: %s", expiryParam)
@@ -183,6 +183,9 @@ const (
 	expiringTest2RegistryHost = "expiring-test2.registry.com"
 	readOnlyTest3RegistryHost = "readonlyregistry-test3.registry.com"
 
-	registryDockerCredentialsExpiryResponse           = `{"auths":{"` + expiringTest2RegistryHost + `":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`
-	registryDockerCredentialsReadOnlyRegistryResponse = `{"auths":{"` + readOnlyTest3RegistryHost + `":{"auth":"Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="}}}`
+	// Test Docker auth token (base64 encoded "credentials:thatexpire" for testing)
+	testDockerAuthToken = "Y3JlZGVudGlhbHM6dGhhdGV4cGlyZQ=="
+
+	registryDockerCredentialsExpiryResponse           = `{"auths":{"` + expiringTest2RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`
+	registryDockerCredentialsReadOnlyRegistryResponse = `{"auths":{"` + readOnlyTest3RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`
 )

--- a/integration/registry_login_test.go
+++ b/integration/registry_login_test.go
@@ -53,13 +53,13 @@ var _ = suite("registry/login", func(t *testing.T, when spec.G, it spec.S) {
 					w.Write([]byte(registryDockerCredentialsExpiryResponse))
 				} else if expiryParam == "2592000" {
 					// Default 30-day expiry response for first test
-					w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`))
+					w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}` /* gitguardian:ignore */))
 				} else if expiryParam == "" {
 					if readWriteParam == "false" {
 						w.Write([]byte(registryDockerCredentialsReadOnlyRegistryResponse))
 					} else {
 						// Fallback for empty expiry (shouldn't happen with current doctl logic)
-						w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`))
+						w.Write([]byte(`{"auths":{"` + expiringTest1RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}` /* gitguardian:ignore */))
 					}
 				} else {
 					t.Fatalf("received unknown value: %s", expiryParam)
@@ -187,8 +187,8 @@ const (
 
 var (
 	// Test Docker auth token (base64 encoded "testuser:testpass" for testing)
-	testDockerAuthToken = base64.StdEncoding.EncodeToString([]byte("testuser:testpass"))
+	testDockerAuthToken = base64.StdEncoding.EncodeToString([]byte("testuser:testpass")) // gitguardian:ignore
 
-	registryDockerCredentialsExpiryResponse           = `{"auths":{"` + expiringTest2RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`
-	registryDockerCredentialsReadOnlyRegistryResponse = `{"auths":{"` + readOnlyTest3RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}`
+	registryDockerCredentialsExpiryResponse           = `{"auths":{"` + expiringTest2RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}` // gitguardian:ignore
+	registryDockerCredentialsReadOnlyRegistryResponse = `{"auths":{"` + readOnlyTest3RegistryHost + `":{"auth":"` + testDockerAuthToken + `"}}}` // gitguardian:ignore
 )


### PR DESCRIPTION
[DO NOT MERGE] intermittent integration test failures for DOCR registry login were resolved by identifying and fixing a keychain race condition, where multiple tests created unique server URLs to prevent simultaneous keychain entry conflicts.