### PR TITLE
Show session Origin on agents list/show (MARSOHS-551)

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -260,7 +260,9 @@ When a HITL approval is pending, the prompt switches to a compact approve/reject
 
 	cmdList := CmdBuilder(cmd, RunAgentsList, "list",
 		"List agent sessions",
-		`Lists agent sessions visible to the caller. Supports pagination and filtering via `+"`"+`--page-size`+"`"+`, `+"`"+`--page-token`+"`"+`, `+"`"+`--status`+"`"+`, and `+"`"+`--name`+"`"+`. When more pages exist, the next page token is printed after the table.`,
+		`Lists agent sessions visible to the caller. Supports pagination and filtering via `+"`"+`--page-size`+"`"+`, `+"`"+`--page-token`+"`"+`, `+"`"+`--status`+"`"+`, and `+"`"+`--name`+"`"+`. When more pages exist, the next page token is printed after the table.
+
+Simulation and evaluation sessions are omitted by the API so customer lists stay free of product-owned internal runs; there is no client-side origin filter. The Origin column shows session.origin.product (`+"`"+`direct`+"`"+` when present). Use `+"`"+`doctl agents show`+"`"+` with a session id to inspect a session the list omits.`,
 		Writer, aliasOpt("ls"),
 		displayerType(&displayers.HostedAgentSession{}))
 	AddIntFlag(cmdList, doctl.ArgAgentPageSize, "", 0, "Maximum number of sessions to return per page")
@@ -271,7 +273,7 @@ When a HITL approval is pending, the prompt switches to a compact approve/reject
 
 	CmdBuilder(cmd, RunAgentsShow, "show <session>",
 		"Show a single agent session",
-		"Prints details of one agent session.",
+		`Prints details of one agent session, including Origin (session.origin.product) when the API returns it. Get by session id still returns simulation/evaluation sessions that List omits.`,
 		Writer, aliasOpt("get"),
 		displayerType(&displayers.HostedAgentSession{}))
 

--- a/commands/displayers/hosted_agents.go
+++ b/commands/displayers/hosted_agents.go
@@ -43,7 +43,7 @@ func (h *HostedAgentSession) JSON(out io.Writer) error {
 }
 
 func (h *HostedAgentSession) Cols() []string {
-	return []string{"SessionID", "Name", "AgentKind", "Status", "RepoHint", "CreatedAt"}
+	return []string{"SessionID", "Name", "AgentKind", "Status", "Origin", "RepoHint", "CreatedAt"}
 }
 
 func (h *HostedAgentSession) ColMap() map[string]string {
@@ -52,6 +52,7 @@ func (h *HostedAgentSession) ColMap() map[string]string {
 		"Name":      "Name",
 		"AgentKind": "Agent",
 		"Status":    "Status",
+		"Origin":    "Origin",
 		"RepoHint":  "Repo",
 		"CreatedAt": "Created",
 	}
@@ -71,11 +72,21 @@ func (h *HostedAgentSession) KV() []map[string]any {
 			"Name":      s.Name,
 			"AgentKind": s.AgentKind,
 			"Status":    s.Status,
+			"Origin":    hostedAgentOriginLabel(s.Origin),
 			"RepoHint":  s.RepoHint,
 			"CreatedAt": s.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z"),
 		})
 	}
 	return out
+}
+
+// hostedAgentOriginLabel renders session.origin.product for table output.
+// Empty when the server omitted origin (older sessions).
+func hostedAgentOriginLabel(o *godo.HostedAgentSessionOrigin) string {
+	if o == nil {
+		return ""
+	}
+	return string(o.Product)
 }
 
 // HostedAgentWorkspaceUpload renders the result of `doctl agents upload`.

