### PR TITLE
APPS: Set CNBBuilderImage_Heroku22 to v0.96.0

### DIFF
--- a/internal/apps/builder/cnb.go
+++ b/internal/apps/builder/cnb.go
@@ -26,7 +26,7 @@ import (
 const (
 	// CNBBuilderImage represents the local cnb builder.
 	CNBBuilderImage_Heroku18 = "digitaloceanapps/cnb-local-builder:heroku-18_v0.73.1"
-	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_v0.87.0"
+	CNBBuilderImage_Heroku22 = "digitaloceanapps/cnb-local-builder:heroku-22_v0.96.0"
 
 	CNBAppsRunImage_Heroku18 = "digitaloceanapps/apps-run:heroku-18_c047ec7"
 


### PR DESCRIPTION
## Details

Updates `CNBBuilderImage_Heroku22` to the latest stable `v0.96.0` tag so `doctl apps dev build` uses the same apps-images release as App Platform production (Node.js buildpack 342 / Node.js 24.15.0).

Related: [APPS-14022](https://do-internal.atlassian.net/browse/APPS-14022)

## Test plan
- [ ] Confirm `internal/apps/builder/cnb.go` uses `heroku-22_v0.96.0`
- [ ] Optional: `doctl apps dev build` against a Node app requesting 24.15.0

[APPS-14022]: https://do-internal.atlassian.net/browse/APPS-14022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