### PR TITLE
fix: always prompt for token in auth init

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -158,20 +158,23 @@ To create new contexts, see the help for `+"`"+`doctl auth init`+"`"+`.`, Writer
 // XDG_CONFIG_HOME is not set, use $HOME/.config. On Windows use %APPDATA%/doctl/config.
 func RunAuthInit(retrieveUserTokenFunc func() (string, error)) func(c *CmdConfig) error {
 	return func(c *CmdConfig) error {
-		token := c.getContextAccessToken()
 		context := strings.ToLower(Context)
 		if context == "" {
 			context = strings.ToLower(viper.GetString("context"))
 		}
 
-		if token == "" {
+		var token string
+		if Token != "" {
+			// Use the token provided via --access-token flag.
+			token = Token
+		} else {
+			// Always prompt for a new token, even if one exists in the config.
+			// This ensures the user can replace an expired or revoked token.
 			in, err := retrieveUserTokenFunc()
 			if err != nil {
 				return fmt.Errorf("Unable to read DigitalOcean access token: %s", err)
 			}
 			token = strings.TrimSpace(in)
-		} else {
-			template.Render(c.Out, `Using token for context {{highlight .}}{{nl}}`, context)
 		}
 
 		c.setContextAccessToken(token)

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -103,9 +103,12 @@ func TestAuthInitConfig(t *testing.T) {
 
 func TestAuthInitWithProvidedToken(t *testing.T) {
 	cfw := cfgFileWriter
+	origToken := Token
+	Token = "valid-token"
 	viper.Set(doctl.ArgAccessToken, "valid-token")
 	defer func() {
 		cfgFileWriter = cfw
+		Token = origToken
 		viper.Set(doctl.ArgAccessToken, nil)
 	}()
 
@@ -123,11 +126,37 @@ func TestAuthInitWithProvidedToken(t *testing.T) {
 	})
 }
 
+func TestAuthInitPromptsWhenTokenExists(t *testing.T) {
+	cfw := cfgFileWriter
+	// Simulate an existing (possibly expired) token in the config.
+	viper.Set(doctl.ArgAccessToken, "expired-token")
+	defer func() {
+		cfgFileWriter = cfw
+		viper.Set(doctl.ArgAccessToken, nil)
+	}()
+
+	retrieveUserTokenFunc := func() (string, error) {
+		return "new-valid-token", nil
+	}
+
+	cfgFileWriter = func() (io.WriteCloser, error) { return &nopWriteCloser{Writer: io.Discard}, nil }
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.oauth.EXPECT().TokenInfo(gomock.Any()).Return(&do.OAuthTokenInfo{}, nil)
+
+		err := RunAuthInit(retrieveUserTokenFunc)(config)
+		assert.NoError(t, err)
+	})
+}
+
 func TestAuthForcesLowercase(t *testing.T) {
 	cfw := cfgFileWriter
+	origToken := Token
+	Token = "valid-token"
 	viper.Set(doctl.ArgAccessToken, "valid-token")
 	defer func() {
 		cfgFileWriter = cfw
+		Token = origToken
 		viper.Set(doctl.ArgAccessToken, nil)
 	}()
 


### PR DESCRIPTION
## Summary

- `doctl auth init` now always prompts the user for a new token, even when one already exists in the config
- Previously, if an expired/revoked token was saved, `auth init` would immediately fail with a 401 error without giving the user a chance to enter a new token
- Tokens passed via the `--access-token` flag are still respected without prompting

## Motivation

When a saved token expires or is revoked, running `doctl auth init` (the command specifically meant to set up authentication) would error out instantly. Users had no way to re-authenticate without manually editing `~/.config/doctl/config.yaml`.

## Test plan

- [x] `TestAuthInit` — basic flow with no existing token
- [x] `TestAuthInitWithProvidedToken` — `--access-token` flag skips prompt  
- [x] `TestAuthInitPromptsWhenTokenExists` — new test for the fix (prompts even when old token exists)
- [x] `TestAuthForcesLowercase` — context handling still works
- [x] All existing auth tests pass (`go test ./commands/ -run TestAuth`)