### PR TITLE
Make --user flag optional for database pool creation

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -1341,11 +1341,8 @@ func buildDatabaseCreatePoolRequestFromArgs(c *CmdConfig) (*godo.DatabaseCreateP
 	}
 	req.Database = db
 
-	user, err := c.Doit.GetString(c.NS, doctl.ArgDatabasePoolUserName)
-	if err != nil {
-		return nil, err
-	}
-	req.User = user
+       user, _ := c.Doit.GetString(c.NS, doctl.ArgDatabasePoolUserName)
+       req.User = user
 
 	return req, nil
 }


### PR DESCRIPTION
Fixes #1758

The --user flag was incorrectly treated as required during database pool creation. 
- Modified databases.go to ignore missing --user flag