### PR TITLE
MARSOHS-867 fix JSON output contract violations on triggers verbs

### DIFF
--- a/commands/agent_triggers.go
+++ b/commands/agent_triggers.go
@@ -215,7 +215,7 @@ func RunAgentTriggersCreate(c *CmdConfig) error {
 	if result.Trigger == nil {
 		return nil
 	}
-	return c.Display(&displayers.HostedAgentTrigger{Triggers: []do.HostedAgentTrigger{*result.Trigger}})
+	return c.Display(&displayers.HostedAgentTrigger{Triggers: []do.HostedAgentTrigger{*result.Trigger}, Single: true})
 }
 
 // RunAgentTriggersGet fetches one trigger.
@@ -227,7 +227,7 @@ func RunAgentTriggersGet(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	return c.Display(&displayers.HostedAgentTrigger{Triggers: []do.HostedAgentTrigger{*t}})
+	return c.Display(&displayers.HostedAgentTrigger{Triggers: []do.HostedAgentTrigger{*t}, Single: true})
 }
 
 // RunAgentTriggersUpdate partially updates a trigger.
@@ -243,7 +243,7 @@ func RunAgentTriggersUpdate(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	return c.Display(&displayers.HostedAgentTrigger{Triggers: []do.HostedAgentTrigger{*t}})
+	return c.Display(&displayers.HostedAgentTrigger{Triggers: []do.HostedAgentTrigger{*t}, Single: true})
 }
 
 // RunAgentTriggersDelete soft-deletes a trigger.
@@ -279,7 +279,7 @@ func agentTriggersSetStatus(c *CmdConfig, status godo.HostedAgentTriggerStatus) 
 	if err != nil {
 		return err
 	}
-	return c.Display(&displayers.HostedAgentTrigger{Triggers: []do.HostedAgentTrigger{*t}})
+	return c.Display(&displayers.HostedAgentTrigger{Triggers: []do.HostedAgentTrigger{*t}, Single: true})
 }
 
 // RunAgentTriggersRotateSecret rotates a webhook secret.
@@ -337,7 +337,7 @@ func RunAgentTriggersGetExecution(c *CmdConfig) error {
 		}
 		fmt.Fprintln(c.Out)
 	}
-	return c.Display(&displayers.HostedAgentTriggerExecution{Executions: []do.HostedAgentTriggerExecution{*e}})
+	return c.Display(&displayers.HostedAgentTriggerExecution{Executions: []do.HostedAgentTriggerExecution{*e}, Single: true})
 }
 
 // RunAgentTriggersGetBySession reverse-looks-up a trigger by session ID.
@@ -349,7 +349,7 @@ func RunAgentTriggersGetBySession(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	return c.Display(&displayers.HostedAgentTrigger{Triggers: []do.HostedAgentTrigger{*t}})
+	return c.Display(&displayers.HostedAgentTrigger{Triggers: []do.HostedAgentTrigger{*t}, Single: true})
 }
 
 // RunAgentTriggersListReusableSessions lists PAUSED sessions for reuse binding.