--- a/commands/displayers/hosted_agents_test.go
+++ b/commands/displayers/hosted_agents_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package displayers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/digitalocean/doctl/do"
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostedAgentSession_OriginColumn(t *testing.T) {
+	h := &HostedAgentSession{
+		Sessions: []do.HostedAgentSession{
+			{
+				HostedAgentSession: &godo.HostedAgentSession{
+					SessionID: "sess_1",
+					Name:      "demo",
+					AgentKind: godo.HostedAgentKindClaudeCode,
+					Status:    godo.HostedAgentSessionStatusReady,
+					CreatedAt: godo.Timestamp{Time: time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)},
+					Origin: &godo.HostedAgentSessionOrigin{
+						Product:  godo.HostedAgentSessionOriginProductDirect,
+						Verified: true,
+					},
+				},
+			},
+			{
+				HostedAgentSession: &godo.HostedAgentSession{
+					SessionID: "sess_2",
+					Name:      "legacy",
+					Status:    godo.HostedAgentSessionStatusReady,
+					CreatedAt: godo.Timestamp{Time: time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)},
+				},
+			},
+		},
+	}
+
+	assert.Contains(t, h.Cols(), "Origin")
+	assert.Equal(t, "Origin", h.ColMap()["Origin"])
+
+	kv := h.KV()
+	assert.Len(t, kv, 2)
+	assert.Equal(t, "direct", kv[0]["Origin"])
+	assert.Equal(t, "", kv[1]["Origin"])
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/creack/pty v1.1.21
-	github.com/digitalocean/godo v1.199.0-beta.1
+	github.com/digitalocean/godo v1.202.0
 	github.com/docker/cli v24.0.5+incompatible
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
@@ -150,3 +150,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+replace github.com/digitalocean/godo => github.com/nveerdixit/godo v1.201.1-0.20260727074806-2205191af9a0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.199.0-beta.1 h1:KQ7A9IYeI2O+uO4t3N3nQVHls77go/nqJTRIPXvJp3k=
-github.com/digitalocean/godo v1.199.0-beta.1/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
@@ -368,6 +366,8 @@ github.com/natefinch/pie v0.0.0-20170715172608-9a0d72014007 h1:Ohgj9L0EYOgXxkDp+
 github.com/natefinch/pie v0.0.0-20170715172608-9a0d72014007/go.mod h1:wKCOWMb6iNlvKiOToY2cNuaovSXvIiv1zDi9QDR7aGQ=
 github.com/nicksnyder/go-i18n v1.10.1 h1:isfg77E/aCD7+0lD/D00ebR2MV5vgeQ276WYyDaCRQc=
 github.com/nicksnyder/go-i18n v1.10.1/go.mod h1:e4Di5xjP9oTVrC6y3C7C0HoSYXjSbhh/dU0eUV32nB4=
+github.com/nveerdixit/godo v1.201.1-0.20260727074806-2205191af9a0 h1:IRqYsm9bloSXwKfpb2pv81FgXf7fm+I4lBQ01Qsywyk=
+github.com/nveerdixit/godo v1.201.1-0.20260727074806-2205191af9a0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.202.0] - 2026-07-27
+
+- #1066 - Add Hosted Agents session client (HostedAgents) with Session.origin product provenance (direct|simulation|evaluation)
+
+## [1.201.0] - 2026-07-24
+
+- #1060 - @DO-rrao - Add GPU partition mode support to Droplets and Sizes
+
 ## [1.200.0] - 2026-07-22
 
 - #1058 - @kwadhwa-source - MDROP-23:add godo support for microdroplets

