### PR TITLE
agents: add port-forward command (WebSocket tunnel POC)

### DIFF
--- a/args.go
+++ b/args.go
@@ -1002,6 +1002,9 @@ const (
 	// ArgAgentCheckpointLabel is an optional user label for an explicit checkpoint.
 	ArgAgentCheckpointLabel = "label"
 
+	// ArgAgentForwardAddress is the local bind address for port-forward listeners.
+	ArgAgentForwardAddress = "address"
+
 	// ArgAgentFromCheckpoint is the checkpoint ID to fork or roll back from.
 	ArgAgentFromCheckpoint = "from-checkpoint"
 

--- a/commands/agent_port_forward.go
+++ b/commands/agent_port_forward.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 
 	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/internal/deviceid"
 	"github.com/gorilla/websocket"
 	"github.com/spf13/viper"
 )
@@ -192,7 +193,7 @@ func (t *wsTracer) handshake(wsURL string, header http.Header, resp *http.Respon
 	t.logger.Println("<-", strconv.Quote(line))
 }
 
-// formatHeader renders headers on one line with the bearer token masked;
+// formatHeader renders headers on one line with sensitive values masked;
 // trace output gets pasted into tickets.
 func formatHeader(h http.Header) string {
 	keys := make([]string, 0, len(h))
@@ -203,12 +204,50 @@ func formatHeader(h http.Header) string {
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
 		v := strings.Join(h[k], ",")
-		if strings.EqualFold(k, "Authorization") {
+		switch {
+		case strings.EqualFold(k, "Authorization"):
 			v = "[redacted]"
+		case strings.EqualFold(k, deviceid.HeaderName):
+			v = redactDeviceID(v)
 		}
 		parts = append(parts, k+": "+v)
 	}
 	return strings.Join(parts, "; ")
+}
+
+// redactDeviceID masks a hardware id the way harness-api's device.Redact does,
+// so a trace line and the server's log line for the same request stay
+// correlatable without either recording the full identifier.
+func redactDeviceID(id string) string {
+	s := strings.TrimSpace(id)
+	switch {
+	case s == "":
+		return ""
+	case len(s) <= 8:
+		return "***"
+	default:
+		return s[:4] + "***" + s[len(s)-4:]
+	}
+}
+
+// tunnelHeader builds the WebSocket upgrade headers. Both values are
+// injected rather than read here so this stays testable: deviceid.Get caches
+// its lookup in a sync.Once.
+//
+// The device id is what the deviceid transport stamps on every /v2/agents
+// request, but that transport wraps godo's RoundTripper and gorilla dials its
+// own connection. Without it the tunnel is the one agents call harness-api's
+// device middleware logs with an empty id, and it is also the one that opens
+// a raw TCP channel into the sandbox.
+func tunnelHeader(token, deviceID string) http.Header {
+	header := http.Header{}
+	if token != "" {
+		header.Set("Authorization", "Bearer "+token)
+	}
+	if deviceID != "" {
+		header.Set(deviceid.HeaderName, deviceID)
+	}
+	return header
 }
 
 // RunAgentsPortForward opens local TCP tunnels to ports inside the session's
@@ -237,10 +276,7 @@ func RunAgentsPortForward(c *CmdConfig) error {
 		warn("binding %s exposes the tunnel to anyone who can reach this address", address)
 	}
 
-	header := http.Header{}
-	if token := c.getContextAccessToken(); token != "" {
-		header.Set("Authorization", "Bearer "+token)
-	}
+	header := tunnelHeader(c.getContextAccessToken(), deviceid.Get())
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/commands/agent_port_forward.go
+++ b/commands/agent_port_forward.go
@@ -2,12 +2,16 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,12 +23,20 @@ import (
 )
 
 // doctl agents port-forward — POC client for the port-forward WebSocket API
-// (docs/design/port-forward.md § User experience). One local TCP listener per
-// requested pair; each accepted connection dials its own WebSocket to
+// (docs/design/port-forward-rfc.md § User experience). One local TCP listener
+// per requested pair; each accepted connection dials its own WebSocket to
 // GET /v2/agents/sessions/{session_id}/port-forward/{port} and pumps binary
 // frames as an opaque byte stream.
 
 const portForwardCopyBuf = 32 << 10
+
+const (
+	// handshakeBodyLimit bounds what we read from a rejected upgrade. gorilla
+	// already caps its replayable copy at 1 KiB; this guards the rest.
+	handshakeBodyLimit = 4 << 10
+	// rejectionMessageMax keeps an HTML error page from flooding the terminal.
+	rejectionMessageMax = 300
+)
 
 // forwardPair is one [<local>:]<remote> mapping. Local 0 lets the OS pick.
 type forwardPair struct {
@@ -83,6 +95,116 @@ func hostedAgentsWSURL(sessionID string, remotePort int) (string, error) {
 	return u.String(), nil
 }
 
+// handshakeBody reads what the server said when it answered the upgrade.
+// gorilla preserves up to 1 KiB of a rejected handshake's body precisely so
+// callers can report it, and replaces the body with an empty reader on
+// success, so this is safe to call either way.
+func handshakeBody(resp *http.Response) string {
+	if resp == nil || resp.Body == nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(io.LimitReader(resp.Body, handshakeBodyLimit))
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// serverRejection explains a refused upgrade in the server's own words. The
+// status code alone cannot tell harness-api declining the guest dial apart
+// from a proxy in front of it failing to reach harness-api at all, and that
+// distinction is usually the entire diagnosis.
+func serverRejection(resp *http.Response, body string, err error) error {
+	if resp == nil {
+		return fmt.Errorf("dialing tunnel: %w", err)
+	}
+	if msg := rejectionMessage(body); msg != "" {
+		return fmt.Errorf("server rejected tunnel (%s): %s", resp.Status, msg)
+	}
+	return fmt.Errorf("server rejected tunnel (%s): %w", resp.Status, err)
+}
+
+// rejectionMessage extracts a human-readable reason from an error body: the
+// {"id","message"} shape the API returns, or the raw text collapsed to one
+// line for anything else (a proxy answering with plain text or HTML).
+func rejectionMessage(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+	var apiErr struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(body), &apiErr); err == nil && apiErr.Message != "" {
+		return apiErr.Message
+	}
+	return collapseToLine(body, rejectionMessageMax)
+}
+
+// collapseToLine squashes whitespace and caps length so an error page stays
+// readable on one terminal line.
+func collapseToLine(s string, max int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	r := []rune(s)
+	if len(r) > max {
+		return string(r[:max]) + "..."
+	}
+	return s
+}
+
+// wsTracer logs the tunnel handshake under --trace. doctl's recorder wraps
+// godo's RoundTripper, but gorilla dials its own connection and never goes
+// through it, so without this the one request worth tracing is the only one
+// --trace cannot see. A nil tracer is a no-op, which is the untraced case.
+type wsTracer struct {
+	logger *log.Logger
+}
+
+func newWSTracer() *wsTracer {
+	if !Trace {
+		return nil
+	}
+	return &wsTracer{logger: log.New(os.Stderr, "doctl: ", log.LstdFlags)}
+}
+
+// handshake logs the upgrade request and whatever came back, using the same
+// "->" / "<-" framing as the godo recorder. gorilla adds the Upgrade,
+// Connection and Sec-WebSocket-* headers itself, so they are absent here.
+func (t *wsTracer) handshake(wsURL string, header http.Header, resp *http.Response, body string) {
+	if t == nil {
+		return
+	}
+	t.logger.Println("->", strconv.Quote(fmt.Sprintf("GET %s %s", wsURL, formatHeader(header))))
+	if resp == nil {
+		return
+	}
+	line := fmt.Sprintf("%s %s %s", resp.Proto, resp.Status, formatHeader(resp.Header))
+	if trimmed := strings.TrimSpace(body); trimmed != "" {
+		line += " " + collapseToLine(trimmed, handshakeBodyLimit)
+	}
+	t.logger.Println("<-", strconv.Quote(line))
+}
+
+// formatHeader renders headers on one line with the bearer token masked;
+// trace output gets pasted into tickets.
+func formatHeader(h http.Header) string {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v := strings.Join(h[k], ",")
+		if strings.EqualFold(k, "Authorization") {
+			v = "[redacted]"
+		}
+		parts = append(parts, k+": "+v)
+	}
+	return strings.Join(parts, "; ")
+}
+
 // RunAgentsPortForward opens local TCP tunnels to ports inside the session's
 // sandbox and blocks until interrupted.
 func RunAgentsPortForward(c *CmdConfig) error {
@@ -117,6 +239,8 @@ func RunAgentsPortForward(c *CmdConfig) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	tracer := newWSTracer()
+
 	var wg sync.WaitGroup
 	listeners := make([]net.Listener, 0, len(pairs))
 	for _, pair := range pairs {
@@ -139,7 +263,7 @@ func RunAgentsPortForward(c *CmdConfig) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			acceptForwardLoop(ctx, c, ln, wsURL, header)
+			acceptForwardLoop(ctx, ln, wsURL, header, tracer)
 		}()
 	}
 	fmt.Fprintln(c.Out, "Ready. Press Ctrl-C to stop.")
@@ -154,7 +278,7 @@ func RunAgentsPortForward(c *CmdConfig) error {
 
 // acceptForwardLoop accepts local connections and bridges each over its own
 // WebSocket. A per-connection failure never kills the listener.
-func acceptForwardLoop(ctx context.Context, c *CmdConfig, ln net.Listener, wsURL string, header http.Header) {
+func acceptForwardLoop(ctx context.Context, ln net.Listener, wsURL string, header http.Header, tracer *wsTracer) {
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
@@ -162,7 +286,7 @@ func acceptForwardLoop(ctx context.Context, c *CmdConfig, ln net.Listener, wsURL
 		}
 		go func() {
 			defer conn.Close()
-			if err := bridgeLocalConn(ctx, conn, wsURL, header); err != nil && ctx.Err() == nil {
+			if err := bridgeLocalConn(ctx, conn, wsURL, header, tracer); err != nil && ctx.Err() == nil {
 				warn("connection closed: %v", err)
 			}
 		}()
@@ -171,13 +295,12 @@ func acceptForwardLoop(ctx context.Context, c *CmdConfig, ln net.Listener, wsURL
 
 // bridgeLocalConn dials the port-forward WebSocket for one accepted TCP
 // connection and pumps bytes both ways until either side closes.
-func bridgeLocalConn(ctx context.Context, local net.Conn, wsURL string, header http.Header) error {
+func bridgeLocalConn(ctx context.Context, local net.Conn, wsURL string, header http.Header, tracer *wsTracer) error {
 	ws, resp, err := websocket.DefaultDialer.DialContext(ctx, wsURL, header)
+	body := handshakeBody(resp)
+	tracer.handshake(wsURL, header, resp, body)
 	if err != nil {
-		if resp != nil {
-			return fmt.Errorf("server rejected tunnel (%s): %w", resp.Status, err)
-		}
-		return fmt.Errorf("dialing tunnel: %w", err)
+		return serverRejection(resp, body, err)
 	}
 	defer ws.Close()
 

--- a/commands/agent_port_forward.go
+++ b/commands/agent_port_forward.go
@@ -1,0 +1,234 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/digitalocean/doctl"
+	"github.com/gorilla/websocket"
+	"github.com/spf13/viper"
+)
+
+// doctl agents port-forward — POC client for the port-forward WebSocket API
+// (docs/design/port-forward.md § User experience). One local TCP listener per
+// requested pair; each accepted connection dials its own WebSocket to
+// GET /v2/agents/sessions/{session_id}/port-forward/{port} and pumps binary
+// frames as an opaque byte stream.
+
+const portForwardCopyBuf = 32 << 10
+
+// forwardPair is one [<local>:]<remote> mapping. Local 0 lets the OS pick.
+type forwardPair struct {
+	local  int
+	remote int
+}
+
+// parseForwardPair parses "[<local-port>:]<remote-port>". A bare port forwards
+// the same port on both ends; "0:<remote>" lets the OS pick the local port.
+func parseForwardPair(arg string) (forwardPair, error) {
+	bad := func() (forwardPair, error) {
+		return forwardPair{}, fmt.Errorf("invalid port pair %q: expected [<local-port>:]<remote-port>", arg)
+	}
+	localRaw, remoteRaw := "", arg
+	if i := strings.IndexByte(arg, ':'); i >= 0 {
+		localRaw, remoteRaw = arg[:i], arg[i+1:]
+	}
+	remote, err := strconv.Atoi(remoteRaw)
+	if err != nil {
+		return bad()
+	}
+	if remote < 1024 || remote > 65535 {
+		return forwardPair{}, fmt.Errorf("remote port must be between 1024 and 65535 (got %d)", remote)
+	}
+	local := remote
+	if localRaw != "" {
+		local, err = strconv.Atoi(localRaw)
+		if err != nil || local < 0 || local > 65535 {
+			return bad()
+		}
+	}
+	return forwardPair{local: local, remote: remote}, nil
+}
+
+// hostedAgentsWSURL builds the WebSocket URL for one remote port, honoring the
+// --api-url / DIGITALOCEAN_API_URL override the HTTP client also uses.
+func hostedAgentsWSURL(sessionID string, remotePort int) (string, error) {
+	raw := viper.GetString("api-url")
+	if raw == "" {
+		raw = doctl.HostedAgentsAPIURL
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid API URL %q: %w", raw, err)
+	}
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	case "http":
+		u.Scheme = "ws"
+	default:
+		return "", fmt.Errorf("unsupported API URL scheme %q", u.Scheme)
+	}
+	u.Path = strings.TrimSuffix(u.Path, "/") +
+		fmt.Sprintf("/v2/agents/sessions/%s/port-forward/%d", sessionID, remotePort)
+	return u.String(), nil
+}
+
+// RunAgentsPortForward opens local TCP tunnels to ports inside the session's
+// sandbox and blocks until interrupted.
+func RunAgentsPortForward(c *CmdConfig) error {
+	if len(c.Args) < 2 {
+		return doctl.NewMissingArgsErr(c.NS)
+	}
+	sessionID, err := resolveSessionRef(c.HostedAgents(), c.Args[0])
+	if err != nil {
+		return err
+	}
+	pairs := make([]forwardPair, 0, len(c.Args)-1)
+	for _, arg := range c.Args[1:] {
+		p, err := parseForwardPair(arg)
+		if err != nil {
+			return err
+		}
+		pairs = append(pairs, p)
+	}
+	address, err := c.Doit.GetString(c.NS, doctl.ArgAgentForwardAddress)
+	if err != nil {
+		return err
+	}
+	if address != "127.0.0.1" && address != "localhost" && address != "::1" {
+		warn("binding %s exposes the tunnel to anyone who can reach this address", address)
+	}
+
+	header := http.Header{}
+	if token := c.getContextAccessToken(); token != "" {
+		header.Set("Authorization", "Bearer "+token)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	var wg sync.WaitGroup
+	listeners := make([]net.Listener, 0, len(pairs))
+	for _, pair := range pairs {
+		wsURL, err := hostedAgentsWSURL(sessionID, pair.remote)
+		if err != nil {
+			return err
+		}
+		ln, err := net.Listen("tcp", net.JoinHostPort(address, strconv.Itoa(pair.local)))
+		if err != nil {
+			for _, l := range listeners {
+				l.Close()
+			}
+			return fmt.Errorf("cannot listen on %s:%d: %w", address, pair.local, err)
+		}
+		listeners = append(listeners, ln)
+		localPort := ln.Addr().(*net.TCPAddr).Port
+		fmt.Fprintf(c.Out, "Forwarding %s:%d -> port %d in session %s\n",
+			address, localPort, pair.remote, sessionID)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			acceptForwardLoop(ctx, c, ln, wsURL, header)
+		}()
+	}
+	fmt.Fprintln(c.Out, "Ready. Press Ctrl-C to stop.")
+
+	<-ctx.Done()
+	for _, ln := range listeners {
+		ln.Close()
+	}
+	wg.Wait()
+	return nil
+}
+
+// acceptForwardLoop accepts local connections and bridges each over its own
+// WebSocket. A per-connection failure never kills the listener.
+func acceptForwardLoop(ctx context.Context, c *CmdConfig, ln net.Listener, wsURL string, header http.Header) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return // listener closed on shutdown
+		}
+		go func() {
+			defer conn.Close()
+			if err := bridgeLocalConn(ctx, conn, wsURL, header); err != nil && ctx.Err() == nil {
+				warn("connection closed: %v", err)
+			}
+		}()
+	}
+}
+
+// bridgeLocalConn dials the port-forward WebSocket for one accepted TCP
+// connection and pumps bytes both ways until either side closes.
+func bridgeLocalConn(ctx context.Context, local net.Conn, wsURL string, header http.Header) error {
+	ws, resp, err := websocket.DefaultDialer.DialContext(ctx, wsURL, header)
+	if err != nil {
+		if resp != nil {
+			return fmt.Errorf("server rejected tunnel (%s): %w", resp.Status, err)
+		}
+		return fmt.Errorf("dialing tunnel: %w", err)
+	}
+	defer ws.Close()
+
+	errCh := make(chan error, 2)
+
+	// WS → local. Read errors include server close frames (normal closure when
+	// the guest hangs up, 4xxx codes for session-end/dial-failure).
+	go func() {
+		for {
+			mt, data, err := ws.ReadMessage()
+			if err != nil {
+				if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+					errCh <- nil
+				} else {
+					errCh <- err
+				}
+				return
+			}
+			if mt != websocket.BinaryMessage {
+				continue
+			}
+			if _, err := local.Write(data); err != nil {
+				errCh <- nil // local reader went away; not an error worth printing
+				return
+			}
+		}
+	}()
+
+	// local → WS. This goroutine owns all WS writes (gorilla allows one
+	// concurrent writer), including the close frame when the local side ends.
+	go func() {
+		buf := make([]byte, portForwardCopyBuf)
+		for {
+			n, err := local.Read(buf)
+			if n > 0 {
+				if werr := ws.WriteMessage(websocket.BinaryMessage, buf[:n]); werr != nil {
+					errCh <- werr
+					return
+				}
+			}
+			if err != nil {
+				_ = ws.WriteMessage(websocket.CloseMessage,
+					websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+				errCh <- nil
+				return
+			}
+		}
+	}()
+
+	err = <-errCh
+	local.Close()
+	ws.Close()
+	return err
+}

--- a/commands/agent_port_forward_test.go
+++ b/commands/agent_port_forward_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseForwardPair(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want forwardPair
+	}{
+		{"bare port forwards both ends", "8080", forwardPair{local: 8080, remote: 8080}},
+		{"explicit pair", "12222:2222", forwardPair{local: 12222, remote: 2222}},
+		{"zero local lets the OS pick", "0:9119", forwardPair{local: 0, remote: 9119}},
+		{"lowest allowed remote", "1024", forwardPair{local: 1024, remote: 1024}},
+		{"highest allowed remote", "65535", forwardPair{local: 65535, remote: 65535}},
+		// Empty local is treated as "same port", not as an OS-assigned one --
+		// only an explicit 0 does that. kubectl reads ":<remote>" as random.
+		{"empty local mirrors the remote", ":8080", forwardPair{local: 8080, remote: 8080}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseForwardPair(tt.arg)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseForwardPairErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+	}{
+		{"empty", ""},
+		{"not a number", "http"},
+		{"remote below the privileged-port floor", "80"},
+		{"remote just below the floor", "1023"},
+		{"remote above the range", "65536"},
+		{"remote negative", "-1"},
+		{"missing remote", "8080:"},
+		{"local not a number", "abc:8080"},
+		{"local above the range", "70000:8080"},
+		{"local negative", "-1:8080"},
+		{"too many segments", "1:2:3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseForwardPair(tt.arg)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// setAPIURL overrides the global --api-url viper key for one test and restores
+// whatever was there before. hostedAgentsWSURL reads it directly, and viper is
+// process-global, so these tests cannot run in parallel.
+func setAPIURL(t *testing.T, v string) {
+	t.Helper()
+	prev := viper.GetString("api-url")
+	viper.Set("api-url", v)
+	t.Cleanup(func() { viper.Set("api-url", prev) })
+}
+
+func TestHostedAgentsWSURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		apiURL string
+		want   string
+	}{
+		{
+			// Unset --api-url falls back to doctl.HostedAgentsAPIURL, whose
+			// trailing slash must not survive into the joined path.
+			name:   "default hosted-agents host",
+			apiURL: "",
+			want:   "wss://ohr-agent.do-ai.run/v2/agents/sessions/sess-1/port-forward/9119",
+		},
+		{
+			name:   "preview host via --api-url",
+			apiURL: "https://ohr-agent.do-ai-test.run",
+			want:   "wss://ohr-agent.do-ai-test.run/v2/agents/sessions/sess-1/port-forward/9119",
+		},
+		{
+			name:   "https upgrades to wss",
+			apiURL: "https://api.example.com/",
+			want:   "wss://api.example.com/v2/agents/sessions/sess-1/port-forward/9119",
+		},
+		{
+			name:   "http downgrades to ws for a local dev stack",
+			apiURL: "http://127.0.0.1:8080",
+			want:   "ws://127.0.0.1:8080/v2/agents/sessions/sess-1/port-forward/9119",
+		},
+		{
+			name:   "base path prefix is preserved",
+			apiURL: "https://api.example.com/edge/",
+			want:   "wss://api.example.com/edge/v2/agents/sessions/sess-1/port-forward/9119",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setAPIURL(t, tt.apiURL)
+			got, err := hostedAgentsWSURL("sess-1", 9119)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHostedAgentsWSURLErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		apiURL string
+	}{
+		{"unparseable url", "://nope"},
+		{"unsupported scheme", "ftp://api.example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setAPIURL(t, tt.apiURL)
+			_, err := hostedAgentsWSURL("sess-1", 9119)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/commands/agent_port_forward_test.go
+++ b/commands/agent_port_forward_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/digitalocean/doctl/internal/deviceid"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -251,6 +252,113 @@ func TestFormatHeaderRedactsAuthorization(t *testing.T) {
 	assert.NotContains(t, got, "super-secret-token")
 	assert.Contains(t, got, "Authorization: [redacted]")
 	assert.Contains(t, got, "User-Agent: doctl/test")
+}
+
+func TestTunnelHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		deviceID string
+		want     map[string]string
+	}{
+		{
+			name:     "token and device id",
+			token:    "tok",
+			deviceID: "DEV-UUID",
+			want: map[string]string{
+				"Authorization":     "Bearer tok",
+				deviceid.HeaderName: "DEV-UUID",
+			},
+		},
+		{
+			name:     "unauthenticated context still carries the device id",
+			deviceID: "DEV-UUID",
+			want:     map[string]string{deviceid.HeaderName: "DEV-UUID"},
+		},
+		{
+			// deviceid.Get returns "" when the lookup fails or the user opted
+			// out with DOCTL_DISABLE_DEVICE_ID; the header must be absent
+			// rather than empty.
+			name:  "device id unavailable",
+			token: "tok",
+			want:  map[string]string{"Authorization": "Bearer tok"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tunnelHeader(tt.token, tt.deviceID)
+
+			assert.Len(t, got, len(tt.want))
+			for k, v := range tt.want {
+				assert.Equal(t, v, got.Get(k))
+			}
+		})
+	}
+}
+
+func TestRedactDeviceID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty stays empty", in: "", want: ""},
+		{name: "whitespace only", in: "   ", want: ""},
+		{name: "short values are fully masked", in: "12345678", want: "***"},
+		{
+			name: "long values keep a correlatable prefix and suffix",
+			in:   "564D8C1A-1234-5678-9ABC-DEF012345678",
+			want: "564D***5678",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, redactDeviceID(tt.in))
+		})
+	}
+}
+
+func TestFormatHeaderRedactsDeviceID(t *testing.T) {
+	h := http.Header{}
+	h.Set(deviceid.HeaderName, "564D8C1A-1234-5678-9ABC-DEF012345678")
+
+	got := formatHeader(h)
+
+	assert.NotContains(t, got, "564D8C1A-1234-5678-9ABC-DEF012345678")
+	// Header.Set canonicalizes the key to X-Device-Uuid, matching what the
+	// deviceid transport already puts on the wire for every other agents call.
+	assert.Contains(t, got, http.CanonicalHeaderKey(deviceid.HeaderName)+": 564D***5678")
+}
+
+// TestBridgeLocalConnSendsDeviceHeader proves the header survives the gorilla
+// dial rather than only being present in the map we hand it.
+func TestBridgeLocalConnSendsDeviceHeader(t *testing.T) {
+	got := make(chan http.Header, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got <- r.Header.Clone()
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") +
+		"/v2/agents/sessions/sess-1/port-forward/9119"
+
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+
+	header := tunnelHeader("tok", "DEV-UUID")
+	_ = bridgeLocalConn(context.Background(), remote, wsURL, header, nil)
+
+	select {
+	case h := <-got:
+		assert.Equal(t, "DEV-UUID", h.Get(deviceid.HeaderName))
+		assert.Equal(t, "Bearer tok", h.Get("Authorization"))
+	default:
+		t.Fatal("server never received the upgrade request")
+	}
 }
 
 // TestBridgeLocalConnSurfacesServerMessage exercises the real gorilla dial:

--- a/commands/agent_port_forward_test.go
+++ b/commands/agent_port_forward_test.go
@@ -14,6 +14,14 @@ limitations under the License.
 package commands
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -139,4 +147,142 @@ func TestHostedAgentsWSURLErrors(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+func TestRejectionMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "api error json yields just the message",
+			body: `{"id": "bad_gateway", "message": "could not reach guest port"}`,
+			want: "could not reach guest port",
+		},
+		{
+			name: "proxy plain text passes through",
+			body: "upstream connect error or disconnect/reset before headers. reset reason: protocol error",
+			want: "upstream connect error or disconnect/reset before headers. reset reason: protocol error",
+		},
+		{
+			name: "multi-line body collapses to one line",
+			body: "<html>\n  <body>502 Bad Gateway</body>\n</html>",
+			want: "<html> <body>502 Bad Gateway</body> </html>",
+		},
+		{"empty body yields nothing", "", ""},
+		{"whitespace-only body yields nothing", "   \n\t ", ""},
+		{"json without a message falls back to raw", `{"id": "x"}`, `{"id": "x"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rejectionMessage(tt.body))
+		})
+	}
+}
+
+func TestRejectionMessageTruncatesLongBodies(t *testing.T) {
+	got := rejectionMessage(strings.Repeat("a", rejectionMessageMax+50))
+	assert.Equal(t, strings.Repeat("a", rejectionMessageMax)+"...", got)
+}
+
+func TestServerRejection(t *testing.T) {
+	dialErr := errors.New("websocket: bad handshake")
+
+	t.Run("no response reports the dial failure", func(t *testing.T) {
+		err := serverRejection(nil, "", dialErr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "dialing tunnel")
+	})
+
+	t.Run("server message replaces the opaque handshake error", func(t *testing.T) {
+		resp := &http.Response{Status: "502 Bad Gateway", StatusCode: 502}
+		err := serverRejection(resp, `{"message": "could not reach guest port"}`, dialErr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "502 Bad Gateway")
+		assert.Contains(t, err.Error(), "could not reach guest port")
+		// The gorilla error carries no diagnostic value once we have the
+		// server's own words; it should not crowd them out.
+		assert.NotContains(t, err.Error(), "bad handshake")
+	})
+
+	t.Run("empty body falls back to the handshake error", func(t *testing.T) {
+		resp := &http.Response{Status: "503 Service Unavailable", StatusCode: 503}
+		err := serverRejection(resp, "", dialErr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "503 Service Unavailable")
+		assert.Contains(t, err.Error(), "bad handshake")
+	})
+}
+
+func TestHandshakeBody(t *testing.T) {
+	t.Run("nil response reads nothing", func(t *testing.T) {
+		assert.Equal(t, "", handshakeBody(nil))
+	})
+
+	t.Run("nil body reads nothing", func(t *testing.T) {
+		assert.Equal(t, "", handshakeBody(&http.Response{}))
+	})
+
+	t.Run("body is returned and closed", func(t *testing.T) {
+		body := &closeTrackingBody{Reader: strings.NewReader("could not reach guest port")}
+		resp := &http.Response{Body: body}
+		assert.Equal(t, "could not reach guest port", handshakeBody(resp))
+		assert.True(t, body.closed, "handshake body must be closed")
+	})
+
+	t.Run("oversized body is bounded", func(t *testing.T) {
+		resp := &http.Response{
+			Body: io.NopCloser(strings.NewReader(strings.Repeat("a", handshakeBodyLimit*2))),
+		}
+		assert.Len(t, handshakeBody(resp), handshakeBodyLimit)
+	})
+}
+
+func TestFormatHeaderRedactsAuthorization(t *testing.T) {
+	h := http.Header{}
+	h.Set("Authorization", "Bearer super-secret-token")
+	h.Set("User-Agent", "doctl/test")
+
+	got := formatHeader(h)
+
+	assert.NotContains(t, got, "super-secret-token")
+	assert.Contains(t, got, "Authorization: [redacted]")
+	assert.Contains(t, got, "User-Agent: doctl/test")
+}
+
+// TestBridgeLocalConnSurfacesServerMessage exercises the real gorilla dial:
+// the unit tests above cover the parsing, but only this proves the message
+// survives the handshake path instead of being replaced by "bad handshake".
+func TestBridgeLocalConnSurfacesServerMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		fmt.Fprint(w, `{"id":"bad_gateway","message":"could not reach guest port"}`)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") +
+		"/v2/agents/sessions/sess-1/port-forward/9119"
+
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+
+	err := bridgeLocalConn(context.Background(), remote, wsURL, http.Header{}, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "502 Bad Gateway")
+	assert.Contains(t, err.Error(), "could not reach guest port")
+}
+
+// closeTrackingBody records whether the reader was closed.
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
 }

--- a/commands/agents.go
+++ b/commands/agents.go
@@ -348,6 +348,15 @@ func Agents() *Command {
 		Writer,
 		displayerType(&displayers.HostedAgentSession{}))
 
+	cmdPortForward := CmdBuilder(cmd, RunAgentsPortForward, "port-forward <session> [<local-port>:]<remote-port> [...]",
+		"Forward local TCP ports into the session's sandbox",
+		`Opens a local TCP tunnel to a port inside the session's sandbox, kubectl-style: connect to `+"`"+`localhost:<local-port>`+"`"+` and traffic flows over an authenticated connection to the sandbox port. Nothing inside the sandbox is exposed publicly.
+
+A bare port forwards the same port on both ends; `+"`"+`0:<remote-port>`+"`"+` lets the OS pick a free local port (printed on the ready line). Remote ports must be between 1024 and 65535. The process runs in the foreground; press Ctrl-C to stop.`,
+		Writer)
+	AddStringFlag(cmdPortForward, doctl.ArgAgentForwardAddress, "", "127.0.0.1", "Local bind address")
+	cmdPortForward.Example = `doctl agents port-forward sess_abc123 3000 8080:8000`
+
 	cmd.AddCommand(AgentCheckpoints())
 	cmd.AddCommand(AgentTriggers())
 	cmd.AddCommand(AgentConfigs())

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -68,7 +68,7 @@ func TestAgentsCommand(t *testing.T) {
 	cmd := Agents()
 	assert.NotNil(t, cmd)
 
-	assertCommandNames(t, cmd, "start", "run", "attach", "list", "show", "logs", "approve", "destroy", "pause", "resume", "upload", "download", "start-proxy", "auth", "fork", "rollback", "checkpoint", "triggers", "config")
+	assertCommandNames(t, cmd, "start", "run", "attach", "list", "show", "logs", "approve", "destroy", "pause", "resume", "upload", "download", "start-proxy", "port-forward", "auth", "fork", "rollback", "checkpoint", "triggers", "config")
 }
 
 func TestAgents_helpers(t *testing.T) {


### PR DESCRIPTION
## Summary

POC of `doctl agents port-forward` (MARSOHS port-forward workstream):

- `doctl agents port-forward <session> [<local-port>:]<remote-port> ...` opens one local TCP listener per pair; each accepted connection dials its own WebSocket to `GET /v2/agents/sessions/{id}/port-forward/{port}` and pumps binary frames as an opaque byte stream (no multiplexing in v1 — one WS per TCP connection).
- `--address` controls the local bind (default `127.0.0.1`; a warning is printed for non-loopback binds). `0:<remote>` lets the OS pick the local port.
- Client-side validation: remote ports 1024–65535; listen failures tear down cleanly.
- Server WS close codes distinguish clean guest close (1000) from session-end / dial-failure (4xxx); a per-connection failure never kills the listener.
- Honors `--api-url` / `DIGITALOCEAN_API_URL` (http(s) → ws(s)), auth via the standard bearer token.

The server-side endpoint and the edge WebSocket route have both landed and are deployed; the tunnel was exercised against production while debugging the two items below.

Two things gorilla's self-dialed connection quietly excluded from the rest of the agents surface, both fixed here:

- **Refusals were undiagnosable.** A rejected upgrade printed only `websocket: bad handshake`, discarding the body. The status alone can't separate the API declining the guest dial from a proxy in front of it failing to reach the API, so diagnosing one meant reproducing it by hand with curl. The body is now read once and reused for both the error and the trace, preferring the API's `{"id","message"}` shape and falling back to raw text collapsed to one line and capped. `--trace` missed this path for the same reason — the recorder wraps godo's `RoundTripper` — so the handshake is now logged with the recorder's framing and the bearer token masked.
- **`X-Device-UUID` was not sent** (thanks @SSharma-10). The server mounts its device middleware on the whole `/v2/agents` subrouter and its non-storing endpoints rely on that middleware's log line for attribution, so the tunnel was the one agents call logged with an empty device id — and it is also the one that opens a raw TCP channel into the sandbox. `--trace` masks it the way the server does (prefix + suffix), so a trace line and a server log line for the same request stay correlatable without either recording the full hardware id.

Also fixes `TestAgentsCommand`, which has been failing on this branch since the command was registered without adding `port-forward` to its expected subcommand list.

## Test plan

- [x] End-to-end against a local harness-api dev stack: forwarded local port → HTTP server inside a codex session sandbox, bidirectional traffic verified with curl
- [x] End-to-end against production, which is what surfaced the two diagnostics gaps above
- [x] Out-of-range remote port rejected client-side; dead remote port surfaces per-connection error without killing the listener
- [x] Unit tests for pair parsing, URL construction, rejection-message parsing, header redaction, and `tunnelHeader`
- [x] Two tests drive a real gorilla dial against an `httptest` server rather than the parsing in isolation: one proves the server's message survives the handshake instead of being replaced by `bad handshake`, the other proves `X-Device-UUID` actually arrives

**Note on the empty check list:** `ci.yml` and `typos.yml` both filter `pull_request` to base branches `main` and `feature/**`. This PR targets `feat/agents-subcommands`, which matches neither, so no Go CI runs here — that applies to every PR into this feature branch, not just this one. `go test ./commands/` was run locally instead: the only failure is `TestRegistryLogout`, which fails identically on a clean `feat/agents-subcommands` worktree (it wants a native keychain).

Made with [Cursor](https://cursor.com)
