### PR TITLE
MARSOHS-887 add regression tests for agents list JSON array shape

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -990,10 +990,13 @@ func workspaceTransferUpload(c *CmdConfig, sessionID, workspacePath string, f *o
 	if written == 0 {
 		written = size
 	}
-	return c.Display(&displayers.HostedAgentWorkspaceUpload{Uploads: []*godo.HostedAgentWorkspaceUploadResponse{{
-		Path:         workspacePath,
-		BytesWritten: written,
-	}}})
+	return c.Display(&displayers.HostedAgentWorkspaceUpload{
+		Uploads: []*godo.HostedAgentWorkspaceUploadResponse{{
+			Path:         workspacePath,
+			BytesWritten: written,
+		}},
+		Single: true,
+	})
 }
 
 // workspacePartUploadURLs mints presigned PUT URLs for one or more 1-based parts.

--- a/commands/displayers/hosted_agents.go
+++ b/commands/displayers/hosted_agents.go
@@ -82,14 +82,20 @@ func (h *HostedAgentSession) KV() []map[string]any {
 }
 
 // HostedAgentWorkspaceUpload renders the result of `doctl agents upload`.
+// Upload is single-file-only today (Uploads always has exactly one element),
+// so JSON() defaults to list semantics (always an array) like every other
+// list-shaped displayer; set Single=true if a future bare-object verb needs it
+// (see MARSOHS-869/887 — a bare len==1 unwrap silently changes the container
+// type based on row count, breaking callers that range or count the result).
 type HostedAgentWorkspaceUpload struct {
 	Uploads []*godo.HostedAgentWorkspaceUploadResponse
+	Single  bool
 }
 
 var _ Displayable = &HostedAgentWorkspaceUpload{}
 
 func (h *HostedAgentWorkspaceUpload) JSON(out io.Writer) error {
-	if len(h.Uploads) == 1 {
+	if h.Single && len(h.Uploads) == 1 {
 		return writeJSON(h.Uploads[0], out)
 	}
 	return writeJSON(h.Uploads, out)

--- a/commands/displayers/hosted_agents_test.go
+++ b/commands/displayers/hosted_agents_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package displayers
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/digitalocean/doctl/do"
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- HostedAgentSession JSON shape (MARSOHS-887) -----------------------------
+
+// List verbs must always emit a JSON array regardless of row count. Get/mutate
+// verbs (Single=true) must emit a bare JSON object. Same contract as
+// HostedAgentTrigger (MARSOHS-869); regressed here once for `agents list`
+// before being fixed alongside the triggers displayers.
+
+func TestHostedAgentSessionJSON_ListEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentSession{Sessions: nil}
+	require.NoError(t, d.JSON(&buf))
+
+	var out []any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "list with 0 items must be a JSON array")
+	assert.Len(t, out, 0)
+}
+
+func TestHostedAgentSessionJSON_ListOneItem(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentSession{
+		Sessions: []do.HostedAgentSession{{
+			HostedAgentSession: &godo.HostedAgentSession{SessionID: "sess_1"},
+		}},
+		// Single defaults to false → list semantics
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out []any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "list with 1 item must still be a JSON array, not a bare object")
+	assert.Len(t, out, 1)
+}
+
+func TestHostedAgentSessionJSON_ListTwoItems(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentSession{
+		Sessions: []do.HostedAgentSession{
+			{HostedAgentSession: &godo.HostedAgentSession{SessionID: "sess_1"}},
+			{HostedAgentSession: &godo.HostedAgentSession{SessionID: "sess_2"}},
+		},
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out []any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "list with 2 items must be a JSON array")
+	assert.Len(t, out, 2)
+}
+
+func TestHostedAgentSessionJSON_GetSingleItem(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentSession{
+		Sessions: []do.HostedAgentSession{{
+			HostedAgentSession: &godo.HostedAgentSession{SessionID: "sess_1"},
+		}},
+		Single: true,
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "get/create (Single=true) with 1 item must be a bare JSON object, not an array")
+	assert.Equal(t, "sess_1", out["session_id"])
+}
+
+// --- HostedAgentWorkspaceUpload JSON shape ------------------------------------
+//
+// Upload is currently single-file-only (always exactly one item), so this
+// isn't user-visible today, but it still carries the same len==1 special case
+// that caused MARSOHS-869/887. Normalized to the Single bool pattern so a
+// future batch-upload can't silently regress into the same bug.
+
+func TestHostedAgentWorkspaceUploadJSON_ListOneItem(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentWorkspaceUpload{
+		Uploads: []*godo.HostedAgentWorkspaceUploadResponse{{Path: "src/main.go", BytesWritten: 42}},
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out []any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "list semantics: 1 item must still be a JSON array")
+	assert.Len(t, out, 1)
+}
+
+func TestHostedAgentWorkspaceUploadJSON_Single(t *testing.T) {
+	var buf bytes.Buffer
+	d := &HostedAgentWorkspaceUpload{
+		Uploads: []*godo.HostedAgentWorkspaceUploadResponse{{Path: "src/main.go", BytesWritten: 42}},
+		Single:  true,
+	}
+	require.NoError(t, d.JSON(&buf))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "Single=true must be a bare JSON object")
+	assert.Equal(t, "src/main.go", out["path"])
+}


