### PR TITLE
displayers: drop SandboxID column from hosted-agent session output

### DIFF
--- a/commands/displayers/hosted_agents.go
+++ b/commands/displayers/hosted_agents.go
@@ -42,7 +42,7 @@ func (h *HostedAgentSession) JSON(out io.Writer) error {
 }
 
 func (h *HostedAgentSession) Cols() []string {
-	return []string{"SessionID", "AgentKind", "Status", "SandboxID", "RepoHint", "CreatedAt"}
+	return []string{"SessionID", "AgentKind", "Status", "RepoHint", "CreatedAt"}
 }
 
 func (h *HostedAgentSession) ColMap() map[string]string {
@@ -50,7 +50,6 @@ func (h *HostedAgentSession) ColMap() map[string]string {
 		"SessionID": "Session",
 		"AgentKind": "Agent",
 		"Status":    "Status",
-		"SandboxID": "Sandbox",
 		"RepoHint":  "Repo",
 		"CreatedAt": "Created",
 	}
@@ -69,7 +68,6 @@ func (h *HostedAgentSession) KV() []map[string]any {
 			"SessionID": s.SessionID,
 			"AgentKind": s.AgentKind,
 			"Status":    s.Status,
-			"SandboxID": s.SandboxID,
 			"RepoHint":  s.RepoHint,
 			"CreatedAt": s.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z"),
 		})

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.197.0] - 2026-06-25
+
+- #1038 - @v-amanjain-afk - nfs access point apis
+- #1039 - @venkatranabothu - Add ErrorMessage to GradientAI CustomModel
+- #1037 - @ritheek-pitti-do - Add run progress model and update tests
+- #1032 - @MaxLivesInTheMatrix - Adding in secrets API support
+
 ## [1.196.0] - 2026-06-16
 
 - #1035 - @bpatra-drop - Add support for evaluation dataset delete api

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.196.0"
+	libraryVersion = "1.197.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -79,6 +79,7 @@ type Client struct {
 	LoadBalancers       LoadBalancersService
 	Monitoring          MonitoringService
 	Security            SecurityService
+	Secrets             SecretsService
 	Nfs                 NfsService
 	NfsActions          NfsActionsService
 	OneClick            OneClickService
@@ -331,6 +332,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.LoadBalancers = &LoadBalancersServiceOp{client: c}
 	c.Monitoring = &MonitoringServiceOp{client: c}
 	c.Security = &SecurityServiceOp{client: c}
+	c.Secrets = &SecretsServiceOp{client: c}
 	c.Nfs = &NfsServiceOp{client: c}
 	c.NfsActions = &NfsActionsServiceOp{client: c}
 	c.VPCNATGateways = &VPCNATGatewaysServiceOp{client: c}

--- a/vendor/github.com/digitalocean/godo/gradientai.go
+++ b/vendor/github.com/digitalocean/godo/gradientai.go
@@ -2309,6 +2309,7 @@ type CustomModel struct {
 	TeamId               string                         `json:"team_id,omitempty"`
 	ConfigJson           map[string]any                 `json:"config_json,omitempty"`
 	StorageRegion        string                         `json:"storage_region,omitempty"`
+	ErrorMessage         string                         `json:"error_message,omitempty"`
 }
 
 // CustomModelSourceRef references the original source of a custom model.
