### PR TITLE
MARSOHS-867 suppress webhook secret banner on stderr in -o json mode

### DIFF
--- a/commands/agent_triggers.go
+++ b/commands/agent_triggers.go
@@ -203,13 +203,9 @@ func RunAgentTriggersCreate(c *CmdConfig) error {
 		return err
 	}
 	if Output == "json" {
-		// In JSON mode the one-time secret must be in the machine-readable output,
-		// not only in a human-readable banner that gets routed to stderr.
-		// Embed it alongside all trigger fields in a single flat JSON object so
-		// consumers can always parse the secret without screen-scraping.
-		if result.WebhookSecret != "" {
-			fmt.Fprint(os.Stderr, displayers.FormatWebhookSecretNotice(result.WebhookSecret))
-		}
+		// JSON mode emits nothing but the document: the one-time secret travels
+		// in the payload, so re-printing it as a human banner would only
+		// duplicate a secret onto a second stream that callers may capture.
 		type jsonCreateResult struct {
 			*godo.HostedAgentTrigger
 			WebhookSecret string `json:"webhook_secret,omitempty"`
@@ -310,7 +306,6 @@ func RunAgentTriggersRotateSecret(c *CmdConfig) error {
 		return err
 	}
 	if Output == "json" {
-		fmt.Fprint(os.Stderr, displayers.FormatWebhookSecretNotice(secret))
 		return json.NewEncoder(c.Out).Encode(map[string]string{"webhook_secret": secret})
 	}
 	fmt.Fprint(c.Out, displayers.FormatWebhookSecretNotice(secret))

--- a/commands/agent_triggers_test.go
+++ b/commands/agent_triggers_test.go
@@ -16,6 +16,7 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -269,11 +270,34 @@ func TestAgentTriggersProvidersReusableBySession(t *testing.T) {
 
 // --- JSON output contract tests (MARSOHS-867, MARSOHS-868) ------------------
 
+// captureProcessStderr swaps os.Stderr for a pipe while fn runs and returns
+// everything fn wrote to it. Needed because the JSON-output contract is about
+// the real process streams, not the injectable CmdConfig.Out.
+func captureProcessStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	require.NoError(t, w.Close())
+	return <-done
+}
+
 // TestAgentTriggersCreateWebhook_JSONMode verifies that in -o json mode:
 //   - stdout is a single valid JSON object
 //   - webhook_secret IS in the JSON payload (it's a one-time value; consumers must be able to parse it)
 //   - trigger fields (trigger_id, name) are also in the JSON payload
-//   - the human-readable banner does NOT appear on stdout
+//   - the human-readable banner appears on neither stdout nor stderr
 func TestAgentTriggersCreateWebhook_JSONMode(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		dir := t.TempDir()
@@ -311,15 +335,17 @@ func TestAgentTriggersCreateWebhook_JSONMode(t *testing.T) {
 		Output = "json"
 		defer func() { Output = prev }()
 
-		require.NoError(t, RunAgentTriggersCreate(config))
+		stderr := captureProcessStderr(t, func() {
+			require.NoError(t, RunAgentTriggersCreate(config))
+		})
 
 		raw := stdout.String()
 		// stdout must be a single valid JSON object from the first byte.
 		var parsed map[string]any
 		require.NoError(t, json.Unmarshal([]byte(raw), &parsed), "stdout must be valid JSON in -o json mode, got: %q", raw)
 
-		// The one-time secret MUST be in the JSON payload — it cannot only live
-		// in a human-readable banner routed to stderr (Joe's concern).
+		// The one-time secret MUST be in the JSON payload — it is shown once and
+		// is unrecoverable afterwards, so it cannot live only in a human banner.
 		assert.Equal(t, "sec_once", parsed["webhook_secret"], "webhook_secret must be in the JSON payload")
 
 		// Trigger fields must also be present (flat, not nested under "trigger").
@@ -329,12 +355,16 @@ func TestAgentTriggersCreateWebhook_JSONMode(t *testing.T) {
 		// Human-readable banner text must NOT appear on stdout.
 		assert.NotContains(t, raw, "store it now", "banner must not appear on stdout in JSON mode")
 		assert.NotContains(t, raw, "Webhook URL:", "webhook URL banner must not appear on stdout in JSON mode")
+
+		// Nor on stderr: the secret is already in the payload, so echoing it to a
+		// second stream would just duplicate a secret into callers' logs.
+		assert.Empty(t, stderr, "nothing may be written to stderr in -o json mode")
 	})
 }
 
 // TestAgentTriggersRotateSecret_JSONMode verifies that in -o json mode:
 //   - stdout is a valid JSON object containing the secret key
-//   - the banner is NOT on stdout
+//   - the banner is on neither stdout nor stderr
 func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1").Return("new_sec", nil)
@@ -347,13 +377,16 @@ func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
 		Output = "json"
 		defer func() { Output = prev }()
 
-		require.NoError(t, RunAgentTriggersRotateSecret(config))
+		stderr := captureProcessStderr(t, func() {
+			require.NoError(t, RunAgentTriggersRotateSecret(config))
+		})
 
 		raw := stdout.String()
 		var parsed map[string]any
 		require.NoError(t, json.Unmarshal([]byte(raw), &parsed), "stdout must be valid JSON in -o json mode, got: %q", raw)
 		assert.Equal(t, "new_sec", parsed["webhook_secret"], "JSON must contain webhook_secret field")
 		assert.NotContains(t, raw, "store it now", "banner must not appear on stdout in JSON mode")
+		assert.Empty(t, stderr, "nothing may be written to stderr in -o json mode")
 	})
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1904 / #1906. [MARSOHS-867](https://do-internal.atlassian.net/browse/MARSOHS-867) was reopened because the human-readable "Webhook secret (shown once...)" banner was still visible when running `doctl agents triggers create|rotate-secret -o json` interactively. That was stdout/stderr interleaving on a shared TTY, not a contract violation (the banner was already on stderr, stdout was pure JSON) — but since the secret already travels inside the JSON payload, echoing it a second time to stderr in `-o json` mode is redundant and risks duplicating a secret into logs that capture stderr.

