### PR TITLE
add support for advanced mysql config get and patch operations

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -2659,6 +2659,7 @@ For a full list of available fields, see the API documentation: https://docs.dig
 		displayerType(&displayers.MySQLConfiguration{}),
 		displayerType(&displayers.PostgreSQLConfiguration{}),
 		displayerType(&displayers.AdvancedPostgresConfiguration{}),
+		displayerType(&displayers.AdvancedMySQLConfiguration{}),
 		displayerType(&displayers.RedisConfiguration{}),
 		displayerType(&displayers.ValkeyConfiguration{}),
 		displayerType(&displayers.MongoDBConfiguration{}),
@@ -2719,17 +2720,18 @@ func RunDatabaseConfigurationGet(c *CmdConfig) error {
 	}
 
 	allowedEngines := map[string]any{
-		"mysql":       nil,
-		"pg":          nil,
-		"advanced_pg": nil,
-		"redis":       nil,
-		"valkey":      nil,
-		"mongodb":     nil,
-		"kafka":       nil,
-		"opensearch":  nil,
+		"mysql":          nil,
+		"pg":             nil,
+		"advanced_pg":    nil,
+		"advanced_mysql": nil,
+		"redis":          nil,
+		"valkey":         nil,
+		"mongodb":        nil,
+		"kafka":          nil,
+		"opensearch":     nil,
 	}
 	if _, ok := allowedEngines[engine]; !ok {
-		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'advanced_pg', 'mysql', 'redis', 'valkey', 'mongodb', 'kafka', opensearch", c.NS)
+		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'advanced_pg', 'mysql', 'advanced_mysql', 'redis', 'valkey', 'mongodb', 'kafka', opensearch", c.NS)
 	}
 
 	dbId := args[0]
@@ -2761,6 +2763,16 @@ func RunDatabaseConfigurationGet(c *CmdConfig) error {
 
 		displayer := displayers.AdvancedPostgresConfiguration{
 			AdvancedPostgresConfig: *config,
+		}
+		return c.Display(&displayer)
+	} else if engine == "advanced_mysql" {
+		config, err := c.Databases().GetAdvancedMySQLConfiguration(dbId)
+		if err != nil {
+			return err
+		}
+
+		displayer := displayers.AdvancedMySQLConfiguration{
+			AdvancedMySQLConfig: *config,
 		}
 		return c.Display(&displayer)
 	} else if engine == "redis" {
@@ -2833,17 +2845,18 @@ func RunDatabaseConfigurationUpdate(c *CmdConfig) error {
 	}
 
 	allowedEngines := map[string]any{
-		"mysql":       nil,
-		"pg":          nil,
-		"advanced_pg": nil,
-		"redis":       nil,
-		"valkey":      nil,
-		"mongodb":     nil,
-		"kafka":       nil,
-		"opensearch":  nil,
+		"mysql":          nil,
+		"pg":             nil,
+		"advanced_pg":    nil,
+		"advanced_mysql": nil,
+		"redis":          nil,
+		"valkey":         nil,
+		"mongodb":        nil,
+		"kafka":          nil,
+		"opensearch":     nil,
 	}
 	if _, ok := allowedEngines[engine]; !ok {
-		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'advanced_pg', 'mysql', 'redis', 'valkey', 'mongodb', 'kafka', 'opensearch'", c.NS)
+		return fmt.Errorf("(%s) command: engine must be one of: 'pg', 'advanced_pg', 'mysql', 'advanced_mysql', 'redis', 'valkey', 'mongodb', 'kafka', 'opensearch'", c.NS)
 	}
 
 	configJson, err := c.Doit.GetString(c.NS, doctl.ArgDatabaseConfigJson)
@@ -2864,6 +2877,11 @@ func RunDatabaseConfigurationUpdate(c *CmdConfig) error {
 		}
 	} else if engine == "advanced_pg" {
 		err := c.Databases().UpdateAdvancedPostgresConfiguration(dbId, configJson)
+		if err != nil {
+			return err
+		}
+	} else if engine == "advanced_mysql" {
+		err := c.Databases().UpdateAdvancedMySQLConfiguration(dbId, configJson)
 		if err != nil {
 			return err
 		}

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -232,6 +232,19 @@ var (
 		},
 	}
 
+	testAdvancedMySQLConfiguration = do.AdvancedMySQLConfig{
+		AdvancedMySQLConfig: &godo.AdvancedMySQLConfig{
+			MySQLParameters: []godo.AdvancedMySQLParameter{
+				{
+					Name:            "max_connections",
+					Value:           "151",
+					DefaultValue:    "151",
+					RequiresRestart: false,
+				},
+			},
+		},
+	}
+
 	testRedisConfiguration = do.RedisConfig{
 		RedisConfig: &godo.RedisConfig{},
 	}
