### PR TITLE
MARSOHS-915 emit JSON ack on stdout for agents destroy/pause/resume/download/approve under -o json

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -753,8 +753,7 @@ func RunAgentsDestroy(c *CmdConfig) error {
 	if err := c.HostedAgents().DestroySession(sessionID); err != nil {
 		return err
 	}
-	notice("Session %s destroyed", sessionID)
-	return nil
+	return sessionStatusNotice(c, sessionID, "destroyed")
 }
 
 // RunAgentsPause pauses a session.
@@ -766,8 +765,7 @@ func RunAgentsPause(c *CmdConfig) error {
 	if err := c.HostedAgents().PauseSession(sessionID); err != nil {
 		return err
 	}
-	notice("Session %s paused", sessionID)
-	return nil
+	return sessionStatusNotice(c, sessionID, "paused")
 }
 
 // RunAgentsResume resumes a paused session.
@@ -779,7 +777,21 @@ func RunAgentsResume(c *CmdConfig) error {
 	if err := c.HostedAgents().ResumeSession(sessionID); err != nil {
 		return err
 	}
-	notice("Session %s resumed", sessionID)
+	return sessionStatusNotice(c, sessionID, "resumed")
+}
+
+// sessionStatusNotice reports the outcome of a no-body mutation (destroy/
+// pause/resume) that the API acknowledges with an empty response. In JSON
+// mode it emits a minimal machine-readable ack instead of the human notice()
+// sentence, so `-o json` never mixes prose onto stdout (MARSOHS-915).
+func sessionStatusNotice(c *CmdConfig, sessionID, status string) error {
+	if Output == "json" {
+		return json.NewEncoder(c.Out).Encode(map[string]string{
+			"session_id": sessionID,
+			"status":     status,
+		})
+	}
+	notice("Session %s %s", sessionID, status)
 	return nil
 }
 
@@ -1102,6 +1114,13 @@ func RunAgentsDownload(c *CmdConfig) error {
 		return err
 	}
 
+	if Output == "json" {
+		return json.NewEncoder(c.Out).Encode(map[string]any{
+			"session_id":    sessionID,
+			"path":          saveTo,
+			"bytes_written": written,
+		})
+	}
 	notice("Downloaded %d bytes to %s", written, saveTo)
 	return nil
 }
@@ -1205,6 +1224,13 @@ func RunAgentsApprove(c *CmdConfig) error {
 		Source:  godo.HostedAgentResolutionSourceOutOfBand,
 	}); err != nil {
 		return err
+	}
+	if Output == "json" {
+		return json.NewEncoder(c.Out).Encode(map[string]string{
+			"session_id": sessionID,
+			"request_id": requestID,
+			"outcome":    string(outcome),
+		})
 	}
 	notice("HITL request %s resolved as %s", requestID, outcome)
 	return nil

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -381,6 +381,69 @@ func TestRunAgentsResume(t *testing.T) {
 	})
 }
 
