### PR TITLE
kubernetes: warn about associated resources before deleting a cluster

### DIFF
--- a/commands/kubernetes.go
+++ b/commands/kubernetes.go
@@ -1048,6 +1048,55 @@ func latestVersionForUpgrade(clusterVersionSlug string, versions []do.Kubernetes
 	return bucket[i].Slug, true, nil
 }
 
+// warnAssociatedResources warns about the DigitalOcean resources associated
+// with a cluster, so that the user can see the cluster isn't empty before
+// confirming an irreversible delete.
+func warnAssociatedResources(kube do.KubernetesService, clusterID, clusterName string) {
+	if !Interactive {
+		// No confirmation prompt follows, so there is nobody to warn.
+		return
+	}
+	resources, err := kube.ListAssociatedResourcesForDeletion(clusterID)
+	if err != nil {
+		warn("Couldn't list the resources associated with cluster %q.", clusterName)
+		return
+	}
+	if msg := associatedResourcesWarning(clusterName, resources); msg != "" {
+		warn("%s", msg)
+	}
+}
+
+// associatedResourcesWarning summarizes a cluster's associated resources. It
+// returns an empty string when the cluster has none.
+func associatedResourcesWarning(clusterName string, resources *do.KubernetesAssociatedResources) string {
+	if resources == nil {
+		return ""
+	}
+	counts := []struct {
+		label string
+		count int
+	}{
+		{"Load balancers", len(resources.LoadBalancers)},
+		{"Volumes", len(resources.Volumes)},
+		{"Volume snapshots", len(resources.VolumeSnapshots)},
+	}
+
+	msg := fmt.Sprintf("Cluster %q has the following associated resources:\n", clusterName)
+	var found bool
+	for _, c := range counts {
+		if c.count == 0 {
+			continue
+		}
+		found = true
+		msg += fmt.Sprintf("  %s: %d\n", c.label, c.count)
+	}
+	if !found {
+		return ""
+	}
+
+	return msg + "Deleting the cluster is irreversible."
+}
+
 // RunKubernetesClusterDelete deletes a Kubernetes cluster
 func (s *KubernetesCommandService) RunKubernetesClusterDelete(c *CmdConfig) error {
 	if len(c.Args) < 1 {
@@ -1076,10 +1125,11 @@ func (s *KubernetesCommandService) RunKubernetesClusterDelete(c *CmdConfig) erro
 			return err
 		}
 
-		if force || AskForConfirmDelete("Kubernetes cluster", 1) == nil {
-			// continue
-		} else {
-			return fmt.Errorf("Operation aborted")
+		if !force {
+			warnAssociatedResources(kube, clusterID, cluster)
+			if AskForConfirmDelete("Kubernetes cluster", 1) != nil {
+				return fmt.Errorf("Operation aborted")
+			}
 		}
 
 		var kubeconfig []byte
@@ -1149,13 +1199,14 @@ func (s *KubernetesCommandService) RunKubernetesClusterDeleteSelective(c *CmdCon
 		return err
 	}
 
-	if force || AskForConfirmDelete("Kubernetes cluster", 1) == nil {
-		// continue
-	} else {
-		return fmt.Errorf("Operation aborted")
-	}
-
 	kube := c.Kubernetes()
+
+	if !force {
+		warnAssociatedResources(kube, clusterID, clusterIDorName)
+		if AskForConfirmDelete("Kubernetes cluster", 1) != nil {
+			return fmt.Errorf("Operation aborted")
+		}
+	}
 
 	var kubeconfig []byte
 	if update {

--- a/commands/kubernetes_test.go
+++ b/commands/kubernetes_test.go
@@ -1236,6 +1236,20 @@ func TestKubernetesDeleteSelective(t *testing.T) {
 	})
 }
 
+func TestAssociatedResourcesWarning(t *testing.T) {
+	assert.Empty(t, associatedResourcesWarning("example-cluster", nil))
+	assert.Empty(t, associatedResourcesWarning("example-cluster", &do.KubernetesAssociatedResources{
+		KubernetesAssociatedResources: &godo.KubernetesAssociatedResources{},
+	}))
+
+	msg := associatedResourcesWarning("example-cluster", &testAssociatedResources)
+	assert.Contains(t, msg, `Cluster "example-cluster" has the following associated resources:`)
+	assert.Contains(t, msg, "Load balancers: 1")
+	assert.Contains(t, msg, "Volumes: 1")
+	assert.Contains(t, msg, "Volume snapshots: 1")
+	assert.Contains(t, msg, "irreversible")
+}
+
 func TestKubernetesListAssociatedResources(t *testing.T) {
 	// by ID
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {


### PR DESCRIPTION
## Summary

Fixes #1875.

`doctl kubernetes cluster delete` asks a generic "Are you sure you want to delete this Kubernetes cluster?" and gives no indication of whether the cluster is empty or running production workloads. This adds a summary of the cluster's associated DigitalOcean resources to the confirmation step, so the operator can tell an idle cluster from a busy one before an irreversible delete.

The counts come from the existing `destroy_with_associated_resources` endpoint already used by `doctl kubernetes cluster list-associated-resources` — no new API surface and no cluster credentials needed.

## Behavior

```
$ doctl kubernetes cluster delete example-cluster
Warning: Cluster "example-cluster" has the following associated resources:
  Load balancers: 3
  Volumes: 8
  Volume snapshots: 2
Deleting the cluster is irreversible.
Are you sure you want to delete this Kubernetes cluster? (y/N)
```

- Nothing is printed when the cluster has no associated resources.
- The lookup only runs when a confirmation prompt actually follows, so `--force` and non-interactive invocations keep their current behavior and make no extra API call.
- A failed lookup warns and lets the delete proceed rather than blocking it.
- The same warning is applied to `delete-selective`, which is equally destructive and shared the same generic prompt.

## Notes

The issue also asks for in-cluster counts (namespaces, pods, PVCs). That would require doctl to authenticate against the cluster's Kubernetes API on the delete path, which is a much bigger change in scope and a new failure mode for unreachable clusters, so this PR covers the DigitalOcean-side resources only. Happy to extend it if you'd like the live-cluster query as well.

## Testing

- `go test ./commands/` passes.
- Added `TestAssociatedResourcesWarning` covering the empty, nil, and populated cases.
