### PR TITLE
agents: decode SPI event stream, surface API errors, ack input

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -282,12 +282,12 @@ func RunAgentsAttach(c *CmdConfig) error {
 			case godo.HostedAgentEventKindHITLRequested:
 				var p hitlRequestedPayload
 				if err := json.Unmarshal(ev.Payload, &p); err == nil {
-					pending.set(p.Request.RequestID)
+					pending.set(p.HitlID)
 				}
 			case godo.HostedAgentEventKindHITLResolved:
 				var p hitlResolvedPayload
 				if err := json.Unmarshal(ev.Payload, &p); err == nil {
-					pending.clearIf(p.Decision.RequestID)
+					pending.clearIf(p.HitlID)
 				}
 			}
 			renderEvent(c.Out, ev)
@@ -344,8 +344,18 @@ func attachLoop(c *CmdConfig, svc do.HostedAgentsService, sessionID string, in i
 			}
 			continue
 		}
-		if _, err := svc.SendInput(sessionID, &godo.HostedAgentSendInputRequest{Text: line}); err != nil {
+		resp, err := svc.SendInput(sessionID, &godo.HostedAgentSendInputRequest{Text: line})
+		if err != nil {
 			fmt.Fprintf(c.Out, "send failed: %v\n", err)
+			continue
+		}
+		// Acknowledge the submit right away. The agent runtime can take tens of
+		// seconds to boot and produce its first token; without this line the
+		// wait looks like a hang and users re-submit, spawning a second run.
+		if resp != nil && resp.RunID != "" {
+			fmt.Fprintf(c.Out, "(queued as %s; waiting for the agent...)\n", resp.RunID)
+		} else {
+			fmt.Fprintln(c.Out, "(queued; waiting for the agent...)")
 		}
 	}
 }
