### PR TITLE
agents/proxy: fix red replay tests and a crash-class race in failAllTrackedTurns

### DIFF
--- a/internal/agentproxy/agentproxytest/harness.go
+++ b/internal/agentproxy/agentproxytest/harness.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+
 	"github.com/digitalocean/godo"
 )
 
@@ -116,11 +117,12 @@ func New(t *testing.T, sessionID string) *Harness {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v2/agents/sessions/{id}", h.handleGetSession)
-	// Live streaming is served by the data plane at .../events. The control
-	// plane's .../stream is deliberately not registered: it serves only
-	// replay-only reads, which no agentproxy caller makes, so a request landing
-	// there is a bug worth failing on.
+	// Two SSE surfaces, matching godo's StreamSession: live reads go to the
+	// data plane at .../events, replay-only reads to the control plane at
+	// .../stream?replay_only=true (see QueueReplayHistory). handleStream
+	// serves both, branching on the replay_only query parameter.
 	mux.HandleFunc("GET /v2/agents/sessions/{id}/events", h.handleStream)
+	mux.HandleFunc("GET /v2/agents/sessions/{id}/stream", h.handleStream)
 	mux.HandleFunc("POST /v2/agents/sessions/{id}/input", h.handleInput)
 	mux.HandleFunc("POST /v2/agents/sessions/{id}/hitl/{requestID}", h.handleHITL)
 

--- a/internal/agentproxy/codex/facade.go
+++ b/internal/agentproxy/codex/facade.go
@@ -1165,9 +1165,17 @@ func (f *Facade) runEventLoop(ctx context.Context) {
 // just recreate the exact "TUI hangs forever" failure mode this facade
 // exists to avoid, just triggered by a dead stream instead of an unhandled
 // HITL kind.
+// The map is copied under f.mu rather than aliased: finishTurn below deletes
+// from f.turns (and a concurrent turn/start inserts into it, and a replay
+// goroutine's own finishTurn deletes from it) while this loop is ranging, so
+// ranging the live map is a "concurrent map iteration and map write" crash,
+// not merely a benign stale read.
 func (f *Facade) failAllTrackedTurns(message string) {
 	f.mu.Lock()
-	turns := f.turns
+	turns := make(map[string]*turnState, len(f.turns))
+	for runID, ts := range f.turns {
+		turns[runID] = ts
+	}
 	f.mu.Unlock()
 
 	for runID, ts := range turns {

--- a/internal/agentproxy/codex/facade_test.go
+++ b/internal/agentproxy/codex/facade_test.go
@@ -3,6 +3,8 @@ package codex
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1007,6 +1009,55 @@ func TestFacade_RunEventLoop_TerminalStreamErrorFailsTurnImmediately(t *testing.
 	require.NotNil(t, params.Turn.Error)
 
 	assert.Equal(t, int32(0), atomic.LoadInt32(sleepCalls), "a terminal error must give up immediately, never retry")
+}
+
+// TestFacade_FailAllTrackedTurns_ConcurrentTurnsWrite is a regression test:
+// failAllTrackedTurns used to alias f.turns rather than copy it under f.mu,
+// then range the live map while finishTurn deleted from it — so anything else
+// touching f.mu-guarded f.turns meanwhile (a turn/start registering a new
+// turn, or a --replay goroutine's own finishTurn) raced the open iterator.
+// That's a "concurrent map iteration and map write" fatal error, which no
+// amount of locking on only the writer's side prevents. Run under -race.
+func TestFacade_FailAllTrackedTurns_ConcurrentTurnsWrite(t *testing.T) {
+	f, _, rec := newTestFacade(t)
+
+	// failAllTrackedTurns emits two notifications per turn, well past
+	// notifierRecorder's buffer, so drain rather than assert on the sequence
+	// — the ordering isn't what's under test here.
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for range rec.ch {
+		}
+	}()
+
+	f.mu.Lock()
+	f.turns = make(map[string]*turnState)
+	for i := 0; i < 32; i++ {
+		runID := fmt.Sprintf("run-%d", i)
+		f.turns[runID] = &turnState{itemID: runID + "-msg"}
+	}
+	f.mu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			f.mu.Lock()
+			if f.turns != nil {
+				f.turns["concurrent"] = &turnState{}
+				delete(f.turns, "concurrent")
+			}
+			f.mu.Unlock()
+		}
+	}()
+
+	f.failAllTrackedTurns("lost connection to hosted session")
+	wg.Wait()
+
+	close(rec.ch)
+	<-drained
 }
 
 // TestFacade_RunEventLoop_ReconnectsAfterTransientStreamError confirms a


### PR DESCRIPTION
Stacked on top of #1893 (base: `juliaye/doctl-proxy2`). Two mechanical fixes found while reviewing that PR; both are verified, and neither changes intended behavior.

## 1. All four `--replay` tests are currently red

`agentproxytest.Harness` only registers the data-plane route:

```go
mux.HandleFunc("GET /v2/agents/sessions/{id}/events", h.handleStream)
```

but godo's `StreamSession` sends replay-only reads to the *control plane* at `.../stream?replay_only=true` (see `hostedAgentSessionStreamPath`, and `StreamSession`'s own doc comment about the two SSE surfaces). So every replay test 404s:

