### PR TITLE
MARSOHS-867 include webhook_secret in JSON output for triggers create

### DIFF
--- a/commands/agent_triggers.go
+++ b/commands/agent_triggers.go
@@ -202,14 +202,32 @@ func RunAgentTriggersCreate(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	if result.WebhookSecret != "" {
-		noticeOut := c.Out
-		if Output == "json" {
-			noticeOut = os.Stderr
+	if Output == "json" {
+		// In JSON mode the one-time secret must be in the machine-readable output,
+		// not only in a human-readable banner that gets routed to stderr.
+		// Embed it alongside all trigger fields in a single flat JSON object so
+		// consumers can always parse the secret without screen-scraping.
+		if result.WebhookSecret != "" {
+			fmt.Fprint(os.Stderr, displayers.FormatWebhookSecretNotice(result.WebhookSecret))
 		}
-		fmt.Fprint(noticeOut, displayers.FormatWebhookSecretNotice(result.WebhookSecret))
+		type jsonCreateResult struct {
+			*godo.HostedAgentTrigger
+			WebhookSecret string `json:"webhook_secret,omitempty"`
+		}
+		var trigger *godo.HostedAgentTrigger
+		if result.Trigger != nil {
+			trigger = result.Trigger.HostedAgentTrigger
+		}
+		return json.NewEncoder(c.Out).Encode(jsonCreateResult{
+			HostedAgentTrigger: trigger,
+			WebhookSecret:      result.WebhookSecret,
+		})
+	}
+	// Text mode: banner to stdout, then the trigger table.
+	if result.WebhookSecret != "" {
+		fmt.Fprint(c.Out, displayers.FormatWebhookSecretNotice(result.WebhookSecret))
 		if result.Trigger != nil && result.Trigger.Webhook != nil && result.Trigger.Webhook.WebhookURL != "" {
-			fmt.Fprintf(noticeOut, "Webhook URL:\n%s\n\n", result.Trigger.Webhook.WebhookURL)
+			fmt.Fprintf(c.Out, "Webhook URL:\n%s\n\n", result.Trigger.Webhook.WebhookURL)
 		}
 	}
 	if result.Trigger == nil {

--- a/commands/agent_triggers_test.go
+++ b/commands/agent_triggers_test.go
@@ -270,8 +270,10 @@ func TestAgentTriggersProvidersReusableBySession(t *testing.T) {
 // --- JSON output contract tests (MARSOHS-867, MARSOHS-868) ------------------
 
 // TestAgentTriggersCreateWebhook_JSONMode verifies that in -o json mode:
-//   - stdout contains only valid JSON (no banner text)
-//   - the banner (secret + URL) is NOT on stdout
+//   - stdout is a single valid JSON object
+//   - webhook_secret IS in the JSON payload (it's a one-time value; consumers must be able to parse it)
+//   - trigger fields (trigger_id, name) are also in the JSON payload
+//   - the human-readable banner does NOT appear on stdout
 func TestAgentTriggersCreateWebhook_JSONMode(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		dir := t.TempDir()
@@ -312,13 +314,21 @@ func TestAgentTriggersCreateWebhook_JSONMode(t *testing.T) {
 		require.NoError(t, RunAgentTriggersCreate(config))
 
 		raw := stdout.String()
-		// stdout must be valid JSON
+		// stdout must be a single valid JSON object from the first byte.
 		var parsed map[string]any
 		require.NoError(t, json.Unmarshal([]byte(raw), &parsed), "stdout must be valid JSON in -o json mode, got: %q", raw)
-		// banner text must NOT appear on stdout
-		assert.NotContains(t, raw, "sec_once", "webhook secret banner must not appear on stdout in JSON mode")
-		assert.NotContains(t, raw, "Webhook URL", "webhook URL banner must not appear on stdout in JSON mode")
+
+		// The one-time secret MUST be in the JSON payload — it cannot only live
+		// in a human-readable banner routed to stderr (Joe's concern).
+		assert.Equal(t, "sec_once", parsed["webhook_secret"], "webhook_secret must be in the JSON payload")
+
+		// Trigger fields must also be present (flat, not nested under "trigger").
+		assert.Equal(t, "tr_new", parsed["trigger_id"], "trigger_id must be in the JSON payload")
+		assert.Equal(t, "gh-ci", parsed["name"], "name must be in the JSON payload")
+
+		// Human-readable banner text must NOT appear on stdout.
 		assert.NotContains(t, raw, "store it now", "banner must not appear on stdout in JSON mode")
+		assert.NotContains(t, raw, "Webhook URL:", "webhook URL banner must not appear on stdout in JSON mode")
 	})
 }
 


### PR DESCRIPTION
## What

Fixes a data-loss gap in the `doctl agents triggers create -o json` output contract.

The previous fix (merged in #1904) correctly routed the human-readable secret banner to stderr in JSON mode, but the JSON payload itself never contained `webhook_secret`. Any consumer parsing `-o json` output would silently lose the one-time secret.

## Why

As Joe Keegan noted in the ticket thread: *"just know for the doctl json output, its likely not as easy as just removing the initial plain text that is output, as that data may not be in the following JSON output. This is especially the case for when you create a trigger and the secret is only included in the plain text output."*

## How

In JSON mode, `RunAgentTriggersCreate` now bypasses the displayer and encodes an inline struct that embeds all `HostedAgentTrigger` fields **plus** `webhook_secret` at the top level, producing a single flat JSON object:

```json
{
  "trigger_id": "tr_abc123",
  "name": "gh-ci",
  "kind": "webhook",
  ...
  "webhook_secret": "sec_once"
}
```

The human-readable banner (secret notice) is still sent to stderr in JSON mode, preserving the existing UX for interactive use.

Text mode is unchanged.

## Test

- `TestAgentTriggersCreateWebhook_JSONMode` now asserts `webhook_secret` and `trigger_id` are present in the parsed JSON object (not just that the output is syntactically valid JSON).
- All existing trigger tests pass.

## Proof of testing

- [x] `go test ./commands/ -run TestAgentTriggers` — all 13 tests pass

Made with [Cursor](https://cursor.com)