### PR TITLE
MARSOHS-340: fail agents attach fast on a terminal session

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -494,6 +494,13 @@ func isTerminalSessionStatus(s godo.HostedAgentSessionStatus) bool {
 	}
 }
 
+// humanSessionStatus renders a session status for display in plain-English
+// messages, e.g. SESSION_STATUS_DESTROYED -> "destroyed". Table output
+// (agents list/get) keeps the raw enum value; this is only for prose.
+func humanSessionStatus(s godo.HostedAgentSessionStatus) string {
+	return strings.ToLower(strings.TrimPrefix(string(s), "SESSION_STATUS_"))
+}
+
 // resolveSessionRef turns a user-supplied session reference into a session ID.
 // References that already look like an ID (a UUID) are returned unchanged with
 // no API call, so existing scripts keep working with no added latency.
@@ -860,6 +867,9 @@ func RunAgentsAttach(c *CmdConfig) error {
 			return errors.New(strings.TrimSpace(msg))
 		}
 		return err
+	}
+	if isTerminalSessionStatus(sess.Status) {
+		return fmt.Errorf("session %s cannot be attached (status: %s)", sessionID, humanSessionStatus(sess.Status))
 	}
 
 	pending := &pendingHITL{}

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -1488,6 +1488,47 @@ func TestRunAgentsAttachAuthFailure(t *testing.T) {
 	})
 }
 
+// TestRunAgentsAttachTerminalSession: attach must fail fast (no banner, no
+// interactive loop) when the session is already destroyed/destroying/failed,
+// instead of connecting and only failing once the user sends input.
+func TestRunAgentsAttachTerminalSession(t *testing.T) {
+	cases := []struct {
+		name   string
+		status godo.HostedAgentSessionStatus
+	}{
+		{"destroyed", godo.HostedAgentSessionStatusDestroyed},
+		{"destroying", godo.HostedAgentSessionStatusDestroying},
+		{"failed", godo.HostedAgentSessionStatusFailed},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				tm.hostedAgents.EXPECT().GetSession("sess_x").Return(&do.HostedAgentSession{
+					HostedAgentSession: &godo.HostedAgentSession{
+						SessionID: "sess_x",
+						Status:    tc.status,
+					},
+				}, nil)
+
+				config.Args = []string{"sess_x"}
+				err := RunAgentsAttach(config)
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "cannot be attached")
+				assert.Contains(t, err.Error(), humanSessionStatus(tc.status))
+			})
+		})
+	}
+}
+
+// TestHumanSessionStatus pins the SESSION_STATUS_ -> lowercase mapping used in
+// attach's terminal-session error message.
+func TestHumanSessionStatus(t *testing.T) {
+	assert.Equal(t, "destroyed", humanSessionStatus(godo.HostedAgentSessionStatusDestroyed))
+	assert.Equal(t, "failed", humanSessionStatus(godo.HostedAgentSessionStatusFailed))
+	assert.Equal(t, "ready", humanSessionStatus(godo.HostedAgentSessionStatusReady))
+}
+
 // TestClassifyStreamError pins the apierr contract: 401/403/404/409 are
 // terminal (409 == V0 single-connection rejection); 5xx/other are transient.
 func TestClassifyStreamError(t *testing.T) {


### PR DESCRIPTION
## Summary
- `doctl agents attach <session_id>` printed "Connected to ..." and dropped into the interactive prompt even for a destroyed/failed/destroying session — it only failed once the user typed something and SendInput returned 404.
- GetSession succeeds for terminal sessions (status is returned, not an error), so the existing error check on GetSession never caught this.
- Adds a check on `sess.Status` right after GetSession succeeds, using the existing `isTerminalSessionStatus` helper, to fail fast with a clear message before printing the banner or starting the stream.

## Before
```
Connected to <session_id> (AGENT_KIND_CODEX_CLI)
Type a message and press Enter to send...
> hello
send failed: ... 404 session not found
```

## After
```
Error: session <session_id> cannot be attached (status: destroyed)
```

## Related
Complements the harness-api server-side fix for MARSOHS-340 [https://do-internal.atlassian.net/browse/MARSOHS-340]

## Test plan
- [x] `go build ./commands/...`
- [ ] Manual repro: start → destroy → attach a session, confirm immediate error
- [ ] Add/verify unit test coverage for terminal-status attach rejection