@@ -393,34 +403,39 @@ func resolveFromAttach(svc do.HostedAgentsService, sessionID string, parts []str
 
 // --- event payload helpers --------------------------------------------------
 //
-// godo defines the generic HostedAgentEvent envelope but leaves the per-kind
-// payload as json.RawMessage. The shapes below are local mirrors used only for
-// rendering and are not on any HTTP wire — they exist to keep the rendering
-// switch tidy.
+// godo decodes the SPI canonical event envelope and leaves the per-kind body
+// (the wire's `data` object) as json.RawMessage on HostedAgentEvent.Payload.
+// The shapes below mirror the SPI data structs (spi/events.go) for the kinds
+// doctl renders; they exist to keep the rendering switch tidy.
 
 type tokenChunkPayload struct {
 	Text string `json:"text"`
 }
 
 type runStartedPayload struct {
-	Run godo.HostedAgentRun `json:"run"`
+	Agent string `json:"agent"`
 }
 
 type toolCallStartedPayload struct {
-	ToolName string `json:"tool_name"`
+	Name string `json:"name"`
 }
 
 type toolCallCompletedPayload struct {
+	OK         bool   `json:"ok"`
 	DurationMS int64  `json:"duration_ms"`
 	Summary    string `json:"summary,omitempty"`
 }
 
 type hitlRequestedPayload struct {
-	Request godo.HostedAgentHITLRequest `json:"request"`
+	HitlID  string         `json:"hitl_id"`
+	Payload map[string]any `json:"payload"`
 }
 
 type hitlResolvedPayload struct {
-	Decision godo.HostedAgentHITLDecision `json:"decision"`
+	HitlID  string `json:"hitl_id"`
+	Outcome int32  `json:"outcome"`
+	Actor   string `json:"actor,omitempty"`
+	Reason  string `json:"reason,omitempty"`
 }
 
 type runCompletedPayload struct {
@@ -430,13 +445,8 @@ type runCompletedPayload struct {
 }
 
 type runFailedPayload struct {
-	Code    godo.HostedAgentRunFailureCode `json:"code"`
-	Message string                         `json:"message,omitempty"`
-}
-
-type sessionUpdatedPayload struct {
-	SessionDelta  godo.HostedAgentSession `json:"session_delta"`
-	ChangedFields []string                `json:"changed_fields"`
+	Code    int32  `json:"code"`
+	Message string `json:"message,omitempty"`
 }
 
 func renderEvent(w io.Writer, ev godo.HostedAgentEvent) {
@@ -449,12 +459,16 @@ func renderEvent(w io.Writer, ev godo.HostedAgentEvent) {
 	case godo.HostedAgentEventKindRunStarted:
 		var p runStartedPayload
 		if err := json.Unmarshal(ev.Payload, &p); err == nil {
-			fmt.Fprintf(w, "\n[run %s started]\n", p.Run.RunID)
+			if p.Agent != "" {
+				fmt.Fprintf(w, "\n[run %s started (%s)]\n", ev.RunID, p.Agent)
+			} else {
+				fmt.Fprintf(w, "\n[run %s started]\n", ev.RunID)
+			}
 		}
 	case godo.HostedAgentEventKindToolCallStarted:
 		var p toolCallStartedPayload
 		if err := json.Unmarshal(ev.Payload, &p); err == nil {
-			fmt.Fprintf(w, "\n> %s ...\n", p.ToolName)
+			fmt.Fprintf(w, "\n> %s ...\n", p.Name)
 		}
 	case godo.HostedAgentEventKindToolCallCompleted:
 		var p toolCallCompletedPayload
@@ -468,12 +482,12 @@ func renderEvent(w io.Writer, ev godo.HostedAgentEvent) {
 	case godo.HostedAgentEventKindHITLRequested:
 		var p hitlRequestedPayload
 		if err := json.Unmarshal(ev.Payload, &p); err == nil {
-			renderHITLRequest(w, p.Request)
+			renderHITLRequest(w, p.HitlID, p.Payload)
 		}
 	case godo.HostedAgentEventKindHITLResolved:
 		var p hitlResolvedPayload
 		if err := json.Unmarshal(ev.Payload, &p); err == nil {
-			fmt.Fprintf(w, "\n[HITL %s -> %s]\n", p.Decision.RequestID, p.Decision.Outcome)
+			fmt.Fprintf(w, "\n[HITL %s -> %s]\n", p.HitlID, hitlOutcomeLabel(p.Outcome))
 		}
 	case godo.HostedAgentEventKindRunCompleted:
 		var p runCompletedPayload
@@ -484,39 +498,40 @@ func renderEvent(w io.Writer, ev godo.HostedAgentEvent) {
 	case godo.HostedAgentEventKindRunFailed:
 		var p runFailedPayload
 		if err := json.Unmarshal(ev.Payload, &p); err == nil {
-			fmt.Fprintf(w, "\n[run failed: %s %s]\n", p.Code, p.Message)
+			if p.Message != "" {
+				fmt.Fprintf(w, "\n[run failed: %s (code %d)]\n", p.Message, p.Code)
+			} else {
+				fmt.Fprintf(w, "\n[run failed: code %d]\n", p.Code)
+			}
 		}
 	case godo.HostedAgentEventKindSessionUpdated:
-		var p sessionUpdatedPayload
-		if err := json.Unmarshal(ev.Payload, &p); err == nil {
-			fmt.Fprintf(w, "\n[session updated: %v]\n", p.ChangedFields)
-		}
+		fmt.Fprint(w, "\n[session updated]\n")
 	}
 }
 
-func renderHITLRequest(w io.Writer, req godo.HostedAgentHITLRequest) {
-	fmt.Fprintln(w, "\n\n[HITL] Action requires approval:")
-	switch req.Action {
-	case godo.HostedAgentHITLActionBash:
-		if cmd, ok := req.Details["command"].(string); ok {
-			fmt.Fprintf(w, "  bash: %s\n", cmd)
-		}
-		if req.Workdir != "" {
-			fmt.Fprintf(w, "  workdir: %s\n", req.Workdir)
-		}
-	case godo.HostedAgentHITLActionGitHubCreatePR:
-		fmt.Fprintln(w, "  github.create_pr")
-		for _, k := range []string{"title", "branch", "base", "repo"} {
-			if v, ok := req.Details[k].(string); ok {
-				fmt.Fprintf(w, "    %s: %s\n", k, v)
-			}
-		}
+// hitlOutcomeLabel maps the proto HITLOutcome int carried on the SPI
+// human_input_received event to a human-readable verb.
+func hitlOutcomeLabel(code int32) string {
+	switch code {
+	case 1:
+		return "approve"
+	case 2:
+		return "reject"
+	case 3:
+		return "defer"
 	default:
-		fmt.Fprintf(w, "  action: %s\n", req.Action)
-		for k, v := range req.Details {
-			fmt.Fprintf(w, "    %s: %v\n", k, v)
+		return fmt.Sprintf("outcome %d", code)
+	}
+}
+
+func renderHITLRequest(w io.Writer, hitlID string, payload map[string]any) {
+	fmt.Fprintln(w, "\n\n[HITL] Action requires approval:")
+	if len(payload) > 0 {
+		// MarshalIndent sorts map keys, so output is stable run-to-run.
+		if b, err := json.MarshalIndent(payload, "  ", "  "); err == nil {
+			fmt.Fprintf(w, "  %s\n", b)
 		}
 	}
-	fmt.Fprintf(w, "  request_id: %s\n", req.RequestID)
-	fmt.Fprintf(w, "  (resolve with `/a %s`, `/r %s`, or `/d %s`)\n", req.RequestID, req.RequestID, req.RequestID)
+	fmt.Fprintf(w, "  hitl_id: %s\n", hitlID)
+	fmt.Fprintf(w, "  (resolve with `/a %s`, `/r %s`, or `/d %s`)\n", hitlID, hitlID, hitlID)
 }

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -14,6 +14,10 @@ limitations under the License.
 package commands
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -155,5 +159,108 @@ func TestRunAgentsApprove(t *testing.T) {
 		tm.hostedAgents.EXPECT().ResolveHITL("sess_test", "req_1", want).Return(nil)
 		config.Args = []string{"sess_test", "req_1", "approve"}
 		assert.NoError(t, RunAgentsApprove(config))
+	})
+}
+
+// TestHostedAgentEventDecodesSPIWire guards against the regression where the
+// SSE stream delivered events but doctl rendered nothing: the harness-api
+// serializes the SPI canonical envelope (type/data/timestamp/tenant_id), which
+// must map onto godo.HostedAgentEvent's Kind/Payload/At/TeamID fields. This is
+// a verbatim run.token_delta frame from the harness-api demo stream.
+func TestHostedAgentEventDecodesSPIWire(t *testing.T) {
+	const frame = `{"event_id":"01KTBXPBY60VYC5YKF6AKDX0ZS","run_id":"run-7f16719a-da1c-449d-a4ca-18e524bb63e3","tenant_id":"120","session_id":"sess_5a1ff33e","timestamp":"2026-06-05T12:56:24.774753219Z","seq":0,"type":"run.token_delta","data":{"text":"Paris"}}`
+
+	var ev godo.HostedAgentEvent
+	assert.NoError(t, json.Unmarshal([]byte(frame), &ev))
+
+	assert.Equal(t, "01KTBXPBY60VYC5YKF6AKDX0ZS", ev.EventID)
+	assert.Equal(t, "run-7f16719a-da1c-449d-a4ca-18e524bb63e3", ev.RunID)
+	assert.Equal(t, "sess_5a1ff33e", ev.SessionID)
+	assert.Equal(t, uint64(120), ev.TeamID)
+	assert.Equal(t, godo.HostedAgentEventKindTokenChunk, ev.Kind)
+	assert.False(t, ev.At.IsZero(), "timestamp should be parsed from the wire `timestamp` field")
+	assert.JSONEq(t, `{"text":"Paris"}`, string(ev.Payload))
+
+	var buf bytes.Buffer
+	renderEvent(&buf, ev)
+	assert.Equal(t, "Paris", buf.String())
+}
+
+func TestRenderEvent(t *testing.T) {
+	cases := []struct {
+		name    string
+		kind    godo.HostedAgentEventKind
+		runID   string
+		payload string
+		want    string
+	}{
+		{"token chunk", godo.HostedAgentEventKindTokenChunk, "", `{"text":"Paris"}`, "Paris"},
+		{"run started", godo.HostedAgentEventKindRunStarted, "run-1", `{"agent":"codex"}`, "\n[run run-1 started (codex)]\n"},
+		{"run started no agent", godo.HostedAgentEventKindRunStarted, "run-2", `{}`, "\n[run run-2 started]\n"},
+		{"tool call started", godo.HostedAgentEventKindToolCallStarted, "", `{"tool_call_id":"t1","name":"bash"}`, "\n> bash ...\n"},
+		{"tool call completed", godo.HostedAgentEventKindToolCallCompleted, "", `{"ok":true,"duration_ms":12,"summary":"ran ls"}`, "  ran ls (12ms)\n"},
+		{"run completed", godo.HostedAgentEventKindRunCompleted, "", `{"total_tokens_in":3,"total_tokens_out":5,"run_cost_micros":1234}`, "\n[run done: 3 in / 5 out tokens, $0.0012]\n"},
+		{"run failed", godo.HostedAgentEventKindRunFailed, "", `{"code":5,"message":"hitl rejected"}`, "\n[run failed: hitl rejected (code 5)]\n"},
+		{"hitl resolved", godo.HostedAgentEventKindHITLResolved, "", `{"hitl_id":"hitl_1","outcome":1}`, "\n[HITL hitl_1 -> approve]\n"},
+		{"session updated", godo.HostedAgentEventKindSessionUpdated, "", `{}`, "\n[session updated]\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			renderEvent(&buf, godo.HostedAgentEvent{
+				Kind:    tc.kind,
+				RunID:   tc.runID,
+				Payload: json.RawMessage(tc.payload),
+			})
+			assert.Equal(t, tc.want, buf.String())
+		})
+	}
+}
+
+// TestErrorResponseSurfacesNestedMessage guards the fix that lets doctl show
+// the harness-api error reason. harness-api returns {"error":{"code","message"}}
+// (nested), not the top-level {"message"} godo historically expected, so a
+// failed SendInput used to print only "...: 400" with no reason.
+func TestErrorResponseSurfacesNestedMessage(t *testing.T) {
+	const body = `{"error":{"code":400,"message":"forward input to OHR: ohr attach: connection error"}}`
+	er := &godo.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Request:    httptest.NewRequest(http.MethodPost, "http://harness/v2/agents/sessions/sess_x/input", nil),
+		},
+	}
+	assert.NoError(t, json.Unmarshal([]byte(body), er))
+	assert.Contains(t, er.Error(), "forward input to OHR: ohr attach: connection error")
+}
+
+func TestRenderEventHITLRequested(t *testing.T) {
+	var buf bytes.Buffer
+	renderEvent(&buf, godo.HostedAgentEvent{
+		Kind:    godo.HostedAgentEventKindHITLRequested,
+		Payload: json.RawMessage(`{"hitl_id":"hitl_42","payload":{"command":"rm -rf /tmp/x"}}`),
+	})
+	out := buf.String()
+	assert.Contains(t, out, "[HITL] Action requires approval:")
+	assert.Contains(t, out, "rm -rf /tmp/x")
+	assert.Contains(t, out, "hitl_id: hitl_42")
+	assert.Contains(t, out, "/a hitl_42")
+}
+
+// TestAttachLoopAcknowledgesSend verifies that a successful submit prints an
+// immediate acknowledgement with the run id. The agent's first token can be
+// tens of seconds away; without this the silence reads as a hang and users
+// re-submit, spawning a duplicate run.
+func TestAttachLoopAcknowledgesSend(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		var buf bytes.Buffer
+		config.Out = &buf
+		tm.hostedAgents.EXPECT().
+			SendInput("sess_x", &godo.HostedAgentSendInputRequest{Text: "What is the capital of France?"}).
+			Return(&godo.HostedAgentSendInputResponse{RunID: "run-abc"}, nil)
+
+		err := attachLoop(config, config.HostedAgents(), "sess_x",
+			strings.NewReader("What is the capital of France?\n"), &pendingHITL{})
+		assert.NoError(t, err)
+		assert.Contains(t, buf.String(), "(queued as run-abc; waiting for the agent...)")
 	})
 }

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -219,6 +219,16 @@ type ErrorResponse struct {
 
 	// Attempts is the number of times the request was attempted when retries are enabled.
 	Attempts int
+
+	// NestedError captures the alternate {"error":{"code":...,"message":...}}
+	// envelope returned by some DigitalOcean services (e.g. the hosted-agents
+	// harness-api) instead of the top-level {"message":...} shape. When the
+	// top-level Message is empty, Error() falls back to this message so callers
+	// see the server's reason rather than a bare status code.
+	NestedError *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
 }
 
 // Rate contains the rate limit for the current client.
