### PR TITLE
added support for advanced pg config

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -2658,6 +2658,7 @@ For a full list of available fields, see the API documentation: https://docs.dig
 		aliasOpt("g"),
 		displayerType(&displayers.MySQLConfiguration{}),
 		displayerType(&displayers.PostgreSQLConfiguration{}),
+		displayerType(&displayers.AdvancedPostgresConfiguration{}),
 		displayerType(&displayers.RedisConfiguration{}),
 		displayerType(&displayers.ValkeyConfiguration{}),
 		displayerType(&displayers.MongoDBConfiguration{}),
@@ -2718,16 +2719,17 @@ func RunDatabaseConfigurationGet(c *CmdConfig) error {
 	}
 
 	allowedEngines := map[string]any{
-		"mysql":      nil,
-		"pg":         nil,
-		"redis":      nil,
-		"valkey":     nil,
-		"mongodb":    nil,
-		"kafka":      nil,
-		"opensearch": nil,
+		"mysql":       nil,
+		"pg":          nil,
+		"advanced_pg": nil,
+		"redis":       nil,
+		"valkey":      nil,
+		"mongodb":     nil,
+		"kafka":       nil,
+		"opensearch":  nil,
 	}
 	if _, ok := allowedEngines[engine]; !ok {
-		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'mysql', 'redis', 'valkey', 'mongodb', 'kafka', opensearch", c.NS)
+		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'advanced_pg', 'mysql', 'redis', 'valkey', 'mongodb', 'kafka', opensearch", c.NS)
 	}
 
 	dbId := args[0]
@@ -2749,6 +2751,16 @@ func RunDatabaseConfigurationGet(c *CmdConfig) error {
 
 		displayer := displayers.PostgreSQLConfiguration{
 			PostgreSQLConfig: *config,
+		}
+		return c.Display(&displayer)
+	} else if engine == "advanced_pg" {
+		config, err := c.Databases().GetAdvancedPostgresConfiguration(dbId)
+		if err != nil {
+			return err
+		}
+
+		displayer := displayers.AdvancedPostgresConfiguration{
+			AdvancedPostgresConfig: *config,
 		}
 		return c.Display(&displayer)
 	} else if engine == "redis" {
@@ -2821,16 +2833,17 @@ func RunDatabaseConfigurationUpdate(c *CmdConfig) error {
 	}
 
 	allowedEngines := map[string]any{
-		"mysql":      nil,
-		"pg":         nil,
-		"redis":      nil,
-		"valkey":     nil,
-		"mongodb":    nil,
-		"kafka":      nil,
-		"opensearch": nil,
+		"mysql":       nil,
+		"pg":          nil,
+		"advanced_pg": nil,
+		"redis":       nil,
+		"valkey":      nil,
+		"mongodb":     nil,
+		"kafka":       nil,
+		"opensearch":  nil,
 	}
 	if _, ok := allowedEngines[engine]; !ok {
-		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'mysql', 'redis', 'valkey', 'mongodb', 'kafka', 'opensearch'", c.NS)
+		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'advanced_pg', 'mysql', 'redis', 'valkey', 'mongodb', 'kafka', 'opensearch'", c.NS)
 	}
 
 	configJson, err := c.Doit.GetString(c.NS, doctl.ArgDatabaseConfigJson)
@@ -2846,6 +2859,11 @@ func RunDatabaseConfigurationUpdate(c *CmdConfig) error {
 		}
 	} else if engine == "pg" {
 		err := c.Databases().UpdatePostgreSQLConfiguration(dbId, configJson)
+		if err != nil {
+			return err
+		}
+	} else if engine == "advanced_pg" {
+		err := c.Databases().UpdateAdvancedPostgresConfiguration(dbId, configJson)
 		if err != nil {
 			return err
 		}

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -219,6 +219,19 @@ var (
 		PostgreSQLConfig: &godo.PostgreSQLConfig{},
 	}
 
+	testAdvancedPostgresConfiguration = do.AdvancedPostgresConfig{
+		AdvancedPostgresConfig: &godo.AdvancedPostgresConfig{
+			PGParameters: []godo.AdvancedPostgresPGParameter{
+				{
+					Name:            "max_connections",
+					Value:           "100",
+					DefaultValue:    "100",
+					RequiresRestart: false,
+				},
+			},
+		},
+	}
+
 	testRedisConfiguration = do.RedisConfig{
 		RedisConfig: &godo.RedisConfig{},
 	}
@@ -1774,6 +1787,16 @@ func TestDatabaseConfigurationGet(t *testing.T) {
 	})
 
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.databases.EXPECT().GetAdvancedPostgresConfiguration(testDBCluster.ID).Return(&testAdvancedPostgresConfiguration, nil)
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "advanced_pg")
+
+		err := RunDatabaseConfigurationGet(config)
+
+		assert.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.databases.EXPECT().GetRedisConfiguration(testDBCluster.ID).Return(&testRedisConfiguration, nil)
 		config.Args = append(config.Args, testDBCluster.ID)
 		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "redis")
