### PR TITLE
Revert "agents: read session events from the data-plane /events endpoint"

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -69,6 +69,20 @@ var (
 	colMuted     = charm.Colors.Muted
 )
 
+// Stream-state transport frames (SSE kind "stream.state"). Defined locally so
+// doctl builds against godo pins that have not yet exported HostedAgentEventKindStreamState
+// / HostedAgentStreamState*. Wire values match the published godo API.
+const (
+	hostedAgentEventKindStreamState  godo.HostedAgentEventKind = "stream.state"
+	hostedAgentStreamStateSuperseded                           = "superseded"
+	hostedAgentStreamStateCatchingUp                           = "catching_up"
+)
+
+type hostedAgentStreamState struct {
+	State  string `json:"state"`
+	Cursor string `json:"cursor,omitempty"`
+}
+
 // detectStyling reports whether ANSI styling should be emitted for the current
 // process: stdout is a terminal and NO_COLOR is unset.
 func detectStyling() bool {
@@ -1587,7 +1601,7 @@ func RunAgentsLogs(c *CmdConfig) error {
 	for stream.Next() {
 		ev := stream.Current()
 		// Connection health, not session activity — never part of the history.
-		if ev.Kind == godo.HostedAgentEventKindStreamState {
+		if ev.Kind == hostedAgentEventKindStreamState {
 			continue
 		}
 		if ev.Kind == godo.HostedAgentEventKindTokenChunk {
@@ -2579,9 +2593,9 @@ func backendPhaseFromEvent(ev godo.HostedAgentEvent) string {
 			return msg
 		}
 		return "runtime log"
-	case godo.HostedAgentEventKindStreamState:
-		var st godo.HostedAgentStreamState
-		if err := json.Unmarshal(ev.Payload, &st); err == nil && st.State == godo.HostedAgentStreamStateCatchingUp {
+	case hostedAgentEventKindStreamState:
+		var st hostedAgentStreamState
+		if err := json.Unmarshal(ev.Payload, &st); err == nil && st.State == hostedAgentStreamStateCatchingUp {
 			return "syncing event stream"
 		}
 	}
@@ -2972,9 +2986,9 @@ func drainStream(stream *godo.HostedAgentSessionStream, out io.Writer, pending *
 
 		// stream.state reports the health of the connection, not session
 		// activity, so it never renders and never moves the cursor.
-		if ev.Kind == godo.HostedAgentEventKindStreamState {
-			var st godo.HostedAgentStreamState
-			if err := json.Unmarshal(ev.Payload, &st); err == nil && st.State == godo.HostedAgentStreamStateSuperseded {
+		if ev.Kind == hostedAgentEventKindStreamState {
+			var st hostedAgentStreamState
+			if err := json.Unmarshal(ev.Payload, &st); err == nil && st.State == hostedAgentStreamStateSuperseded {
 				thinking.stop()
 				acc.flush(out)
 				flushAwaitingApproval(out, &awaiting)

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -2817,7 +2817,7 @@ func TestStreamWithReconnect_supersededStopsWithoutReconnect(t *testing.T) {
 	stubReconnectSleep(t)
 
 	body := sseFrame("evt-1", string(godo.HostedAgentEventKindSessionUpdated), `{}`) +
-		sseFrame("", string(godo.HostedAgentEventKindStreamState), `{"state":"superseded","cursor":""}`)
+		sseFrame("", string(hostedAgentEventKindStreamState), `{"state":"superseded","cursor":""}`)
 	srv := httptest.NewServer(hostedAgentSSEHandler(body, nil))
 	t.Cleanup(srv.Close)
 
@@ -2876,9 +2876,9 @@ func TestDrainStream_HITLReattachShowsCommand(t *testing.T) {
 // frame is transport bookkeeping: it renders nothing and must not become the
 // reconnect cursor, or a reconnect would resume from a position no event holds.
 func TestDrainStream_skipsStreamStateControlFrames(t *testing.T) {
-	body := sseFrame("", string(godo.HostedAgentEventKindStreamState), `{"state":"live","cursor":""}`) +
+	body := sseFrame("", string(hostedAgentEventKindStreamState), `{"state":"live","cursor":""}`) +
 		sseFrame("evt-7", string(godo.HostedAgentEventKindSessionUpdated), `{}`) +
-		sseFrame("", string(godo.HostedAgentEventKindStreamState), `{"state":"catching_up","cursor":""}`)
+		sseFrame("", string(hostedAgentEventKindStreamState), `{"state":"catching_up","cursor":""}`)
 	srv := httptest.NewServer(hostedAgentSSEHandler(body, nil))
 	t.Cleanup(srv.Close)
 
@@ -2993,9 +2993,8 @@ func TestStreamWithReconnect_replayCursorAfterMidStreamDrop(t *testing.T) {
 		mu.Lock()
 		calls++
 		n := calls
-		// The live stream carries the resume cursor in the standard SSE
-		// Last-Event-ID header, not a replay_from query parameter.
-		replayFrom := r.Header.Get("Last-Event-ID")
+		// Resume cursor rides as replay_from on control-plane /stream.
+		replayFrom := r.URL.Query().Get("replay_from")
 		mu.Unlock()
 
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/commands/command_config.go
+++ b/commands/command_config.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/digitalocean/godo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -112,14 +111,6 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 				return fmt.Errorf("Unable to initialize DigitalOcean API client: %s", err)
 			}
 
-			// The hosted-agents surface lives on its own host rather than
-			// api.digitalocean.com, so it gets its own client. --api-url still
-			// overrides both (see doctl.HostedAgentsAPIURL).
-			agentsClient, err := c.Doit.GetGodoClient(Trace, true, accessToken, godo.SetBaseURL(doctl.HostedAgentsAPIURL))
-			if err != nil {
-				return fmt.Errorf("Unable to initialize DigitalOcean Hosted Agents API client: %s", err)
-			}
-
 			c.Keys = func() do.KeysService { return do.NewKeysService(godoClient) }
 			c.Sizes = func() do.SizesService { return do.NewSizesService(godoClient) }
 			c.Regions = func() do.RegionsService { return do.NewRegionsService(godoClient) }
@@ -176,9 +167,9 @@ func NewCmdConfig(ns string, dc doctl.Config, out io.Writer, args []string, init
 			c.Nfs = func() do.NfsService { return do.NewNfsService(godoClient) }
 			c.NfsActions = func() do.NfsActionsService { return do.NewNfsActionsService(godoClient) }
 			c.Security = func() do.SecurityService { return do.NewSecurityService(godoClient) }
-			c.HostedAgents = func() do.HostedAgentsService { return do.NewHostedAgentsService(agentsClient) }
+			c.HostedAgents = func() do.HostedAgentsService { return do.NewHostedAgentsService(godoClient) }
 			c.HostedAgentTriggers = func() do.HostedAgentTriggersService {
-				return do.NewHostedAgentTriggersService(agentsClient)
+				return do.NewHostedAgentTriggersService(godoClient)
 			}
 			c.Secrets = func() do.SecretsService { return do.NewSecretsService(godoClient) }
 			return nil

--- a/doit.go
+++ b/doit.go
@@ -47,16 +47,6 @@ import (
 const (
 	// LatestReleaseURL is the latest release URL endpoint.
 	LatestReleaseURL = "https://api.github.com/repos/digitalocean/doctl/releases/latest"
-
-	// HostedAgentsAPIURL is the API endpoint the `doctl agents` commands use.
-	// Hosted agents are fronted by their own host, which serves both the
-	// session control plane (/v2/agents/...) and the data-plane event stream
-	// (.../events), rather than by api.digitalocean.com.
-	//
-	// An explicit --api-url (DIGITALOCEAN_API_URL) still wins, which is how a
-	// non-production environment is reached — the preview host, for instance,
-	// is https://ohr-agent.do-ai-test.run.
-	HostedAgentsAPIURL = "https://ohr-agent.do-ai.run/"
 )
 
 // Version is the version info for doit.
@@ -219,7 +209,7 @@ func (glv *GithubLatestVersioner) LatestVersion() (string, error) {
 
 // Config is an interface that represent doit's config.
 type Config interface {
-	GetGodoClient(trace, allowRetries bool, accessToken string, opts ...godo.ClientOpt) (*godo.Client, error)
+	GetGodoClient(trace, allowRetries bool, accessToken string) (*godo.Client, error)
 	GetDockerEngineClient() (builder.DockerEngineClient, error)
 	SSH(user, host, keyPath string, port int, opts ssh.Options) runner.Runner
 	Listen(url *url.URL, token string, schemaFunc listen.SchemaFunc, out io.Writer, inCh <-chan []byte) listen.ListenerService
@@ -245,10 +235,8 @@ type LiveConfig struct {
 
 var _ Config = &LiveConfig{}
 
-// GetGodoClient returns a GodoClient. opts are applied before the --api-url
-// override, so a caller-supplied default base URL (see HostedAgentsAPIURL)
-// yields to an endpoint the user asked for explicitly.
-func (c *LiveConfig) GetGodoClient(trace, allowRetries bool, accessToken string, opts ...godo.ClientOpt) (*godo.Client, error) {
+// GetGodoClient returns a GodoClient.
+func (c *LiveConfig) GetGodoClient(trace, allowRetries bool, accessToken string) (*godo.Client, error) {
 	if accessToken == "" {
 		return nil, fmt.Errorf("access token is required. (hint: run 'doctl auth init')")
 	}
@@ -284,8 +272,6 @@ func (c *LiveConfig) GetGodoClient(trace, allowRetries bool, accessToken string,
 
 		args = append(args, godo.WithRetryAndBackoffs(retryConfig))
 	}
-
-	args = append(args, opts...)
 
 	apiURL := viper.GetString("api-url")
 	if apiURL != "" {
@@ -549,7 +535,7 @@ func NewTestConfig() *TestConfig {
 
 // GetGodoClient mocks a GetGodoClient call. The returned godo client will
 // be nil.
-func (c *TestConfig) GetGodoClient(trace, allowRetries bool, accessToken string, opts ...godo.ClientOpt) (*godo.Client, error) {
+func (c *TestConfig) GetGodoClient(trace, allowRetries bool, accessToken string) (*godo.Client, error) {
 	return &godo.Client{}, nil
 }
 

--- a/doit_test.go
+++ b/doit_test.go
@@ -17,9 +17,6 @@ import (
 	"os"
 	"regexp"
 	"testing"
-
-	"github.com/digitalocean/godo"
-	"github.com/spf13/viper"
 )
 
 func TestMain(m *testing.M) {
@@ -129,55 +126,6 @@ type stubLatestRelease struct {
 
 func (slr stubLatestRelease) LatestVersion() (string, error) {
 	return slr.version, nil
-}
-
-// TestGetGodoClientBaseURL pins the precedence that lets the `doctl agents`
-// commands default to their own host without taking the endpoint away from a
-// user who named one: caller-supplied options set a default, --api-url
-// overrides it.
-func TestGetGodoClientBaseURL(t *testing.T) {
-	cases := []struct {
-		name   string
-		apiURL string
-		opts   []godo.ClientOpt
-		want   string
-	}{
-		{
-			name: "no options and no api-url leaves godo's default",
-			want: "https://api.digitalocean.com/",
-		},
-		{
-			name: "caller-supplied base URL applies",
-			opts: []godo.ClientOpt{godo.SetBaseURL(HostedAgentsAPIURL)},
-			want: HostedAgentsAPIURL,
-		},
-		{
-			name:   "api-url wins over a caller-supplied base URL",
-			apiURL: "https://ohr-agent.do-ai-test.run/",
-			opts:   []godo.ClientOpt{godo.SetBaseURL(HostedAgentsAPIURL)},
-			want:   "https://ohr-agent.do-ai-test.run/",
-		},
-		{
-			name:   "api-url applies with no caller options",
-			apiURL: "https://example.test/",
-			want:   "https://example.test/",
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			viper.Set("api-url", c.apiURL)
-			t.Cleanup(func() { viper.Set("api-url", "") })
-
-			client, err := (&LiveConfig{}).GetGodoClient(false, false, "fake-token", c.opts...)
-			if err != nil {
-				t.Fatalf("GetGodoClient() unexpected error: %v", err)
-			}
-			if got := client.BaseURL.String(); got != c.want {
-				t.Errorf("BaseURL = %q; want %q", got, c.want)
-			}
-		})
-	}
 }
 
 func TestCommandName(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/creack/pty v1.1.21
-	github.com/digitalocean/godo v1.204.0-beta.4
+	github.com/digitalocean/godo v1.204.0-beta.3
 	github.com/docker/cli v24.0.5+incompatible
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.204.0-beta.4 h1:Lr43wwKDT3izh9/ZLB7nD83NasPll4KwqjSCkNkID1Y=
-github.com/digitalocean/godo v1.204.0-beta.4/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
+github.com/digitalocean/godo v1.204.0-beta.3 h1:iCNDLPfQOxe8AZhwOI0Drg3pJBN+03tPn//W25pD1wE=
+github.com/digitalocean/godo v1.204.0-beta.3/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=

--- a/internal/agentproxy/agentproxytest/harness.go
+++ b/internal/agentproxy/agentproxytest/harness.go
@@ -19,12 +19,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/digitalocean/godo"
 	"github.com/google/uuid"
 )
 
 // Event is one canned SSE event the harness streams back from
-// GET /v2/agents/sessions/{id}/events, matching the event-specific part of
+// GET /v2/agents/sessions/{id}/stream, matching the event-specific part of
 // godo.HostedAgentEvent's wire shape (see HostedAgentEventKind's doc comment
 // for the canonical type strings).
 type Event struct {
@@ -101,8 +100,8 @@ type Harness struct {
 	lastRelay            []byte        // most recent POST .../request frame, for test assertions (LastRelay)
 	relayReply           []byte        // answered by the next POST .../request call; empty = adapter declined
 	relayStatus          int           // 0 = answer normally; nonzero = fail POST .../request with this status
-	events               []Event       // streamed, in order, by the next GET .../events call
-	replayEvents         []Event       // streamed instead of events when GET .../events carries replay_only=true
+	events               []Event       // streamed, in order, by the next GET .../stream call
+	replayEvents         []Event       // streamed instead of events when GET .../stream carries replay_only=true
 	streamErrorStatus    int           // 0 = serve normally; nonzero = return this HTTP status instead
 	streamErrorRemaining int           // >0: decrement per hit, clearing streamErrorStatus at 0; <=0 with status set: permanent
 	streamErrorSkip      int           // succeed this many opens before applying streamErrorStatus (reconnect-path tests)
@@ -146,13 +145,13 @@ func New(t *testing.T, sessionID string) *Harness {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v2/agents/sessions/{id}", h.handleGetSession)
-	// One SSE surface, matching godo's StreamSession: both the live and the
-	// replay-only read go to the data plane at .../events, the latter carrying
-	// replay_only=true (see QueueReplayHistory). handleStream serves both,
-	// branching on that query parameter. The control plane's .../stream is
-	// deliberately not registered, so a request landing there fails the test
-	// instead of quietly passing against a route the client no longer uses.
+	// Two SSE surfaces, matching godo's StreamSession: live reads go to the
+	// data plane at .../events, replay-only reads to the control plane at
+	// .../stream?replay_only=true (see QueueReplayHistory). handleStream
+	// serves both, branching on the replay_only query parameter.
 	mux.HandleFunc("GET /v2/agents/sessions/{id}/events", h.handleStream)
+	// Temporarily on control-plane .../stream until OHP /events is on stage2.
+	mux.HandleFunc("GET /v2/agents/sessions/{id}/stream", h.handleStream)
 	mux.HandleFunc("POST /v2/agents/sessions/{id}/input", h.handleInput)
 	mux.HandleFunc("POST /v2/agents/sessions/{id}/request", h.handleRelay)
 	mux.HandleFunc("POST /v2/agents/sessions/{id}/hitl/{requestID}", h.handleHITL)
@@ -163,7 +162,7 @@ func New(t *testing.T, sessionID string) *Harness {
 }
 
 // QueueRun arranges for the next POST .../input call to return runID, and
-// for GET .../events to then emit events (in order, tagged with runID),
+// for GET .../stream to then emit events (in order, tagged with runID),
 // flushing after each one so a concurrent reader observes them incrementally
 // rather than all at once at EOF.
 //
@@ -191,7 +190,7 @@ func assignEventIDs(events []Event) []Event {
 	return events
 }
 
-// QueueReplayHistory arranges for a GET .../events call carrying
+// QueueReplayHistory arranges for a GET .../stream call carrying
 // replay_only=true to return these events instead of whatever QueueRun set
 // up, then end — mirrors harness-api's own handleStreamSession, which never
 // continues a replay_only request into a live tail (see
@@ -204,7 +203,7 @@ func (h *Harness) QueueReplayHistory(events ...Event) {
 	h.replayEvents = assignEventIDs(events)
 }
 
-// SetStreamErrorStatus makes GET .../events return status immediately
+// SetStreamErrorStatus makes GET .../stream return status immediately
 // (instead of opening an SSE stream) for the next `times` calls, then
 // resume normal behavior (serving whatever's queued via QueueRun) —
 // simulating a StreamSession failure rather than a mid-stream drop. times
@@ -230,12 +229,12 @@ func (h *Harness) SetStreamErrorStatusAfter(skip, status, times int) {
 	h.streamErrorRemaining = times
 }
 
-// DropConnectionAfterEvents makes the very next GET .../events call return
+// DropConnectionAfterEvents makes the very next GET .../stream call return
 // after sending only the first n queued events (a clean end, no error —
 // exactly how a genuine mid-stream drop/idle-timeout looks from the
 // client's side) instead of the whole list, then resets to 0 so any later
 // connection serves normally. One-shot: simulates a real drop-and-resume for
-// a test verifying a reconnect actually resumes (via Last-Event-ID) and dedups
+// a test verifying a reconnect actually resumes (via replay_from) and dedups
 // whatever prefix gets redelivered, rather than only ever seeing a stream
 // that's already run to completion.
 func (h *Harness) DropConnectionAfterEvents(n int) {
@@ -423,20 +422,20 @@ func (h *Harness) handleStream(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	flusher, canFlush := w.(http.Flusher)
 
-	// The data plane opens every stream with a stream.state control frame. It
-	// belongs to no run, so consumers must skip it rather than mistake it for
-	// session activity — emit it here so tests exercise that.
+	// Optional stream.state control frame (same wire value as the data-plane
+	// transport). Consumers must skip it — emit it so tests exercise that.
+	const streamStateKind = "stream.state"
 	streamState, err := json.Marshal(eventWire{
 		TenantID:  "15726539",
 		SessionID: sessionID,
 		Timestamp: "2026-01-01T00:00:00Z",
-		Type:      string(godo.HostedAgentEventKindStreamState),
+		Type:      streamStateKind,
 		Data:      json.RawMessage(`{"state":"live","cursor":""}`),
 	})
 	if err != nil {
 		panic(fmt.Sprintf("agentproxytest: stream.state does not marshal to JSON: %v", err))
 	}
-	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", godo.HostedAgentEventKindStreamState, streamState)
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", streamStateKind, streamState)
 	if canFlush {
 		flusher.Flush()
 	}

--- a/internal/agentproxy/codex/facade_test.go
+++ b/internal/agentproxy/codex/facade_test.go
@@ -1351,7 +1351,7 @@ func TestFacade_Replay_ThreadResume(t *testing.T) {
 // touches replay-only history, even when a session has some queued — the
 // flag must actually gate the behavior, not just always run it. Asserts
 // both "no notifications" and "replay never started": a silent fetch
-// failure (e.g. the harness 404ing .../events) would satisfy expectNone
+// failure (e.g. the harness 404ing .../stream) would satisfy expectNone
 // alone and hide a broken gate.
 func TestFacade_Replay_Disabled(t *testing.T) {
 	f, h, rec := newTestFacade(t)
@@ -1453,7 +1453,7 @@ func TestFacade_Replay_UnaffectedByConcurrentLiveTurnsReset(t *testing.T) {
 // no-op forever the way a plain sync.Once would have.
 //
 // The first attempt must fail for a reason that only hits once the
-// data-plane .../events route is actually registered (injected 500) —
+// control-plane .../stream route is actually registered (injected 500) —
 // a missing-route 404 would also unwind without marking replayDone and
 // make this half of the test pass for the wrong reason.
 func TestFacade_Replay_RetriesAfterAbortedAttempt(t *testing.T) {

--- a/vendor/github.com/digitalocean/godo/hosted_agents.go
+++ b/vendor/github.com/digitalocean/godo/hosted_agents.go
@@ -22,7 +22,7 @@ const (
 
 	hostedAgentsSessionsBasePath                    = "/v2/agents/sessions"
 	hostedAgentSessionByIDPath                      = hostedAgentsSessionsBasePath + "/%s"
-	hostedAgentSessionEventsPath                    = hostedAgentSessionByIDPath + "/events"
+	hostedAgentSessionStreamPath                    = hostedAgentSessionByIDPath + "/stream"
 	hostedAgentSessionInputPath                     = hostedAgentSessionByIDPath + "/input"
 	hostedAgentSessionRequestPath                   = hostedAgentSessionByIDPath + "/request"
 	hostedAgentSessionHITLPath                      = hostedAgentSessionByIDPath + "/hitl/%s"
@@ -52,10 +52,6 @@ const (
 	workspaceContentSHA256Header = "X-Content-Sha256"
 	workspaceIsArchiveHeader     = "X-Workspace-Is-Archive"
 	workspaceSizeBytesHeader     = "X-Workspace-Size-Bytes"
-
-	// sseLastEventIDHeader is the standard SSE resume cursor. The data-plane
-	// events endpoint takes the cursor here rather than as a query parameter.
-	sseLastEventIDHeader = "Last-Event-ID"
 
 	// workspaceDownloadFooter is appended by OHS after a successful download
 	// payload so integrity survives intermediaries that strip HTTP trailers
@@ -262,39 +258,6 @@ const (
 	HostedAgentEventKindRunSandboxReleased   HostedAgentEventKind = "run.sandbox_released"
 	HostedAgentEventKindRunCostAccrued       HostedAgentEventKind = "run.cost_accrued"
 	HostedAgentEventKindRunLog               HostedAgentEventKind = "run.log"
-
-	// HostedAgentEventKindStreamState is a transport control frame, not an agent
-	// event: it reports the health of the SSE connection itself. Only the
-	// data-plane events endpoint emits it. It arrives in the same envelope as an
-	// event, but only SessionID, At and Payload are meaningful — decode Payload
-	// with HostedAgentStreamState. Renderers should skip it rather than display
-	// it as session activity.
-	HostedAgentEventKindStreamState HostedAgentEventKind = "stream.state"
-)
-
-// HostedAgentStreamState is the payload of a HostedAgentEventKindStreamState
-// frame: the current health of the SSE connection.
-type HostedAgentStreamState struct {
-	State  HostedAgentStreamStateValue `json:"state"`
-	Cursor string                      `json:"cursor,omitempty"`
-}
-
-// HostedAgentStreamStateValue enumerates the stream health states.
-type HostedAgentStreamStateValue string
-
-const (
-	// HostedAgentStreamStateLive means events are being delivered contiguously.
-	HostedAgentStreamStateLive HostedAgentStreamStateValue = "live"
-	// HostedAgentStreamStateCatchingUp means the connection is replaying recent
-	// history before it joins the live tail.
-	HostedAgentStreamStateCatchingUp HostedAgentStreamStateValue = "catching_up"
-	// HostedAgentStreamStateDegraded means delivery continues with reduced
-	// guarantees (the server fell back to polling).
-	HostedAgentStreamStateDegraded HostedAgentStreamStateValue = "degraded"
-	// HostedAgentStreamStateSuperseded means a newer connection from the same
-	// device took over. The server closes this stream; the client should stop
-	// rather than reconnect, or the two connections will evict each other.
-	HostedAgentStreamStateSuperseded HostedAgentStreamStateValue = "superseded"
 )
 
 // HostedAgentSessionOriginProduct identifies the product workflow that created
@@ -386,7 +349,7 @@ type HostedAgentHITLDecision struct {
 	Reason    string                 `json:"reason,omitempty"`
 }
 
-// HostedAgentEvent is one SSE payload from a session stream (see StreamSession).
+// HostedAgentEvent is one SSE payload from GET /v2/agents/sessions/{id}/stream.
 //
 // The server serializes the SPI canonical event envelope, whose JSON shape
 // differs from this struct's field names: the discriminator is `type` (not
@@ -494,17 +457,8 @@ type HostedAgentSessionsListResponse struct {
 }
 
 // HostedAgentSessionStreamOptions configures the session SSE stream.
-//
-// ReplayOnly selects between the two modes StreamSession can open on the events
-// endpoint (see StreamSession); Before and Limit page backwards through history
-// within the replay-only mode.
 type HostedAgentSessionStreamOptions struct {
-	// ReplayFrom is the resume cursor: the id of the last event the caller
-	// already rendered. On the live stream it is sent as Last-Event-ID; on a
-	// ReplayOnly read it is sent as the replay_from query parameter.
 	ReplayFrom string
-	// ReplayOnly reads the stored event history and ends the stream at the last
-	// stored event instead of holding the connection open for live events.
 	ReplayOnly bool
 
 	// Before turns the request into a single backward page of durable
@@ -925,66 +879,37 @@ func (s *HostedAgentsServiceOp) ResumeSession(ctx context.Context, sessionID str
 }
 
 // StreamSession opens the SSE stream for a session. Callers MUST Close the stream.
-//
-// Both reads are served by the data plane at GET .../sessions/{id}/events; the
-// two modes differ in where the stream starts and whether it ends:
-//
-//   - Live (the default) delivers forward-only from the moment of attach,
-//     preceded by whatever recent history the server decides to replay, and
-//     holds the connection open. ReplayFrom is sent as the standard
-//     Last-Event-ID header.
-//   - ReplayOnly adds ?replay_only=true: the server writes the session's stored
-//     event history and then ends the stream, so the read terminates on its own.
-//     ReplayFrom is sent as the replay_from query parameter, since it is an
-//     explicit pagination cursor here rather than a resume hint. Before and
-//     Limit page backwards from an event id within this mode; see
-//     HostedAgentSessionStreamOptions.Before and HasMore.
-//
-// Both carry HostedAgentEventKindStreamState control frames (see
-// HostedAgentStreamState). A replay-only read reports catching_up and then
-// simply ends; it never reaches live.
 func (s *HostedAgentsServiceOp) StreamSession(ctx context.Context, sessionID string, opt *HostedAgentSessionStreamOptions) (*HostedAgentSessionStream, *Response, error) {
 	if sessionID == "" {
 		return nil, nil, errors.New("hosted agents: session id is required")
 	}
-	replayOnly := opt != nil && opt.ReplayOnly
-	cursor := ""
-	before := ""
-	limit := 0
-	includeRaw := false
+	path := fmt.Sprintf(hostedAgentSessionStreamPath, sessionID)
 	if opt != nil {
 		// The server answers this combination with a 400; rejecting it here
 		// spends no round trip to learn the same thing.
 		if opt.Before != "" && !opt.ReplayOnly {
 			return nil, nil, errors.New("hosted agents: before requires replay only")
 		}
-		cursor = opt.ReplayFrom
-		before = opt.Before
-		limit = opt.Limit
-		includeRaw = opt.IncludeRaw
-	}
-
-	path := fmt.Sprintf(hostedAgentSessionEventsPath, sessionID)
-	q := url.Values{}
-	if replayOnly {
-		q.Set("replay_only", "true")
-		if cursor != "" {
-			q.Set("replay_from", cursor)
+		q := url.Values{}
+		if opt.ReplayFrom != "" {
+			q.Set("replay_from", opt.ReplayFrom)
 		}
-		if before != "" {
-			q.Set("before", before)
+		if opt.ReplayOnly {
+			q.Set("replay_only", "true")
 		}
-		if limit > 0 {
-			q.Set("limit", strconv.Itoa(limit))
+		if opt.Before != "" {
+			q.Set("before", opt.Before)
+		}
+		if opt.Limit > 0 {
+			q.Set("limit", strconv.Itoa(opt.Limit))
+		}
+		if opt.IncludeRaw {
+			q.Set("include_raw", "true")
+		}
+		if encoded := q.Encode(); encoded != "" {
+			path += "?" + encoded
 		}
 	}
-	if includeRaw {
-		q.Set("include_raw", "true")
-	}
-	if encoded := q.Encode(); encoded != "" {
-		path += "?" + encoded
-	}
-
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
@@ -992,9 +917,6 @@ func (s *HostedAgentsServiceOp) StreamSession(ctx context.Context, sessionID str
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Connection", "keep-alive")
-	if !replayOnly && cursor != "" {
-		req.Header.Set(sseLastEventIDHeader, cursor)
-	}
 
 	resp, err := s.client.DoStream(ctx, req)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -103,7 +103,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.204.0-beta.4
+# github.com/digitalocean/godo v1.204.0-beta.3
 ## explicit; go 1.23.0
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
Reverts 5d0ad616 (#1899), on top of `feat/agents-subcommands` (#1853).

## Why

Two things came back with that commit that don't hold yet:

- **Attach reads from the data plane.** The data plane only holds a session's events when the owning team is in the `ohp_preview` flipper — that gate is what stamps the forwarder config into the guest and makes the in-guest runtime tee its stream. Without it the data plane serves an empty stream and `attach` hangs on an open connection with nothing on it. harness-api receives events either way, so `/v2/agents/sessions/{id}/stream` works for every team.
- **The agents commands pinned their own API host.** That hostname is region-scoped at the edge while `api.digitalocean.com` serves the other region, and the two share no session storage — so a session created through one is invisible to the other. Dropping the pin puts the agents surface back on the same host as the rest of doctl.

`godo` goes back to `v1.204.0-beta.3`, whose `StreamSession` builds the `/stream` path natively, so the pin and the vendored tree agree.

## Resolutions that differ from a mechanical revert

Ten commits landed on top of the reverted one, so three files needed hand-merging:

- `commands/agents.go` keeps the `open-harness-runtime` root command help rather than restoring the old text.
- `agentproxytest` serves `/stream` but keeps the fields later tests rely on (`lastInput`, `lastRelay`, `relayReply`, `relayStatus`).
- `backendPhaseFromEvent`, which was added after the reverted commit, moves to doctl's local `stream.state` constants — the revert restores those and beta.3 doesn't export godo's. It also gains the `catching_up` value the local copy was missing.

Region selection by env var is a separate change and is not in this PR.

## Test plan

- [x] `go build` clean across the tree (`./integration` fails to build on this branch already, unrelated to this change).
- [x] `go test ./commands/... ./internal/... .` — only pre-existing `TestRegistryLogin`/`TestRegistryLogout` keychain failures remain.
- [ ] `doctl agents attach` against a real session, confirming events arrive over `/stream` for a team that is not in `ohp_preview`.

Made with [Cursor](https://cursor.com)