@@ -680,12 +690,17 @@ func (r *ErrorResponse) Error() string {
 		attempted = fmt.Sprintf("; giving up after %d attempt(s)", r.Attempts)
 	}
 
+	message := r.Message
+	if message == "" && r.NestedError != nil {
+		message = r.NestedError.Message
+	}
+
 	if r.RequestID != "" {
 		return fmt.Sprintf("%v %v: %d (request %q) %v%s",
-			r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.RequestID, r.Message, attempted)
+			r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.RequestID, message, attempted)
 	}
 	return fmt.Sprintf("%v %v: %d %v%s",
-		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.Message, attempted)
+		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, message, attempted)
 }
 
 // CheckResponse checks the API response for errors, and returns them if present. A response is considered an

--- a/vendor/github.com/digitalocean/godo/hosted_agents.go
+++ b/vendor/github.com/digitalocean/godo/hosted_agents.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -142,20 +143,32 @@ const (
 	HostedAgentRunFailureCodeInternal       HostedAgentRunFailureCode = "RUN_FAILURE_CODE_INTERNAL"
 )
 
-// HostedAgentEventKind is the SSE event discriminator for session stream payloads.
+// HostedAgentEventKind is the SSE event discriminator for session stream
+// payloads. The values are the canonical SPI event type names (dot-separated)
+// emitted on the wire's `type` field — NOT proto enum names. They mirror the
+// spi.EventType constants owned by the hosted-agents stack.
 type HostedAgentEventKind string
 
 const (
-	HostedAgentEventKindUnspecified       HostedAgentEventKind = "EVENT_KIND_UNSPECIFIED"
-	HostedAgentEventKindRunStarted        HostedAgentEventKind = "EVENT_KIND_RUN_STARTED"
-	HostedAgentEventKindTokenChunk        HostedAgentEventKind = "EVENT_KIND_TOKEN_CHUNK"
-	HostedAgentEventKindToolCallStarted   HostedAgentEventKind = "EVENT_KIND_TOOL_CALL_STARTED"
-	HostedAgentEventKindToolCallCompleted HostedAgentEventKind = "EVENT_KIND_TOOL_CALL_COMPLETED"
-	HostedAgentEventKindHITLRequested     HostedAgentEventKind = "EVENT_KIND_HITL_REQUESTED"
-	HostedAgentEventKindHITLResolved      HostedAgentEventKind = "EVENT_KIND_HITL_RESOLVED"
-	HostedAgentEventKindRunCompleted      HostedAgentEventKind = "EVENT_KIND_RUN_COMPLETED"
-	HostedAgentEventKindRunFailed         HostedAgentEventKind = "EVENT_KIND_RUN_FAILED"
-	HostedAgentEventKindSessionUpdated    HostedAgentEventKind = "EVENT_KIND_SESSION_UPDATED"
+	HostedAgentEventKindUnspecified          HostedAgentEventKind = ""
+	HostedAgentEventKindRunStarted           HostedAgentEventKind = "run.started"
+	HostedAgentEventKindTokenChunk           HostedAgentEventKind = "run.token_delta"
+	HostedAgentEventKindToolCallStarted      HostedAgentEventKind = "run.tool_call_started"
+	HostedAgentEventKindToolCallCompleted    HostedAgentEventKind = "run.tool_call_completed"
+	HostedAgentEventKindHITLRequested        HostedAgentEventKind = "run.human_input_requested"
+	HostedAgentEventKindHITLResolved         HostedAgentEventKind = "run.human_input_received"
+	HostedAgentEventKindRunCompleted         HostedAgentEventKind = "run.completed"
+	HostedAgentEventKindRunFailed            HostedAgentEventKind = "run.failed"
+	HostedAgentEventKindRunPaused            HostedAgentEventKind = "run.paused"
+	HostedAgentEventKindRunResumed           HostedAgentEventKind = "run.resumed"
+	HostedAgentEventKindSessionUpdated       HostedAgentEventKind = "session.updated"
+	HostedAgentEventKindRunStateCheckpointed HostedAgentEventKind = "run.state_checkpointed"
+	HostedAgentEventKindRunHandoff           HostedAgentEventKind = "run.handoff"
+	HostedAgentEventKindRunUsageRecorded     HostedAgentEventKind = "run.usage_recorded"
+	HostedAgentEventKindRunSandboxAllocated  HostedAgentEventKind = "run.sandbox_allocated"
+	HostedAgentEventKindRunSandboxReleased   HostedAgentEventKind = "run.sandbox_released"
+	HostedAgentEventKindRunCostAccrued       HostedAgentEventKind = "run.cost_accrued"
+	HostedAgentEventKindRunLog               HostedAgentEventKind = "run.log"
 )
 
 // HostedAgentSession is a provisioned hosted-agent sandbox session.