@@ -1851,6 +1874,16 @@ func TestDatabaseConfigurationUpdate(t *testing.T) {
 		tm.databases.EXPECT().UpdatePostgreSQLConfiguration(testDBCluster.ID, "").Return(nil)
 		config.Args = append(config.Args, testDBCluster.ID)
 		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "pg")
+
+		err := RunDatabaseConfigurationUpdate(config)
+
+		assert.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.databases.EXPECT().UpdateAdvancedPostgresConfiguration(testDBCluster.ID, "").Return(nil)
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "advanced_pg")
 
 		err := RunDatabaseConfigurationUpdate(config)
 

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -2338,6 +2338,50 @@ func (dc *OpensearchConfiguration) KV() []map[string]any {
 	return o
 }
 
+type AdvancedPostgresConfiguration struct {
+	AdvancedPostgresConfig do.AdvancedPostgresConfig
+}
+
+var _ Displayable = &AdvancedPostgresConfiguration{}
+
+func (dc *AdvancedPostgresConfiguration) JSON(out io.Writer) error {
+	return writeJSON(dc.AdvancedPostgresConfig, out)
+}
+
+func (dc *AdvancedPostgresConfiguration) Cols() []string {
+	return []string{
+		"Name",
+		"Value",
+		"Default Value",
+		"Requires Restart",
+		"Description",
+	}
+}
+
+func (dc *AdvancedPostgresConfiguration) ColMap() map[string]string {
+	return map[string]string{
+		"Name":             "Name",
+		"Value":            "Value",
+		"Default Value":    "Default Value",
+		"Requires Restart": "Requires Restart",
+		"Description":      "Description",
+	}
+}
+
+func (dc *AdvancedPostgresConfiguration) KV() []map[string]any {
+	o := []map[string]any{}
+	for _, p := range dc.AdvancedPostgresConfig.PGParameters {
+		o = append(o, map[string]any{
+			"Name":             p.Name,
+			"Value":            p.Value,
+			"Default Value":    p.DefaultValue,
+			"Requires Restart": p.RequiresRestart,
+			"Description":      p.Description,
+		})
+	}
+	return o
+}
+
 type DatabaseEvents struct {
 	DatabaseEvents do.DatabaseEvents
 }

--- a/do/databases.go
+++ b/do/databases.go
@@ -120,6 +120,11 @@ type PostgreSQLConfig struct {
 	*godo.PostgreSQLConfig
 }
 