@@ -1797,6 +1810,16 @@ func TestDatabaseConfigurationGet(t *testing.T) {
 	})
 
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.databases.EXPECT().GetAdvancedMySQLConfiguration(testDBCluster.ID).Return(&testAdvancedMySQLConfiguration, nil)
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "advanced_mysql")
+
+		err := RunDatabaseConfigurationGet(config)
+
+		assert.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.databases.EXPECT().GetRedisConfiguration(testDBCluster.ID).Return(&testRedisConfiguration, nil)
 		config.Args = append(config.Args, testDBCluster.ID)
 		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "redis")
@@ -1884,6 +1907,16 @@ func TestDatabaseConfigurationUpdate(t *testing.T) {
 		tm.databases.EXPECT().UpdateAdvancedPostgresConfiguration(testDBCluster.ID, "").Return(nil)
 		config.Args = append(config.Args, testDBCluster.ID)
 		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "advanced_pg")
+
+		err := RunDatabaseConfigurationUpdate(config)
+
+		assert.NoError(t, err)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.databases.EXPECT().UpdateAdvancedMySQLConfiguration(testDBCluster.ID, "").Return(nil)
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseEngine, "advanced_mysql")
 
 		err := RunDatabaseConfigurationUpdate(config)
 

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -2382,6 +2382,50 @@ func (dc *AdvancedPostgresConfiguration) KV() []map[string]any {
 	return o
 }
 
+type AdvancedMySQLConfiguration struct {
+	AdvancedMySQLConfig do.AdvancedMySQLConfig
+}
+
+var _ Displayable = &AdvancedMySQLConfiguration{}
+
+func (dc *AdvancedMySQLConfiguration) JSON(out io.Writer) error {
+	return writeJSON(dc.AdvancedMySQLConfig, out)
+}
+
+func (dc *AdvancedMySQLConfiguration) Cols() []string {
+	return []string{
+		"Name",
+		"Value",
+		"Default Value",
+		"Requires Restart",
+		"Description",
+	}
+}
+
+func (dc *AdvancedMySQLConfiguration) ColMap() map[string]string {
+	return map[string]string{
+		"Name":             "Name",
+		"Value":            "Value",
+		"Default Value":    "Default Value",
+		"Requires Restart": "Requires Restart",
+		"Description":      "Description",
+	}
+}
+
+func (dc *AdvancedMySQLConfiguration) KV() []map[string]any {
+	o := []map[string]any{}
+	for _, p := range dc.AdvancedMySQLConfig.MySQLParameters {
+		o = append(o, map[string]any{
+			"Name":             p.Name,
+			"Value":            p.Value,
+			"Default Value":    p.DefaultValue,
+			"Requires Restart": p.RequiresRestart,
+			"Description":      p.Description,
+		})
+	}
+	return o
+}
+
 type DatabaseEvents struct {
 	DatabaseEvents do.DatabaseEvents
 }

--- a/do/databases.go
+++ b/do/databases.go
@@ -125,6 +125,11 @@ type AdvancedPostgresConfig struct {
 	*godo.AdvancedPostgresConfig
 }
 