```
codex facade: replay history fetch failed, will retry on next connect:
GET .../v2/agents/sessions/sess_test123/stream?replay_only=true: 404 404 page not found
```

```
--- FAIL: TestFacade_Replay_ThreadResume
--- FAIL: TestFacade_Replay_FiresOnlyOnce
--- FAIL: TestFacade_Replay_UnaffectedByConcurrentLiveTurnsReset
--- FAIL: TestFacade_Replay_RetriesAfterAbortedAttempt
```

`handleStream` already branches on `replay_only` and `QueueReplayHistory` already documents serving it, so only the route registration was missing. This looks like a merge artifact: the `.../events` migration landed on `feat/agents-subcommands`, and the merge kept the base's route list while the branch's new replay code needs `.../stream`. Registering it makes all four pass.

The stale comment claiming `.../stream` is "deliberately not registered" is updated to describe what the harness actually does.

## 2. `failAllTrackedTurns` can crash the process

```go
f.mu.Lock()
turns := f.turns
f.mu.Unlock()

for runID, ts := range turns { // ranges the *live* map
    f.finishTurn(runID, ts, "failed", ...)
}
```

`turns` aliases `f.turns`, so this ranges the live map. Meanwhile `finishTurn` deletes from it, a concurrent `turn/start` inserts into it via `trackTurn`, and a `--replay` goroutine's own `finishTurn` deletes from it too — all under `f.mu`, but holding the lock on only the writer's side does not protect an open iterator. That's `fatal error: concurrent map iteration and map write`: an unrecoverable crash, not a benign stale read. It fires precisely on the connection-loss path, which is where users are least able to afford one.

Confirmed under `-race`:

```
WARNING: DATA RACE
Write at 0x00c0003c78c0 by goroutine 10:
  runtime.mapassign_faststr()
Previous read at 0x00c0003c78c0 by goroutine 9:
  runtime.mapIterStart()
  codex.(*Facade).failAllTrackedTurns() facade.go:1173
```

Fixed by copying the map under `f.mu` — chosen over detaching with `f.turns = nil`, which would have widened the existing window where a `turn/start` racing `runEventLoop`'s exit registers a turn into a map that the deferred cleanup then discards. The copy is a pure race fix with no behavior change.

Added `TestFacade_FailAllTrackedTurns_ConcurrentTurnsWrite`, which fails under `-race` without the fix and passes with it.

## 3. `gofmt`

`harness.go`'s `godo` import was inside the stdlib group; `gofmt -l` flagged the file.

## Test plan

- [x] `go test -race ./internal/agentproxy/...` — green (was 4 failures)
- [x] Regression test verified to fail under `-race` with the `failAllTrackedTurns` fix reverted
- [x] `gofmt -l internal/agentproxy/` — clean
- [x] `GOOS=windows go build ./commands/` — builds

Remaining review findings on #1893 (attach-race regression, shared-`Facade` notifier race, replayed HITL re-prompts) are behavioral/design calls and are left to the author; they're written up in a review comment there rather than changed here.

Made with [Cursor](https://cursor.com)