### PR TITLE
Fix auth switch writing to a stale config path

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -355,7 +355,18 @@ func writeConfig() error {
 // When using the default config file path the default config home directory will be created; Otherwise
 // the custom config home directory must exist and be writable to the user issuing the auth command.
 func defaultConfigFileWriter() (io.WriteCloser, error) {
-	cfgFile := viper.GetString("config")
+	// Write to the config file viper actually loaded, not the value of the
+	// "config" key. writeConfig persists viper.AllSettings(), which includes the
+	// bound "config" flag, so a top-level "config:" entry ends up in the file. On
+	// a later run viper reads it back, and because a config-file value outranks a
+	// flag's default, viper.GetString("config") returns that stored path. When the
+	// config was copied from another machine the path is stale, and auth switch
+	// would silently write there instead of the live config. ConfigFileUsed() is
+	// the path set at init, before the file is read, so it is not hijacked.
+	cfgFile := viper.ConfigFileUsed()
+	if cfgFile == "" {
+		cfgFile = viper.GetString("config")
+	}
 
 	defaultCfgFile := filepath.Join(defaultConfigHome(), defaultConfigName)
 	if cfgFile == defaultCfgFile {

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/digitalocean/doctl/do"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -160,6 +162,45 @@ func TestAuthForcesLowercase(t *testing.T) {
 		// should not error because context does exist
 		assert.NoError(t, err)
 	})
+}
+
+func TestDefaultConfigFileWriterUsesLoadedConfig(t *testing.T) {
+	// Regression: a config carrying a stale top-level "config:" path (e.g. copied
+	// from another machine) must not hijack where auth switch writes. The write
+	// must land in the config file viper actually loaded.
+	origContext := viper.Get("context")
+	origConfig := viper.Get("config")
+	origFile := viper.ConfigFileUsed()
+	defer func() {
+		viper.Set("context", origContext)
+		viper.Set("config", origConfig)
+		viper.SetConfigFile(origFile)
+	}()
+
+	dir := t.TempDir()
+	realCfg := filepath.Join(dir, "config.yaml")
+	staleCfg := filepath.Join(dir, "copied-from-another-host.yaml")
+
+	require.NoError(t, os.WriteFile(realCfg,
+		[]byte("context: default\nconfig: "+staleCfg+"\n"), 0600))
+
+	// Mimic initConfig: point viper at the real file and read it in.
+	viper.SetConfigFile(realCfg)
+	require.NoError(t, viper.ReadInConfig())
+
+	// The loaded file now carries `config: <staleCfg>`. The pre-fix code used
+	// viper.GetString("config") as the write target and would land on staleCfg;
+	// the assertions below prove the writer targets the loaded file instead.
+	w, err := defaultConfigFileWriter()
+	require.NoError(t, err)
+	_, err = io.WriteString(w, "context: newcontext\n")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	assert.NoFileExists(t, staleCfg, "must not write to the stale config path")
+	got, err := os.ReadFile(realCfg)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "newcontext", "must rewrite the loaded config file")
 }
 
 func TestAuthList(t *testing.T) {


### PR DESCRIPTION
Fixes #1882

## What

`doctl auth switch --context <name>` prints `Now using context [<name>] by default` but silently fails to persist when the config file carries a top-level `config:` key pointing somewhere other than the file in use. It writes the update to that stale path and leaves the live config unchanged.

## Why

`writeConfig()` marshals `viper.AllSettings()`, which includes the bound `config` flag, so a top-level `config:` key gets baked into the file on every write. On the next run viper reads it back, and because a config-file value outranks a flag's default, `viper.GetString("config")` returns that stored path. `defaultConfigFileWriter()` then uses it as the write target. When the config was copied between machines (e.g. macOS `~/Library/Application Support/doctl/` → a Linux container's `~/.config/doctl/`), the stored path is stale and the write misses the live file. `--config <path>` masks the bug because an explicitly-set flag outranks the config-file value.

## Fix

Write to `viper.ConfigFileUsed()` — the path resolved at init, before the config file is read — falling back to `viper.GetString("config")` only if it is unset. This can't be hijacked by the persisted key. The file still contains the `config:` key (unchanged behavior, still asserted by `TestAuthInitConfig`); only the write *target* is corrected.

## Test

`TestDefaultConfigFileWriterUsesLoadedConfig` loads a config that carries a stale `config:` path and asserts the writer targets the loaded file, not the stale path. It fails on `main` and passes with this change.

```
ok  github.com/digitalocean/doctl/commands
```

## Reproduce (before this change)

```bash
sed -i 's#^config: .*#config: /tmp/doctl-STALE.yaml#' ~/.config/doctl/config.yaml
doctl auth switch --context myteam      # prints success
grep '^context:' ~/.config/doctl/config.yaml   # unchanged
grep '^context:' /tmp/doctl-STALE.yaml         # context: myteam  (written here instead)
```
