### PR TITLE
Update GitHub actions to their latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install Go
       uses: actions/setup-go@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v5
 
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # https://github.com/marketplace/actions/goreleaser-action#usage
           # note the fetch-depth: 0 input in Checkout step. It is required for
@@ -65,7 +65,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # fetch-depth: 0 fetches all history for all branches and tags
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,8 @@ jobs:
         uses: snapcore/action-build@v1
         id: build
 
-      - uses: snapcore/action-publish@master
+      - name: Publish snap
+        uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: 1.24.x
 
@@ -46,7 +46,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: 1.24.x
 

--- a/.github/workflows/snapcraft-candidate.yml
+++ b/.github/workflows/snapcraft-candidate.yml
@@ -20,7 +20,8 @@ jobs:
         uses: snapcore/action-build@v1
         id: build
 
-      - uses: snapcore/action-publish@master
+      - name: Publish snap
+        uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_TOKEN }}
         with:

--- a/.github/workflows/snapcraft-candidate.yml
+++ b/.github/workflows/snapcraft-candidate.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           # fetch-depth: 0 fetches all history for all branches and tags
           fetch-depth: 0

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Check spelling
       uses: crate-ci/typos@v1.23.2
-

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -17,4 +17,4 @@ jobs:
       uses: actions/checkout@v5
 
     - name: Check spelling
-      uses: crate-ci/typos@v1.23.2
+      uses: crate-ci/typos@v1.38.1


### PR DESCRIPTION
In #1441 most of these versions were last updated. Moreover, Dependabot was configured there to update these, but apparently there is some reason this is not happening.

Therefore I've opened this PR to ensure all actions are up-to-date. It may be worthwhile to investigate why Dependabot PRs are not automatically generated for this.