@@ -202,14 +215,57 @@ type HostedAgentHITLDecision struct {
 }
 
 // HostedAgentEvent is one SSE payload from GET /v2/agents/sessions/{id}/stream.
+//
+// The server serializes the SPI canonical event envelope, whose JSON shape
+// differs from this struct's field names: the discriminator is `type` (not
+// `kind`), the per-kind body is `data` (not `payload`), the timestamp is
+// `timestamp` (not `at`), and the team id rides as a decimal string in
+// `tenant_id`. UnmarshalJSON maps that wire shape onto these fields, so callers
+// read Kind/Payload/At/TeamID directly.
 type HostedAgentEvent struct {
+	EventID   string
+	SessionID string
+	RunID     string
+	TeamID    uint64
+	Seq       uint64
+	At        Timestamp
+	Kind      HostedAgentEventKind
+	Payload   json.RawMessage
+}
+
+// hostedAgentEventWire is the on-the-wire SPI canonical event envelope.
+type hostedAgentEventWire struct {
 	EventID   string               `json:"event_id"`
+	RunID     string               `json:"run_id"`
+	TenantID  string               `json:"tenant_id"`
 	SessionID string               `json:"session_id"`
-	RunID     string               `json:"run_id,omitempty"`
-	TeamID    uint64               `json:"team_id"`
-	At        Timestamp            `json:"at"`
-	Kind      HostedAgentEventKind `json:"kind"`
-	Payload   json.RawMessage      `json:"payload,omitempty"`
+	Timestamp Timestamp            `json:"timestamp"`
+	Seq       uint64               `json:"seq"`
+	Type      HostedAgentEventKind `json:"type"`
+	Data      json.RawMessage      `json:"data"`
+}
+
+// UnmarshalJSON decodes the SPI canonical event wire shape.
+func (e *HostedAgentEvent) UnmarshalJSON(b []byte) error {
+	var w hostedAgentEventWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.EventID = w.EventID
+	e.RunID = w.RunID
+	e.SessionID = w.SessionID
+	e.Seq = w.Seq
+	e.At = w.Timestamp
+	e.Kind = w.Type
+	e.Payload = w.Data
+	if w.TenantID != "" {
+		id, err := strconv.ParseUint(w.TenantID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("hosted agents: tenant_id %q: %w", w.TenantID, err)
+		}
+		e.TeamID = id
+	}
+	return nil
 }
 
 // HostedAgentSessionCreateRequest is the body for POST /v2/agents/sessions.


### PR DESCRIPTION
doctl agent attach connected but printed nothing: the harness-api SSE stream emits the SPI canonical event envelope (type/data/timestamp/ tenant_id, dot-separated event names) while vendored godo decoded kind/payload/at/team_id, so every event fell through renderEvent.

- godo HostedAgentEvent: decode the SPI wire via UnmarshalJSON and switch the HostedAgentEventKind constants to the dot-separated SPI names.
- godo ErrorResponse: also read the nested {"error":{code,message}} envelope so failed calls show the server's reason, not a bare status.
- agents: align event payload structs/rendering and HITL tracking to the SPI data shapes, and acknowledge each submit with its run id so the agent's startup latency isn't mistaken for a hang (which caused duplicate submits).
- tests for the wire decode, rendering, nested-error surfacing, and ack.

The vendored godo edits mirror the fix being upstreamed to digitalocean/godo and are in-tree until godo is re-vendored.