### PR TITLE
Fixes #1822: fix list-job-invocations command

### DIFF
--- a/commands/apps.go
+++ b/commands/apps.go
@@ -201,8 +201,8 @@ Only basic information is included with the text output format. For complete app
 		displayerType(&displayers.JobInvocations{}),
 	)
 
-	AddStringSliceFlag(listJobInvocations, doctl.ArgAppDeployment, "", []string{}, "The deployment ID to filter job invocations for. If not provided, all job invocations for given app are returned.")
-	AddStringSliceFlag(listJobInvocations, doctl.ArgAppJobName, "", []string{}, "The job name to filter job invocations for. If not provided, all job invocations for given app are returned.")
+	AddStringFlag(listJobInvocations, doctl.ArgAppDeployment, "", "", "The deployment ID to filter job invocations for. If not provided, all job invocations for given app are returned.")
+	AddStringFlag(listJobInvocations, doctl.ArgAppJobName, "", "", "The job name to filter job invocations for. If not provided, all job invocations for given app are returned.")
 
 	listJobInvocations.Example = `The following example retrieves the list of job invocations for the app with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + ` and the deployment ID ` + "`" + `418b7972-fc67-41ea-ab4b-6f9477c4f7d8` + "`" + ` and the job ` + "`" + `cron` + "`" + `: doctl apps list-job-invocations f81d4fae-7dec-11d0-a765-00a0c91e6bf6 --job-name cron --deployment 418b7972-fc67-41ea-ab4b-6f9477c4f7d8`
 
@@ -1478,7 +1478,10 @@ func RunAppsListJobInvocations(c *CmdConfig) error {
 
 	opts := &godo.ListJobInvocationsOptions{
 		DeploymentID: deploymentID,
-		JobNames:     []string{jobName},
+	}
+
+	if jobName != "" {
+		opts.JobNames = []string{jobName}
 	}
 
 	invocations, err := c.Apps().ListJobInvocations(appID, opts)


### PR DESCRIPTION
## Details:

`--job-name` flag is used to send job-name as query_param in the API but it was also sedning empty strings, causing it to return no results.
This PR adds an empty string check to fix this.

<img width="1369" height="236" alt="Screenshot 2026-03-23 at 6 33 48 PM" src="https://github.com/user-attachments/assets/56397c94-3b21-4786-a658-a987388e25f9" />