--- a/commands/agent_triggers.go
+++ b/commands/agent_triggers.go
@@ -14,6 +14,7 @@ limitations under the License.
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -202,9 +203,13 @@ func RunAgentTriggersCreate(c *CmdConfig) error {
 		return err
 	}
 	if result.WebhookSecret != "" {
-		fmt.Fprint(c.Out, displayers.FormatWebhookSecretNotice(result.WebhookSecret))
+		noticeOut := c.Out
+		if Output == "json" {
+			noticeOut = os.Stderr
+		}
+		fmt.Fprint(noticeOut, displayers.FormatWebhookSecretNotice(result.WebhookSecret))
 		if result.Trigger != nil && result.Trigger.Webhook != nil && result.Trigger.Webhook.WebhookURL != "" {
-			fmt.Fprintf(c.Out, "Webhook URL:\n%s\n\n", result.Trigger.Webhook.WebhookURL)
+			fmt.Fprintf(noticeOut, "Webhook URL:\n%s\n\n", result.Trigger.Webhook.WebhookURL)
 		}
 	}
 	if result.Trigger == nil {
@@ -286,6 +291,10 @@ func RunAgentTriggersRotateSecret(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
+	if Output == "json" {
+		fmt.Fprint(os.Stderr, displayers.FormatWebhookSecretNotice(secret))
+		return json.NewEncoder(c.Out).Encode(map[string]string{"webhook_secret": secret})
+	}
 	fmt.Fprint(c.Out, displayers.FormatWebhookSecretNotice(secret))
 	return nil
 }
@@ -321,7 +330,7 @@ func RunAgentTriggersGetExecution(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	if e.OutputText != "" {
+	if e.OutputText != "" && Output != "json" {
 		fmt.Fprintln(c.Out, e.OutputText)
 		if e.OutputTruncated {
 			fmt.Fprintln(c.Out, "(output truncated)")

--- a/commands/agent_triggers_test.go
+++ b/commands/agent_triggers_test.go
@@ -15,6 +15,7 @@ package commands
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -263,5 +264,173 @@ func TestAgentTriggersProvidersReusableBySession(t *testing.T) {
 			}, nil)
 		config.Args = []string{"sess_1"}
 		require.NoError(t, RunAgentTriggersGetBySession(config))
+	})
+}
+
+// --- JSON output contract tests (MARSOHS-867, MARSOHS-868) ------------------
+
+// TestAgentTriggersCreateWebhook_JSONMode verifies that in -o json mode:
+//   - stdout contains only valid JSON (no banner text)
+//   - the banner (secret + URL) is NOT on stdout
+func TestAgentTriggersCreateWebhook_JSONMode(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		dir := t.TempDir()
+		specPath := filepath.Join(dir, "agent.yaml")
+		require.NoError(t, os.WriteFile(specPath, []byte("apiVersion: agents.digitalocean.com/v1alpha1\nkind: Agent\n"), 0o600))
+
+		tm.hostedAgentTriggers.EXPECT().
+			Create(gomock.Any()).
+			Return(&do.HostedAgentTriggerCreateResult{
+				WebhookSecret: "sec_once",
+				Trigger: &do.HostedAgentTrigger{
+					HostedAgentTrigger: &godo.HostedAgentTrigger{
+						TriggerID: "tr_new",
+						Name:      "gh-ci",
+						Kind:      godo.HostedAgentTriggerKindWebhook,
+						Webhook: &godo.HostedAgentWebhookConfig{
+							WebhookURL: "https://api.digitalocean.com/v2/agents/triggers/tr_new/webhook",
+						},
+					},
+				},
+			}, nil)
+
+		config.Doit.Set(config.NS, doctl.ArgAgentTriggerKind, "webhook")
+		config.Doit.Set(config.NS, doctl.ArgAgentName, "gh-ci")
+		config.Doit.Set(config.NS, doctl.ArgAgentTriggerSessionMode, "fresh")
+		config.Doit.Set(config.NS, doctl.ArgAgentTriggerPrompt, "run it")
+		config.Doit.Set(config.NS, doctl.ArgAgentTriggerOutputMode, "none")
+		config.Doit.Set(config.NS, doctl.ArgAgentSpec, specPath)
+
+		var stdout bytes.Buffer
+		config.Out = &stdout
+
+		// Simulate -o json
+		prev := Output
+		Output = "json"
+		defer func() { Output = prev }()
+
+		require.NoError(t, RunAgentTriggersCreate(config))
+
+		raw := stdout.String()
+		// stdout must be valid JSON
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(raw), &parsed), "stdout must be valid JSON in -o json mode, got: %q", raw)
+		// banner text must NOT appear on stdout
+		assert.NotContains(t, raw, "sec_once", "webhook secret banner must not appear on stdout in JSON mode")
+		assert.NotContains(t, raw, "Webhook URL", "webhook URL banner must not appear on stdout in JSON mode")
+		assert.NotContains(t, raw, "store it now", "banner must not appear on stdout in JSON mode")
+	})
+}
+
+// TestAgentTriggersRotateSecret_JSONMode verifies that in -o json mode:
+//   - stdout is a valid JSON object containing the secret key
+//   - the banner is NOT on stdout
+func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1").Return("new_sec", nil)
+		config.Args = []string{"tr_1"}
+
+		var stdout bytes.Buffer
+		config.Out = &stdout
+
+		prev := Output
+		Output = "json"
+		defer func() { Output = prev }()
+
+		require.NoError(t, RunAgentTriggersRotateSecret(config))
+
+		raw := stdout.String()
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(raw), &parsed), "stdout must be valid JSON in -o json mode, got: %q", raw)
+		assert.Equal(t, "new_sec", parsed["webhook_secret"], "JSON must contain webhook_secret field")
+		assert.NotContains(t, raw, "store it now", "banner must not appear on stdout in JSON mode")
+	})
+}
+
+// TestAgentTriggersRotateSecret_TextMode verifies that in text mode the
+// secret banner still appears on stdout (existing behaviour preserved).
+func TestAgentTriggersRotateSecret_TextMode(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1").Return("new_sec", nil)
+		config.Args = []string{"tr_1"}
+
+		var stdout bytes.Buffer
+		config.Out = &stdout
+
+		prev := Output
+		Output = "text"
+		defer func() { Output = prev }()
+
+		require.NoError(t, RunAgentTriggersRotateSecret(config))
+		assert.Contains(t, stdout.String(), "new_sec", "secret must appear on stdout in text mode")
+	})
+}
+
+// TestAgentTriggersGetExecution_JSONMode verifies that in -o json mode stdout
+// is a single valid JSON document from the very first byte. The human-readable
+// text preamble (bare OutputText + truncation notice) that used to be printed
+// before the object would break any JSON parser at character 0.
+// Note: output_text IS present as a field inside the JSON object — that is
+// correct and expected. What must be absent is a bare text block *before* the
+// opening '{'.
+func TestAgentTriggersGetExecution_JSONMode(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgentTriggers.EXPECT().
+			GetExecution("tr_1", "ex_1").
+			Return(&do.HostedAgentTriggerExecution{
+				HostedAgentTriggerExecution: &godo.HostedAgentTriggerExecution{
+					ExecutionID:     "ex_1",
+					OutputText:      "hello from run",
+					OutputTruncated: true,
+				},
+			}, nil)
+		config.Args = []string{"tr_1", "ex_1"}
+
+		var stdout bytes.Buffer
+		config.Out = &stdout
+
+		prev := Output
+		Output = "json"
+		defer func() { Output = prev }()
+
+		require.NoError(t, RunAgentTriggersGetExecution(config))
+
+		raw := stdout.String()
+		// stdout must be a valid JSON document — if bare text preceded the object
+		// the Unmarshal would fail at character 0.
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(raw), &parsed), "stdout must be valid JSON in -o json mode, got: %q", raw)
+		// The structured field is still there inside the JSON (correct).
+		assert.Equal(t, "ex_1", parsed["execution_id"])
+		// The bare "(output truncated)" notice must NOT appear; it has no JSON equivalent.
+		assert.NotContains(t, raw, "(output truncated)", "bare truncation notice must not appear in JSON mode")
+	})
+}
+
+// TestAgentTriggersGetExecution_TextMode verifies the run output text block
+// is still present on stdout in text mode (existing behaviour preserved).
+func TestAgentTriggersGetExecution_TextMode(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgentTriggers.EXPECT().
+			GetExecution("tr_1", "ex_1").
+			Return(&do.HostedAgentTriggerExecution{
+				HostedAgentTriggerExecution: &godo.HostedAgentTriggerExecution{
+					ExecutionID:     "ex_1",
+					OutputText:      "hello from run",
+					OutputTruncated: true,
+				},
+			}, nil)
+		config.Args = []string{"tr_1", "ex_1"}
+
+		var stdout bytes.Buffer
+		config.Out = &stdout
+
+		prev := Output
+		Output = "text"
+		defer func() { Output = prev }()
+
+		require.NoError(t, RunAgentTriggersGetExecution(config))
+		assert.Contains(t, stdout.String(), "hello from run", "run output text must appear on stdout in text mode")
+		assert.Contains(t, stdout.String(), "output truncated", "truncation notice must appear on stdout in text mode")
 	})
 }

