### PR TITLE
databases: preserve existing firewall rule fields on append and remove

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -2527,16 +2527,12 @@ func RunDatabaseFirewallRulesAppend(c *CmdConfig) error {
 		return err
 	}
 
-	// Add old rules to allRules slice.
+	// Add old rules to allRules slice. Copy each rule as a whole rather than
+	// field by field, so that attributes doctl does not manage, such as a
+	// rule's description, survive the update.
 	for _, rule := range oldRules {
-
-		firewallRule := new(godo.DatabaseFirewallRule)
-		firewallRule.Type = rule.Type
-		firewallRule.Value = rule.Value
-		firewallRule.ClusterUUID = rule.ClusterUUID
-		firewallRule.UUID = rule.UUID
-
-		allRules = append(allRules, firewallRule)
+		firewallRule := *rule.DatabaseFirewallRule
+		allRules = append(allRules, &firewallRule)
 	}
 
 	// Run update firewall rules with old rules + new rule
@@ -2573,15 +2569,14 @@ func RunDatabaseFirewallRulesRemove(c *CmdConfig) error {
 	// Create a slice of database firewall rules containing only the new rule.
 	firewallRules := []*godo.DatabaseFirewallRule{}
 
-	// only append rules that do not match the firewall rule with uuid to be removed.
+	// only append rules that do not match the firewall rule with uuid to be
+	// removed. Copy each rule as a whole rather than field by field, so that
+	// attributes doctl does not manage, such as a rule's description, survive
+	// the update.
 	for _, rule := range rules {
 		if rule.UUID != firewallRuleUUIDArg {
-			firewallRules = append(firewallRules, &godo.DatabaseFirewallRule{
-				UUID:        rule.UUID,
-				ClusterUUID: rule.ClusterUUID,
-				Type:        rule.Type,
-				Value:       rule.Value,
-			})
+			firewallRule := *rule.DatabaseFirewallRule
+			firewallRules = append(firewallRules, &firewallRule)
 		}
 	}
 

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -291,8 +291,67 @@ var (
 		testKafkaTopic,
 	}
 
+	testDBFirewallRule = do.DatabaseFirewallRule{
+		DatabaseFirewallRule: &godo.DatabaseFirewallRule{
+			UUID:        "cdb689c2-56e6-48e6-869d-306c85af178d",
+			ClusterUUID: testDBCluster.ID,
+			Type:        "ip_addr",
+			Value:       "192.168.1.1",
+			CreatedAt:   time.Date(2019, 1, 11, 18, 37, 36, 0, time.UTC),
+		},
+	}
+
 	errTest = errors.New("error")
 )
+
+func TestDatabasesFirewallRulesAppendPreservesExistingRules(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		newRule := &godo.DatabaseFirewallRule{
+			Type:        "tag",
+			Value:       "example-tag",
+			ClusterUUID: testDBCluster.ID,
+		}
+		// The existing rule must be sent back untouched, otherwise the update
+		// wipes attributes doctl does not manage, such as its description.
+		r := &godo.DatabaseUpdateFirewallRulesRequest{
+			Rules: []*godo.DatabaseFirewallRule{newRule, testDBFirewallRule.DatabaseFirewallRule},
+		}
+
+		tm.databases.EXPECT().GetFirewallRules(testDBCluster.ID).Return(do.DatabaseFirewallRules{testDBFirewallRule}, nil).Times(2)
+		tm.databases.EXPECT().UpdateFirewallRules(testDBCluster.ID, r).Return(nil)
+
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseFirewallRule, "tag:example-tag")
+
+		err := RunDatabaseFirewallRulesAppend(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestDatabasesFirewallRulesRemovePreservesRemainingRules(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		removed := do.DatabaseFirewallRule{
+			DatabaseFirewallRule: &godo.DatabaseFirewallRule{
+				UUID:        "d168d635-1c88-4616-b9b4-793b7c573927",
+				ClusterUUID: testDBCluster.ID,
+				Type:        "tag",
+				Value:       "example-tag",
+			},
+		}
+		r := &godo.DatabaseUpdateFirewallRulesRequest{
+			Rules: []*godo.DatabaseFirewallRule{testDBFirewallRule.DatabaseFirewallRule},
+		}
+
+		tm.databases.EXPECT().GetFirewallRules(testDBCluster.ID).Return(do.DatabaseFirewallRules{testDBFirewallRule, removed}, nil).Times(2)
+		tm.databases.EXPECT().UpdateFirewallRules(testDBCluster.ID, r).Return(nil)
+
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseFirewallRuleUUID, removed.UUID)
+
+		err := RunDatabaseFirewallRulesRemove(config)
+		assert.NoError(t, err)
+	})
+}
 
 func TestDatabasesCommand(t *testing.T) {
 	cmd := Databases()


### PR DESCRIPTION
## Summary

Works toward #1869 — `doctl databases firewalls append` clearing the descriptions of the rules that were already on the cluster.

`PUT /v2/databases/{id}/firewall` replaces the entire rule set, so `append` and `remove` read the current rules and write them all back. Both rebuilt each existing rule field by field:

```go
firewallRule := new(godo.DatabaseFirewallRule)
firewallRule.Type = rule.Type
firewallRule.Value = rule.Value
firewallRule.ClusterUUID = rule.ClusterUUID
firewallRule.UUID = rule.UUID
```

Anything not listed there is dropped from rules the user never asked to change. This copies each existing rule as a whole instead, so every attribute round-trips.

## Note on the description field

This is half the fix. The other half is in godo: `godo.DatabaseFirewallRule` has no `Description` field, even though the API [returns and accepts one](https://github.com/digitalocean/openapi/blob/main/specification/resources/databases/models/firewall_rule.yml), so descriptions are already discarded at decode time. I opened digitalocean/godo#1088 to add it.

With that field in place and a routine godo bump, descriptions round-trip through `append` and `remove` with no further change here — which is why this PR deliberately does not name the field. Merging it first means the godo bump alone closes #1869.

Two follow-ups I left out as separate concerns:
- `doctl databases firewalls list` could show a `Description` column once godo carries the field.
- `--rule` has no syntax for setting a description (`replace` therefore still clears them by design, since the user supplies the full rule set).

## Testing

- `go test ./commands/` passes.
- Added `TestDatabasesFirewallRulesAppendPreservesExistingRules` and `TestDatabasesFirewallRulesRemovePreservesRemainingRules`, which assert the existing rules are handed to `UpdateFirewallRules` unmodified. Both fail against the previous field-by-field copy.
