### PR TITLE
fix(registry): use RepositoryV2 displayer for list-v2 commands

### DIFF
--- a/commands/displayers/registry.go
+++ b/commands/displayers/registry.go
@@ -113,7 +113,7 @@ type RepositoryV2 struct {
 	Repositories []do.RepositoryV2
 }
 
-var _ Displayable = &Repository{}
+var _ Displayable = &RepositoryV2{}
 
 func (r *RepositoryV2) JSON(out io.Writer) error {
 	return writeJSON(r.Repositories, out)

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -181,7 +181,7 @@ func Repository() *Command {
 		cmd,
 		RunListRepositoriesV2, "list-v2",
 		"List repositories for a container registry", listRepositoriesV2Desc,
-		Writer, aliasOpt("ls2"), displayerType(&displayers.Repository{}),
+		Writer, aliasOpt("ls2"), displayerType(&displayers.RepositoryV2{}),
 	)
 	cmdListRepositoriesV2.overrideNS = overrideNS
 	addRegistryFlag(cmdListRepositoriesV2)
@@ -1581,7 +1581,7 @@ func RegistriesRepository() *Command {
 		cmd,
 		RunRegistriesListRepositoriesV2, "list-v2 <registry-name>",
 		"List repositories for a container registry", listRepositoriesV2Desc,
-		Writer, aliasOpt("ls2"), displayerType(&displayers.Repository{}),
+		Writer, aliasOpt("ls2"), displayerType(&displayers.RepositoryV2{}),
 	)
 	cmdListRepositoriesV2.overrideNS = overrideNS
 	cmdListRepositoriesV2.Example = `The following example lists repositories in a registry named ` + "`" + `example-registry` + "`" + ` and uses the ` + "`" + `--format` + "`" + ` flag to return only the name and update time of each repository: doctl registries repository list-v2 example-registry --format Name,UpdatedAt`

--- a/commands/registry_test.go
+++ b/commands/registry_test.go
@@ -334,6 +334,24 @@ func TestRepositoryListV2(t *testing.T) {
 			assert.False(t, strings.Contains(output, testRepositoryV2NoTags.LatestManifest.Blobs[0].Digest))
 		})
 	})
+
+	t.Run("respects format and no-header flags", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			tm.registry.EXPECT().Get().Return(&testRegistry, nil)
+			tm.registry.EXPECT().ListRepositoriesV2(testRepositoryV2.RegistryName).Return([]do.RepositoryV2{testRepositoryV2}, nil)
+
+			config.NS = "registry.repository.list-v2"
+			config.Doit.Set(config.NS, doctl.ArgFormat, "Name")
+			config.Doit.Set(config.NS, doctl.ArgNoHeader, true)
+
+			var buf bytes.Buffer
+			config.Out = &buf
+			err := RunListRepositoriesV2(config)
+			assert.NoError(t, err)
+
+			assert.Equal(t, testRepositoryV2.Name+"\n", buf.String())
+		})
+	})
 }
 
 func TestRepositoryListTags(t *testing.T) {


### PR DESCRIPTION
## Summary

- Register `displayers.RepositoryV2` for `registry repository list-v2` and `registries repository list-v2` so `--format` and `--no-header` use the correct column definitions.
- Fix the `RepositoryV2` `Displayable` compile-time assertion.
- Add a unit test that verifies `--format Name --no-header` output.

## Problem

`list-v2` registered the v1 `Repository` displayer while rendering v2 data. That caused `--format` help to list the wrong columns and prevented scripted output from honoring `--format` / `--no-header` as reported in #1797.

## Test plan

- [x] `go test ./commands/ -run TestRepositoryListV2 -count=1`
- [ ] `doctl registry repository list-v2 --format Name --no-header` returns only repository names

Fixes #1797