+// TestRunAgentsDestroy_JSONMode, TestRunAgentsPause_JSONMode, and
+// TestRunAgentsResume_JSONMode pin the fix for MARSOHS-915: destroy/pause/
+// resume have no resource body to render through the Displayable interface,
+// so they used to fall back to the human notice() sentence unconditionally,
+// even under -o json. They must instead emit a minimal JSON ack on stdout and
+// skip the sentence.
+func TestRunAgentsDestroy_JSONMode(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().DestroySession("sess_test").Return(nil)
+
+		Output = "json"
+		defer func() { Output = "text" }()
+
+		var buf bytes.Buffer
+		config.Out = &buf
+		config.Args = []string{"sess_test"}
+		assert.NoError(t, RunAgentsDestroy(config))
+
+		stdout := buf.String()
+		assert.True(t, json.Valid([]byte(stdout)), "stdout must be valid JSON, got: %q", stdout)
+		assert.NotContains(t, stdout, "Notice")
+		assert.JSONEq(t, `{"session_id":"sess_test","status":"destroyed"}`, stdout)
+	})
+}
+
+func TestRunAgentsPause_JSONMode(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().PauseSession("sess_test").Return(nil)
+
+		Output = "json"
+		defer func() { Output = "text" }()
+
+		var buf bytes.Buffer
+		config.Out = &buf
+		config.Args = []string{"sess_test"}
+		assert.NoError(t, RunAgentsPause(config))
+
+		stdout := buf.String()
+		assert.True(t, json.Valid([]byte(stdout)), "stdout must be valid JSON, got: %q", stdout)
+		assert.NotContains(t, stdout, "Notice")
+		assert.JSONEq(t, `{"session_id":"sess_test","status":"paused"}`, stdout)
+	})
+}
+
+func TestRunAgentsResume_JSONMode(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().ResumeSession("sess_test").Return(nil)
+
+		Output = "json"
+		defer func() { Output = "text" }()
+
+		var buf bytes.Buffer
+		config.Out = &buf
+		config.Args = []string{"sess_test"}
+		assert.NoError(t, RunAgentsResume(config))
+
+		stdout := buf.String()
+		assert.True(t, json.Valid([]byte(stdout)), "stdout must be valid JSON, got: %q", stdout)
+		assert.NotContains(t, stdout, "Notice")
+		assert.JSONEq(t, `{"session_id":"sess_test","status":"resumed"}`, stdout)
+	})
+}
+
 func TestResolveSessionRef(t *testing.T) {
 	t.Run("uuid id passes through without a lookup", func(t *testing.T) {
 		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
@@ -549,6 +612,31 @@ func TestRunAgentsApprove(t *testing.T) {
 		tm.hostedAgents.EXPECT().ResolveHITL("sess_test", "req_1", want).Return(nil)
 		config.Args = []string{"sess_test", "req_1", "approve"}
 		assert.NoError(t, RunAgentsApprove(config))
+	})
+}
+
+// TestRunAgentsApprove_JSONMode pins the fix for MARSOHS-915: same no-body
+// notice() gap as destroy/pause/resume, on the approve verb.
+func TestRunAgentsApprove_JSONMode(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		want := &godo.HostedAgentResolveHITLRequest{
+			Outcome: godo.HostedAgentHITLOutcomeApprove,
+			Source:  godo.HostedAgentResolutionSourceOutOfBand,
+		}
+		tm.hostedAgents.EXPECT().ResolveHITL("sess_test", "req_1", want).Return(nil)
+
+		Output = "json"
+		defer func() { Output = "text" }()
+
+		var buf bytes.Buffer
+		config.Out = &buf
+		config.Args = []string{"sess_test", "req_1", "approve"}
+		assert.NoError(t, RunAgentsApprove(config))
+
+		stdout := buf.String()
+		assert.True(t, json.Valid([]byte(stdout)), "stdout must be valid JSON, got: %q", stdout)
+		assert.NotContains(t, stdout, "Notice")
+		assert.JSONEq(t, `{"session_id":"sess_test","request_id":"req_1","outcome":"HITL_OUTCOME_APPROVE"}`, stdout)
 	})
 }
 
@@ -840,6 +928,58 @@ func TestRunAgentsDownload(t *testing.T) {
 		got, err := os.ReadFile(saveTo)
 		assert.NoError(t, err)
 		assert.Equal(t, contents, got)
+	})
+}
+
+// TestRunAgentsDownload_JSONMode pins the fix for MARSOHS-915: same no-body
+// notice() gap as destroy/pause/resume/approve, on the download verb.
+func TestRunAgentsDownload_JSONMode(t *testing.T) {
+	prevPoll := workspaceTransferPollInterval
+	workspaceTransferPollInterval = 0
+	defer func() { workspaceTransferPollInterval = prevPoll }()
+
+	dir := t.TempDir()
+	saveTo := filepath.Join(dir, "out.go")
+	contents := []byte("package main\n\nfunc main() {}\n")
+	wantSum := sha256.Sum256(contents)
+
+	objServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(contents)
+	}))
+	defer objServer.Close()
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().
+			CreateWorkspaceTransfer("sess_test", gomock.Any()).
+			Return(&godo.HostedAgentWorkspaceTransfer{
+				TransferID: "xfer_dl",
+				Status:     godo.HostedAgentWorkspaceTransferStatusPending,
+			}, nil)
+		tm.hostedAgents.EXPECT().
+			GetWorkspaceTransfer("sess_test", "xfer_dl").
+			Return(&godo.HostedAgentWorkspaceTransfer{
+				TransferID:  "xfer_dl",
+				Status:      godo.HostedAgentWorkspaceTransferStatusCompleted,
+				SHA256:      hex.EncodeToString(wantSum[:]),
+				DownloadURL: objServer.URL,
+			}, nil)
+
+		Output = "json"
+		defer func() { Output = "text" }()
+
+		var buf bytes.Buffer
+		config.Out = &buf
+		config.Args = []string{"sess_test"}
+		config.Doit.Set(config.NS, doctl.ArgAgentWorkspacePath, "src/main.go")
+		config.Doit.Set(config.NS, doctl.ArgAgentSaveTo, saveTo)
+		assert.NoError(t, RunAgentsDownload(config))
+
+		stdout := buf.String()
+		assert.True(t, json.Valid([]byte(stdout)), "stdout must be valid JSON, got: %q", stdout)
+		assert.NotContains(t, stdout, "Notice")
+		assert.JSONEq(t,
+			fmt.Sprintf(`{"session_id":"sess_test","path":%q,"bytes_written":%d}`, saveTo, len(contents)),
+			stdout)
 	})
 }
 


