### PR TITLE
doctl apps spec get not returning authority correctly #1782

### DIFF
--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -955,6 +955,289 @@ services:
 	})
 }
 
+func TestRunAppSpecGet_AuthoritySerialization(t *testing.T) {
+	exactEmpty := ""
+	exactDomain := "example.com"
+	pathPrefixSlash := "/"
+	pathPrefixEmpty := ""
+
+	tests := []struct {
+		name         string
+		exact        *string
+		pathPrefix   *string // nil means use "/"
+		wantJSON     string
+		wantYAML     string
+	}{
+		{
+			name:  "authority with empty exact string",
+			exact: &exactEmpty,
+			pathPrefix: nil,
+			wantJSON: `{
+  "name": "test",
+  "services": [
+    {
+      "name": "service",
+      "github": {
+        "repo": "digitalocean/doctl",
+        "branch": "main"
+      }
+    }
+  ],
+  "ingress": {
+    "rules": [
+      {
+        "match": {
+          "path": {
+            "prefix": "/"
+          },
+          "authority": {
+            "exact": ""
+          }
+        },
+        "component": {
+          "name": "service"
+        }
+      }
+    ]
+  }
+}
+`,
+			wantYAML: `ingress:
+  rules:
+  - component:
+      name: service
+    match:
+      authority:
+        exact: ""
+      path:
+        prefix: /
+name: test
+services:
+- github:
+    branch: main
+    repo: digitalocean/doctl
+  name: service
+`,
+		},
+		{
+			name:  "authority with non-empty exact string",
+			exact: &exactDomain,
+			pathPrefix: nil,
+			wantJSON: `{
+  "name": "test",
+  "services": [
+    {
+      "name": "service",
+      "github": {
+        "repo": "digitalocean/doctl",
+        "branch": "main"
+      }
+    }
+  ],
+  "ingress": {
+    "rules": [
+      {
+        "match": {
+          "path": {
+            "prefix": "/"
+          },
+          "authority": {
+            "exact": "example.com"
+          }
+        },
+        "component": {
+          "name": "service"
+        }
+      }
+    ]
+  }
+}
+`,
+			wantYAML: `ingress:
+  rules:
+  - component:
+      name: service
+    match:
+      authority:
+        exact: example.com
+      path:
+        prefix: /
+name: test
+services:
+- github:
+    branch: main
+    repo: digitalocean/doctl
+  name: service
+`,
+		},
+		{
+			name:  "no authority set",
+			exact: nil,
+			pathPrefix: nil,
+			wantJSON: `{
+  "name": "test",
+  "services": [
+    {
+      "name": "service",
+      "github": {
+        "repo": "digitalocean/doctl",
+        "branch": "main"
+      }
+    }
+  ],
+  "ingress": {
+    "rules": [
+      {
+        "match": {
+          "path": {
+            "prefix": "/"
+          }
+        },
+        "component": {
+          "name": "service"
+        }
+      }
+    ]
+  }
+}
+`,
+			wantYAML: `ingress:
+  rules:
+  - component:
+      name: service
+    match:
+      path:
+        prefix: /
+name: test
+services:
+- github:
+    branch: main
+    repo: digitalocean/doctl
+  name: service
+`,
+		},
+		{
+			name:  "authority with empty exact string and empty path prefix",
+			exact: &exactEmpty,
+			pathPrefix: &pathPrefixEmpty,
+			wantJSON: `{
+  "name": "test",
+  "services": [
+    {
+      "name": "service",
+      "github": {
+        "repo": "digitalocean/doctl",
+        "branch": "main"
+      }
+    }
+  ],
+  "ingress": {
+    "rules": [
+      {
+        "match": {
+          "path": {
+            "prefix": ""
+          },
+          "authority": {
+            "exact": ""
+          }
+        },
+        "component": {
+          "name": "service"
+        }
+      }
+    ]
+  }
+}
+`,
+			wantYAML: `ingress:
+  rules:
+  - component:
+      name: service
+    match:
+      authority:
+        exact: ""
+      path:
+        prefix: ""
+name: test
+services:
+- github:
+    branch: main
+    repo: digitalocean/doctl
+  name: service
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				var authority *godo.AppIngressSpecRuleStringMatch
+				if tc.exact != nil {
+					authority = &godo.AppIngressSpecRuleStringMatch{Exact: tc.exact}
+				}
+
+				pathForMatch := &pathPrefixSlash
+				if tc.pathPrefix != nil {
+					pathForMatch = tc.pathPrefix
+				}
+
+				spec := &godo.AppSpec{
+					Name: "test",
+					Services: []*godo.AppServiceSpec{
+						{
+							Name: "service",
+							GitHub: &godo.GitHubSourceSpec{
+								Repo:   "digitalocean/doctl",
+								Branch: "main",
+							},
+						},
+					},
+					Ingress: &godo.AppIngressSpec{
+						Rules: []*godo.AppIngressSpecRule{
+							{
+								Match: &godo.AppIngressSpecRuleMatch{
+									Path:      &godo.AppIngressSpecRuleStringMatch{Prefix: pathForMatch},
+									Authority: authority,
+								},
+								Component: &godo.AppIngressSpecRuleRoutingComponent{Name: "service"},
+							},
+						},
+					},
+				}
+
+				app := &godo.App{
+					ID:   uuid.New().String(),
+					Spec: spec,
+				}
+
+				tm.apps.EXPECT().Get(app.ID).Times(2).Return(app, nil)
+
+				t.Run("json", func(t *testing.T) {
+					var buf bytes.Buffer
+					config.Doit.Set(config.NS, doctl.ArgFormat, "json")
+					config.Args = append(config.Args, app.ID)
+					config.Out = &buf
+
+					err := RunAppsSpecGet(config)
+					require.NoError(t, err)
+					require.Equal(t, tc.wantJSON, buf.String())
+				})
+
+				t.Run("yaml", func(t *testing.T) {
+					var buf bytes.Buffer
+					config.Doit.Set(config.NS, doctl.ArgFormat, "yaml")
+					config.Args = append(config.Args, app.ID)
+					config.Out = &buf
+
+					err := RunAppsSpecGet(config)
+					require.NoError(t, err)
+					require.Equal(t, tc.wantYAML, buf.String())
+				})
+			})
+		})
+	}
+}
 func TestRunAppsListRegions(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		regions := []*godo.AppRegion{{

--- a/commands/apps_test.go
+++ b/commands/apps_test.go
@@ -962,15 +962,15 @@ func TestRunAppSpecGet_AuthoritySerialization(t *testing.T) {
 	pathPrefixEmpty := ""
 
 	tests := []struct {
-		name         string
-		exact        *string
-		pathPrefix   *string // nil means use "/"
-		wantJSON     string
-		wantYAML     string
+		name       string
+		exact      *string
+		pathPrefix *string // nil means use "/"
+		wantJSON   string
+		wantYAML   string
 	}{
 		{
-			name:  "authority with empty exact string",
-			exact: &exactEmpty,
+			name:       "authority with empty exact string",
+			exact:      &exactEmpty,
 			pathPrefix: nil,
 			wantJSON: `{
   "name": "test",
@@ -1020,8 +1020,8 @@ services:
 `,
 		},
 		{
-			name:  "authority with non-empty exact string",
-			exact: &exactDomain,
+			name:       "authority with non-empty exact string",
+			exact:      &exactDomain,
 			pathPrefix: nil,
 			wantJSON: `{
   "name": "test",
@@ -1071,8 +1071,8 @@ services:
 `,
 		},
 		{
-			name:  "no authority set",
-			exact: nil,
+			name:       "no authority set",
+			exact:      nil,
 			pathPrefix: nil,
 			wantJSON: `{
   "name": "test",
@@ -1117,8 +1117,8 @@ services:
 `,
 		},
 		{
-			name:  "authority with empty exact string and empty path prefix",
-			exact: &exactEmpty,
+			name:       "authority with empty exact string and empty path prefix",
+			exact:      &exactEmpty,
 			pathPrefix: &pathPrefixEmpty,
 			wantJSON: `{
   "name": "test",

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -373,8 +373,8 @@ type AppIngressSpecRuleRoutingRedirect struct {
 // AppIngressSpecRuleStringMatch The string match configuration.
 type AppIngressSpecRuleStringMatch struct {
 	// Prefix-based match. For example, `/api` will match `/api`, `/api/`, and any nested paths such as `/api/v1/endpoint`.
-	Prefix string `json:"prefix,omitempty"`
-	Exact  string `json:"exact,omitempty"`
+	Prefix *string `json:"prefix,omitempty"`
+	Exact  *string `json:"exact,omitempty"`
 }
 
 type AppSecureHeaderSpec struct {

--- a/vendor/github.com/digitalocean/godo/apps_accessors.go
+++ b/vendor/github.com/digitalocean/godo/apps_accessors.go
@@ -1047,18 +1047,18 @@ func (a *AppIngressSpecRuleRoutingRedirect) GetUri() string {
 
 // GetExact returns the Exact field.
 func (a *AppIngressSpecRuleStringMatch) GetExact() string {
-	if a == nil {
+	if a == nil || a.Exact == nil {
 		return ""
 	}
-	return a.Exact
+	return *a.Exact
 }
 
 // GetPrefix returns the Prefix field.
 func (a *AppIngressSpecRuleStringMatch) GetPrefix() string {
-	if a == nil {
+	if a == nil || a.Prefix == nil {
 		return ""
 	}
-	return a.Prefix
+	return *a.Prefix
 }
 
 // GetComponentName returns the ComponentName field.


### PR DESCRIPTION
Root Cause
The bug is in the AppIngressSpecRuleStringMatch struct in godo (v1.184.0), defined in vendor/github.com/digitalocean/godo/apps.gen.go:


type AppIngressSpecRuleStringMatch struct {
    Prefix string `json:"prefix,omitempty"`
    Exact  string `json:"exact,omitempty"`
}

Fix
Changed Prefix and Exact from string to *string in AppIngressSpecRuleStringMatch

Issue - https://github.com/digitalocean/doctl/issues/1782
https://github.com/digitalocean/godo/issues/937