- `RunAgentTriggersCreate` / `RunAgentTriggersRotateSecret`: drop the stderr banner entirely when `Output == "json"`. Text mode (default) is unchanged — banner still prints on stdout for interactive users.
- Tests: `TestAgentTriggersCreateWebhook_JSONMode` / `TestAgentTriggersRotateSecret_JSONMode` now swap the real `os.Stderr` for a pipe (`captureProcessStderr`) and assert it's empty, so this can't regress silently again — asserting against the injectable `CmdConfig.Out` alone wasn't catching this class of bug.

## Test plan

- [x] `go build ./commands/...` — clean
- [x] `gofmt -l commands/agent_triggers.go commands/agent_triggers_test.go` — clean
- [x] `go test ./commands/... -run Trigger -v` — all pass, including the two tightened JSON-mode tests
- [x] Built the real `doctl` binary (`go build -mod=vendor -o doctl-dev ./cmd/doctl`) and drove it as a subprocess against a local mock DO API server (`httptest.Server`), capturing stdout/stderr on separate streams (not `CombinedOutput`) to reproduce the exact reported repro:
  - `agents triggers create --kind webhook ... -o json` → stdout: 698 bytes pure JSON incl. `webhook_secret`; stderr: 0 bytes
  - `agents triggers rotate-secret <id> -o json` → stdout: 86 bytes pure JSON incl. `webhook_secret`; stderr: 0 bytes
  - `agents triggers rotate-secret <id>` (text mode, regression check) → banner still prints on stdout as before

Full output posted on the Jira ticket.

Made with [Cursor](https://cursor.com)

[MARSOHS-867]: https://do-internal.atlassian.net/browse/MARSOHS-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