### PR DESCRIPTION
## Summary

MARSOHS-915: found during the black-box JSON-purity audit for MARSOHS-887/#1908. Initial diagnosis was that the shared `notice()` helper (`commands/errors.go`) leaked a human-readable banner onto stdout for 5 commands that have no resource body to render through the `Displayable` interface — `agents destroy`, `agents pause`, `agents resume`, `agents download`, `agents approve`.

**That diagnosis was wrong and got corrected before this PR was opened** (see the ticket comments): `commands/errors.go` has a package-wide `init()` that redirects `notice()`'s writer to `os.Stderr` unconditionally, for every call site in the codebase, `-o json` or not:

```go
func init() {
	color.Output = ansicolor.NewAnsiColorWriter(os.Stderr)
}
```

Verified directly against the **unmodified** binary + a mock API server: `doctl agents destroy <id> -o json` already has `stdout=""` / `stderr="Notice: Session <id> destroyed\n"`. Stdout was already clean — nothing was leaking.

The real (smaller) gap: these 5 commands left stdout **completely empty** on success under `-o json`, instead of emitting any document at all. `doctl agents destroy <id> -o json | jq .` still breaks (`Unexpected end of JSON input` on empty stdin), just not for the reason originally suspected. This is inconsistent with every other `-o json` command in `agents.go` (list/get/create), which always emit a parseable document.

## Change

For `RunAgentsDestroy` / `RunAgentsPause` / `RunAgentsResume` / `RunAgentsDownload` / `RunAgentsApprove`: emit a small JSON acknowledgement object on stdout when `Output == "json"`, and skip the stderr `notice()` sentence in that mode. Text mode is unchanged (notice() still fires on stderr as before).

* `destroy`/`pause`/`resume` → `{"session_id": "...", "status": "destroyed|paused|resumed"}`
* `download` → `{"session_id": "...", "path": "...", "bytes_written": N}`
* `approve` → `{"session_id": "...", "request_id": "...", "outcome": "HITL_OUTCOME_APPROVE|..."}`

## Test plan

* `gofmt -l commands/agents.go commands/agents_test.go` — clean
* `go vet ./commands/...` — clean
* `go test ./commands/... -run Agent` — all pass, including 5 new `_JSONMode` regression tests (destroy/pause/resume/approve/download) asserting `json.Valid`, absence of `"Notice"`, and the exact JSON shape
* Built the real binary and drove it against a mock API server returning HTTP 204 (no body), confirming:
  * `agents destroy -o json` → clean JSON ack on stdout, empty stderr
  * `agents pause -o json` → clean JSON ack on stdout, empty stderr
  * `agents destroy` (text mode) → notice still on stderr, as before (no regression)

Full audit trail (including the self-correction) posted on [MARSOHS-915](https://do-internal.atlassian.net/browse/MARSOHS-915).

Made with Cursor

Made with [Cursor](https://cursor.com)

[MARSOHS-915]: https://do-internal.atlassian.net/browse/MARSOHS-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