### PR TITLE
agents: support the flat agents.yaml manifest format

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -240,26 +240,31 @@ Commands that act on a single session accept either the session ID or its name. 
 		"Start a new agent session",
 		`Creates a new agent session from an agent manifest file and prints its session id and status.
 
-The `+"`"+`--spec`+"`"+` flag is required and accepts a YAML manifest matching the `+"`"+`agents.digitalocean.com/v1alpha1`+"`"+` schema. `+"`"+`${VAR}`+"`"+` references in the manifest are resolved from your local environment before upload; referencing an unset variable is an error, and `+"`"+`$${VAR}`+"`"+` escapes to a literal `+"`"+`${VAR}`+"`"+`. The expanded manifest is then sent to the server, which owns parsing and validation.
+The `+"`"+`--spec`+"`"+` flag is required and accepts a flat agents.yaml manifest: no envelope, a top-level `+"`"+`agent:`+"`"+` key naming the coding agent, snake_case keys, and duration strings (`+"`"+`idle_timeout: 10m`+"`"+`). The minimal manifest is a single line:
 
-For `+"`"+`adapter: codex-agentapi`+"`"+` (OpenAI sandbox provider), doctl first creates an OpenAI Agents session using `+"`"+`spec.runtime.config`+"`"+` (or legacy `+"`"+`spec.openai`+"`"+`) and `+"`"+`$OPENAI_API_KEY`+"`"+`, injects the returned environment id into `+"`"+`${ENV_ID}`+"`"+`, and passes the OpenAI session id to DigitalOcean as `+"`"+`?openai_session_id=`+"`"+`.
+  agent: opencode
 
-Use `+"`"+`--name`+"`"+` to name the session (this sets the manifest's `+"`"+`metadata.name`+"`"+`). If omitted, the server auto-generates a name. The name must be unique among your team's active sessions, and once set you can reference the session by name in other commands (e.g. `+"`"+`doctl agents attach <name>`+"`"+`).
+`+"`"+`${VAR}`+"`"+` references in the manifest are resolved from your local environment before upload; referencing an unset variable is an error, and `+"`"+`$${VAR}`+"`"+` escapes to a literal `+"`"+`${VAR}`+"`"+`. The expanded manifest is then sent to the server, which owns parsing and validation.
 
-Add inline Agent Skills via `+"`"+`spec.skills`+"`"+`, a list of skill objects with `+"`"+`name`+"`"+`, `+"`"+`description`+"`"+`, and `+"`"+`instructions`+"`"+` (plus optional `+"`"+`license`+"`"+`, `+"`"+`metadata`+"`"+`, `+"`"+`allowedTools`+"`"+`). `+"`"+`instructions`+"`"+` is advisory context for the agent, not a security boundary -- use `+"`"+`spec.permissions`+"`"+` for enforcement. Example:
+The legacy `+"`"+`agents.digitalocean.com/v1alpha1`+"`"+` envelope format (`+"`"+`apiVersion`+"`"+`/`+"`"+`kind`+"`"+`/`+"`"+`metadata`+"`"+`/`+"`"+`spec`+"`"+`) is deprecated: it is still accepted, but doctl prints a deprecation notice and the server appends a warning to the session; it will be rejected after the transition window.
 
-  spec:
-    adapter: opencode
-    skills:
-      - name: pr-style-guide
-        description: Our team's pull request description conventions
-        instructions: |
-          Summarize the change in 1-2 sentences before the details.
-          Link related issues with "Fixes #123" syntax.`,
+For `+"`"+`agent: codex-agentapi`+"`"+` (OpenAI sandbox provider), doctl first creates an OpenAI Agents session using the manifest's `+"`"+`config`+"`"+` block (legacy: `+"`"+`spec.runtime.config`+"`"+` or `+"`"+`spec.openai`+"`"+`) and `+"`"+`$OPENAI_API_KEY`+"`"+`, injects the returned environment id into `+"`"+`${ENV_ID}`+"`"+`, and passes the OpenAI session id to DigitalOcean as `+"`"+`?openai_session_id=`+"`"+`.
+
+Use `+"`"+`--name`+"`"+` to name the session (this sets the manifest's `+"`"+`name`+"`"+`; `+"`"+`metadata.name`+"`"+` in the legacy envelope). If omitted, the server auto-generates a name. The name must be unique among your team's active sessions, and once set you can reference the session by name in other commands (e.g. `+"`"+`doctl agents attach <name>`+"`"+`).
+
+Add inline Agent Skills via `+"`"+`skills`+"`"+`, a list of skill objects with `+"`"+`name`+"`"+`, `+"`"+`description`+"`"+`, and `+"`"+`instructions`+"`"+` (plus optional `+"`"+`license`+"`"+`, `+"`"+`metadata`+"`"+`, `+"`"+`allowed_tools`+"`"+`). `+"`"+`instructions`+"`"+` is advisory context for the agent, not a security boundary -- use `+"`"+`permissions`+"`"+` for enforcement. Example:
+
+  agent: opencode
+  skills:
+    - name: pr-style-guide
+      description: Our team's pull request description conventions
+      instructions: |
+        Summarize the change in 1-2 sentences before the details.
+        Link related issues with "Fixes #123" syntax.`,
 		Writer, aliasOpt("deploy"),
 		displayerType(&displayers.HostedAgentSession{}))
-	AddStringFlag(cmdStart, doctl.ArgAgentSpec, "", "", `Path to an agent manifest in YAML or JSON. Set to "-" to read from stdin. ${VAR} references are resolved from the local environment.`, requiredOpt())
-	AddStringFlag(cmdStart, doctl.ArgAgentName, "", "", "Name for the new session (sets the manifest's metadata.name). If omitted, the server auto-generates a name. Must be unique among your team's active sessions.")
+	AddStringFlag(cmdStart, doctl.ArgAgentSpec, "", "", `Path to an agent manifest in YAML or JSON (flat format; minimal: "agent: opencode"). Set to "-" to read from stdin. ${VAR} references are resolved from the local environment.`, requiredOpt())
+	AddStringFlag(cmdStart, doctl.ArgAgentName, "", "", "Name for the new session (sets the manifest's name). If omitted, the server auto-generates a name. Must be unique among your team's active sessions.")
 	cmdStart.Example = `doctl agents start --spec agent-spec.yaml --name my-session`
 
 	cmdStartProxy := CmdBuilder(cmd, RunAgentsStartProxy, "start-proxy",
@@ -399,7 +404,12 @@ func RunAgentsStart(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	// --name is a convenience that sets the manifest's metadata.name. When it's
+	if manifestUsesLegacyEnvelope(raw) {
+		warn("this manifest uses the deprecated apiVersion/kind/metadata/spec envelope format; " +
+			"switch to the flat format (top-level `agent:` key, no envelope — see `doctl agents start --help`). " +
+			"The envelope is still accepted for now but will be rejected after the transition window")
+	}
+	// --name is a convenience that sets the manifest's session name. When it's
 	// omitted the manifest is sent verbatim and the server auto-generates a name.
 	raw, err = injectManifestName(raw, name)
 	if err != nil {
@@ -585,7 +595,22 @@ func expandManifestEnvLookup(manifest []byte, lookup func(string) (string, bool)
 	return out, nil
 }
 
-// injectManifestName sets metadata.name on the manifest to name. An empty name
+// manifestUsesLegacyEnvelope reports whether the manifest is written in the
+// deprecated `agents.digitalocean.com/v1alpha1` envelope format. Detection
+// matches the server's routing rule: a top-level `apiVersion` key selects the
+// legacy parser; its absence selects the flat format. Unparseable YAML returns
+// false — the server will produce the authoritative error.
+func manifestUsesLegacyEnvelope(manifest []byte) bool {
+	var doc map[string]any
+	if err := yaml.Unmarshal(manifest, &doc); err != nil {
+		return false
+	}
+	_, ok := doc["apiVersion"]
+	return ok
+}
+
+// injectManifestName sets the session name on the manifest: top-level `name`
+// for flat manifests, `metadata.name` for legacy envelope ones. An empty name
 // returns the manifest unchanged so the server can auto-generate one. The
 // server still owns full manifest validation (including name syntax); this only
 // wires the --name convenience flag into the YAML the server parses.
@@ -602,13 +627,17 @@ func injectManifestName(manifest []byte, name string) ([]byte, error) {
 		doc = map[string]any{}
 	}
 
-	// yaml.v2 decodes nested mappings as map[any]any.
-	meta, ok := doc["metadata"].(map[any]any)
-	if !ok {
-		meta = map[any]any{}
+	if _, legacy := doc["apiVersion"]; legacy {
+		// yaml.v2 decodes nested mappings as map[any]any.
+		meta, ok := doc["metadata"].(map[any]any)
+		if !ok {
+			meta = map[any]any{}
+		}
+		meta["name"] = name
+		doc["metadata"] = meta
+	} else {
+		doc["name"] = name
 	}
-	meta["name"] = name
-	doc["metadata"] = meta
 
 	out, err := yaml.Marshal(doc)
 	if err != nil {

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -50,6 +50,12 @@ spec:
   adapter: opencode
 `
 
+// sampleFlatManifest is the flat-format equivalent of sampleManifest: no
+// envelope, top-level agent key.
+const sampleFlatManifest = `name: test-agent
+agent: opencode
+`
+
 func testAttachStateFromPending(pending *pendingHITL) *attachState {
 	if pending == nil {
 		pending = &pendingHITL{}
@@ -261,6 +267,25 @@ spec:
 		assert.Error(t, err)
 	})
 
+	t.Run("flat manifest gets a top-level name", func(t *testing.T) {
+		out, err := injectManifestName([]byte("agent: opencode\n"), "my-session")
+		assert.NoError(t, err)
+		var doc map[string]any
+		assert.NoError(t, yaml.Unmarshal(out, &doc))
+		assert.Equal(t, "my-session", doc["name"])
+		assert.NotContains(t, doc, "metadata")
+	})
+
+	t.Run("overrides an existing flat name", func(t *testing.T) {
+		out, err := injectManifestName([]byte(sampleFlatManifest), "override")
+		assert.NoError(t, err)
+		var doc map[string]any
+		assert.NoError(t, yaml.Unmarshal(out, &doc))
+		assert.Equal(t, "override", doc["name"])
+		assert.Equal(t, "opencode", doc["agent"])
+		assert.NotContains(t, doc, "metadata")
+	})
+
 	t.Run("preserves multi-line spec.skills instructions", func(t *testing.T) {
 		const withSkills = `apiVersion: agents.digitalocean.com/v1alpha1
 kind: Agent
@@ -289,6 +314,40 @@ spec:
 		skill := skills[0].(map[any]any)
 		assert.Equal(t, "example-skill", skill["name"])
 		assert.Equal(t, wantInstructions, skill["instructions"])
+	})
+}
+
+func TestManifestUsesLegacyEnvelope(t *testing.T) {
+	assert.True(t, manifestUsesLegacyEnvelope([]byte(sampleManifest)))
+	assert.False(t, manifestUsesLegacyEnvelope([]byte(sampleFlatManifest)))
+	assert.False(t, manifestUsesLegacyEnvelope([]byte("agent: opencode\n")))
+	// Unparseable YAML defers to the server for the authoritative error.
+	assert.False(t, manifestUsesLegacyEnvelope([]byte("::: not yaml :::")))
+}
+
+func TestRunAgentsStart_FlatWithName(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "agent.yaml")
+	assert.NoError(t, os.WriteFile(specPath, []byte("agent: opencode\n"), 0o644))
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		// The manifest sent to the server must carry a top-level name (flat
+		// format), not the legacy metadata.name.
+		tm.hostedAgents.EXPECT().
+			CreateSessionFromManifest(gomock.Any(), nil).
+			DoAndReturn(func(manifest []byte, opt *godo.HostedAgentManifestCreateOptions) (*do.HostedAgentSession, error) {
+				var doc map[string]any
+				assert.NoError(t, yaml.Unmarshal(manifest, &doc))
+				assert.Equal(t, "my-session", doc["name"])
+				assert.NotContains(t, doc, "metadata")
+				return &do.HostedAgentSession{
+					HostedAgentSession: &godo.HostedAgentSession{SessionID: "sess_test", Name: "my-session"},
+				}, nil
+			})
+
+		config.Doit.Set(config.NS, doctl.ArgAgentSpec, specPath)
+		config.Doit.Set(config.NS, doctl.ArgAgentName, "my-session")
+		assert.NoError(t, RunAgentsStart(config))
 	})
 }
 

--- a/commands/openai_agents.go
+++ b/commands/openai_agents.go
@@ -311,19 +311,36 @@ func truncateForErr(b []byte) string {
 	return s[:max] + "…"
 }
 
-// agentManifestDoc is the subset of agents.yaml we need for OpenAI orchestration.
+// agentManifestDoc is the subset of agents.yaml we need for OpenAI
+// orchestration, covering both manifest formats: the flat format reads
+// top-level `agent` and `config`; the deprecated v1alpha1 envelope reads
+// `spec.runtime.adapter`, `spec.runtime.config`, and legacy `spec.openai`.
 type agentManifestDoc struct {
+	// Agent is the flat format's adapter selector.
+	Agent string `yaml:"agent"`
+	// Config holds the flat format's OpenAI create-session body
+	// (agent/environment/input).
+	Config any `yaml:"config"`
+
 	Spec struct {
 		Runtime struct {
 			Adapter string `yaml:"adapter"`
 			// Config holds the OpenAI create-session body (agent/environment/input)
-			// under the DO agentspec. Preferred over legacy spec.openai.
+			// under the legacy envelope. Preferred over legacy spec.openai.
 			Config any `yaml:"config"`
 		} `yaml:"runtime"`
 		// OpenAI is the legacy client-only location for the create body. Still
 		// accepted for extraction, but stripped before the DO create call.
 		OpenAI any `yaml:"openai"`
 	} `yaml:"spec"`
+}
+
+// adapter returns the manifest's agent selector regardless of format.
+func (d *agentManifestDoc) adapter() string {
+	if a := strings.TrimSpace(d.Agent); a != "" {
+		return a
+	}
+	return strings.TrimSpace(d.Spec.Runtime.Adapter)
 }
 
 func parseAgentManifest(manifest []byte) (*agentManifestDoc, error) {
@@ -347,7 +364,7 @@ func hasOpenAICreateBody(doc *agentManifestDoc) bool {
 	if doc == nil {
 		return false
 	}
-	return doc.Spec.Runtime.Config != nil || doc.Spec.OpenAI != nil
+	return doc.Config != nil || doc.Spec.Runtime.Config != nil || doc.Spec.OpenAI != nil
 }
 
 func extractOpenAICreateBody(manifest []byte) (json.RawMessage, error) {
@@ -355,16 +372,20 @@ func extractOpenAICreateBody(manifest []byte) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Prefer spec.runtime.config (current DO agentspec). Fall back to legacy
-	// spec.openai for older manifests.
-	source := doc.Spec.Runtime.Config
-	sourceName := "spec.runtime.config"
+	// Prefer the flat format's top-level config, then the legacy envelope's
+	// spec.runtime.config, then legacy client-only spec.openai.
+	source := doc.Config
+	sourceName := "config"
+	if source == nil {
+		source = doc.Spec.Runtime.Config
+		sourceName = "spec.runtime.config"
+	}
 	if source == nil {
 		source = doc.Spec.OpenAI
 		sourceName = "spec.openai"
 	}
 	if source == nil {
-		return nil, fmt.Errorf("manifest adapter %q requires a non-empty %s (or legacy spec.openai) block", openAIAgentsAdapter, "spec.runtime.config")
+		return nil, fmt.Errorf("manifest agent %q requires a non-empty config block (legacy envelope: spec.runtime.config or spec.openai)", openAIAgentsAdapter)
 	}
 	// yaml.v2 decodes nested maps as map[interface{}]interface{}; normalize
 	// before JSON encoding so Marshal succeeds.
@@ -452,11 +473,11 @@ func prepareOpenAISandboxStart(ctx context.Context, manifest []byte) (openaiSess
 	if err != nil {
 		return "", nil, err
 	}
-	if !isOpenAISandboxAdapter(doc.Spec.Runtime.Adapter) && !hasOpenAICreateBody(doc) {
+	if !isOpenAISandboxAdapter(doc.adapter()) && !hasOpenAICreateBody(doc) {
 		return "", nil, nil
 	}
-	if !isOpenAISandboxAdapter(doc.Spec.Runtime.Adapter) {
-		return "", nil, fmt.Errorf("spec.runtime.config (or legacy spec.openai) is only valid with adapter %q (got %q)", openAIAgentsAdapter, doc.Spec.Runtime.Adapter)
+	if !isOpenAISandboxAdapter(doc.adapter()) {
+		return "", nil, fmt.Errorf("an OpenAI create-session config block is only valid with agent %q (got %q)", openAIAgentsAdapter, doc.adapter())
 	}
 
 	apiKey := strings.TrimSpace(os.Getenv(openAIAPIKeyEnv))

--- a/commands/openai_agents_test.go
+++ b/commands/openai_agents_test.go
@@ -84,6 +84,27 @@ spec:
       workspace_directory: /workspace
 `
 
+// sampleFlatOpenAIManifest is the flat-format equivalent of
+// sampleOpenAIManifest: top-level agent + config, no envelope.
+const sampleFlatOpenAIManifest = `name: codex-agentapi-session
+agent: codex-agentapi
+config:
+  agent:
+    model: gpt-5.6-sol
+    instructions: "Answer clearly."
+  environment:
+    type: self_hosted
+    workspace_directory: /workspace
+  input:
+    - role: user
+      content:
+        - type: input_text
+          text: "hello"
+env:
+  CODEX_ENVIRONMENT_ID: ${ENV_ID}
+  CODEX_API_KEY: ${OPENAI_API_KEY}
+`
+
 func TestParseOpenAIAgentsSession(t *testing.T) {
 	sess, err := parseOpenAIAgentsSession([]byte(`{
 		"id": "sess_a91f3",
@@ -147,11 +168,61 @@ spec:
 	assert.Equal(t, "from-config", agent["model"])
 }
 
+func TestExtractOpenAICreateBody_Flat(t *testing.T) {
+	body, err := extractOpenAICreateBody([]byte(sampleFlatOpenAIManifest))
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(body, &payload))
+	agent, ok := payload["agent"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "gpt-5.6-sol", agent["model"])
+	env, ok := payload["environment"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "self_hosted", env["type"])
+}
+
 func TestPrepareOpenAISandboxStart_NonOpenAI(t *testing.T) {
 	id, overlay, err := prepareOpenAISandboxStart(context.Background(), []byte(sampleManifest))
 	require.NoError(t, err)
 	assert.Empty(t, id)
 	assert.Nil(t, overlay)
+}
+
+func TestPrepareOpenAISandboxStart_FlatNonOpenAI(t *testing.T) {
+	id, overlay, err := prepareOpenAISandboxStart(context.Background(), []byte("agent: opencode\n"))
+	require.NoError(t, err)
+	assert.Empty(t, id)
+	assert.Nil(t, overlay)
+}
+
+func TestPrepareOpenAISandboxStart_FlatConfigRequiresCodexAgent(t *testing.T) {
+	const manifest = `agent: opencode
+config:
+  agent:
+    model: gpt-5.6-sol
+`
+	_, _, err := prepareOpenAISandboxStart(context.Background(), []byte(manifest))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "codex-agentapi")
+	assert.Contains(t, err.Error(), `"opencode"`)
+}
+
+func TestPrepareOpenAISandboxStart_FlatCreatesSession(t *testing.T) {
+	t.Setenv(openAIAPIKeyEnv, "sk-test")
+	orig := createOpenAIAgentsSession
+	t.Cleanup(func() { createOpenAIAgentsSession = orig })
+	createOpenAIAgentsSession = func(ctx context.Context, apiKey string, body json.RawMessage) (*openAIAgentsSession, error) {
+		assert.Equal(t, "sk-test", apiKey)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(body, &payload))
+		assert.Contains(t, payload, "agent")
+		return &openAIAgentsSession{ID: "sess_flat1", EnvironmentID: "env_flat1"}, nil
+	}
+
+	id, overlay, err := prepareOpenAISandboxStart(context.Background(), []byte(sampleFlatOpenAIManifest))
+	require.NoError(t, err)
+	assert.Equal(t, "sess_flat1", id)
+	assert.Equal(t, map[string]string{"ENV_ID": "env_flat1"}, overlay)
 }
 
 func TestPrepareOpenAISandboxStart_CreatesSession(t *testing.T) {
@@ -256,6 +327,49 @@ func TestRunAgentsStart_OpenAI(t *testing.T) {
 						Status:              godo.HostedAgentSessionStatusReady,
 						OpenAISessionID:     "sess_a91f3",
 						OpenAIEnvironmentID: "env_abc123",
+					},
+				}, nil
+			})
+
+		config.Doit.Set(config.NS, doctl.ArgAgentSpec, specPath)
+		assert.NoError(t, RunAgentsStart(config))
+	})
+}
+
+func TestRunAgentsStart_OpenAIFlat(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "agent.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(sampleFlatOpenAIManifest), 0o644))
+	t.Setenv(openAIAPIKeyEnv, "sk-test-key")
+
+	orig := createOpenAIAgentsSession
+	t.Cleanup(func() { createOpenAIAgentsSession = orig })
+	createOpenAIAgentsSession = func(ctx context.Context, apiKey string, body json.RawMessage) (*openAIAgentsSession, error) {
+		return &openAIAgentsSession{ID: "sess_flat1", EnvironmentID: "env_flat1"}, nil
+	}
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().
+			CreateSessionFromManifest(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(manifest []byte, opt *godo.HostedAgentManifestCreateOptions) (*do.HostedAgentSession, error) {
+				require.NotNil(t, opt)
+				assert.Equal(t, "sess_flat1", opt.OpenAISessionID)
+				assert.Contains(t, string(manifest), "CODEX_ENVIRONMENT_ID: env_flat1")
+				assert.Contains(t, string(manifest), "CODEX_API_KEY: sk-test-key")
+				assert.NotContains(t, string(manifest), "${")
+				// The flat manifest carries no envelope and keeps its config
+				// block for DO.
+				assert.NotContains(t, string(manifest), "apiVersion")
+				assert.Contains(t, string(manifest), "gpt-5.6-sol")
+				assert.Contains(t, string(manifest), "config:")
+				return &do.HostedAgentSession{
+					HostedAgentSession: &godo.HostedAgentSession{
+						SessionID:           "sess_do_2",
+						Name:                "codex-agentapi-session",
+						AgentKind:           godo.HostedAgentKindOpenAICodex,
+						Status:              godo.HostedAgentSessionStatusReady,
+						OpenAISessionID:     "sess_flat1",
+						OpenAIEnvironmentID: "env_flat1",
 					},
 				}, nil
 			})


### PR DESCRIPTION
## Summary

MARSOHS manifest-simplification, doctl milestone (M6). The platform now accepts a flat `agents.yaml` format (top-level `agent:` key, snake_case, no `apiVersion`/`kind`/`metadata`/`spec` envelope) alongside the deprecated `v1alpha1` envelope. This PR makes doctl's client-side manifest handling dual-format:

- `--name` injection is format-aware: flat manifests get a top-level `name`, legacy envelopes keep `metadata.name` (previously a flat manifest would have been corrupted with an injected `metadata` block the server rejects).
- codex-agentapi (OpenAI sandbox provider) orchestration reads the create-session body from the flat top-level `config` block, falling back to legacy `spec.runtime.config` / `spec.openai`; adapter detection reads flat `agent` or legacy `spec.runtime.adapter`.
- `doctl agents start` prints a deprecation notice when the manifest uses the legacy envelope (detection mirrors the server's routing rule: presence of a top-level `apiVersion` key).
- `agents start` help text and examples are rewritten flat-primary (minimal manifest `agent: opencode`; skills example uses flat `skills` with `allowed_tools`), with a short legacy-deprecation note.

`${VAR}` expansion is unchanged. The server still owns full manifest parsing and validation.

## Merge gate

Per the workstream landing order, this must not ship in a doctl release before the harness-api flat parser is **deployed** to production (flat manifests emitted by the new help/examples must be accepted). Targeting `feat/agents-subcommands` keeps it behind that gate.

## Testing

- New unit tests: format detection, flat/legacy `--name` injection, flat codex-agentapi create-body extraction and session prep (including the wrong-agent error), full `agents start` flow with a flat manifest.
- `go vet ./commands/...` and `go test ./commands/` pass (pre-existing local keychain failures in `TestRegistryLogin`/`TestRegistryLogout` unrelated, fail on the base branch too).

Made with [Cursor](https://cursor.com)