### PR TITLE
MARSOHS-883 verify and polish spec.skills doctl authoring flow

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -244,7 +244,18 @@ The `+"`"+`--spec`+"`"+` flag is required and accepts a YAML manifest matching t
 
 For `+"`"+`adapter: codex-agentapi`+"`"+` (OpenAI sandbox provider), doctl first creates an OpenAI Agents session using `+"`"+`spec.runtime.config`+"`"+` (or legacy `+"`"+`spec.openai`+"`"+`) and `+"`"+`$OPENAI_API_KEY`+"`"+`, injects the returned environment id into `+"`"+`${ENV_ID}`+"`"+`, and passes the OpenAI session id to DigitalOcean as `+"`"+`?openai_session_id=`+"`"+`.
 
-Use `+"`"+`--name`+"`"+` to name the session (this sets the manifest's `+"`"+`metadata.name`+"`"+`). If omitted, the server auto-generates a name. The name must be unique among your team's active sessions, and once set you can reference the session by name in other commands (e.g. `+"`"+`doctl agents attach <name>`+"`"+`).`,
+Use `+"`"+`--name`+"`"+` to name the session (this sets the manifest's `+"`"+`metadata.name`+"`"+`). If omitted, the server auto-generates a name. The name must be unique among your team's active sessions, and once set you can reference the session by name in other commands (e.g. `+"`"+`doctl agents attach <name>`+"`"+`).
+
+Add inline Agent Skills via `+"`"+`spec.skills`+"`"+`, a list of skill objects with `+"`"+`name`+"`"+`, `+"`"+`description`+"`"+`, and `+"`"+`instructions`+"`"+` (plus optional `+"`"+`license`+"`"+`, `+"`"+`metadata`+"`"+`, `+"`"+`allowedTools`+"`"+`). `+"`"+`instructions`+"`"+` is advisory context for the agent, not a security boundary -- use `+"`"+`spec.permissions`+"`"+` for enforcement. Example:
+
+  spec:
+    adapter: opencode
+    skills:
+      - name: pr-style-guide
+        description: Our team's pull request description conventions
+        instructions: |
+          Summarize the change in 1-2 sentences before the details.
+          Link related issues with "Fixes #123" syntax.`,
 		Writer, aliasOpt("deploy"),
 		displayerType(&displayers.HostedAgentSession{}))
 	AddStringFlag(cmdStart, doctl.ArgAgentSpec, "", "", `Path to an agent manifest in YAML or JSON. Set to "-" to read from stdin. ${VAR} references are resolved from the local environment.`, requiredOpt())

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -260,6 +260,36 @@ spec:
 		_, err := injectManifestName([]byte("::: not yaml :::"), "x")
 		assert.Error(t, err)
 	})
+
+	t.Run("preserves multi-line spec.skills instructions", func(t *testing.T) {
+		const withSkills = `apiVersion: agents.digitalocean.com/v1alpha1
+kind: Agent
+spec:
+  adapter: opencode
+  skills:
+    - name: example-skill
+      description: A test skill with multi-line instructions
+      instructions: |
+        Step one: do the first thing.
+        Step two: do the second thing.
+
+        Step three: finish up.
+`
+		const wantInstructions = "Step one: do the first thing.\nStep two: do the second thing.\n\nStep three: finish up.\n"
+
+		out, err := injectManifestName([]byte(withSkills), "my-session")
+		assert.NoError(t, err)
+
+		var doc map[string]any
+		assert.NoError(t, yaml.Unmarshal(out, &doc))
+		spec := doc["spec"].(map[any]any)
+		skills, ok := spec["skills"].([]any)
+		assert.True(t, ok)
+		assert.Len(t, skills, 1)
+		skill := skills[0].(map[any]any)
+		assert.Equal(t, "example-skill", skill["name"])
+		assert.Equal(t, wantInstructions, skill["instructions"])
+	})
 }
 
 func TestRunAgentsList(t *testing.T) {
@@ -951,6 +981,40 @@ func TestErrorResponseSurfacesNestedMessage(t *testing.T) {
 	}
 	assert.NoError(t, json.Unmarshal([]byte(body), er))
 	assert.Contains(t, er.Error(), "forward input to OHR: ohr attach: connection error")
+}
+
+// TestRunAgentsStart_SkillsEnvSizeCapError pins that harness-api's
+// HARNESS_SKILLS env-size-cap rejection (agentspec.validateSkillsEnvSize,
+// returned as a 400 with the nested {"error":{"code":...,"message":...}}
+// envelope) surfaces to the CLI user as the server's own readable message,
+// not a raw JSON/HTTP dump.
+func TestRunAgentsStart_SkillsEnvSizeCapError(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "agent.yaml")
+	assert.NoError(t, os.WriteFile(specPath, []byte(sampleManifest), 0o644))
+
+	const wantMessage = `agentspec: spec.skills would encode to 65537 bytes as the HARNESS_SKILLS guest env value, exceeding the sandbox's 65536-byte limit; trim instructions/descriptions or reduce the number of skills (temporary limit while skill delivery rides an env var)`
+	const body = `{"error":{"code":400,"message":"` + wantMessage + `"}}`
+	er := &godo.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Request:    httptest.NewRequest(http.MethodPost, "http://harness/v2/agents/sessions", nil),
+		},
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), er))
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().
+			CreateSessionFromManifest(gomock.Any(), nil).
+			Return(nil, er)
+
+		config.Doit.Set(config.NS, doctl.ArgAgentSpec, specPath)
+		err := RunAgentsStart(config)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), wantMessage)
+		assert.NotContains(t, err.Error(), `{"error"`)
+		assert.NotContains(t, err.Error(), `{"message"`)
+	})
 }
 
 func TestRenderEventHITLRequested(t *testing.T) {

--- a/commands/openai_agents_test.go
+++ b/commands/openai_agents_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const sampleOpenAIManifest = `apiVersion: agents.digitalocean.com/v1alpha1
@@ -276,6 +277,41 @@ func TestStripSpecOpenAI(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(out), "gpt-5.6-sol")
 	assert.Contains(t, string(out), "config:")
+}
+
+func TestStripSpecOpenAI_PreservesMultiLineSkillsInstructions(t *testing.T) {
+	const withSkills = `apiVersion: agents.digitalocean.com/v1alpha1
+kind: Agent
+spec:
+  runtime:
+    adapter: codex-agentapi
+  skills:
+    - name: example-skill
+      description: A test skill with multi-line instructions
+      instructions: |
+        Step one: do the first thing.
+        Step two: do the second thing.
+
+        Step three: finish up.
+  openai:
+    agent:
+      model: gpt-5.6-sol
+`
+	const wantInstructions = "Step one: do the first thing.\nStep two: do the second thing.\n\nStep three: finish up.\n"
+
+	out, err := stripSpecOpenAI([]byte(withSkills))
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "openai:")
+
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &doc))
+	spec := doc["spec"].(map[any]any)
+	skills, ok := spec["skills"].([]any)
+	require.True(t, ok)
+	require.Len(t, skills, 1)
+	skill := skills[0].(map[any]any)
+	assert.Equal(t, "example-skill", skill["name"])
+	assert.Equal(t, wantInstructions, skill["instructions"])
 }
 
 func TestIsOpenAISandboxSession(t *testing.T) {


### PR DESCRIPTION
Add test coverage proving multi-line `spec.skills ` instructions survive the --name/legacy-openai manifest round-trips, and that harness-api's `HARNESS_SKILLS` size-cap rejection surfaces as a readable CLI message rather than a raw JSON/HTTP dump. Add a `spec.skills` example to the agents start --help text.