+// AdvancedMySQLConfig is a wrapper for godo.AdvancedMySQLConfig
+type AdvancedMySQLConfig struct {
+	*godo.AdvancedMySQLConfig
+}
+
 // RedisConfig is a wrapper for godo.RedisConfig
 type RedisConfig struct {
 	*godo.RedisConfig
@@ -233,6 +238,7 @@ type DatabasesService interface {
 	GetMySQLConfiguration(databaseID string) (*MySQLConfig, error)
 	GetPostgreSQLConfiguration(databaseID string) (*PostgreSQLConfig, error)
 	GetAdvancedPostgresConfiguration(databaseID string) (*AdvancedPostgresConfig, error)
+	GetAdvancedMySQLConfiguration(databaseID string) (*AdvancedMySQLConfig, error)
 	GetRedisConfiguration(databaseID string) (*RedisConfig, error)
 	GetValkeyConfiguration(databaseID string) (*ValkeyConfig, error)
 	GetMongoDBConfiguration(databaseID string) (*MongoDBConfig, error)
@@ -242,6 +248,7 @@ type DatabasesService interface {
 	UpdateMySQLConfiguration(databaseID string, confString string) error
 	UpdatePostgreSQLConfiguration(databaseID string, confString string) error
 	UpdateAdvancedPostgresConfiguration(databaseID string, confString string) error
+	UpdateAdvancedMySQLConfiguration(databaseID string, confString string) error
 	UpdateRedisConfiguration(databaseID string, confString string) error
 	UpdateValkeyConfiguration(databaseID string, confString string) error
 	UpdateMongoDBConfiguration(databaseID string, confString string) error
@@ -753,6 +760,17 @@ func (ds *databasesService) GetAdvancedPostgresConfiguration(databaseID string) 
 	}, nil
 }
 
+func (ds *databasesService) GetAdvancedMySQLConfiguration(databaseID string) (*AdvancedMySQLConfig, error) {
+	cfg, _, err := ds.client.Databases.GetAdvancedMySQLConfig(context.TODO(), databaseID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AdvancedMySQLConfig{
+		AdvancedMySQLConfig: cfg,
+	}, nil
+}
+
 func (ds *databasesService) GetRedisConfiguration(databaseID string) (*RedisConfig, error) {
 	cfg, _, err := ds.client.Databases.GetRedisConfig(context.TODO(), databaseID)
 	if err != nil {
@@ -846,6 +864,21 @@ func (ds *databasesService) UpdateAdvancedPostgresConfiguration(databaseID strin
 	}
 
 	_, err = ds.client.Databases.UpdateAdvancedPostgresSQLConfig(context.TODO(), databaseID, &conf)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ds *databasesService) UpdateAdvancedMySQLConfiguration(databaseID string, confString string) error {
+	var conf godo.AdvancedMySQLConfigUpdate
+	err := json.Unmarshal([]byte(confString), &conf)
+	if err != nil {
+		return err
+	}
+
+	_, err = ds.client.Databases.UpdateAdvancedMySQLConfig(context.TODO(), databaseID, &conf)
 	if err != nil {
 		return err
 	}

--- a/do/mocks/DatabasesService.go
+++ b/do/mocks/DatabasesService.go
@@ -244,6 +244,21 @@ func (mr *MockDatabasesServiceMockRecorder) Get(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDatabasesService)(nil).Get), arg0)
 }
 
+// GetAdvancedMySQLConfiguration mocks base method.
+func (m *MockDatabasesService) GetAdvancedMySQLConfiguration(databaseID string) (*do.AdvancedMySQLConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAdvancedMySQLConfiguration", databaseID)
+	ret0, _ := ret[0].(*do.AdvancedMySQLConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAdvancedMySQLConfiguration indicates an expected call of GetAdvancedMySQLConfiguration.
+func (mr *MockDatabasesServiceMockRecorder) GetAdvancedMySQLConfiguration(databaseID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdvancedMySQLConfiguration", reflect.TypeOf((*MockDatabasesService)(nil).GetAdvancedMySQLConfiguration), databaseID)
+}
+
 // GetAdvancedPostgresConfiguration mocks base method.
 func (m *MockDatabasesService) GetAdvancedPostgresConfiguration(databaseID string) (*do.AdvancedPostgresConfig, error) {
 	m.ctrl.T.Helper()
@@ -782,6 +797,20 @@ func (mr *MockDatabasesServiceMockRecorder) SetSQLMode(arg0 any, arg1 ...any) *g
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSQLMode", reflect.TypeOf((*MockDatabasesService)(nil).SetSQLMode), varargs...)
+}
+
+// UpdateAdvancedMySQLConfiguration mocks base method.
+func (m *MockDatabasesService) UpdateAdvancedMySQLConfiguration(databaseID, confString string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAdvancedMySQLConfiguration", databaseID, confString)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAdvancedMySQLConfiguration indicates an expected call of UpdateAdvancedMySQLConfiguration.
+func (mr *MockDatabasesServiceMockRecorder) UpdateAdvancedMySQLConfiguration(databaseID, confString any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAdvancedMySQLConfiguration", reflect.TypeOf((*MockDatabasesService)(nil).UpdateAdvancedMySQLConfiguration), databaseID, confString)
 }
 
 // UpdateAdvancedPostgresConfiguration mocks base method.


### PR DESCRIPTION
The Aim of this PR is to add support for `ADVANCED_MYSQL` configuration `patch` and `get` operations


```
doctl databases configuration get <CLUSTER_UUID> \
  --engine advanced_mysql \
  -o json \
  --api-url=https://api.digitalocean.com \
  --access-token <ACCESS_TOKEN>
```
  
<img width="1188" height="794" alt="image" src="https://github.com/user-attachments/assets/0da43f51-0673-4630-aaff-8e2291a16961" />


```
doctl databases configuration update <CLUSTER_UUID> \
  --engine advanced_mysql \
  --config-json '{"mysql_parameters":{"max_connections":"200"}}' \
  --api-url=https://api.digitalocean.com \
  --access-token  <ACCESS_TOKEN>
```

<img width="2182" height="754" alt="image" src="https://github.com/user-attachments/assets/fe2ee376-71c7-489d-b896-f2c4c785ee1a" />