@@ -2520,17 +2521,18 @@ type ModelEvaluationRunDeleteResponse struct {
 // ModelEvaluationRunSummary is a lightweight view of an evaluation run used in
 // run history listings and the cancel response.
 type ModelEvaluationRunSummary struct {
-	CandidateModelName   string                   `json:"candidate_model_name,omitempty"`
-	CandidateModelSource CandidateModelSource     `json:"candidate_model_source,omitempty"`
-	CandidateModelUuid   string                   `json:"candidate_model_uuid,omitempty"`
-	CreatedAt            *Timestamp               `json:"created_at,omitempty"`
-	DatasetName          string                   `json:"dataset_name,omitempty"`
-	DatasetUuid          string                   `json:"dataset_uuid,omitempty"`
-	EvalRunUuid          string                   `json:"eval_run_uuid,omitempty"`
-	JudgeModelName       string                   `json:"judge_model_name,omitempty"`
-	JudgeModelUuid       string                   `json:"judge_model_uuid,omitempty"`
-	Name                 string                   `json:"name,omitempty"`
-	Status               ModelEvaluationRunStatus `json:"status,omitempty"`
+	CandidateModelName   string                      `json:"candidate_model_name,omitempty"`
+	CandidateModelSource CandidateModelSource        `json:"candidate_model_source,omitempty"`
+	CandidateModelUuid   string                      `json:"candidate_model_uuid,omitempty"`
+	CreatedAt            *Timestamp                  `json:"created_at,omitempty"`
+	DatasetName          string                      `json:"dataset_name,omitempty"`
+	DatasetUuid          string                      `json:"dataset_uuid,omitempty"`
+	EvalRunUuid          string                      `json:"eval_run_uuid,omitempty"`
+	JudgeModelName       string                      `json:"judge_model_name,omitempty"`
+	JudgeModelUuid       string                      `json:"judge_model_uuid,omitempty"`
+	Name                 string                      `json:"name,omitempty"`
+	Progress             *ModelEvaluationRunProgress `json:"progress,omitempty"`
+	Status               ModelEvaluationRunStatus    `json:"status,omitempty"`
 }
 
 // CancelModelEvaluationRunRequest represents the request payload for cancelling
@@ -2834,6 +2836,24 @@ type ModelEvaluationRunResultSummary struct {
 	TotalDurationSeconds int64                    `json:"total_duration_seconds,omitempty"`
 }
 
+// ModelEvaluationRunProgress reports per-phase progress for a model evaluation
+// run. The candidate phase invokes the candidate model once per dataset row;
+// the judge phase scores each candidate-success row with the configured
+// metrics. Counts grow as the run advances; compare against TotalRows to render
+// a progress bar.
+type ModelEvaluationRunProgress struct {
+	// CandidateRowsEvaluated is the number of dataset rows whose candidate model
+	// call has completed (success or failure).
+	CandidateRowsEvaluated *int64 `json:"candidate_rows_evaluated,omitempty"`
+	// JudgeRowsEvaluated is the number of candidate-success rows the judge has
+	// finished (scored or skipped). It caps at the number of candidate
+	// successes, which may be below TotalRows.
+	JudgeRowsEvaluated *int64 `json:"judge_rows_evaluated,omitempty"`
+	// TotalRows is the total number of dataset rows for the run, sourced from the
+	// evaluation dataset.
+	TotalRows *int64 `json:"total_rows,omitempty"`
+}
+
 // ModelEvaluationRunDetail is the full view of a model evaluation run
 // returned when fetching a specific run.
 type ModelEvaluationRunDetail struct {
@@ -2853,6 +2873,7 @@ type ModelEvaluationRunDetail struct {
 	JudgeModelUuid           string                           `json:"judge_model_uuid,omitempty"`
 	Metrics                  []*EvaluationMetric              `json:"metrics,omitempty"`
 	Name                     string                           `json:"name,omitempty"`
+	Progress                 *ModelEvaluationRunProgress      `json:"progress,omitempty"`
 	ResultSummary            *ModelEvaluationRunResultSummary `json:"result_summary,omitempty"`
 	StarMetric               *StarMetric                      `json:"star_metric,omitempty"`
 	StartedAt                *Timestamp                       `json:"started_at,omitempty"`

--- a/vendor/github.com/digitalocean/godo/hosted_agents.go
+++ b/vendor/github.com/digitalocean/godo/hosted_agents.go
@@ -3,9 +3,12 @@ package godo
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"net/http"
 	"net/url"
@@ -14,14 +17,21 @@ import (
 )
 
 const (
-	hostedAgentManifestMediaType = "application/x-yaml"
+	hostedAgentManifestMediaType  = "application/x-yaml"
+	hostedAgentWorkspaceMediaType = "application/octet-stream"
 
-	hostedAgentsSessionsBasePath      = "/v2/agents/sessions"
-	hostedAgentSessionByIDPath        = hostedAgentsSessionsBasePath + "/%s"
-	hostedAgentSessionStreamPath      = hostedAgentSessionByIDPath + "/stream"
-	hostedAgentSessionInputPath       = hostedAgentSessionByIDPath + "/input"
-	hostedAgentSessionHITLPath        = hostedAgentSessionByIDPath + "/hitl/%s"
-	hostedAgentSessionSandboxExecPath = hostedAgentSessionByIDPath + "/sandbox/exec"
+	hostedAgentsSessionsBasePath            = "/v2/agents/sessions"
+	hostedAgentSessionByIDPath              = hostedAgentsSessionsBasePath + "/%s"
+	hostedAgentSessionStreamPath            = hostedAgentSessionByIDPath + "/stream"
+	hostedAgentSessionInputPath             = hostedAgentSessionByIDPath + "/input"
+	hostedAgentSessionHITLPath              = hostedAgentSessionByIDPath + "/hitl/%s"
+	hostedAgentSessionSandboxExecPath       = hostedAgentSessionByIDPath + "/sandbox/exec"
+	hostedAgentSessionWorkspaceUploadPath   = hostedAgentSessionByIDPath + "/workspace/upload"
+	hostedAgentSessionWorkspaceDownloadPath = hostedAgentSessionByIDPath + "/workspace/download"
+
+	workspaceContentSHA256Header = "X-Content-Sha256"
+	workspaceIsArchiveHeader     = "X-Workspace-Is-Archive"
+	workspaceSizeBytesHeader     = "X-Workspace-Size-Bytes"
 )
 
 // HostedAgentsService exposes the DigitalOcean Hosted Agents session API
@@ -41,6 +51,8 @@ type HostedAgentsService interface {
 	SendInput(context.Context, string, *HostedAgentSendInputRequest) (*HostedAgentSendInputResponse, *Response, error)
 	ResolveHITL(context.Context, string, string, *HostedAgentResolveHITLRequest) (*Response, error)
 	ExecInSandbox(context.Context, string, *HostedAgentSandboxExecRequest) (*HostedAgentSandboxExecResponse, *Response, error)
+	UploadWorkspace(context.Context, string, *HostedAgentWorkspaceUploadRequest) (*HostedAgentWorkspaceUploadResponse, *Response, error)
+	DownloadWorkspace(context.Context, string, *HostedAgentWorkspaceDownloadRequest) (*HostedAgentWorkspaceDownload, *Response, error)
 }
 
 // HostedAgentsServiceOp handles communication with Hosted Agents session methods.
@@ -177,7 +189,6 @@ type HostedAgentSession struct {
 	TeamID       uint64                                  `json:"team_id"`
 	AgentKind    HostedAgentKind                         `json:"agent_kind"`
 	Status       HostedAgentSessionStatus                `json:"status"`
-	SandboxID    string                                  `json:"sandbox_id,omitempty"`
 	CreatedAt    Timestamp                               `json:"created_at"`
 	LastEventAt  Timestamp                               `json:"last_event_at"`
 	RepoHint     string                                  `json:"repo_hint,omitempty"`
@@ -323,6 +334,44 @@ type HostedAgentSandboxExecResponse struct {
 	ExitCode int    `json:"exit_code"`
 	Stdout   string `json:"stdout,omitempty"`
 	Stderr   string `json:"stderr,omitempty"`
+}
+
+// HostedAgentWorkspaceUploadRequest is the input for UploadWorkspace.
+type HostedAgentWorkspaceUploadRequest struct {
+	// Path is the destination resolved inside the workspace root (/workspace). Required.
+	Path string
+	// IsArchive indicates Body is a tar archive to extract at Path.
+	IsArchive bool
+	// ContentSHA256 is an optional hex SHA-256 digest of the payload, forwarded to the guest for verification.
+	ContentSHA256 string
+	// Body is the raw file or tar bytes to upload. Required.
+	Body io.Reader
+}
+
+// HostedAgentWorkspaceUploadResponse is returned by UploadWorkspace.
+type HostedAgentWorkspaceUploadResponse struct {
+	Path         string `json:"path"`
+	BytesWritten int64  `json:"bytes_written"`
+}
+
+// HostedAgentWorkspaceDownloadRequest is the input for DownloadWorkspace.
+type HostedAgentWorkspaceDownloadRequest struct {
+	// Path is the source resolved inside the workspace root (/workspace). Required.
+	Path string
+	// AsArchive tar-streams the directory at Path when true.
+	AsArchive bool
+}
+
+// HostedAgentWorkspaceDownload is the streaming result of DownloadWorkspace.
+// Body verifies the SHA-256 integrity trailer: read it to EOF and then Close
+// it. A missing trailer or checksum mismatch is surfaced as an error; discard
+// the output in that case.
+type HostedAgentWorkspaceDownload struct {
+	Body io.ReadCloser
+	// IsArchive is true when the payload is a tar stream.
+	IsArchive bool
+	// SizeBytes is the X-Workspace-Size-Bytes hint (0 when unknown); not a Content-Length.
+	SizeBytes int64
 }
 
 type hostedAgentSessionRoot struct {
@@ -546,6 +595,156 @@ func (s *HostedAgentsServiceOp) ExecInSandbox(ctx context.Context, sessionID str
 		return nil, resp, err
 	}
 	return root, resp, nil
+}
+
+// UploadWorkspace streams a file (or tar archive) into the session workspace.
+func (s *HostedAgentsServiceOp) UploadWorkspace(ctx context.Context, sessionID string, input *HostedAgentWorkspaceUploadRequest) (*HostedAgentWorkspaceUploadResponse, *Response, error) {
+	if sessionID == "" {
+		return nil, nil, errors.New("hosted agents: session id is required")
+	}
+	if input == nil {
+		return nil, nil, errors.New("hosted agents: upload request is required")
+	}
+	if input.Path == "" {
+		return nil, nil, errors.New("hosted agents: path is required")
+	}
+	if input.Body == nil {
+		return nil, nil, errors.New("hosted agents: body is required")
+	}
+
+	path := fmt.Sprintf(hostedAgentSessionWorkspaceUploadPath, sessionID)
+	u, err := s.client.BaseURL.Parse(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	q := url.Values{}
+	q.Set("path", input.Path)
+	if input.IsArchive {
+		q.Set("is_archive", "true")
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), input.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Content-Type", hostedAgentWorkspaceMediaType)
+	req.Header.Set("Accept", mediaType)
+	req.Header.Set("User-Agent", s.client.UserAgent)
+	if input.ContentSHA256 != "" {
+		req.Header.Set(workspaceContentSHA256Header, input.ContentSHA256)
+	}
+
+	root := new(HostedAgentWorkspaceUploadResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// DownloadWorkspace streams a file (or tar archive) out of the session
+// workspace. Callers MUST read the returned Body to EOF and then Close it; both
+// verify the SHA-256 integrity trailer.
+func (s *HostedAgentsServiceOp) DownloadWorkspace(ctx context.Context, sessionID string, input *HostedAgentWorkspaceDownloadRequest) (*HostedAgentWorkspaceDownload, *Response, error) {
+	if sessionID == "" {
+		return nil, nil, errors.New("hosted agents: session id is required")
+	}
+	if input == nil {
+		return nil, nil, errors.New("hosted agents: download request is required")
+	}
+	if input.Path == "" {
+		return nil, nil, errors.New("hosted agents: path is required")
+	}
+
+	path := fmt.Sprintf(hostedAgentSessionWorkspaceDownloadPath, sessionID)
+	q := url.Values{}
+	q.Set("path", input.Path)
+	if input.AsArchive {
+		q.Set("as_archive", "true")
+	}
+	path += "?" + q.Encode()
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Accept", hostedAgentWorkspaceMediaType)
+
+	resp, err := s.client.DoStream(ctx, req)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	out := &HostedAgentWorkspaceDownload{
+		Body: &workspaceDownloadBody{
+			resp:   resp.Response,
+			body:   resp.Body,
+			hasher: sha256.New(),
+		},
+	}
+	if archive, perr := strconv.ParseBool(strings.TrimSpace(resp.Header.Get(workspaceIsArchiveHeader))); perr == nil {
+		out.IsArchive = archive
+	}
+	if hint := strings.TrimSpace(resp.Header.Get(workspaceSizeBytesHeader)); hint != "" {
+		if n, perr := strconv.ParseInt(hint, 10, 64); perr == nil {
+			out.SizeBytes = n
+		}
+	}
+	return out, resp, nil
+}
+
+// workspaceDownloadBody hashes bytes as they are read and verifies the
+// X-Content-Sha256 trailer at EOF, since Go only populates response trailers
+// once the body is fully consumed.
+type workspaceDownloadBody struct {
+	resp     *http.Response
+	body     io.ReadCloser
+	hasher   hash.Hash
+	verified bool
+	verr     error
+}
+
+func (b *workspaceDownloadBody) Read(p []byte) (int, error) {
+	n, err := b.body.Read(p)
+	if n > 0 {
+		b.hasher.Write(p[:n])
+	}
+	if errors.Is(err, io.EOF) {
+		if verr := b.verify(); verr != nil {
+			return n, verr
+		}
+	}
+	return n, err
+}
+
+func (b *workspaceDownloadBody) verify() error {
+	if b.verified {
+		return b.verr
+	}
+	b.verified = true
+
+	want := strings.TrimSpace(b.resp.Trailer.Get(workspaceContentSHA256Header))
+	if want == "" {
+		b.verr = errors.New("hosted agents: missing X-Content-Sha256 integrity trailer; workspace download was truncated or corrupted")
+		return b.verr
+	}
+	got := hex.EncodeToString(b.hasher.Sum(nil))
+	if !strings.EqualFold(want, got) {
+		b.verr = fmt.Errorf("hosted agents: workspace download checksum mismatch: want %q, got %q", want, got)
+		return b.verr
+	}
+	return nil
+}
+
+func (b *workspaceDownloadBody) Close() error {
+	if cerr := b.body.Close(); cerr != nil {
+		return cerr
+	}
+	if b.verified {
+		return b.verr
+	}
+	return nil
 }
 
 // HostedAgentSessionStream is a typed iterator over a session SSE stream.

--- a/vendor/github.com/digitalocean/godo/nfs.go
+++ b/vendor/github.com/digitalocean/godo/nfs.go
@@ -10,6 +10,10 @@ const nfsBasePath = "v2/nfs"
 
 const nfsSnapshotsBasePath = "v2/nfs/snapshots"
 
+const nfsSharesBasePath = "v2/nfs/shares"
+
+const nfsAccessPointsBasePath = "v2/nfs/access_points"
+
 // NfsShareStatus represents the status of an NFS share.
 type NfsShareStatus string
 
@@ -33,6 +37,36 @@ const (
 	NfsSnapshotDeleted  = NfsSnapshotStatus("DELETED")
 )
 
+// NfsAccessPointStatus represents the status of an NFS access point.
+type NfsAccessPointStatus string
+
+// Possible states for an NFS access point.
+const (
+	NfsAccessPointCreating = NfsAccessPointStatus("ACCESS_POINT_CREATING")
+	NfsAccessPointActive   = NfsAccessPointStatus("ACCESS_POINT_ACTIVE")
+	NfsAccessPointFailed   = NfsAccessPointStatus("ACCESS_POINT_FAILED")
+	NfsAccessPointDeleted  = NfsAccessPointStatus("ACCESS_POINT_DELETED")
+)
+
+// NfsAccessPolicyProtocol represents an allowed protocol in an NFS access policy.
+type NfsAccessPolicyProtocol string
+
+// Possible protocol values for an NFS access policy.
+const (
+	NfsAccessPolicyProtocolNFS  = NfsAccessPolicyProtocol("NFS")
+	NfsAccessPolicyProtocolNFS4 = NfsAccessPolicyProtocol("NFS4")
+)
+
+// NfsSquashConfig represents the squash mode in an NFS access policy.
+type NfsSquashConfig string
+
+// Possible squash config values for an NFS access policy.
+const (
+	NfsSquashConfigNoSquash   = NfsSquashConfig("NO_SQUASH")
+	NfsSquashConfigRootSquash = NfsSquashConfig("ROOT_SQUASH")
+	NfsSquashConfigAllSquash  = NfsSquashConfig("ALL_SQUASH")
+)
+
 type NfsService interface {
 	// List retrieves a list of NFS shares filtered by region
 	List(ctx context.Context, opts *ListOptions, region string) ([]*Nfs, *Response, error)
@@ -48,6 +82,14 @@ type NfsService interface {
 	GetSnapshot(ctx context.Context, nfsSnapshotID string, region string) (*NfsSnapshot, *Response, error)
 	// Delete removes an NFS snapshot by its ID and region
 	DeleteSnapshot(ctx context.Context, nfsSnapshotID string, region string) (*Response, error)
+	// CreateAccessPoint creates a new access point for a share.
+	CreateAccessPoint(ctx context.Context, shareID string, createRequest *NfsCreateAccessPointRequest) (*NfsAccessPointActionResponse, *Response, error)
+	// GetAccessPoint retrieves an NFS access point by ID.
+	GetAccessPoint(ctx context.Context, accessPointID string) (*NfsAccessPoint, *Response, error)
+	// ListAccessPoints retrieves access points for a given share.
+	ListAccessPoints(ctx context.Context, shareID string, opts *NfsListAccessPointsOptions) ([]*NfsAccessPoint, *Response, error)
+	// DeleteAccessPoint soft-deletes an NFS access point by ID.
+	DeleteAccessPoint(ctx context.Context, accessPointID string) (*NfsAccessPointActionResponse, *Response, error)
 }
 
 // NfsServiceOp handles communication with the NFS related methods of the
@@ -80,6 +122,8 @@ type Nfs struct {
 	MountPath string `json:"mount_path"`
 	//PerformanceTier is the performance tier of the NFS share
 	PerformanceTier string `json:"performance_tier"`
+	// AccessPoints is the list of access points configured for the NFS share.
+	AccessPoints []*NfsAccessPoint `json:"access_points,omitempty"`
 }
 
 type NfsSnapshot struct {
@@ -99,6 +143,29 @@ type NfsSnapshot struct {
 	ShareID string `json:"share_id"`
 }
 
+// NfsAccessPolicy represents the export policy of an NFS access point.
+type NfsAccessPolicy struct {
+	Anonuid                    uint64                    `json:"anonuid"`
+	Anongid                    uint64                    `json:"anongid"`
+	Protocols                  []NfsAccessPolicyProtocol `json:"protocols"`
+	SquashConfig               NfsSquashConfig           `json:"squash_config"`
+	IdentityEnforcementEnabled bool                      `json:"identity_enforcement_enabled"`
+}
+
+// NfsAccessPoint represents an NFS access point.
+type NfsAccessPoint struct {
+	ID           string               `json:"id"`
+	Name         string               `json:"name"`
+	ShareID      string               `json:"share_id"`
+	Path         string               `json:"path"`
+	Status       NfsAccessPointStatus `json:"status"`
+	AccessPolicy NfsAccessPolicy      `json:"access_policy"`
+	CreatedAt    string               `json:"created_at"`
+	UpdatedAt    string               `json:"updated_at"`
+	IsDefault    bool                 `json:"is_default"`
+	VpcID        *string              `json:"vpc_id,omitempty"`
+}
+
 // NfsCreateRequest represents a request to create an NFS share.
 type NfsCreateRequest struct {
 	Name            string   `json:"name"`
@@ -106,6 +173,25 @@ type NfsCreateRequest struct {
 	Region          string   `json:"region"`
 	VpcIDs          []string `json:"vpc_ids,omitempty"`
 	PerformanceTier string   `json:"performance_tier,omitempty"`
+}
+
+// NfsCreateAccessPointRequest represents a request to create an NFS access point.
+type NfsCreateAccessPointRequest struct {
+	Name         string          `json:"name"`
+	Path         string          `json:"path"`
+	AccessPolicy NfsAccessPolicy `json:"access_policy"`
+	VpcID        string          `json:"vpc_id"`
+}
+
+// NfsListAccessPointsOptions represents filters for listing access points.
+type NfsListAccessPointsOptions struct {
+	Status NfsAccessPointStatus `url:"status,omitempty"`
+}
+
+// NfsAccessPointActionResponse represents an access point mutation response.
+type NfsAccessPointActionResponse struct {
+	AccessPoint *NfsAccessPoint `json:"access_point"`
+	Action      *NfsAction      `json:"action"`
 }
 
 // nfsRoot represents a response from the DigitalOcean API
@@ -130,6 +216,22 @@ type nfsSnapshotListRoot struct {
 	Snapshots []*NfsSnapshot `json:"snapshots,omitempty"`
 	Links     *Links         `json:"links,omitempty"`
 	Meta      *Meta          `json:"meta"`
+}
+
+// nfsAccessPointRoot represents a response from the DigitalOcean API.
+type nfsAccessPointRoot struct {
+	AccessPoint *NfsAccessPoint `json:"access_point"`
+}
+
+// nfsAccessPointListRoot represents a response from the DigitalOcean API.
+type nfsAccessPointListRoot struct {
+	AccessPoints []*NfsAccessPoint `json:"access_points,omitempty"`
+}
+
+// nfsAccessPointActionRoot represents a response from access point mutation APIs.
+type nfsAccessPointActionRoot struct {
+	AccessPoint *NfsAccessPoint `json:"access_point"`
+	Action      *NfsAction      `json:"action"`
 }
 
 // nfsOptions represents the query param options for NFS operations
@@ -339,4 +441,102 @@ func (s *NfsServiceOp) DeleteSnapshot(ctx context.Context, nfsSnapshotID string,
 	}
 
 	return resp, nil
+}
+
+// CreateAccessPoint creates a new access point for a share.
+func (s *NfsServiceOp) CreateAccessPoint(ctx context.Context, shareID string, createRequest *NfsCreateAccessPointRequest) (*NfsAccessPointActionResponse, *Response, error) {
+	if shareID == "" {
+		return nil, nil, NewArgError("shareID", "cannot be empty")
+	}
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+	if createRequest.VpcID == "" {
+		return nil, nil, NewArgError("vpc_id", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s/access_points", nfsSharesBasePath, shareID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(nfsAccessPointActionRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &NfsAccessPointActionResponse{AccessPoint: root.AccessPoint, Action: root.Action}, resp, nil
+}
+
+// GetAccessPoint retrieves an NFS access point by ID.
+func (s *NfsServiceOp) GetAccessPoint(ctx context.Context, accessPointID string) (*NfsAccessPoint, *Response, error) {
+	if accessPointID == "" {
+		return nil, nil, NewArgError("accessPointID", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", nfsAccessPointsBasePath, accessPointID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(nfsAccessPointRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.AccessPoint, resp, nil
+}
+
+// ListAccessPoints returns all access points for a share.
+func (s *NfsServiceOp) ListAccessPoints(ctx context.Context, shareID string, opts *NfsListAccessPointsOptions) ([]*NfsAccessPoint, *Response, error) {
+	if shareID == "" {
+		return nil, nil, NewArgError("shareID", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s/access_points", nfsSharesBasePath, shareID)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(nfsAccessPointListRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.AccessPoints, resp, nil
+}
+
+// DeleteAccessPoint soft-deletes an NFS access point by ID.
+func (s *NfsServiceOp) DeleteAccessPoint(ctx context.Context, accessPointID string) (*NfsAccessPointActionResponse, *Response, error) {
+	if accessPointID == "" {
+		return nil, nil, NewArgError("accessPointID", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", nfsAccessPointsBasePath, accessPointID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(nfsAccessPointActionRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &NfsAccessPointActionResponse{AccessPoint: root.AccessPoint, Action: root.Action}, resp, nil
 }

--- a/vendor/github.com/digitalocean/godo/secrets.go
+++ b/vendor/github.com/digitalocean/godo/secrets.go
@@ -1,0 +1,319 @@
+package godo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const secretsBasePath = "v2/security/secrets"
+
+// SecretsService is an interface for interacting with the Secrets endpoints of
+// the DigitalOcean API.
+type SecretsService interface {
+	List(context.Context, *ListOptions) (*SecretsList, *Response, error)
+	Get(context.Context, string, string) (*Secret, *Response, error)
+	ListVersions(context.Context, string, string) ([]*SecretVersion, *Response, error)
+	Create(context.Context, *SecretCreateRequest) (*SecretWriteResult, *Response, error)
+	Update(context.Context, string, *SecretUpdateRequest) (*SecretWriteResult, *Response, error)
+	Delete(context.Context, string, string) (*Response, error)
+	Restore(context.Context, string, string) (*Response, error)
+}
+
+// SecretsServiceOp handles communication with Secrets related methods of the
+// DigitalOcean API.
+type SecretsServiceOp struct {
+	client *Client
+}
+
+var _ SecretsService = &SecretsServiceOp{}
+
+// Secret represents a DigitalOcean secret.
+type Secret struct {
+	Name              string            `json:"secret"`
+	Region            string            `json:"region,omitempty"`
+	Version           int               `json:"version"`
+	Values            map[string]string `json:"values,omitempty"`
+	CreatedAt         string            `json:"created_at"`
+	UpdatedAt         string            `json:"updated_at,omitempty"`
+	DeleteRequestedAt *string           `json:"delete_requested_at,omitempty"`
+}
+
+// SecretVersion represents a version of a secret.
+type SecretVersion struct {
+	Version   int    `json:"version"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// SecretCreateRequest represents a request to create a secret.
+type SecretCreateRequest struct {
+	Name   string            `json:"name"`
+	Region string            `json:"region"`
+	Values map[string]string `json:"values"`
+}
+
+// SecretUpdateRequest represents a request to update a secret.
+type SecretUpdateRequest struct {
+	Region  string            `json:"region"`
+	Version int               `json:"version"`
+	Values  map[string]string `json:"values"`
+}
+
+// SecretWriteResult represents the response from creating or updating a secret.
+type SecretWriteResult struct {
+	Name    string `json:"name"`
+	Region  string `json:"region"`
+	Version int    `json:"version"`
+}
+
+// SecretsList holds the result of a list secrets request.
+type SecretsList struct {
+	Secrets            []*Secret
+	UnavailableRegions []string
+}
+
+type secretRegionOptions struct {
+	Region string `url:"region"`
+}
+
+type secretsListRoot struct {
+	Secrets            []*Secret `json:"secrets"`
+	Links              *Links    `json:"links"`
+	Meta               *Meta     `json:"meta"`
+	UnavailableRegions []string  `json:"unavailable_regions,omitempty"`
+}
+
+type secretVersionsRoot struct {
+	Versions []*SecretVersion `json:"versions"`
+}
+
+// List returns a paginated list of secrets across all regions.
+func (s *SecretsServiceOp) List(ctx context.Context, opts *ListOptions) (*SecretsList, *Response, error) {
+	path, err := addOptions(secretsBasePath, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(secretsListRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return &SecretsList{
+		Secrets:            root.Secrets,
+		UnavailableRegions: root.UnavailableRegions,
+	}, resp, nil
+}
+
+// Get retrieves a secret by name and region.
+func (s *SecretsServiceOp) Get(ctx context.Context, name, region string) (*Secret, *Response, error) {
+	if name == "" {
+		return nil, nil, NewArgError("name", "cannot be empty")
+	}
+	if region == "" {
+		return nil, nil, NewArgError("region", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", secretsBasePath, name)
+	path, err := addOptions(path, &secretRegionOptions{Region: region})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secret := new(Secret)
+	resp, err := s.client.Do(ctx, req, secret)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secret, resp, nil
+}
+
+// ListVersions returns all versions of a secret.
+func (s *SecretsServiceOp) ListVersions(ctx context.Context, name, region string) ([]*SecretVersion, *Response, error) {
+	if name == "" {
+		return nil, nil, NewArgError("name", "cannot be empty")
+	}
+	if region == "" {
+		return nil, nil, NewArgError("region", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s/versions", secretsBasePath, name)
+	path, err := addOptions(path, &secretRegionOptions{Region: region})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(secretVersionsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Versions, resp, nil
+}
+
+// Create creates a new secret.
+func (s *SecretsServiceOp) Create(ctx context.Context, createRequest *SecretCreateRequest) (*SecretWriteResult, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+	if createRequest.Region == "" {
+		return nil, nil, NewArgError("region", "cannot be empty")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, secretsBasePath, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(SecretWriteResult)
+	resp, err := s.doDecodeJSON(ctx, req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Update updates an existing secret.
+func (s *SecretsServiceOp) Update(ctx context.Context, name string, updateRequest *SecretUpdateRequest) (*SecretWriteResult, *Response, error) {
+	if name == "" {
+		return nil, nil, NewArgError("name", "cannot be empty")
+	}
+	if updateRequest == nil {
+		return nil, nil, NewArgError("updateRequest", "cannot be nil")
+	}
+	if updateRequest.Region == "" {
+		return nil, nil, NewArgError("region", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", secretsBasePath, name)
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(SecretWriteResult)
+	resp, err := s.doDecodeJSON(ctx, req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Delete schedules a secret for soft deletion.
+func (s *SecretsServiceOp) Delete(ctx context.Context, name, region string) (*Response, error) {
+	if name == "" {
+		return nil, NewArgError("name", "cannot be empty")
+	}
+	if region == "" {
+		return nil, NewArgError("region", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", secretsBasePath, name)
+	path, err := addOptions(path, &secretRegionOptions{Region: region})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// Restore restores a secret that was scheduled for deletion.
+func (s *SecretsServiceOp) Restore(ctx context.Context, name, region string) (*Response, error) {
+	if name == "" {
+		return nil, NewArgError("name", "cannot be empty")
+	}
+	if region == "" {
+		return nil, NewArgError("region", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s/restore", secretsBasePath, name)
+	path, err := addOptions(path, &secretRegionOptions{Region: region})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// doDecodeJSON sends a request and decodes the JSON response body even when
+// the API returns 204 No Content with a body.
+func (s *SecretsServiceOp) doDecodeJSON(ctx context.Context, req *http.Request, v interface{}) (*Response, error) {
+	c := s.client
+	if c.rateLimiter != nil {
+		if err := c.rateLimiter.Wait(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	resp, err := DoRequestWithClient(ctx, c.HTTPClient, req)
+	if err != nil {
+		return nil, err
+	}
+	if c.onRequestCompleted != nil {
+		c.onRequestCompleted(req, resp)
+	}
+
+	defer func() {
+		const maxBodySlurpSize = 2 << 10
+		if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
+			io.CopyN(io.Discard, resp.Body, maxBodySlurpSize)
+		}
+		resp.Body.Close()
+	}()
+
+	response := newResponse(resp)
+	c.ratemtx.Lock()
+	c.Rate = response.Rate
+	c.ratemtx.Unlock()
+
+	if err = CheckResponse(resp); err != nil {
+		return response, err
+	}
+
+	if v != nil {
+		if err = json.NewDecoder(resp.Body).Decode(v); err != nil {
+			return response, err
+		}
+	}
+
+	return response, nil
+}


### PR DESCRIPTION
Removes the SandboxID column from commands/displayers/hosted_agents.go (Cols, ColMap, KV) as a pre-release cleanup — the field was never populated by the API. The vendored godo copy is left untouched; a follow-up PR will bump go.mod once the godo removal merges and a new beta tag is cut.