+// AdvancedPostgresConfig is a wrapper for godo.AdvancedPostgresConfig
+type AdvancedPostgresConfig struct {
+	*godo.AdvancedPostgresConfig
+}
+
 // RedisConfig is a wrapper for godo.RedisConfig
 type RedisConfig struct {
 	*godo.RedisConfig
@@ -227,6 +232,7 @@ type DatabasesService interface {
 
 	GetMySQLConfiguration(databaseID string) (*MySQLConfig, error)
 	GetPostgreSQLConfiguration(databaseID string) (*PostgreSQLConfig, error)
+	GetAdvancedPostgresConfiguration(databaseID string) (*AdvancedPostgresConfig, error)
 	GetRedisConfiguration(databaseID string) (*RedisConfig, error)
 	GetValkeyConfiguration(databaseID string) (*ValkeyConfig, error)
 	GetMongoDBConfiguration(databaseID string) (*MongoDBConfig, error)
@@ -235,6 +241,7 @@ type DatabasesService interface {
 
 	UpdateMySQLConfiguration(databaseID string, confString string) error
 	UpdatePostgreSQLConfiguration(databaseID string, confString string) error
+	UpdateAdvancedPostgresConfiguration(databaseID string, confString string) error
 	UpdateRedisConfiguration(databaseID string, confString string) error
 	UpdateValkeyConfiguration(databaseID string, confString string) error
 	UpdateMongoDBConfiguration(databaseID string, confString string) error
@@ -735,6 +742,17 @@ func (ds *databasesService) GetPostgreSQLConfiguration(databaseID string) (*Post
 	}, nil
 }
 
+func (ds *databasesService) GetAdvancedPostgresConfiguration(databaseID string) (*AdvancedPostgresConfig, error) {
+	cfg, _, err := ds.client.Databases.GetAdvancedPostgresSQLConfig(context.TODO(), databaseID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AdvancedPostgresConfig{
+		AdvancedPostgresConfig: cfg,
+	}, nil
+}
+
 func (ds *databasesService) GetRedisConfiguration(databaseID string) (*RedisConfig, error) {
 	cfg, _, err := ds.client.Databases.GetRedisConfig(context.TODO(), databaseID)
 	if err != nil {
@@ -813,6 +831,21 @@ func (ds *databasesService) UpdatePostgreSQLConfiguration(databaseID string, con
 	}
 
 	_, err = ds.client.Databases.UpdatePostgreSQLConfig(context.TODO(), databaseID, &conf)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ds *databasesService) UpdateAdvancedPostgresConfiguration(databaseID string, confString string) error {
+	var conf godo.AdvancedPostgresConfigUpdate
+	err := json.Unmarshal([]byte(confString), &conf)
+	if err != nil {
+		return err
+	}
+
+	_, err = ds.client.Databases.UpdateAdvancedPostgresSQLConfig(context.TODO(), databaseID, &conf)
 	if err != nil {
 		return err
 	}

--- a/do/mocks/DatabasesService.go
+++ b/do/mocks/DatabasesService.go
@@ -244,6 +244,21 @@ func (mr *MockDatabasesServiceMockRecorder) Get(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDatabasesService)(nil).Get), arg0)
 }
 
+// GetAdvancedPostgresConfiguration mocks base method.
+func (m *MockDatabasesService) GetAdvancedPostgresConfiguration(databaseID string) (*do.AdvancedPostgresConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAdvancedPostgresConfiguration", databaseID)
+	ret0, _ := ret[0].(*do.AdvancedPostgresConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAdvancedPostgresConfiguration indicates an expected call of GetAdvancedPostgresConfiguration.
+func (mr *MockDatabasesServiceMockRecorder) GetAdvancedPostgresConfiguration(databaseID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdvancedPostgresConfiguration", reflect.TypeOf((*MockDatabasesService)(nil).GetAdvancedPostgresConfiguration), databaseID)
+}
+
 // GetCA mocks base method.
 func (m *MockDatabasesService) GetCA(arg0 string) (*do.DatabaseCA, error) {
 	m.ctrl.T.Helper()
@@ -767,6 +782,20 @@ func (mr *MockDatabasesServiceMockRecorder) SetSQLMode(arg0 any, arg1 ...any) *g
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSQLMode", reflect.TypeOf((*MockDatabasesService)(nil).SetSQLMode), varargs...)
+}
+
+// UpdateAdvancedPostgresConfiguration mocks base method.
+func (m *MockDatabasesService) UpdateAdvancedPostgresConfiguration(databaseID, confString string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAdvancedPostgresConfiguration", databaseID, confString)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAdvancedPostgresConfiguration indicates an expected call of UpdateAdvancedPostgresConfiguration.
+func (mr *MockDatabasesServiceMockRecorder) UpdateAdvancedPostgresConfiguration(databaseID, confString any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAdvancedPostgresConfiguration", reflect.TypeOf((*MockDatabasesService)(nil).UpdateAdvancedPostgresConfiguration), databaseID, confString)
 }
 
 // UpdateFirewallRules mocks base method.


### PR DESCRIPTION
The Aim of this PR is to add support for `ADVANCED_PG` configuration operation (`patch` and `get`)

`doctl databases configuration -h`

<img width="2984" height="1298" alt="image" src="https://github.com/user-attachments/assets/2fbc9161-2f81-4ab3-9423-7c50a718896c" />


```
doctl databases configuration get <CLUSTER_UUID> \
  --engine advanced_pg \
  --api-url=https://api.digitalocean.com \
  --access-token <ACCESS_TOKEN>
```

<img width="3434" height="1876" alt="image" src="https://github.com/user-attachments/assets/a0528ab3-566b-4527-8652-80f1feae27a4" />


```
.doctl databases configuration update <CLUSTER_UUID> \
  --engine advanced_pg \
  --config-json '{"pg_parameters":{"work_mem":"1024"}}' \
  --api-url=https://api.digitalocean.com \
  --access-token <ACCESS_TOKEN>
```

<img width="2566" height="718" alt="image" src="https://github.com/user-attachments/assets/35dd33cb-2653-435e-99dc-a35eee814451" />