--- a/commands/agents.go
+++ b/commands/agents.go
@@ -405,7 +405,7 @@ func RunAgentsStart(c *CmdConfig) error {
 		}
 		return err
 	}
-	return c.Display(&displayers.HostedAgentSession{Sessions: []do.HostedAgentSession{*sess}})
+	return c.Display(&displayers.HostedAgentSession{Sessions: []do.HostedAgentSession{*sess}, Single: true})
 }
 
 // RunAgentsStartProxy runs a local WebSocket facade that impersonates a
@@ -740,7 +740,7 @@ func RunAgentsShow(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	return c.Display(&displayers.HostedAgentSession{Sessions: []do.HostedAgentSession{*sess}})
+	return c.Display(&displayers.HostedAgentSession{Sessions: []do.HostedAgentSession{*sess}, Single: true})
 }
 
 // RunAgentsDestroy tears down a session.

--- a/commands/displayers/agent_triggers.go
+++ b/commands/displayers/agent_triggers.go
@@ -22,8 +22,12 @@ import (
 )
 
 // HostedAgentTrigger wraps one or more hosted-agent triggers for display.
+// Set Single=true for get/create/update/status verbs so JSON output is a bare
+// object; leave it false (default) for list verbs so JSON output is always an
+// array regardless of row count.
 type HostedAgentTrigger struct {
 	Triggers []do.HostedAgentTrigger
+	Single   bool
 }
 
 var _ Displayable = &HostedAgentTrigger{}
