### PR TITLE
fix --format and --no-header on gradient commands

### DIFF
--- a/commands/displayers/gradientai.go
+++ b/commands/displayers/gradientai.go
@@ -26,7 +26,7 @@ func (v *Agent) JSON(out io.Writer) error {
 
 func (a *Agent) Cols() []string {
 	return []string{
-		"Id",
+		"ID",
 		"Name",
 		"Region",
 		"Project-id",
@@ -38,7 +38,7 @@ func (a *Agent) Cols() []string {
 
 func (a *Agent) ColMap() map[string]string {
 	return map[string]string{
-		"Id":         "ID",
+		"ID":         "ID",
 		"Name":       "Name",
 		"Region":     "Region",
 		"Project-id": "Project ID",
@@ -59,7 +59,7 @@ func (a *Agent) KV() []map[string]any {
 			modelID = agent.Model.Uuid
 		}
 		out = append(out, map[string]any{
-			"Id":         agent.Uuid,
+			"ID":         agent.Uuid,
 			"Name":       agent.Name,
 			"Region":     agent.Region,
 			"Project-id": agent.ProjectId,
@@ -372,7 +372,7 @@ func (f *FunctionRoute) JSON(out io.Writer) error {
 
 func (f *FunctionRoute) Cols() []string {
 	return []string{
-		"Uuid",
+		"UUID",
 		"Name",
 		"Description",
 		"FaasName",
@@ -384,7 +384,7 @@ func (f *FunctionRoute) Cols() []string {
 
 func (f *FunctionRoute) ColMap() map[string]string {
 	return map[string]string{
-		"Uuid":          "UUID",
+		"UUID":          "UUID",
 		"Name":          "Name",
 		"Description":   "Description",
 		"FaasName":      "FaaS Name",
@@ -402,7 +402,7 @@ func (f *FunctionRoute) KV() []map[string]any {
 	out := make([]map[string]any, 0, len(f.Agent.Functions))
 	for _, fn := range f.Agent.Functions {
 		out = append(out, map[string]any{
-			"Uuid":          fn.Uuid,
+			"UUID":          fn.Uuid,
 			"Name":          fn.Name,
 			"Description":   fn.Description,
 			"FaasName":      fn.FaasName,
@@ -426,7 +426,7 @@ func (a *AgentRoute) JSON(out io.Writer) error {
 
 func (a *AgentRoute) Cols() []string {
 	return []string{
-		"Id",
+		"ID",
 		"ParentAgentId",
 		"ChildAgentId",
 		"Rollback",
@@ -435,9 +435,9 @@ func (a *AgentRoute) Cols() []string {
 
 func (a *AgentRoute) ColMap() map[string]string {
 	return map[string]string{
-		"Id":            "Id",
-		"ParentAgentId": "Parent Agent Id",
-		"ChildAgentId":  "Child Agent Id",
+		"ID":            "ID",
+		"ParentAgentId": "Parent Agent ID",
+		"ChildAgentId":  "Child Agent ID",
 		"Rollback":      "Rollback",
 	}
 }
@@ -450,7 +450,7 @@ func (a *AgentRoute) KV() []map[string]any {
 
 	for _, response := range a.AgentRouteResponses {
 		o := map[string]any{
-			"Id":            response.UUID,
+			"ID":            response.UUID,
 			"ParentAgentId": response.ParentAgentUuid,
 			"ChildAgentId":  response.ChildAgentUuid,
 			"Rollback":      response.Rollback,
@@ -469,7 +469,7 @@ func (v *ApiKeyInfo) JSON(out io.Writer) error {
 
 func (a *ApiKeyInfo) Cols() []string {
 	return []string{
-		"Id",
+		"ID",
 		"Name",
 		"CreatedBy",
 		"SecretKey",
@@ -480,7 +480,7 @@ func (a *ApiKeyInfo) Cols() []string {
 
 func (a *ApiKeyInfo) ColMap() map[string]string {
 	return map[string]string{
-		"Id":        "ID",
+		"ID":        "ID",
 		"Name":      "Name",
 		"SecretKey": "Secret Key",
 		"CreatedBy": "Created By",
@@ -497,7 +497,7 @@ func (a *ApiKeyInfo) KV() []map[string]any {
 	for _, apikey := range a.ApiKeyInfo {
 
 		out = append(out, map[string]any{
-			"Id":        apikey.Uuid,
+			"ID":        apikey.Uuid,
 			"Name":      apikey.Name,
 			"SecretKey": apikey.SecretKey,
 			"CreatedBy": apikey.CreatedBy,
@@ -625,7 +625,7 @@ func (m *Model) JSON(out io.Writer) error {
 }
 func (m *Model) Cols() []string {
 	return []string{
-		"Id",
+		"ID",
 		"Name",
 		"Agreement",
 		"CreatedAt",
@@ -640,7 +640,7 @@ func (m *Model) Cols() []string {
 
 func (m *Model) ColMap() map[string]string {
 	return map[string]string{
-		"Id":             "ID",
+		"ID":             "ID",
 		"Name":           "Name",
 		"Agreement":      "Agreement",
 		"CreatedAt":      "Created At",
@@ -672,7 +672,7 @@ func (m *Model) KV() []map[string]any {
 		}
 
 		out = append(out, map[string]any{
-			"Id":             model.Uuid,
+			"ID":             model.Uuid,
 			"Name":           model.Name,
 			"Agreement":      agreementName,
 			"CreatedAt":      model.CreatedAt,

--- a/commands/gradientai.go
+++ b/commands/gradientai.go
@@ -32,9 +32,9 @@ func GradientAI() *Command {
 	// Add the knowledgebase command as a subcommand to Gradient AI
 	cmd.AddCommand(KnowledgeBaseCmd())
 	// Add the model command as a subcommand to Gradient AI
-	cmd.AddCommand(ListModelsCmd())
+	cmd.AddCommand(ListModelsCmd(cmd))
 	// Add the region command as a subcommand to Gradient AI
-	cmd.AddCommand(ListRegionsCmd())
+	cmd.AddCommand(ListRegionsCmd(cmd))
 	// Add the OpenAI keys command as a subcommand to Gradient AI
 	cmd.AddCommand(OpenAIKeyCmd())
 

--- a/commands/gradientai_list_models.go
+++ b/commands/gradientai_list_models.go
@@ -4,8 +4,8 @@ import (
 	"github.com/digitalocean/doctl/commands/displayers"
 )
 
-func ListModelsCmd() *Command {
-	cmd := CmdBuilder(nil, RunGradientAIListModels, "list-models", "List Gradient AI models", `The `+"`doctl gradient list-models`"+` command lists all available Gradient AI models.
+func ListModelsCmd(parent *Command) *Command {
+	cmd := CmdBuilder(parent, RunGradientAIListModels, "list-models", "List Gradient AI models", `The `+"`doctl gradient list-models`"+` command lists all available Gradient AI models.
 
 The command returns the following details for each model:
 	- The model ID

--- a/commands/gradientai_list_models_test.go
+++ b/commands/gradientai_list_models_test.go
@@ -116,7 +116,7 @@ func TestRunGradientAIListModelsFormatNoHeader(t *testing.T) {
 		var buf bytes.Buffer
 		config.NS = "gradient.list-models"
 		config.Out = &buf
-		config.Doit.Set(config.NS, doctl.ArgFormat, "Id,Name")
+		config.Doit.Set(config.NS, doctl.ArgFormat, "ID,Name")
 		config.Doit.Set(config.NS, doctl.ArgNoHeader, true)
 
 		err := RunGradientAIListModels(config)

--- a/commands/gradientai_list_models_test.go
+++ b/commands/gradientai_list_models_test.go
@@ -14,11 +14,14 @@ limitations under the License.
 package commands
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
+	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/do"
 	"github.com/digitalocean/godo"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,7 +81,8 @@ var (
 )
 
 func TestListModelsCommand(t *testing.T) {
-	cmd := ListModelsCmd()
+	parent := &Command{Command: &cobra.Command{Use: "gradient"}}
+	cmd := ListModelsCmd(parent)
 	assert.NotNil(t, cmd)
 	assert.Equal(t, "list-models", cmd.Use)
 	assert.Contains(t, cmd.Aliases, "models")
@@ -102,5 +106,21 @@ func TestRunGradientAIListModelsError(t *testing.T) {
 
 		err := RunGradientAIListModels(config)
 		assert.Error(t, err)
+	})
+}
+
+func TestRunGradientAIListModelsFormatNoHeader(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.gradientAI.EXPECT().ListAvailableModels().Return(testModels, nil)
+
+		var buf bytes.Buffer
+		config.NS = "gradient.list-models"
+		config.Out = &buf
+		config.Doit.Set(config.NS, doctl.ArgFormat, "Id,Name")
+		config.Doit.Set(config.NS, doctl.ArgNoHeader, true)
+
+		err := RunGradientAIListModels(config)
+		assert.NoError(t, err)
+		assert.Equal(t, "model-1    GPT-4 Turbo\nmodel-2    Claude 3.5 Sonnet\n", buf.String())
 	})
 }

--- a/commands/gradientai_list_regions.go
+++ b/commands/gradientai_list_regions.go
@@ -4,8 +4,8 @@ import (
 	"github.com/digitalocean/doctl/commands/displayers"
 )
 
-func ListRegionsCmd() *Command {
-	cmd := CmdBuilder(nil, RunGradientAIListRegions, "list-regions", "List Gradient AI regions", `The `+"`doctl gradient list-regions`"+` command lists all available Gradient AI regions.
+func ListRegionsCmd(parent *Command) *Command {
+	cmd := CmdBuilder(parent, RunGradientAIListRegions, "list-regions", "List Gradient AI regions", `The `+"`doctl gradient list-regions`"+` command lists all available Gradient AI regions.
 
 The command returns the following details for each region:
 	- Inference URL: The URL for the inference server

--- a/commands/gradientai_list_regions_test.go
+++ b/commands/gradientai_list_regions_test.go
@@ -14,8 +14,10 @@ limitations under the License.
 package commands
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/do"
 	"github.com/digitalocean/godo"
 	"github.com/spf13/cobra"
@@ -62,7 +64,8 @@ var (
 )
 
 func TestListRegionsCommand(t *testing.T) {
-	cmd := ListRegionsCmd()
+	parent := &Command{Command: &cobra.Command{Use: "gradient"}}
+	cmd := ListRegionsCmd(parent)
 	assert.NotNil(t, cmd)
 	assert.Equal(t, "list-regions", cmd.Use)
 	assert.Equal(t, "List Gradient AI regions", cmd.Short)
@@ -88,5 +91,26 @@ func TestRunGradientAIListRegionsError(t *testing.T) {
 
 		err := RunGradientAIListRegions(config)
 		assert.Error(t, err)
+	})
+}
+
+func TestRunGradientAIListRegionsFormatNoHeader(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.gradientAI.EXPECT().ListDatacenterRegions(nil, nil).Return(testDatacenterRegions, nil)
+
+		var buf bytes.Buffer
+		config.NS = "gradient.list-regions"
+		config.Out = &buf
+		config.Command = &cobra.Command{}
+		config.Doit.Set(config.NS, doctl.ArgFormat, "Region,InferenceURL")
+		config.Doit.Set(config.NS, doctl.ArgNoHeader, true)
+
+		err := RunGradientAIListRegions(config)
+		assert.NoError(t, err)
+		expected := "" +
+			"nyc1    https://inference.nyc1.digitalocean.com\n" +
+			"sfo3    https://inference.sfo3.digitalocean.com\n" +
+			"tor1    https://inference.tor1.digitalocean.com\n"
+		assert.Equal(t, expected, buf.String())
 	})
 }

--- a/integration/gradientai_agent_route_update_test.go
+++ b/integration/gradientai_agent_route_update_test.go
@@ -99,9 +99,9 @@ var _ = suite("gen-ai/agent/route/update", func(t *testing.T, when spec.G, it sp
 		expect.NoError(err, fmt.Sprintf("received error output: %s", output))
 		outputStr := string(output)
 
-		expect.Contains(outputStr, "Id")
-		expect.Contains(outputStr, "Parent Agent Id")
-		expect.Contains(outputStr, "Child Agent Id")
+		expect.Contains(outputStr, "ID")
+		expect.Contains(outputStr, "Parent Agent ID")
+		expect.Contains(outputStr, "Child Agent ID")
 		expect.Contains(outputStr, "Rollback")
 
 		expect.Contains(outputStr, "00000000-0000-4000-a000-000000000000")


### PR DESCRIPTION
This PR contains two fixes:
- `--format` and `--no-header` was ignored on `doctl gradient list-models` and `list-regions`
- `--format ID` was not working on the list, even though the header was advertising ID, Id was expected which is inconsistent with the header and the rest of doctl, hence having moved to ID consistently