### PR TITLE
fix(databases): make --user optional for pool create (#1758)

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -1319,7 +1319,6 @@ func RunDatabasePoolCreate(c *CmdConfig) error {
 
 	return displayDatabasePools(c, *pool)
 }
-
 func buildDatabaseCreatePoolRequestFromArgs(c *CmdConfig) (*godo.DatabaseCreatePoolRequest, error) {
 	req := &godo.DatabaseCreatePoolRequest{Name: c.Args[1]}
 
@@ -1335,17 +1334,17 @@ func buildDatabaseCreatePoolRequestFromArgs(c *CmdConfig) (*godo.DatabaseCreateP
 	}
 	req.Size = size
 
-	db, err := c.Doit.GetString(c.NS, doctl.ArgDatabasePoolDBName)
+	db, err := c.Doit.GetString(c.NS, doctl.ArgDago version
+tabasePoolDBName)
 	if err != nil {
 		return nil, err
 	}
 	req.Database = db
 
-	user, err := c.Doit.GetString(c.NS, doctl.ArgDatabasePoolUserName)
-	if err != nil {
-		return nil, err
+	user, _ := c.Doit.GetString(c.NS, doctl.ArgDatabasePoolUserName)
+	if user != "" {
+		req.User = user
 	}
-	req.User = user
 
 	return req, nil
 }


### PR DESCRIPTION
Closes #1758

This PR makes the `--user` flag optional in `doctl databases pool create`.

Previously, omitting the flag caused:
> Error: (pool.create.user) command is missing required arguments

According to the API and docs, user is optional — if not supplied, the server uses the default inbound user.  
This change skips setting `req.User` when no flag value is provided.

- Keeps behavior unchanged when `--user` is supplied.
- Prevents unnecessary error when omitted.
- Passes local build and formatting checks.