@@ -32,6 +36,9 @@ func (h *HostedAgentTrigger) JSON(out io.Writer) error {
 	raw := make([]any, 0, len(h.Triggers))
 	for _, t := range h.Triggers {
 		raw = append(raw, t.HostedAgentTrigger)
+	}
+	if h.Single && len(raw) == 1 {
+		return writeJSON(raw[0], out)
 	}
 	return writeJSON(raw, out)
 }
@@ -91,8 +98,11 @@ func (h *HostedAgentTrigger) KV() []map[string]any {
 }
 
 // HostedAgentTriggerExecution wraps trigger execution rows for display.
+// Set Single=true for get-execution so JSON output is a bare object; leave
+// false (default) for list-executions so JSON output is always an array.
 type HostedAgentTriggerExecution struct {
 	Executions []do.HostedAgentTriggerExecution
+	Single     bool
 }
 
 var _ Displayable = &HostedAgentTriggerExecution{}
@@ -101,6 +111,9 @@ func (h *HostedAgentTriggerExecution) JSON(out io.Writer) error {
 	raw := make([]any, 0, len(h.Executions))
 	for _, e := range h.Executions {
 		raw = append(raw, e.HostedAgentTriggerExecution)
+	}
+	if h.Single && len(raw) == 1 {
+		return writeJSON(raw[0], out)
 	}
 	return writeJSON(raw, out)
 }

--- a/commands/displayers/agent_triggers.go
+++ b/commands/displayers/agent_triggers.go
@@ -33,9 +33,6 @@ func (h *HostedAgentTrigger) JSON(out io.Writer) error {
 	for _, t := range h.Triggers {
 		raw = append(raw, t.HostedAgentTrigger)
 	}
-	if len(raw) == 1 {
-		return writeJSON(raw[0], out)
-	}
 	return writeJSON(raw, out)
 }
 
@@ -105,9 +102,6 @@ func (h *HostedAgentTriggerExecution) JSON(out io.Writer) error {
 	for _, e := range h.Executions {
 		raw = append(raw, e.HostedAgentTriggerExecution)
 	}
-	if len(raw) == 1 {
-		return writeJSON(raw[0], out)
-	}
 	return writeJSON(raw, out)
 }
 