--- a/vendor/github.com/digitalocean/godo/droplets.go
+++ b/vendor/github.com/digitalocean/godo/droplets.go
@@ -44,6 +44,14 @@ type DropletsServiceOp struct {
 
 var _ DropletsService = &DropletsServiceOp{}
 
+// GPU partition modes supported when creating a GPU Droplet. Omitting the value
+// (or sending an empty string) is treated as PARTITION_MODE_UNSET, i.e. a full
+// GPU with SPX/NPS1 behavior.
+const (
+	GPUPartitionModeSPXNPS1 = "PARTITION_MODE_SPX_NPS1"
+	GPUPartitionModeDPXNPS2 = "PARTITION_MODE_DPX_NPS2"
+)
+
 // Droplet represents a DigitalOcean Droplet
 type Droplet struct {
 	ID               int           `json:"id,float64,omitempty"`
@@ -67,6 +75,10 @@ type Droplet struct {
 	Tags             []string      `json:"tags,omitempty"`
 	VolumeIDs        []string      `json:"volume_ids"`
 	VPCUUID          string        `json:"vpc_uuid,omitempty"`
+	// GPUPartitionMode is echoed back on create when the Droplet was created
+	// with a partitioned GPU. Note: read-back on droplet GET is not delivered in
+	// v1, so this is only reliably populated on the create response.
+	GPUPartitionMode string `json:"gpu_partition_mode,omitempty"`
 }
 
 // PublicIPv4 returns the public IPv4 address for the Droplet.
@@ -238,6 +250,10 @@ type DropletCreateRequest struct {
 	WithDropletAgent  *bool                       `json:"with_droplet_agent,omitempty"`
 	BackupPolicy      *DropletBackupPolicyRequest `json:"backup_policy,omitempty"`
 	PublicNetworking  *bool                       `json:"public_networking,omitempty"`
+	// GPUPartitionMode selects the partition mode for a GPU Droplet. Omit or
+	// leave empty for PARTITION_MODE_UNSET (full GPU). Use one of the
+	// GPUPartitionMode* constants for supported values.
+	GPUPartitionMode string `json:"gpu_partition_mode,omitempty"`
 }
 
 // DropletMultiCreateRequest is a request to create multiple Droplets.
@@ -257,6 +273,10 @@ type DropletMultiCreateRequest struct {
 	WithDropletAgent  *bool                       `json:"with_droplet_agent,omitempty"`
 	BackupPolicy      *DropletBackupPolicyRequest `json:"backup_policy,omitempty"`
 	PublicNetworking  *bool                       `json:"public_networking,omitempty"`
+	// GPUPartitionMode selects the partition mode for the GPU Droplets. Omit or
+	// leave empty for PARTITION_MODE_UNSET (full GPU). Use one of the
+	// GPUPartitionMode* constants for supported values.
+	GPUPartitionMode string `json:"gpu_partition_mode,omitempty"`
 }
 
 // DropletBackupPolicyRequest defines the backup policy when creating a Droplet.

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.200.0"
+	libraryVersion = "1.202.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -104,10 +104,10 @@ type Client struct {
 	VPCs                VPCsService
 	PartnerAttachment   PartnerAttachmentService
 	GradientAI          GradientAIService
-	HostedAgents        HostedAgentsService
 	DedicatedInference  DedicatedInferenceService
 	BatchInference      BatchInferenceService
 	BYOIPPrefixes       BYOIPPrefixesService
+	HostedAgents        HostedAgentsService
 
 	// Serverless Inference resources at https://inference.do-ai.run.
 	Chat             *ChatService
@@ -361,10 +361,10 @@ func NewClient(httpClient *http.Client) *Client {
 	c.VPCs = &VPCsServiceOp{client: c}
 	c.PartnerAttachment = &PartnerAttachmentServiceOp{client: c}
 	c.GradientAI = &GradientAIServiceOp{client: c}
-	c.HostedAgents = &HostedAgentsServiceOp{client: c}
 	c.DedicatedInference = &DedicatedInferenceServiceOp{client: c}
 	batchInferenceURL, _ := url.Parse(defaultBatchInferenceBaseURL)
 	c.BatchInference = &BatchInferenceServiceOp{client: c, baseURL: batchInferenceURL}
+	c.HostedAgents = &HostedAgentsServiceOp{client: c}
 	serverlessInferenceURL, _ := url.Parse(defaultServerlessInferenceBaseURL)
 	t := newInferenceTransport(c, serverlessInferenceURL)
 	c.Chat = &ChatService{Completions: &ChatCompletionService{inferenceTransport: t}}

--- a/vendor/github.com/digitalocean/godo/hosted_agents.go
+++ b/vendor/github.com/digitalocean/godo/hosted_agents.go
@@ -195,6 +195,34 @@ const (
 	HostedAgentEventKindRunLog               HostedAgentEventKind = "run.log"
 )
 
+// HostedAgentSessionOriginProduct identifies the product workflow that created
+// a session. Wire values match harness SessionOrigin.product.
+type HostedAgentSessionOriginProduct string
+
+const (
+	HostedAgentSessionOriginProductDirect     HostedAgentSessionOriginProduct = "direct"
+	HostedAgentSessionOriginProductSimulation HostedAgentSessionOriginProduct = "simulation"
+	HostedAgentSessionOriginProductEvaluation HostedAgentSessionOriginProduct = "evaluation"
+)
+
+// HostedAgentSessionOriginRequest is the product-provenance claim on create.
+// Omission creates a verified direct session. Simulation and evaluation require
+// resource_id; direct forbids it. verified is server-assigned and must not be
+// sent on create (see HostedAgentSessionOrigin).
+type HostedAgentSessionOriginRequest struct {
+	Product    HostedAgentSessionOriginProduct `json:"product"`
+	ResourceID string                          `json:"resource_id,omitempty"`
+}
+
+// HostedAgentSessionOrigin is server-returned product-workflow provenance.
+// Verified is true for direct sessions and for product claims established
+// through a trusted adapter.
+type HostedAgentSessionOrigin struct {
+	Product    HostedAgentSessionOriginProduct `json:"product"`
+	ResourceID string                          `json:"resource_id,omitempty"`
+	Verified   bool                            `json:"verified"`
+}
+
 // HostedAgentSession is a provisioned hosted-agent sandbox session.
 type HostedAgentSession struct {
 	SessionID    string                                  `json:"session_id"`
@@ -206,6 +234,9 @@ type HostedAgentSession struct {
 	LastEventAt  Timestamp                               `json:"last_event_at"`
 	RepoHint     string                                  `json:"repo_hint,omitempty"`
 	ProviderAuth map[string]HostedAgentProviderAuthState `json:"provider_auth,omitempty"`
+	// Origin is present for newly created sessions (including direct). Older
+	// sessions may omit it.
+	Origin *HostedAgentSessionOrigin `json:"origin,omitempty"`
 }
 
 // HostedAgentRun represents a single execution within a session.
@@ -297,6 +328,9 @@ type HostedAgentSessionCreateRequest struct {
 	AgentKind          HostedAgentKind `json:"agent_kind"`
 	RepoHint           string          `json:"repo_hint,omitempty"`
 	IdleTimeoutSeconds int64           `json:"idle_timeout_seconds,omitempty"`
+	// Origin claims product-workflow provenance. Omit for a verified direct
+	// session. Simulation/evaluation require resource_id.
+	Origin *HostedAgentSessionOriginRequest `json:"origin,omitempty"`
 }
 
 // HostedAgentSessionListOptions specifies optional list filters.
@@ -456,6 +490,10 @@ func (s *HostedAgentsServiceOp) newCreateSessionPostRequest(ctx context.Context,
 }
 
 // ListSessions returns sessions visible to the caller's team.
+//
+// The server omits simulation and evaluation sessions from the list so customer
+// surfaces stay free of product-owned internal runs. GetSession by session_id
+// still returns those sessions for the owning product workflow.
 func (s *HostedAgentsServiceOp) ListSessions(ctx context.Context, opt *HostedAgentSessionListOptions) (*HostedAgentSessionsListResponse, *Response, error) {
 	path, err := addOptions(hostedAgentsSessionsBasePath, opt)
 	if err != nil {

--- a/vendor/github.com/digitalocean/godo/nfs.go
+++ b/vendor/github.com/digitalocean/godo/nfs.go
@@ -164,7 +164,6 @@ type NfsAccessPoint struct {
 	UpdatedAt    string               `json:"updated_at"`
 	IsDefault    bool                 `json:"is_default"`
 	VpcID        *string              `json:"vpc_id,omitempty"`
-	VpcIDs       []string             `json:"vpc_ids,omitempty"`
 }
 
 // NfsCreateRequest represents a request to create an NFS share.

--- a/vendor/github.com/digitalocean/godo/sizes.go
+++ b/vendor/github.com/digitalocean/godo/sizes.go
@@ -54,6 +54,10 @@ type GPUInfo struct {
 	Count int    `json:"count,omitempty"`
 	VRAM  *VRAM  `json:"vram,omitempty"`
 	Model string `json:"model,omitempty"`
+	// SupportedPartitionModes lists the GPU partition modes available for this
+	// size. It is only returned to callers with access to the feature, so an
+	// empty/absent value means the partition-mode picker should be hidden.
+	SupportedPartitionModes []string `json:"supported_partition_modes,omitempty"`
 }
 
 // VRAM provides information about the amount of VRAM available to the GPU.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -103,7 +103,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.199.0-beta.1
+# github.com/digitalocean/godo v1.202.0 => github.com/nveerdixit/godo v1.201.1-0.20260727074806-2205191af9a0
 ## explicit; go 1.23.0
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics
@@ -723,3 +723,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/digitalocean/godo => github.com/nveerdixit/godo v1.201.1-0.20260727074806-2205191af9a0


### PR DESCRIPTION
## Summary
- Vendor godo HostedAgents tip with `Session.origin` via replace to `nveerdixit/godo` (depends on https://github.com/digitalocean/godo/pull/1066, plus NestedError for harness-api error envelopes).
- Add Origin column to agents list/show displayers; update list/show help to document server-side omission of simulation/evaluation sessions.
- No client-side list filter and no `--origin` flags (Private Beta).

## Related
- godo: https://github.com/digitalocean/godo/pull/1066
- openapi: https://github.com/digitalocean/openapi/pull/1207

## Test plan
- [x] `go test ./commands/displayers/ -run HostedAgentSession_Origin`
- [x] `go test ./commands/ -run 'TestRunAgentsList$|TestRunAgentsShow'`
- [ ] CI green on draft PR
- [ ] After godo #1066 merges: drop replace / point at released godo version

Made with [Cursor](https://cursor.com)