### PR DESCRIPTION
## Summary

[MARSOHS-887](https://do-internal.atlassian.net/browse/MARSOHS-887) (filed by Joe) reports that `doctl agents list -o json` returns a bare JSON object instead of a one-element array when exactly one session exists — the exact same bug class as [MARSOHS-869](https://do-internal.atlassian.net/browse/MARSOHS-869) on `agents triggers list`, which was fixed via the `Single` bool pattern in `displayers/agent_triggers.go`.

**Investigation finding:** the underlying fix for `agents list` was already shipped, bundled into #1904 (see the second-to-last commit on that PR, "fix same JSON list-shape bug in HostedAgentSession displayer") — `RunAgentsList` already omits `Single` (defaults `false` → always an array), and `RunAgentsGet`/`RunAgentsCreate` already set `Single: true` (bare object). Verified live with the real binary against a mock API server at 0/1/2 rows — all three shapes are correct.

So the code fix predates this ticket; what was missing was **regression coverage** — there was no test pinning the array-vs-object contract for `HostedAgentSession`, unlike the trigger displayers which got dedicated shape tests in the same PR. This PR closes that gap:

- Add `commands/displayers/hosted_agents_test.go`: `HostedAgentSession.JSON()` at 0/1/2 rows (always array) and `Single: true` (bare object).
- Normalize `HostedAgentWorkspaceUpload.JSON()` (`doctl agents upload`) to the same `Single` bool pattern. It still had the bare `len(h.Uploads) == 1` unwrap with no row-count guard — harmless today since upload is single-file-only (`Uploads` always has exactly one element), but it's the identical latent trap that caused MARSOHS-869/887, so fixing it proactively before a future batch-upload feature could resurrect the bug.

## Test plan

- [x] `go build ./commands/...` — clean
- [x] `gofmt -l` on all touched files — clean
- [x] `go test ./commands/... -run Agent -v` — all pass, including the 6 new displayer shape tests
- [x] Built the real binary (`go build -mod=vendor -o doctl-dev ./cmd/doctl`) and drove it against a local mock API server:
  - `agents list -o json` at 0/1/2 sessions → array of length 0/1/2 in all three cases
  - `agents show <id> -o json` → still a bare object (Single=true unaffected)

Full output posted on the Jira ticket.

Made with [Cursor](https://cursor.com)

[MARSOHS-887]: https://do-internal.atlassian.net/browse/MARSOHS-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MARSOHS-869]: https://do-internal.atlassian.net/browse/MARSOHS-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