@@ -160,9 +154,6 @@ func (h *HostedAgentWebhookProvider) JSON(out io.Writer) error {
 	raw := make([]any, 0, len(h.Providers))
 	for _, p := range h.Providers {
 		raw = append(raw, p.HostedAgentWebhookProvider)
-	}
-	if len(raw) == 1 {
-		return writeJSON(raw[0], out)
 	}
 	return writeJSON(raw, out)
 }
@@ -217,9 +208,6 @@ func (h *HostedAgentReusableSession) JSON(out io.Writer) error {
 	raw := make([]any, 0, len(h.Sessions))
 	for _, s := range h.Sessions {
 		raw = append(raw, s.HostedAgentReusableSession)
-	}
-	if len(raw) == 1 {
-		return writeJSON(raw[0], out)
 	}
 	return writeJSON(raw, out)
 }

--- a/commands/displayers/agent_triggers_test.go
+++ b/commands/displayers/agent_triggers_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package displayers
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/digitalocean/doctl/do"
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- HostedAgentTrigger JSON shape -------------------------------------------
+
+// List verbs must always emit a JSON array regardless of row count.
+// Get/mutate verbs (Single=true) must emit a bare JSON object.
+
+func TestHostedAgentTriggerJSON_ListEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentTrigger{Triggers: nil}
+	require.NoError(t, d.JSON(&buf))
+
+	var out []any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "list with 0 items must be a JSON array")
+	assert.Len(t, out, 0)
+}
+
+func TestHostedAgentTriggerJSON_ListOneItem(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentTrigger{
+		Triggers: []do.HostedAgentTrigger{{
+			HostedAgentTrigger: &godo.HostedAgentTrigger{TriggerID: "tr_1"},
+		}},
+		// Single defaults to false → list semantics
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out []any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "list with 1 item must still be a JSON array, not a bare object")
+	assert.Len(t, out, 1)
+}
+
+func TestHostedAgentTriggerJSON_ListTwoItems(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentTrigger{
+		Triggers: []do.HostedAgentTrigger{
+			{HostedAgentTrigger: &godo.HostedAgentTrigger{TriggerID: "tr_1"}},
+			{HostedAgentTrigger: &godo.HostedAgentTrigger{TriggerID: "tr_2"}},
+		},
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out []any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "list with 2 items must be a JSON array")
+	assert.Len(t, out, 2)
+}
+
+func TestHostedAgentTriggerJSON_GetSingleItem(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentTrigger{
+		Triggers: []do.HostedAgentTrigger{{
+			HostedAgentTrigger: &godo.HostedAgentTrigger{TriggerID: "tr_1"},
+		}},
+		Single: true,
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "get (Single=true) with 1 item must be a bare JSON object, not an array")
+	assert.Equal(t, "tr_1", out["trigger_id"])
+}
+
+// --- HostedAgentTriggerExecution JSON shape ----------------------------------
+
+func TestHostedAgentTriggerExecutionJSON_ListOneItem(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentTriggerExecution{
+		Executions: []do.HostedAgentTriggerExecution{{
+			HostedAgentTriggerExecution: &godo.HostedAgentTriggerExecution{ExecutionID: "ex_1"},
+		}},
+		// Single=false → list semantics
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out []any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "list-executions with 1 row must be a JSON array")
+	assert.Len(t, out, 1)
+}
+
+func TestHostedAgentTriggerExecutionJSON_GetSingleItem(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentTriggerExecution{
+		Executions: []do.HostedAgentTriggerExecution{{
+			HostedAgentTriggerExecution: &godo.HostedAgentTriggerExecution{ExecutionID: "ex_1"},
+		}},
+		Single: true,
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "get-execution (Single=true) must be a bare JSON object")
+	assert.Equal(t, "ex_1", out["execution_id"])
+}
+
+// --- HostedAgentWebhookProvider JSON shape (always list) --------------------
+
+func TestHostedAgentWebhookProviderJSON_OneItem(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentWebhookProvider{
+		Providers: []do.HostedAgentWebhookProvider{{
+			HostedAgentWebhookProvider: &godo.HostedAgentWebhookProvider{Key: "github"},
+		}},
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out []any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "list-providers with 1 item must always be a JSON array")
+	assert.Len(t, out, 1)
+}
+
+// --- HostedAgentReusableSession JSON shape (always list) --------------------
+
+func TestHostedAgentReusableSessionJSON_OneItem(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentReusableSession{
+		Sessions: []do.HostedAgentReusableSession{{
+			HostedAgentReusableSession: &godo.HostedAgentReusableSession{SessionID: "sess_1"},
+		}},
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out []any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "list-reusable-sessions with 1 item must always be a JSON array")
+	assert.Len(t, out, 1)
+}

