### PR TITLE
Adding support for beta tag automation

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -76,7 +76,7 @@ jobs:
         id: version
         run: |
           BETA_TAG=${GITHUB_REF#refs/tags/}
-          STABLE_TAG=${BETA_TAG%-beta*}
+          STABLE_TAG=${BETA_TAG%-beta}
           echo "stable_tag=$STABLE_TAG" >> $GITHUB_OUTPUT
           echo "Beta tag: $BETA_TAG"
           echo "Stable tag: $STABLE_TAG"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -3,7 +3,7 @@ name: beta-release
 on:
   push:
     tags:
-      - 'v[1-9].[0-9]+.[0-9]+-beta*'
+      - 'v[1-9].[0-9]+.[0-9]+-beta'
 
 jobs:
   integration-tests:

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,79 @@
+name: beta-release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-beta*'
+
+jobs:
+  integration-tests:
+    name: 'Integration Tests'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - name: Run integration tests
+        run: make test_integration
+
+  beta-release:
+    name: 'Beta Release'
+    needs: integration-tests
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - name: Run GoReleaser (Beta)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  promote-to-stable:
+    name: 'Promote to Stable'
+    needs: [integration-tests, beta-release]
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from beta tag
+        id: version
+        run: |
+          BETA_TAG=${GITHUB_REF#refs/tags/}
+          STABLE_TAG=${BETA_TAG%-beta*}
+          echo "stable_tag=$STABLE_TAG" >> $GITHUB_OUTPUT
+          echo "Beta tag: $BETA_TAG"
+          echo "Stable tag: $STABLE_TAG"
+
+      - name: Create stable tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ steps.version.outputs.stable_tag }}
+          git push origin ${{ steps.version.outputs.stable_tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -3,7 +3,7 @@ name: beta-release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+-beta*'
+      - 'v[1-9].[0-9]+.[0-9]+-beta*'
 
 jobs:
   integration-tests:
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.24.x
 
       - name: Run integration tests
         run: make test_integration
@@ -35,11 +35,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.24.x
 
       - name: Run GoReleaser (Beta)
         uses: goreleaser/goreleaser-action@v6
@@ -47,6 +52,13 @@ jobs:
           distribution: goreleaser
           version: "~> v2"
           args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Mark beta as pre-release
+        run: |
+          BETA_TAG=${GITHUB_REF#refs/tags/}
+          gh release edit "$BETA_TAG" --prerelease
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,33 @@ name: tagged-release
 on:
   push:
     tags:
-      - 'v[1-9].[0-9]+.[0-9]+'
+      - 'v[1-9].[0-9]+.[0-9]'
 
 jobs:
+  integration-tests:
+    name: 'Integration Tests'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.24.x
+
+      - name: Run integration tests
+        run: make test_integration
+
   github-release:
     name: 'GitHub Release'
+    needs: integration-tests
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout code
@@ -40,6 +62,7 @@ jobs:
 
   snapcraft-stable:
     name: 'Snapcraft: Stable Release'
+    needs: integration-tests
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,16 +3,15 @@ name: tagged-release
 on:
   push:
     tags:
-      - 'v[1-9].[0-9]+.[0-9]'
+      - 'v[1-9].[0-9]+.[0-9]+'
 
 jobs:
   integration-tests:
     name: 'Integration Tests'
-    runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        runs-on: ${{ matrix.os }}
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,40 +3,41 @@ name: tagged-release
 on:
   push:
     tags:
-      - 'v[1-9].[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  integration-tests:
-    name: 'Integration Tests'
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+  check-beta:
+    name: 'Check Beta Release'
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.24.x
-
-      - name: Run integration tests
-        run: make test_integration
+      - name: Verify beta tag exists
+        run: |
+          STABLE_TAG=${GITHUB_REF#refs/tags/}
+          BETA_TAG="${STABLE_TAG}-beta"
+          
+          echo "Checking for beta tag: $BETA_TAG"
+          
+          if git tag -l | grep -q "^${BETA_TAG}$"; then
+            echo "✅ Beta tag $BETA_TAG found"
+          else
+            echo "❌ Beta tag $BETA_TAG not found"
+            echo "Please create and test a beta release first: make beta-tag BUMP=<version>"
+            exit 1
+          fi
 
   github-release:
     name: 'GitHub Release'
-    needs: integration-tests
+    needs: check-beta
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # https://github.com/marketplace/actions/goreleaser-action#usage
-          # note the fetch-depth: 0 input in Checkout step. It is required for
-          # the changelog to work correctly
           fetch-depth: 0
 
       - name: Login to Docker Hub
@@ -48,7 +49,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24.x
+          go-version: 1.21.x
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
@@ -61,13 +62,12 @@ jobs:
 
   snapcraft-stable:
     name: 'Snapcraft: Stable Release'
-    needs: integration-tests
+    needs: check-beta
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # fetch-depth: 0 fetches all history for all branches and tags
           fetch-depth: 0
 
       - name: Build snap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,18 @@ name: tagged-release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[1-9].[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      stable_tag:
+        description: 'Stable tag to release'
+        required: true
+        type: string
+      promoted_from_beta:
+        description: 'Was this promoted from beta?'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   check-beta:
@@ -13,20 +24,33 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          # https://github.com/marketplace/actions/goreleaser-action#usage
+          # note the fetch-depth: 0 input in Checkout step. It is required for
+          # the changelog to work correctly
           fetch-depth: 0
 
       - name: Verify beta tag exists
         run: |
-          STABLE_TAG=${GITHUB_REF#refs/tags/}
-          BETA_TAG="${STABLE_TAG}-beta"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            STABLE_TAG="${{ github.event.inputs.stable_tag }}"
+            echo "Manual trigger for: $STABLE_TAG"
+            if [ "${{ github.event.inputs.promoted_from_beta }}" = "true" ]; then
+              echo "✅ This is a beta promotion, skipping beta check"
+              exit 0
+            fi
+          else
+            STABLE_TAG=${GITHUB_REF#refs/tags/}
+            echo "Tag-triggered release for: $STABLE_TAG"
+          fi
           
+          BETA_TAG="${STABLE_TAG}-beta"
           echo "Checking for beta tag: $BETA_TAG"
           
           if git tag -l | grep -q "^${BETA_TAG}$"; then
             echo "✅ Beta tag $BETA_TAG found"
           else
             echo "❌ Beta tag $BETA_TAG not found"
-            echo "Please create and test a beta release first: make beta-tag BUMP=<version>"
+            echo "Please create and test a beta release first: make tag BUMP=<version>"
             exit 1
           fi
 
@@ -49,7 +73,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.24.x
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
@@ -68,6 +92,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          # fetch-depth: 0 fetches all history for all branches and tags
           fetch-depth: 0
 
       - name: Build snap

--- a/scripts/bumpversion.sh
+++ b/scripts/bumpversion.sh
@@ -35,7 +35,7 @@ elif [[ $(git status --porcelain -b | grep -e "ahead" -e "behind") != "" ]]; the
 fi  
 
 echo
-new_version="v${major}.${minor}.${patch}"
+new_version="v${major}.${minor}.${patch}-beta"
 
 git tag -m "release ${new_version}" -a "$new_version" && git push "${ORIGIN}" tag "$new_version"
 


### PR DESCRIPTION
Adding a beta tag where all release activities will be tested and only post completion will the release be marked as latest

End-to-End Flow:
Developer: make tag BUMP=minor
Creates: v1.23.0-beta tag
Beta workflow triggers:
✅ Runs integration tests (Ubuntu + macOS)
✅ Creates beta release (marked as pre-release)
✅ Auto-creates stable tag v1.23.0
Stable workflow triggers:
✅ Verifies beta tag exists
✅ Creates stable release (marked as latest)
✅ Publishes to Snapcraft