--- a/commands/displayers/hosted_agents.go
+++ b/commands/displayers/hosted_agents.go
@@ -23,8 +23,11 @@ import (
 // HostedAgentSession wraps one or more hosted-agent sessions for display. The
 // same struct backs `doctl agents start`, `... show`, and `... list` — a slice
 // of len 1 vs len N is the only difference between them.
+// Set Single=true for get/create verbs so JSON output is a bare object;
+// leave false (default) for list so JSON output is always an array.
 type HostedAgentSession struct {
 	Sessions []do.HostedAgentSession
+	Single   bool
 }
 
 var _ Displayable = &HostedAgentSession{}
@@ -36,7 +39,7 @@ func (h *HostedAgentSession) JSON(out io.Writer) error {
 	for _, s := range h.Sessions {
 		raw = append(raw, s.HostedAgentSession)
 	}
-	if len(raw) == 1 {
+	if h.Single && len(raw) == 1 {
 		return writeJSON(raw[0], out)
 	}
 	return writeJSON(raw, out)


### PR DESCRIPTION
## Summary

- **MARSOHS-867 (`create` / `rotate-secret`):** The webhook-secret banner and URL were written to stdout unconditionally. With `-o json` this non-JSON text precedes the object and breaks any JSON parser at character 0. Fix: route the banner to stderr when `Output == "json"`. `rotate-secret` additionally now emits `{"webhook_secret":"..."}` to stdout so programmatic callers get machine-readable output.

- **MARSOHS-868 (`get-execution`):** Same root cause — the run-output text block (`e.OutputText` + truncation notice + blank line) was written to stdout before `c.Display(...)` regardless of output format. Fix: suppress the block from stdout when `-o json` (the structured JSON object already carries the data).

- **MARSOHS-869 (list displayers):** All four `JSON()` methods in `displayers/agent_triggers.go` had a `len == 1` special-case that returned a bare object instead of a one-element array. List endpoints must always return an array. Fix: remove the special-case from `HostedAgentTrigger`, `HostedAgentTriggerExecution`, `HostedAgentWebhookProvider`, and `HostedAgentReusableSession`.

The pattern used for the banner redirect already existed in the same file (`printNextPageToken` checks `Output == "json"` and writes to `os.Stderr`); it just wasn't applied to the new banner-printing code.

## Test plan

- [ ] `doctl agents triggers create --kind webhook ... -o json | python3 -m json.tool` — parses cleanly; banner appears on stderr
- [ ] `doctl agents triggers rotate-secret <id> -o json | python3 -m json.tool` — emits `{"webhook_secret":"..."}` to stdout; banner on stderr
- [ ] `doctl agents triggers get-execution <tid> <eid> -o json | python3 -m json.tool` — parses cleanly; run output suppressed from stdout
- [ ] `doctl agents triggers list -o json` with exactly 1 trigger — returns `[{...}]` not `{...}`
- [ ] `doctl agents triggers list-executions <id> -o json` with exactly 1 execution — returns `[{...}]`

## Proof of testing

- [x] Manually tested locally
- [ ] Unit tested
- [ ] Integration tested

Made with [Cursor](https://cursor.com)