### PR TITLE
feat(agents): stream reasoning live and keep run status visible in attach

### DIFF
--- a/commands/agent_configs.go
+++ b/commands/agent_configs.go
@@ -317,7 +317,7 @@ func printAgentConfigsList(w io.Writer, configs []godo.HostedAgentConfigSummary)
 			meta = append(meta, colorize(id, colMuted))
 		}
 		if !cfg.CreatedAt.Time.IsZero() {
-			meta = append(meta, colorize(cfg.CreatedAt.Time.UTC().Format("2006-01-02 15:04"), colMuted))
+			meta = append(meta, colorize(createdAgo(cfg.CreatedAt.Time), colMuted))
 		}
 		if len(meta) > 0 {
 			fmt.Fprintf(w, "  %s\n", strings.Join(meta, colorize(" · ", colMuted)))
@@ -351,7 +351,7 @@ func printAgentConfigCard(w io.Writer, cfg *godo.HostedAgentConfig, created bool
 		body.WriteString(cardRow("Hash", colorize(hash, colMuted)))
 	}
 	if !cfg.CreatedAt.Time.IsZero() {
-		body.WriteString(cardRow("Created", colorize(cfg.CreatedAt.Time.UTC().Format("2006-01-02 15:04 UTC"), colMuted)))
+		body.WriteString(cardRow("Created", colorize(formatCreatedAt(cfg.CreatedAt.Time), colMuted)))
 	}
 
 	if id := strings.TrimSpace(cfg.ID); id != "" {

--- a/commands/agent_configs_test.go
+++ b/commands/agent_configs_test.go
@@ -71,21 +71,33 @@ func TestPrintAgentConfigsList(t *testing.T) {
 	prev := stylingEnabled
 	stylingEnabled = false
 	t.Cleanup(func() { stylingEnabled = prev })
+	prevVerbose := Verbose
+	t.Cleanup(func() { Verbose = prevVerbose })
 
-	var buf bytes.Buffer
-	printAgentConfigsList(&buf, []godo.HostedAgentConfigSummary{{
+	created := time.Now().Add(-5 * time.Minute)
+	configs := []godo.HostedAgentConfigSummary{{
 		ID:          "01a01e58-6209-7c75-8b31-6cb80f7301ff",
 		Name:        "session-opencode-20260820-084503",
-		CreatedAt:   godo.Timestamp{Time: time.Date(2026, 8, 20, 8, 45, 3, 0, time.UTC)},
+		CreatedAt:   godo.Timestamp{Time: created},
 		ContentHash: "c0c95e3b975398c69bd0b235d32f21647171bf825aa08369de820ee240569b35",
-	}})
+	}}
 
+	Verbose = false
+	var buf bytes.Buffer
+	printAgentConfigsList(&buf, configs)
 	out := buf.String()
 	assert.Contains(t, out, "1 config")
 	assert.Contains(t, out, "session-opencode-20260820-084503")
 	assert.Contains(t, out, "01a01e58-6209-7c75-8b31-6cb80f7301ff")
-	assert.Contains(t, out, "2026-08-20 08:45")
+	assert.Contains(t, out, "5m ago")
 	assert.NotContains(t, out, "c0c95e3b975398c69bd0b235d32f21647171bf825aa08369de820ee240569b35")
+
+	Verbose = true
+	var verboseBuf bytes.Buffer
+	printAgentConfigsList(&verboseBuf, configs)
+	verboseOut := verboseBuf.String()
+	assert.Contains(t, verboseOut, created.UTC().Format("2006-01-02 15:04"))
+	assert.NotContains(t, verboseOut, "5m ago")
 }
 
 func TestTruncateMiddle(t *testing.T) {

--- a/commands/agents.go
+++ b/commands/agents.go
@@ -36,6 +36,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"text/tabwriter"
 	"time"
 
 	"github.com/charmbracelet/glamour"
@@ -471,6 +472,7 @@ func RunAgentsStart(c *CmdConfig) error {
 	prog := (*creationProgress)(nil)
 	if Output != "json" {
 		prog = newCreationProgress(c.Out)
+		defer prog.stop()
 		prog.header("Launching agent session")
 	}
 
@@ -579,6 +581,7 @@ func finishAgentsStartSession(c *CmdConfig, sess *do.HostedAgentSession, prog *c
 
 	if prog == nil {
 		prog = newCreationProgress(c.Out)
+		defer prog.stop()
 	}
 	sess, err := waitForSessionReady(ctx, c.HostedAgents(), sessionID, prog)
 	if err != nil {
@@ -1158,6 +1161,13 @@ func RunAgentsUpload(c *CmdConfig) error {
 		return err
 	}
 
+	return runWorkspaceUpload(c, sessionID, localFile, workspacePath, isArchive)
+}
+
+// runWorkspaceUpload validates and streams a local file (or tar archive) into
+// a session's workspace sandbox. Shared by `doctl agents upload` and the
+// interactive attach `/upload` command.
+func runWorkspaceUpload(c *CmdConfig, sessionID, localFile, workspacePath string, isArchive bool) error {
 	info, err := os.Stat(localFile)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1445,7 +1455,14 @@ func RunAgentsDownload(c *CmdConfig) error {
 		return err
 	}
 
-	written, err := workspaceTransferDownload(c.HostedAgents(), sessionID, workspacePath, saveTo, asArchive)
+	return runWorkspaceDownload(c, c.HostedAgents(), sessionID, workspacePath, saveTo, asArchive)
+}
+
+// runWorkspaceDownload fetches a file (or tar archive) from a session
+// workspace sandbox. Shared by `doctl agents download` and the interactive
+// attach `/download` command.
+func runWorkspaceDownload(c *CmdConfig, svc do.HostedAgentsService, sessionID, workspacePath, saveTo string, asArchive bool) error {
+	written, err := workspaceTransferDownload(svc, sessionID, workspacePath, saveTo, asArchive)
 	if err != nil {
 		return err
 	}
@@ -3323,6 +3340,10 @@ func attachLoop(c *CmdConfig, svc do.HostedAgentsService, sessionID string, in i
 			}
 		}
 		if strings.HasPrefix(line, "/") {
+			if isAttachExitCommand(line) {
+				printDetachNotice(c.Out, state.sessionRef)
+				return nil
+			}
 			if err := handleAttachCommand(c, svc, sessionID, line, pending); err != nil {
 				fmt.Fprintf(c.Out, "error: %v\n", err)
 			}
@@ -4366,6 +4387,9 @@ func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string
 			return true, nil
 		}
 		return false, nil
+	case 0x09: // Tab: autocomplete the "/" command verb (arguments aren't completed)
+		completeAttachSlashCommand(c, state)
+		return false, nil
 	default:
 		// Printable ASCII only; UTF-8 multibyte is still dropped in V0.
 		if b >= 0x20 && b < 0x7f {
@@ -4391,6 +4415,66 @@ func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string
 	}
 }
 
+// attachSlashCommands lists the first-word verbs the attach REPL recognizes,
+// used to drive Tab-completion when a line starts with "/".
+var attachSlashCommands = []string{
+	"/help", "/pending", "/exit",
+	"/a", "/approve", "/r", "/reject", "/d", "/defer",
+	"/pause", "/resume", "/upload", "/download",
+}
+
+// isAttachExitCommand reports whether line is the /exit command, which
+// detaches the same way Ctrl-D does — closing the local connection only;
+// the hosted session keeps running.
+func isAttachExitCommand(line string) bool {
+	parts := strings.Fields(line)
+	return len(parts) == 1 && parts[0] == "/exit"
+}
+
+// matchAttachSlashCommands returns every known verb that starts with prefix.
+func matchAttachSlashCommands(prefix string) []string {
+	var matches []string
+	for _, cmd := range attachSlashCommands {
+		if strings.HasPrefix(cmd, prefix) {
+			matches = append(matches, cmd)
+		}
+	}
+	return matches
+}
+
+// completeAttachSlashCommand handles Tab: only fires while the caret sits at
+// the end of a single, space-free "/word" (i.e. the user is still typing the
+// verb, not an argument). One match fills it in with a trailing space so the
+// user can keep typing an argument; multiple matches are listed so the user
+// can narrow it down, mirroring shell-style completion.
+func completeAttachSlashCommand(c *CmdConfig, state *attachState) {
+	state.mu.Lock()
+	buf := string(state.lineBuf)
+	atEnd := state.cursor == len(state.lineBuf)
+	state.mu.Unlock()
+	if !atEnd || !strings.HasPrefix(buf, "/") || strings.ContainsAny(buf, " \t") {
+		return
+	}
+
+	matches := matchAttachSlashCommands(buf)
+	switch len(matches) {
+	case 0:
+		return
+	case 1:
+		if matches[0] == buf {
+			return
+		}
+		state.mu.Lock()
+		state.lineBuf = []byte(matches[0] + " ")
+		state.cursor = len(state.lineBuf)
+		state.mu.Unlock()
+		state.display.redraw()
+	default:
+		fmt.Fprintln(c.Out, strings.Join(matches, "  "))
+		state.display.redraw()
+	}
+}
+
 // processAttachLine dispatches an Enter-submitted line: HITL word shortcut,
 // slash command, or SendInput. Returns detach=true when the session can no
 // longer accept input (terminal run) and the loop should exit.
@@ -4409,6 +4493,10 @@ func processAttachLine(c *CmdConfig, svc do.HostedAgentsService, sessionID, line
 		}
 	}
 	if strings.HasPrefix(line, "/") {
+		if isAttachExitCommand(line) {
+			printDetachNotice(c.Out, state.sessionRef)
+			return true
+		}
 		if err := handleAttachCommand(c, svc, sessionID, line, state.pending); err != nil {
 			fmt.Fprintf(c.Out, "error: %v\n", err)
 		}
@@ -4499,21 +4587,7 @@ func handleAttachCommand(c *CmdConfig, svc do.HostedAgentsService, sessionID, li
 	verb := parts[0]
 	switch verb {
 	case "/help":
-		fmt.Fprintln(c.Out, "Detach (does NOT remove the session):")
-		fmt.Fprintln(c.Out, "  Ctrl-D           close the connection; reattach later with `doctl open-harness-runtime attach`")
-		fmt.Fprintln(c.Out, "  Ctrl-C           same as Ctrl-D")
-		fmt.Fprintln(c.Out, "Remove the session: `doctl open-harness-runtime remove <session>`")
-		fmt.Fprintln(c.Out, "When a HITL approval is pending (no Enter needed in a TTY):")
-		fmt.Fprintln(c.Out, "  ↑ / ↓ then Enter  move the highlight and confirm the selected outcome")
-		fmt.Fprintln(c.Out, "  y | a             approve the oldest pending request")
-		fmt.Fprintln(c.Out, "  n | r             reject  the oldest pending request")
-		fmt.Fprintln(c.Out, "  d                 defer   the oldest pending request")
-		fmt.Fprintln(c.Out, "  (piped input: send `yes` / `no` / `defer` followed by a newline)")
-		fmt.Fprintln(c.Out, "With an explicit request id (works on any queued request):")
-		fmt.Fprintln(c.Out, "  /a [request-id]   approve (defaults to the oldest pending)")
-		fmt.Fprintln(c.Out, "  /r [request-id]   reject")
-		fmt.Fprintln(c.Out, "  /d [request-id]   defer")
-		fmt.Fprintln(c.Out, "  /pending          list all HITL approvals waiting on you")
+		printAttachHelp(c.Out)
 		return nil
 	case "/pending":
 		return listPendingHITLs(c, pending)
@@ -4523,9 +4597,62 @@ func handleAttachCommand(c *CmdConfig, svc do.HostedAgentsService, sessionID, li
 		return resolveFromAttach(svc, sessionID, parts, pending, godo.HostedAgentHITLOutcomeReject)
 	case "/d", "/defer":
 		return resolveFromAttach(svc, sessionID, parts, pending, godo.HostedAgentHITLOutcomeDefer)
+	case "/pause":
+		if err := svc.PauseSession(sessionID); err != nil {
+			return err
+		}
+		printAgentSuccess(c.Out, "Session paused")
+		return nil
+	case "/resume":
+		if err := svc.ResumeSession(sessionID); err != nil {
+			return err
+		}
+		printAgentSuccess(c.Out, "Session resumed")
+		return nil
+	case "/upload":
+		return attachUploadFromArgs(c, sessionID, parts[1:])
+	case "/download":
+		return attachDownloadFromArgs(c, svc, sessionID, parts[1:])
+	case "/exit":
+		// The caller (attachLoop / processAttachLine) intercepts /exit before
+		// reaching here, prints the detach notice, and stops the loop.
+		return nil
 	default:
 		return fmt.Errorf("unknown command %q (try /help)", verb)
 	}
+}
+
+// splitAttachTransferArgs pulls the "--archive" flag out of a /upload or
+// /download command's remaining tokens, leaving only positional arguments.
+func splitAttachTransferArgs(args []string) (positional []string, archive bool) {
+	for _, a := range args {
+		if a == "--archive" {
+			archive = true
+			continue
+		}
+		positional = append(positional, a)
+	}
+	return positional, archive
+}
+
+// attachUploadFromArgs implements the interactive `/upload` command, mirroring
+// `doctl agents upload` without requiring cobra flag parsing.
+func attachUploadFromArgs(c *CmdConfig, sessionID string, args []string) error {
+	positional, archive := splitAttachTransferArgs(args)
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: /upload <local-file> <workspace-path> [--archive]")
+	}
+	return runWorkspaceUpload(c, sessionID, positional[0], positional[1], archive)
+}
+
+// attachDownloadFromArgs implements the interactive `/download` command,
+// mirroring `doctl agents download` without requiring cobra flag parsing.
+func attachDownloadFromArgs(c *CmdConfig, svc do.HostedAgentsService, sessionID string, args []string) error {
+	positional, archive := splitAttachTransferArgs(args)
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: /download <workspace-path> <local-file> [--archive]")
+	}
+	return runWorkspaceDownload(c, svc, sessionID, positional[0], positional[1], archive)
 }
 
 // listPendingHITLs renders the current HITL queue. The head is marked with
@@ -4826,7 +4953,8 @@ func renderAgentCard(w io.Writer, body string) {
 }
 
 // printAttachBanner renders the styled connection header and a compact help
-// key shown when an interactive session is attached.
+// key shown when an interactive session is attached. Every line is
+// left-aligned (no column padding) to keep the card compact and scannable.
 func printAttachBanner(w io.Writer, sess *do.HostedAgentSession, bridgeNote string) {
 	ref := displaySessionRef(sess)
 	agent := prettyAgentKind(sess.AgentKind)
@@ -4834,37 +4962,109 @@ func printAttachBanner(w io.Writer, sess *do.HostedAgentSession, bridgeNote stri
 	var body strings.Builder
 	fmt.Fprintf(&body, "%s\n\n", boldColor("Connected", colSuccess))
 
-	body.WriteString(cardRow("Session", ref))
-	if sess != nil && strings.TrimSpace(sess.SessionID) != "" && sess.SessionID != ref {
-		body.WriteString(cardRow("ID", colorize(sess.SessionID, colMuted)))
+	fmt.Fprintf(&body, "%s %s\n", boldColor("Agent", colHighlight), agent)
+	fmt.Fprintf(&body, "%s %s\n", boldColor("Session", colHighlight), ref)
+	if Verbose && sess != nil && strings.TrimSpace(sess.SessionID) != "" && sess.SessionID != ref {
+		fmt.Fprintf(&body, "%s %s\n", boldColor("ID", colHighlight), colorize(sess.SessionID, colMuted))
 	}
-	body.WriteString(cardRow("Agent", agent))
 	if note := strings.TrimSpace(bridgeNote); note != "" {
-		body.WriteString(cardRow("Bridge", colorize(note, colMuted)))
+		fmt.Fprintf(&body, "%s %s\n", boldColor("Bridge", colHighlight), colorize(note, colMuted))
 	}
 
 	fmt.Fprintln(&body)
-	fmt.Fprintln(&body, colorize("Quick help", colMuted))
+	fmt.Fprintln(&body, colorize("Press Ctrl + D to detach locally", colMuted))
 
+	fmt.Fprintln(&body)
+	fmt.Fprintf(&body, "type a message and press %s\n", colorize("Enter", colHighlight))
 	yn := colorize("y", colSuccess) + colorize("/a", colSuccess) + " approve · " +
 		colorize("n", colError) + colorize("/r", colError) + " reject · " +
 		colorize("d", colWarning) + " defer"
-	body.WriteString(cardRow("send", "type a message and press Enter"))
-	body.WriteString(cardRow("approve", "↑/↓ then Enter, or "+yn))
-	body.WriteString(cardRow("detach", colorize("Ctrl-D", colMuted)+" closes connection only — session keeps running"))
-	body.WriteString(cardRow("remove", colorize("doctl open-harness-runtime remove "+ref, colMuted)))
-	body.WriteString(cardRow("help", "type "+boldColor("/help", colHighlight)+" for the full command list"))
+	fmt.Fprintf(&body, "%s then Enter, or %s\n", colorize("↑/↓", colHighlight), yn)
+
+	fmt.Fprintln(&body)
+	fmt.Fprintln(&body, colorize("use /help for full command list", colMuted))
 
 	renderAgentCard(w, body.String())
 }
 
-// prettyAgentKind turns AGENT_KIND_OPENCODE into a friendly "opencode" label.
-func prettyAgentKind(k godo.HostedAgentKind) string {
-	s := strings.ToLower(strings.ReplaceAll(strings.TrimPrefix(string(k), "AGENT_KIND_"), "_", " "))
-	if s == "" || s == "unspecified" {
-		return "agent"
+// helpRow is one entry in a printAttachHelp section: a command/key on the
+// left, its description on the right.
+type helpRow struct {
+	key  string
+	desc string
+}
+
+// printAttachHelp renders the /help output as plain, left-aligned text
+// grouped into sections (no card/border — this is a reference list, not a
+// status card). Each section's key column is aligned via tabwriter instead
+// of hand-counted spaces — those drift out of alignment across terminals,
+// fonts, and edits, which is what made the old /help output look broken.
+func printAttachHelp(w io.Writer) {
+	var body strings.Builder
+	fmt.Fprintf(&body, "%s\n\n", boldColor("Attach help", colHighlight))
+
+	writeHelpSection(&body, "Detach (session keeps running)", []helpRow{
+		{"Ctrl-D, Ctrl-C, /exit", "close the local connection"},
+	})
+	fmt.Fprintln(&body)
+	writeHelpSection(&body, "Session controls", []helpRow{
+		{"/pause", "pause the session"},
+		{"/resume", "resume a paused session"},
+		{"/upload <file> <dest> [--archive]", "upload into the workspace"},
+		{"/download <src> <file> [--archive]", "download from the workspace"},
+	})
+	fmt.Fprintln(&body)
+	writeHelpSection(&body, "Approvals pending (no Enter needed in a TTY)", []helpRow{
+		{"↑/↓ then Enter", "move highlight, confirm the selected outcome"},
+		{"y, a", "approve the oldest pending request"},
+		{"n, r", "reject the oldest pending request"},
+		{"d", "defer the oldest pending request"},
+		{"/a, /r, /d [request-id]", "resolve a specific request (defaults to oldest)"},
+		{"/pending", "list requests waiting on you"},
+		{"(piped input)", "send `yes` / `no` / `defer` followed by a newline"},
+	})
+	fmt.Fprintln(&body)
+	writeHelpSection(&body, "Other", []helpRow{
+		{"/ then Tab", "autocomplete a command"},
+		{agentCLI + " attach <session>", "reattach after detaching"},
+		{agentCLI + " remove <session>", "remove the session"},
+	})
+
+	fmt.Fprint(w, strings.TrimRight(body.String(), "\n")+"\n")
+}
+
+// writeHelpSection writes a muted section title followed by its rows, key
+// and description columns aligned with tabwriter.
+func writeHelpSection(b *strings.Builder, title string, rows []helpRow) {
+	fmt.Fprintln(b, colorize(title, colMuted))
+	tw := tabwriter.NewWriter(b, 0, 0, 3, ' ', 0)
+	for _, row := range rows {
+		fmt.Fprintf(tw, "  %s\t%s\n", boldColor(row.key, colHighlight), row.desc)
 	}
-	return s
+	tw.Flush()
+}
+
+// agentKindDisplayNames maps hosted-agent kinds to their canonical,
+// user-facing product names (e.g. AGENT_KIND_OPENCODE -> "OpenCode") so every
+// agent surface — session cards, lists, triggers — uses consistent casing.
+var agentKindDisplayNames = map[godo.HostedAgentKind]string{
+	godo.HostedAgentKindClaudeCode:  "Claude Code",
+	godo.HostedAgentKindOpenCode:    "OpenCode",
+	godo.HostedAgentKindCodexCLI:    "Codex CLI",
+	godo.HostedAgentKindCursorCLI:   "Cursor CLI",
+	godo.HostedAgentKindOpenAICodex: "Codex",
+	godo.HostedAgentKindCustom:      "Custom",
+	godo.HostedAgentKindNone:        "None",
+}
+
+// prettyAgentKind turns AGENT_KIND_OPENCODE into the friendly "OpenCode"
+// label. Falls back to the sentinel "agent" for unspecified or unrecognized
+// kinds; callers use that sentinel to fall back to a different display name.
+func prettyAgentKind(k godo.HostedAgentKind) string {
+	if name, ok := agentKindDisplayNames[k]; ok {
+		return name
+	}
+	return "agent"
 }
 
 // renderApprovalLine prints the one-line approval prompt with an optional

--- a/commands/agents.go
+++ b/commands/agents.go
@@ -31,6 +31,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -107,6 +108,16 @@ func boldColor(s string, c lipgloss.Color) string {
 		return s
 	}
 	return lipgloss.NewStyle().Foreground(c).Bold(true).Render(s)
+}
+
+// italicMuted renders text dim and italic when styling is enabled, used for
+// the model's reasoning/"thinking" content so it reads as distinct from its
+// final answer.
+func italicMuted(s string) string {
+	if !stylingEnabled {
+		return s
+	}
+	return lipgloss.NewStyle().Foreground(colMuted).Italic(true).Render(s)
 }
 
 // renderMarkdown turns a markdown document into styled terminal text. With
@@ -205,12 +216,30 @@ func mdWrapWidth() int {
 // raw tokens one at a time.
 type msgAccumulator struct {
 	buf strings.Builder
+	// tail mirrors the most recent previewTailMaxRunes runes written via add,
+	// kept independent of buf so a live "thinking" preview (see
+	// thinkingState.setLabel) stays O(1) per token instead of re-scanning the
+	// whole (potentially large) accumulated message on every delta.
+	tail string
 }
 
-func (m *msgAccumulator) add(s string) { m.buf.WriteString(s) }
+// previewTailMaxRunes caps how much recent text msgAccumulator keeps around
+// for the live spinner preview — comfortably more than thinkingPreviewLabel
+// ends up showing, so trimming there never runs out of material.
+const previewTailMaxRunes = 200
+
+func (m *msgAccumulator) add(s string) {
+	m.buf.WriteString(s)
+	m.tail = trimTailRunes(m.tail+s, previewTailMaxRunes)
+}
+
+// previewTail returns the most recently streamed text, for a live "thinking"
+// preview while the message is still being buffered.
+func (m *msgAccumulator) previewTail() string { return m.tail }
 
 // flush renders the buffered message as markdown and writes it, then resets.
 func (m *msgAccumulator) flush(out io.Writer) {
+	m.tail = ""
 	if m.buf.Len() == 0 {
 		return
 	}
@@ -221,6 +250,67 @@ func (m *msgAccumulator) flush(out io.Writer) {
 		rendered += "\n"
 	}
 	fmt.Fprint(out, rendered)
+}
+
+// trimTailRunes keeps only the last n runes of s, respecting UTF-8
+// boundaries (a plain byte slice would risk cutting a multi-byte rune).
+func trimTailRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[len(r)-n:])
+}
+
+// reasoningStreamer prints model reasoning/"thinking" content live, styled
+// distinctly (dim italic) from the final answer, as it arrives — unlike
+// msgAccumulator, it never buffers for a later markdown render. Reasoning is
+// plain prose and the point is to show it as it streams in, not after the
+// fact. Shared by the SPI drainStream loop (run.token_delta with
+// is_reasoning=true) and the OpenAI sandbox attach renderer (its own
+// reasoning delta/item events).
+type reasoningStreamer struct {
+	out      io.Writer
+	thinking *thinkingState
+	active   bool
+}
+
+// stream writes a reasoning chunk, printing a leading label the first time a
+// block starts and pausing the thinking spinner while the block is live.
+func (r *reasoningStreamer) stream(text string) {
+	if text == "" {
+		return
+	}
+	if !r.active {
+		if r.thinking != nil {
+			r.thinking.stop()
+		}
+		fmt.Fprint(r.out, italicMuted("reasoning  "))
+		r.active = true
+	}
+	fmt.Fprint(r.out, italicMuted(text))
+}
+
+// end closes out a streamed reasoning block, if one is open, and resumes the
+// thinking spinner for whatever comes next in the turn.
+func (r *reasoningStreamer) end() {
+	r.endWithLabel("")
+}
+
+// endWithLabel is like end, but seeds the resumed spinner's label
+// immediately — see thinkingState.startWithLabel. Callers that already know
+// the next preview (the final answer's first chunk, right as a reasoning
+// block closes) should use this instead of end()+setLabel so the spinner
+// never visibly reverts to the generic caption in between.
+func (r *reasoningStreamer) endWithLabel(label string) {
+	if !r.active {
+		return
+	}
+	fmt.Fprintln(r.out)
+	r.active = false
+	if r.thinking != nil {
+		r.thinking.startWithLabel(label)
+	}
 }
 
 // Agents creates the `doctl open-harness-runtime` command tree (aliases: agent, agents).
@@ -1696,7 +1786,7 @@ func runAgentsAttachSession(c *CmdConfig, sessionID string) error {
 
 	go streamWithReconnect(ctx, svc, sessionID, c.Out, pending, cursor, thinking, warmup)
 
-	return runAttach(c, svc, sessionID, os.Stdin, state, warmup)
+	return runAttach(c, svc, sessionID, os.Stdin, state, warmup, thinking)
 }
 
 func isOpenAISandboxSession(sess *do.HostedAgentSession) bool {
@@ -1765,15 +1855,30 @@ func runOpenAIAgentsAttach(c *CmdConfig, sess *do.HostedAgentSession) error {
 // openAIAttachRenderer maps OpenAI Agents SSE events onto the same attach UX
 // primitives used by the DO stream (spinner, tool lines, markdown replies).
 type openAIAttachRenderer struct {
-	out      io.Writer
-	thinking *thinkingState
-	warmup   *warmupState
-	acc      msgAccumulator
+	out       io.Writer
+	thinking  *thinkingState
+	warmup    *warmupState
+	acc       msgAccumulator
+	reasoning reasoningStreamer
 	// sawOutputDelta tracks whether we already buffered streamed assistant text
 	// so output_text.done does not duplicate it.
 	sawOutputDelta bool
 	// activeToolCmd is the in-flight command_execution command line.
 	activeToolCmd string
+	// sawReasoningDelta tracks whether this reasoning item already streamed
+	// via delta events, so the item.done fallback (full summary text) does
+	// not duplicate it — mirrors sawOutputDelta for output_text.
+	sawReasoningDelta bool
+}
+
+// ensureReasoning lazily wires the shared reasoningStreamer to this
+// renderer's out/thinking — needed because reasoning is a value field (so
+// zero-value openAIAttachRenderer{} literals in tests still work) but must
+// write to the same writer/spinner the rest of the renderer uses.
+func (r *openAIAttachRenderer) ensureReasoning() *reasoningStreamer {
+	r.reasoning.out = r.out
+	r.reasoning.thinking = r.thinking
+	return &r.reasoning
 }
 
 func (r *openAIAttachRenderer) clearWarmup() {
@@ -1788,6 +1893,7 @@ func (r *openAIAttachRenderer) handle(evt map[string]any) {
 	case "session.in_progress", "session.turn.in_progress", "session.turn.created":
 		r.clearWarmup()
 		if r.thinking != nil {
+			r.thinking.setTurnRunning(true)
 			r.thinking.start()
 		}
 	case "session.environment.connected":
@@ -1833,6 +1939,21 @@ func (r *openAIAttachRenderer) handle(evt map[string]any) {
 				r.acc.add(text)
 			}
 		}
+	case "session.turn.reasoning_summary_text.delta", "session.turn.reasoning_text.delta":
+		r.clearWarmup()
+		if d, ok := evt["delta"].(string); ok && d != "" {
+			r.ensureReasoning().stream(d)
+			r.sawReasoningDelta = true
+		}
+	case "session.turn.reasoning_summary_text.done", "session.turn.reasoning_text.done":
+		r.clearWarmup()
+		if !r.sawReasoningDelta {
+			if text, ok := evt["text"].(string); ok && text != "" {
+				r.ensureReasoning().stream(text)
+			}
+		}
+		r.ensureReasoning().end()
+		r.sawReasoningDelta = false
 	case "session.turn.item.added":
 		r.clearWarmup()
 		r.handleItemAdded(evt)
@@ -1841,7 +1962,9 @@ func (r *openAIAttachRenderer) handle(evt map[string]any) {
 		r.handleItemDone(evt)
 	case "session.turn.completed":
 		r.clearWarmup()
+		r.ensureReasoning().end()
 		if r.thinking != nil {
+			r.thinking.setTurnRunning(false)
 			r.thinking.stop()
 		}
 		r.acc.flush(r.out)
@@ -1859,7 +1982,9 @@ func (r *openAIAttachRenderer) handle(evt map[string]any) {
 		fmt.Fprintln(r.out, colorize(runSeparator, colMuted))
 	case "session.turn.failed":
 		r.clearWarmup()
+		r.ensureReasoning().end()
 		if r.thinking != nil {
+			r.thinking.setTurnRunning(false)
 			r.thinking.stop()
 		}
 		r.acc.flush(r.out)
@@ -1875,7 +2000,9 @@ func (r *openAIAttachRenderer) handle(evt map[string]any) {
 		fmt.Fprintln(r.out, colorize(runSeparator, colMuted))
 	case "session.idle":
 		r.clearWarmup()
+		r.ensureReasoning().end()
 		if r.thinking != nil {
+			r.thinking.setTurnRunning(false)
 			r.thinking.stop()
 		}
 		r.acc.flush(r.out)
@@ -1883,14 +2010,17 @@ func (r *openAIAttachRenderer) handle(evt map[string]any) {
 		r.activeToolCmd = ""
 	case "session.failed":
 		r.clearWarmup()
+		r.ensureReasoning().end()
 		if r.thinking != nil {
+			r.thinking.setTurnRunning(false)
 			r.thinking.stop()
 		}
 		r.acc.flush(r.out)
 		r.activeToolCmd = ""
 		fmt.Fprintf(r.out, "\n%s %s\n", colorize("✗", colError), colorize("session failed", colError))
 	default:
-		// Suppress noisy protocol events (reasoning dumps, item echoes, etc.).
+		// Suppress noisy protocol events (item echoes, etc.). Reasoning
+		// deltas/items are handled explicitly above.
 	}
 }
 
@@ -1901,6 +2031,7 @@ func (r *openAIAttachRenderer) handleItemAdded(evt map[string]any) {
 	}
 	switch item["type"] {
 	case "command_execution":
+		r.ensureReasoning().end()
 		if r.thinking != nil {
 			r.thinking.stop()
 		}
@@ -1912,6 +2043,10 @@ func (r *openAIAttachRenderer) handleItemAdded(evt map[string]any) {
 		if r.thinking != nil {
 			r.thinking.start()
 		}
+	case "reasoning":
+		// item.added for a reasoning item typically carries no content yet —
+		// the summary text lands on item.done (or via the delta events above).
+		r.sawReasoningDelta = false
 	}
 }
 
@@ -1963,6 +2098,26 @@ func (r *openAIAttachRenderer) handleItemDone(evt map[string]any) {
 				}
 			}
 		}
+	case "reasoning":
+		// Reasoning is preferred via the delta events; this is the fallback
+		// for reasoning that only ever arrives as a complete item, whose
+		// content lands in a "summary" array of {type: summary_text, text}
+		// parts (OpenAI's ResponseReasoningItem shape).
+		if !r.sawReasoningDelta {
+			if summary, ok := item["summary"].([]any); ok {
+				for _, s := range summary {
+					part, _ := s.(map[string]any)
+					if part == nil {
+						continue
+					}
+					if text, ok := part["text"].(string); ok && text != "" {
+						r.ensureReasoning().stream(text)
+					}
+				}
+			}
+		}
+		r.ensureReasoning().end()
+		r.sawReasoningDelta = false
 	}
 }
 
@@ -2117,13 +2272,22 @@ func startThinkingIfReady(thinking *thinkingState, warmup *warmupState) {
 	}
 }
 
-func printAttachSendAck(out io.Writer, warmup *warmupState) {
+// printAttachSendAck acknowledges a successfully sent message. There's no
+// server-side "queued" signal (a queued send returns the same 202 + run_id
+// shape as one that starts immediately — see the OHR queueing research), so
+// this infers it from local state: a still-warming-up session, or a prior
+// turn's run that hasn't emitted RunCompleted/RunFailed yet.
+func printAttachSendAck(out io.Writer, warmup *warmupState, thinking *thinkingState) {
 	if warmup != nil && warmup.isActive() {
 		// The warm-up banner already shows the queued notice in-place.
 		if warmup.isBannerVisible() {
 			return
 		}
 		fmt.Fprintln(out, colorize("Message queued — will send when agent is ready", colMuted))
+		return
+	}
+	if thinking != nil && thinking.isTurnRunning() {
+		fmt.Fprintln(out, colorize("Message queued — will send once the current run finishes", colMuted))
 		return
 	}
 	fmt.Fprintln(out, colorize("… waiting for the agent", colMuted))
@@ -2181,10 +2345,10 @@ func handleOpenAIAttachByte(c *CmdConfig, ctx context.Context, client openAIAgen
 	}
 	if state.pasting {
 		handlePastedByte(b, state)
+		// noteQueued already repaints the warm-up banner's own queued-status
+		// row itself when relevant; no need for a second, redundant redraw of
+		// the whole prompt on every pasted byte.
 		warmup.noteQueued()
-		if warmup.isBannerVisible() {
-			state.display.redraw()
-		}
 		return false, nil
 	}
 	if handleAttachEscapeSequence(b, state) {
@@ -2217,7 +2381,9 @@ func handleOpenAIAttachByte(c *CmdConfig, ctx context.Context, client openAIAgen
 					fmt.Fprintf(c.Out, "send failed: %v\n", err)
 				} else if warmup.isActive() {
 					warmup.markInputQueued()
-					printAttachSendAck(c.Out, warmup)
+					printAttachSendAck(c.Out, warmup, thinking)
+				} else if thinking != nil && thinking.isTurnRunning() {
+					printAttachSendAck(c.Out, warmup, thinking)
 				}
 			}
 		}
@@ -2280,14 +2446,14 @@ func handleOpenAIAttachByte(c *CmdConfig, ctx context.Context, client openAIAgen
 
 // runAttach dispatches to the raw-mode TTY loop or the legacy bufio line-mode
 // loop based on whether stdin is an interactive terminal.
-func runAttach(c *CmdConfig, svc do.HostedAgentsService, sessionID string, in io.Reader, state *attachState, warmup *warmupState) error {
+func runAttach(c *CmdConfig, svc do.HostedAgentsService, sessionID string, in io.Reader, state *attachState, warmup *warmupState, thinking *thinkingState) error {
 	if f, ok := in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
-		return attachLoopTTY(c, svc, sessionID, f, state, warmup)
+		return attachLoopTTY(c, svc, sessionID, f, state, warmup, thinking)
 	}
 	if warmup != nil {
 		warmup.start()
 	}
-	return attachLoop(c, svc, sessionID, in, state)
+	return attachLoop(c, svc, sessionID, in, state, thinking)
 }
 
 // eventCursor holds the EventID of the latest event rendered. The stream
@@ -2352,15 +2518,40 @@ var (
 	warmupStatusInterval = 2 * time.Second
 )
 
-// thinkingState shows a spinner between RunStarted and the first real
-// output. Animates above the prompt when out is a *promptDisplay; falls back
-// to a one-shot "(thinking...)" print otherwise (pipes, line-mode).
+// thinkingState shows a sticky "Run in progress" spinner one row above the
+// prompt, kept up for the entire run — not just the gap before the first
+// token — so a multi-second tool call or any other silent stretch never
+// reads as the agent having gone quiet. drainStream stops it only to print a
+// discrete line (so the two don't race for the same terminal row) and
+// restarts it right after, for as long as the run is still open and no HITL
+// approval is pending (that has its own visible prompt). Animates above the
+// prompt when out is a *promptDisplay; falls back to a one-shot
+// "(Run in progress)" print otherwise (pipes, line-mode).
+//
+// Reasoning content on the SPI protocol arrives as a plain run.token_delta
+// with data.is_reasoning=true — the same event kind as the final answer, just
+// flagged. drainStream streams flagged chunks live via a reasoningStreamer
+// (see below) instead of buffering them like the final answer. For anything
+// that streams unflagged (a harness/model that never reasons, or reasoning
+// that a future adapter doesn't flag), label still mirrors the buffered
+// preview so the spinner reads as a live typing indicator rather than a
+// static caption while the eventual markdown-rendered flush is assembled.
+//
+// turnRunning is a second, independent signal from active: active tracks
+// whether the *spinner* is currently showing (it toggles off around each
+// discrete line), while turnRunning tracks whether a run is open at all — set
+// on RunStarted, cleared on RunCompleted/RunFailed. It gates both the
+// sticky-restart behavior above and whether the input loop warns a user their
+// message will be queued behind the current run rather than started
+// immediately.
 type thinkingState struct {
-	mu     sync.Mutex
-	out    io.Writer
-	active bool
-	cancel context.CancelFunc
-	done   chan struct{}
+	mu          sync.Mutex
+	out         io.Writer
+	active      bool
+	turnRunning bool
+	cancel      context.CancelFunc
+	done        chan struct{}
+	label       string
 }
 
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -2369,24 +2560,60 @@ func newThinkingState(out io.Writer) *thinkingState {
 	return &thinkingState{out: out}
 }
 
+// setTurnRunning records whether a run is currently open for the session
+// (RunStarted seen, no RunCompleted/RunFailed yet).
+func (s *thinkingState) setTurnRunning(v bool) {
+	s.mu.Lock()
+	s.turnRunning = v
+	s.mu.Unlock()
+}
+
+// isTurnRunning reports whether a run is currently open — used by the input
+// loop to tell a user their message will be queued behind it rather than
+// started immediately.
+func (s *thinkingState) isTurnRunning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.turnRunning
+}
+
+// start begins the spinner fresh, with no live preview yet — used for a
+// genuinely new turn (RunStarted), where defaultThinkingLabel ("Run in
+// progress") is the only honest thing to show.
 func (s *thinkingState) start() {
+	s.startWithLabel("")
+}
+
+// startWithLabel is like start, but seeds the label the very first frame
+// shows instead of leaving it blank (which falls back to
+// defaultThinkingLabel for at least one frame). Used to resume the spinner
+// mid-turn when the caller already has a preview ready — e.g. the final
+// answer's first chunk, arriving in the same instant a reasoning block
+// closes — so there's no visible flash back to the generic "Run in
+// progress" caption before the next setLabel + animator tick catches up.
+func (s *thinkingState) startWithLabel(label string) {
 	s.mu.Lock()
 	if s.active {
 		s.mu.Unlock()
 		return
 	}
 	s.active = true
+	s.label = label
+	frameLabel := label
+	if frameLabel == "" {
+		frameLabel = defaultThinkingLabel
+	}
 
 	display, ok := s.out.(*promptDisplay)
 	if !ok {
-		fmt.Fprintln(s.out, "(thinking...)")
+		fmt.Fprintf(s.out, "(%s)\n", frameLabel)
 		s.mu.Unlock()
 		return
 	}
 	// Reserve the spinner line and draw its first frame atomically so no
 	// redraw or token can slip in between and shift the line the animator
 	// (and stop) expect one row above the prompt.
-	display.spinnerInit(spinnerFrames[0], "thinking...")
+	display.spinnerInit(spinnerFrames[0], frameLabel)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	s.cancel = cancel
@@ -2430,9 +2657,65 @@ func (s *thinkingState) animate(ctx context.Context, d *promptDisplay, done chan
 			return
 		case <-t.C:
 			ix = (ix + 1) % len(spinnerFrames)
-			d.spinnerFrame(spinnerFrames[ix], "thinking...")
+			d.spinnerFrame(spinnerFrames[ix], s.currentLabel())
 		}
 	}
+}
+
+// isSticky reports whether this thinkingState can show a persistent,
+// redrawing indicator (out is a *promptDisplay) rather than only the
+// one-shot fallback print. Callers that restart the spinner after every
+// discrete event (to keep "Run in progress" sticky for the whole run) should
+// gate on this, or the non-interactive fallback would reprint its one-shot
+// line after every single event instead of just once.
+func (s *thinkingState) isSticky() bool {
+	_, ok := s.out.(*promptDisplay)
+	return ok
+}
+
+// setLabel updates the live preview shown next to the spinner. Safe to call
+// whether or not the spinner is currently active/animating — the next tick
+// (or the next start()) picks it up; there's nothing to redraw synchronously.
+func (s *thinkingState) setLabel(text string) {
+	s.mu.Lock()
+	s.label = text
+	s.mu.Unlock()
+}
+
+// defaultThinkingLabel is the spinner caption shown whenever no live preview
+// is available — before the first token, and for stretches of a run (tool
+// execution, lifecycle events) that produce no streamed text of their own.
+const defaultThinkingLabel = "Run in progress"
+
+// currentLabel returns the live preview, falling back to defaultThinkingLabel
+// before any content has streamed in yet.
+func (s *thinkingState) currentLabel() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.label == "" {
+		return defaultThinkingLabel
+	}
+	return s.label
+}
+
+// thinkingPreviewMaxRunes caps the live preview label so a long streamed
+// line can't wrap and corrupt the single reserved spinner row.
+const thinkingPreviewMaxRunes = 60
+
+// thinkingPreviewLabel turns raw streamed text into a single-line, length
+// capped label: whitespace (including embedded newlines) collapses to single
+// spaces, and only the tail — the most recently streamed content — is kept,
+// since that's what makes a "still working" indicator feel live.
+func thinkingPreviewLabel(text string) string {
+	text = strings.Join(strings.Fields(text), " ")
+	if text == "" {
+		return ""
+	}
+	r := []rune(text)
+	if len(r) > thinkingPreviewMaxRunes {
+		return "…" + string(r[len(r)-thinkingPreviewMaxRunes:])
+	}
+	return text
 }
 
 // warmupState shows "Agent is warming up…" on attach for sessions still in
@@ -2985,10 +3268,13 @@ func sessionLimitErr(err error) bool {
 // not reconnect from: re-attaching would supersede the connection that just
 // superseded us, and the two would evict each other indefinitely.
 func drainStream(stream *godo.HostedAgentSessionStream, out io.Writer, pending *pendingHITL, cursor *eventCursor, thinking *thinkingState, warmup *warmupState, dedup *tokenDeduper) (superseded bool) {
-	// acc buffers the current assistant turn's tokens; the thinking spinner
-	// stays up for the whole turn and the buffered text is rendered as markdown
-	// when the run finishes or a discrete event interrupts it.
+	// acc buffers the current assistant turn's final-answer tokens; the
+	// thinking spinner stays up for the whole turn and the buffered text is
+	// rendered as markdown when the run finishes or a discrete event
+	// interrupts it. reasoning streams the same turn's is_reasoning=true
+	// chunks live and separately — see reasoningStreamer.
 	acc := &msgAccumulator{}
+	reasoning := &reasoningStreamer{out: out, thinking: thinking}
 	// awaiting is a FIFO queue of HITL approvals whose lines haven't printed
 	// yet: we hold each until a paired tool-call reveals the command being
 	// approved, so the approval shows "● Approval required · <command>" on one
@@ -2998,6 +3284,12 @@ func drainStream(stream *godo.HostedAgentSessionStream, out io.Writer, pending *
 	// The summary captured from the HITL payload is the fallback label when no
 	// paired tool call arrives to name the command.
 	var awaiting []awaitingApproval
+	// hitlLabels remembers the label each approval line was rendered with, so
+	// its resolution (run.human_input_received) can reprint the exact same
+	// "<status>  ·  <label>  ·  <id>" line instead of a disconnected receipt —
+	// entries are added wherever renderApprovalLine is called and removed once
+	// the matching resolution renders.
+	hitlLabels := map[string]string{}
 	for stream.Next() {
 		ev := stream.Current()
 
@@ -3006,9 +3298,10 @@ func drainStream(stream *godo.HostedAgentSessionStream, out io.Writer, pending *
 		if ev.Kind == hostedAgentEventKindStreamState {
 			var st hostedAgentStreamState
 			if err := json.Unmarshal(ev.Payload, &st); err == nil && st.State == hostedAgentStreamStateSuperseded {
+				reasoning.end()
 				thinking.stop()
 				acc.flush(out)
-				flushAwaitingApproval(out, &awaiting)
+				flushAwaitingApproval(out, &awaiting, hitlLabels)
 				fmt.Fprintf(out, "\n%s\n", msgSuperseded)
 				return true
 			}
@@ -3032,9 +3325,11 @@ func drainStream(stream *godo.HostedAgentSessionStream, out io.Writer, pending *
 		switch ev.Kind {
 		case godo.HostedAgentEventKindRunStarted:
 			warmup.clear()
+			thinking.setTurnRunning(true)
+			reasoning.end()
 			thinking.stop()
 			acc.flush(out)
-			flushAwaitingApproval(out, &awaiting)
+			flushAwaitingApproval(out, &awaiting, hitlLabels)
 			dedup.reset()
 			renderEvent(out, ev)
 			thinking.start()
@@ -3042,10 +3337,31 @@ func drainStream(stream *godo.HostedAgentSessionStream, out io.Writer, pending *
 			warmup.clear()
 			var p tokenChunkPayload
 			if err := json.Unmarshal(ev.Payload, &p); err == nil && dedup.allow(p.Text) {
-				acc.add(p.Text)
+				if p.IsReasoning {
+					// SPI TokenChunk.is_reasoning: stream live and separately
+					// from the final answer, which starts at the first
+					// is_reasoning=false chunk.
+					reasoning.stream(p.Text)
+				} else {
+					acc.add(p.Text)
+					// Buffered (not streamed raw) because the whole point is a
+					// clean markdown render once the message is complete; the
+					// live preview keeps the spinner from looking dead in the
+					// meantime.
+					label := thinkingPreviewLabel(acc.previewTail())
+					// endWithLabel (not end()+setLabel): if this chunk is the
+					// one closing out a reasoning block, the spinner it
+					// resumes should show this preview on its very first
+					// frame, not flash the generic "Run in progress" caption
+					// first — that flash is what looked like the indicator
+					// showing twice per turn.
+					reasoning.endWithLabel(label)
+					thinking.setLabel(label)
+				}
 			}
 		case godo.HostedAgentEventKindHITLRequested:
 			warmup.clear()
+			reasoning.end()
 			thinking.stop()
 			acc.flush(out)
 			dedup.reset()
@@ -3058,6 +3374,7 @@ func drainStream(stream *godo.HostedAgentSessionStream, out io.Writer, pending *
 			}
 		case godo.HostedAgentEventKindToolCallStarted:
 			warmup.clear()
+			reasoning.end()
 			thinking.stop()
 			acc.flush(out)
 			dedup.reset()
@@ -3073,9 +3390,23 @@ func drainStream(stream *godo.HostedAgentSessionStream, out io.Writer, pending *
 				if cmd == "" {
 					cmd = a.summary
 				}
+				hitlLabels[a.id] = cmd
 				renderApprovalLine(out, a.id, cmd)
 			} else {
 				renderToolStart(out, cmd)
+			}
+		case godo.HostedAgentEventKindHITLResolved:
+			warmup.clear()
+			reasoning.end()
+			thinking.stop()
+			acc.flush(out)
+			flushAwaitingApproval(out, &awaiting, hitlLabels)
+			dedup.reset()
+			var p hitlResolvedPayload
+			if err := json.Unmarshal(ev.Payload, &p); err == nil {
+				label := hitlLabels[p.HitlID]
+				delete(hitlLabels, p.HitlID)
+				renderApprovalResolvedLine(out, p.HitlID, label, p.Outcome)
 			}
 		case godo.HostedAgentEventKindSessionUpdated,
 			godo.HostedAgentEventKindRunSandboxAllocated,
@@ -3086,16 +3417,18 @@ func drainStream(stream *godo.HostedAgentSessionStream, out io.Writer, pending *
 			if warmup.noteBackendEvent(ev) {
 				continue
 			}
+			reasoning.end()
 			thinking.stop()
 			acc.flush(out)
-			flushAwaitingApproval(out, &awaiting)
+			flushAwaitingApproval(out, &awaiting, hitlLabels)
 			dedup.reset()
 			renderEvent(out, ev)
 		default:
 			warmup.clear()
+			reasoning.end()
 			thinking.stop()
 			acc.flush(out)
-			flushAwaitingApproval(out, &awaiting)
+			flushAwaitingApproval(out, &awaiting, hitlLabels)
 			dedup.reset()
 			renderEvent(out, ev)
 		}
@@ -3103,18 +3436,39 @@ func drainStream(stream *godo.HostedAgentSessionStream, out io.Writer, pending *
 		// A finished run means the server has cancelled any still-pending tool
 		// calls, so flush the local queue rather than leave stale entries.
 		if ev.Kind == godo.HostedAgentEventKindRunCompleted || ev.Kind == godo.HostedAgentEventKindRunFailed {
+			thinking.setTurnRunning(false)
 			if n := pending.reset(); n > 0 {
 				fmt.Fprintf(out, "(%d pending approval(s) cancelled — run ended)\n", n)
 			}
+		}
+
+		// Every other case above stops the spinner before printing its own
+		// discrete line, so restart it here — once, after whatever just
+		// rendered — for as long as the run is still open. This is what makes
+		// "Run in progress" sticky across the whole run instead of just the
+		// gap before the first token: a tool call that takes 7 seconds
+		// otherwise looks identical to a hung session. Skip it while a HITL
+		// approval is pending (that already has its own visible y/n/d
+		// prompt); skip it for the non-interactive fallback (isSticky false)
+		// so a piped/line-mode consumer doesn't get the one-shot notice
+		// reprinted after every event; and skip it for TokenChunk, which
+		// manages the spinner itself (reasoningStreamer stops it for exactly
+		// one reasoning block and restarts it on end(), while the buffered
+		// final-answer path never stops it at all) — restarting here too
+		// would fight that pairing and reinit the spinner mid-line.
+		if ev.Kind != godo.HostedAgentEventKindTokenChunk &&
+			thinking.isTurnRunning() && pending.len() == 0 && thinking.isSticky() {
+			thinking.start()
 		}
 
 		cursor.set(ev.EventID)
 	}
 	// Stream ended without a terminal run event (e.g. transient disconnect):
 	// render whatever assistant text we have so it isn't lost.
+	reasoning.end()
 	thinking.stop()
 	acc.flush(out)
-	flushAwaitingApproval(out, &awaiting)
+	flushAwaitingApproval(out, &awaiting, hitlLabels)
 	return false
 }
 
@@ -3128,9 +3482,14 @@ type awaitingApproval struct {
 
 // flushAwaitingApproval prints any still-unpaired approval lines (oldest
 // first), using the label captured from each HITL payload when no tool call
-// named the command, then clears the queue.
-func flushAwaitingApproval(out io.Writer, awaiting *[]awaitingApproval) {
+// named the command, then clears the queue. Each printed label is recorded in
+// hitlLabels (may be nil) so the eventual resolution can reprint the same
+// label instead of a disconnected receipt.
+func flushAwaitingApproval(out io.Writer, awaiting *[]awaitingApproval, hitlLabels map[string]string) {
 	for _, a := range *awaiting {
+		if hitlLabels != nil {
+			hitlLabels[a.id] = a.summary
+		}
 		renderApprovalLine(out, a.id, a.summary)
 	}
 	*awaiting = nil
@@ -3266,7 +3625,7 @@ func (p *pendingHITL) reset() int {
 	return n
 }
 
-func attachLoop(c *CmdConfig, svc do.HostedAgentsService, sessionID string, in io.Reader, state *attachState) error {
+func attachLoop(c *CmdConfig, svc do.HostedAgentsService, sessionID string, in io.Reader, state *attachState, thinking *thinkingState) error {
 	pending := state.pending
 	reader := bufio.NewReader(in)
 	lines := startAttachLineReader(reader)
@@ -3367,7 +3726,7 @@ func attachLoop(c *CmdConfig, svc do.HostedAgentsService, sessionID string, in i
 			case largePasteSendTogether:
 			case largePasteSendSeparately:
 				for _, part := range splitSubmittedLines(line) {
-					if detach := processAttachLine(c, svc, sessionID, part, state, nil); detach {
+					if detach := processAttachLine(c, svc, sessionID, part, state, nil, thinking); detach {
 						return nil
 					}
 				}
@@ -3387,7 +3746,7 @@ func attachLoop(c *CmdConfig, svc do.HostedAgentsService, sessionID string, in i
 			fmt.Fprintf(c.Out, "send failed: %v\n", err)
 			continue
 		}
-		fmt.Fprintln(c.Out, colorize("… waiting for the agent", colMuted))
+		printAttachSendAck(c.Out, nil, thinking)
 	}
 }
 
@@ -3658,6 +4017,22 @@ func (s *attachState) moveLineCursor(delta int) bool {
 	return true
 }
 
+// insertNewlineAtCursor inserts a literal newline at the caret without
+// submitting — used by Option/Alt+Enter to compose a multi-line message. The
+// prompt still displays lineBuf flattened to one row (displayInputBuffer
+// swaps '\n' for a space) but the real newline is preserved and restored by
+// submittedInput when the message is finally sent.
+func (s *attachState) insertNewlineAtCursor() {
+	s.mu.Lock()
+	if s.cursor >= len(s.lineBuf) {
+		s.lineBuf = append(s.lineBuf, '\n')
+	} else {
+		s.lineBuf = append(s.lineBuf[:s.cursor], append([]byte{'\n'}, s.lineBuf[s.cursor:]...)...)
+	}
+	s.cursor++
+	s.mu.Unlock()
+}
+
 func displayInputBuffer(buf []byte) string {
 	if len(buf) == 0 {
 		return ""
@@ -3811,6 +4186,20 @@ func handleAttachEscapeSequence(b byte, state *attachState) bool {
 			state.display.redraw()
 		}
 		return true
+	case bytes.Equal(seq, []byte{0x1b, 0x0d}), bytes.Equal(seq, []byte{0x1b, 0x0a}):
+		// Option/Alt+Enter: most terminals (iTerm2 and Terminal.app's default
+		// "Option key: Esc+" setting, plus anything else that encodes Meta as
+		// a plain ESC prefix) send this as ESC followed by CR/LF. Treat it as
+		// "insert a newline" instead of submitting, so a message can span
+		// multiple lines — mirroring how a pasted multi-line block already
+		// lands in lineBuf (appendBufferedInput) and is restored to real
+		// newlines on submit (submittedInput).
+		state.escSeq = nil
+		if state.pending.get() == "" {
+			state.insertNewlineAtCursor()
+			state.display.redraw()
+		}
+		return true
 	case isKnownEscPrefix(seq):
 		return true
 	default:
@@ -3819,6 +4208,14 @@ func handleAttachEscapeSequence(b byte, state *attachState) bool {
 	}
 }
 
+// handlePastedByte buffers one byte of a bracketed paste into the line
+// buffer. It deliberately does *not* redraw on every byte: paintPromptLocked
+// only erases the terminal's current row (\x1b[K), so repainting a
+// still-growing, terminal-width-wrapping line hundreds of times in a row — a
+// large paste is exactly that — leaves every earlier, shorter wrapped block
+// behind as stale duplicate lines instead of a single clean one. Buffering
+// silently and painting once, when the paste actually ends, avoids that
+// entirely and is far cheaper besides.
 func handlePastedByte(b byte, state *attachState) {
 	if len(state.escSeq) > 0 || b == 0x1b {
 		if len(state.escSeq) == 0 {
@@ -3836,15 +4233,11 @@ func handlePastedByte(b byte, state *attachState) {
 		if isPrefix(seq, bracketedPasteEnd) {
 			return
 		}
-		if appendBufferedInput(state, seq) {
-			state.display.redraw()
-		}
+		appendBufferedInput(state, seq)
 		state.escSeq = nil
 		return
 	}
-	if appendBufferedInput(state, []byte{b}) {
-		state.display.redraw()
-	}
+	appendBufferedInput(state, []byte{b})
 }
 
 // promptDisplay serializes terminal writes between the input loop and the
@@ -4181,7 +4574,7 @@ func (p *promptDisplay) warmupStop() {
 // attachLoopTTY runs the raw-mode byte-by-byte input state machine. A 50ms
 // ticker polls pending-HITL so a HITL event flips the prompt instantly,
 // without needing the user to press Enter to "wake up" the loop.
-func attachLoopTTY(c *CmdConfig, svc do.HostedAgentsService, sessionID string, f *os.File, state *attachState, warmup *warmupState) error {
+func attachLoopTTY(c *CmdConfig, svc do.HostedAgentsService, sessionID string, f *os.File, state *attachState, warmup *warmupState, thinking *thinkingState) error {
 	fd := int(f.Fd())
 	oldState, err := term.MakeRaw(fd)
 	if err != nil {
@@ -4189,7 +4582,7 @@ func attachLoopTTY(c *CmdConfig, svc do.HostedAgentsService, sessionID string, f
 		if warmup != nil {
 			warmup.start()
 		}
-		return attachLoop(c, svc, sessionID, f, state)
+		return attachLoop(c, svc, sessionID, f, state, thinking)
 	}
 	defer term.Restore(fd, oldState)
 	setBracketedPasteMode(f, true)
@@ -4231,7 +4624,7 @@ func attachLoopTTY(c *CmdConfig, svc do.HostedAgentsService, sessionID string, f
 		}
 		select {
 		case b := <-bytesCh:
-			stop, err := handleAttachByte(c, svc, sessionID, b, state, warmup)
+			stop, err := handleAttachByte(c, svc, sessionID, b, state, warmup, thinking)
 			if err != nil {
 				return err
 			}
@@ -4251,13 +4644,13 @@ func attachLoopTTY(c *CmdConfig, svc do.HostedAgentsService, sessionID string, f
 
 // handleAttachByte is the per-byte state machine. stop=true exits the loop
 // (Ctrl-C, Ctrl-D on empty line).
-func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string, b byte, state *attachState, warmup *warmupState) (stop bool, err error) {
+func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string, b byte, state *attachState, warmup *warmupState, thinking *thinkingState) (stop bool, err error) {
 	if confirm := state.largePasteConfirmation(); confirm != nil {
 		switch b {
 		case 'y', 'Y':
 			state.display.echo([]byte{b, '\r', '\n'})
 			state.takeLargePasteConfirmation()
-			if detach := processAttachLine(c, svc, sessionID, confirm.text, state, nil); detach {
+			if detach := processAttachLine(c, svc, sessionID, confirm.text, state, nil, thinking); detach {
 				return true, nil
 			}
 			state.display.redraw()
@@ -4266,7 +4659,7 @@ func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string
 			state.display.echo([]byte("\r\n"))
 			state.takeLargePasteConfirmation()
 			for _, part := range splitSubmittedLines(confirm.text) {
-				if detach := processAttachLine(c, svc, sessionID, part, state, nil); detach {
+				if detach := processAttachLine(c, svc, sessionID, part, state, nil, thinking); detach {
 					return true, nil
 				}
 			}
@@ -4284,10 +4677,10 @@ func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string
 	}
 	if state.pasting {
 		handlePastedByte(b, state)
+		// noteQueued already repaints the warm-up banner's own queued-status
+		// row itself when relevant; no need for a second, redundant redraw of
+		// the whole prompt on every pasted byte.
 		warmup.noteQueued()
-		if warmup.isBannerVisible() {
-			state.display.redraw()
-		}
 		return false, nil
 	}
 	if handleAttachEscapeSequence(b, state) {
@@ -4348,7 +4741,7 @@ func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string
 				state.display.redraw()
 				return false, nil
 			}
-			if detach := processAttachLine(c, svc, sessionID, line, state, warmup); detach {
+			if detach := processAttachLine(c, svc, sessionID, line, state, warmup, thinking); detach {
 				return true, nil
 			}
 		}
@@ -4478,7 +4871,7 @@ func completeAttachSlashCommand(c *CmdConfig, state *attachState) {
 // processAttachLine dispatches an Enter-submitted line: HITL word shortcut,
 // slash command, or SendInput. Returns detach=true when the session can no
 // longer accept input (terminal run) and the loop should exit.
-func processAttachLine(c *CmdConfig, svc do.HostedAgentsService, sessionID, line string, state *attachState, warmup *warmupState) (detach bool) {
+func processAttachLine(c *CmdConfig, svc do.HostedAgentsService, sessionID, line string, state *attachState, warmup *warmupState, thinking *thinkingState) (detach bool) {
 	if outcome, ok := hitlLetterShortcut(line); ok {
 		if id := state.pending.get(); id != "" {
 			if err := svc.ResolveHITL(sessionID, id, &godo.HostedAgentResolveHITLRequest{
@@ -4513,7 +4906,7 @@ func processAttachLine(c *CmdConfig, svc do.HostedAgentsService, sessionID, line
 	if warmup != nil && warmup.isActive() {
 		warmup.markInputQueued()
 	}
-	printAttachSendAck(c.Out, warmup)
+	printAttachSendAck(c.Out, warmup, thinking)
 	return false
 }
 
@@ -4636,23 +5029,51 @@ func splitAttachTransferArgs(args []string) (positional []string, archive bool) 
 }
 
 // attachUploadFromArgs implements the interactive `/upload` command, mirroring
-// `doctl agents upload` without requiring cobra flag parsing.
+// `doctl agents upload` without requiring cobra flag parsing. workspace-path is
+// optional — like `curl -O`, it defaults to the local file's basename at the
+// workspace root, since retyping an identical filename twice is just noise.
 func attachUploadFromArgs(c *CmdConfig, sessionID string, args []string) error {
 	positional, archive := splitAttachTransferArgs(args)
-	if len(positional) != 2 {
-		return fmt.Errorf("usage: /upload <local-file> <workspace-path> [--archive]")
+	if len(positional) < 1 || len(positional) > 2 {
+		return fmt.Errorf("usage: /upload <local-file> [workspace-path] [--archive]")
 	}
-	return runWorkspaceUpload(c, sessionID, positional[0], positional[1], archive)
+	localFile := positional[0]
+	workspacePath := ""
+	if len(positional) == 2 {
+		workspacePath = positional[1]
+	} else {
+		base := filepath.Base(localFile)
+		if base == "" || base == "." || base == string(filepath.Separator) {
+			return fmt.Errorf("usage: /upload <local-file> <workspace-path> [--archive]  (couldn't infer a workspace filename from %q)", localFile)
+		}
+		workspacePath = base
+	}
+	return runWorkspaceUpload(c, sessionID, localFile, workspacePath, archive)
 }
 
 // attachDownloadFromArgs implements the interactive `/download` command,
 // mirroring `doctl agents download` without requiring cobra flag parsing.
+// local-file is optional — like `curl -O`, it defaults to the workspace
+// path's basename in the current directory.
 func attachDownloadFromArgs(c *CmdConfig, svc do.HostedAgentsService, sessionID string, args []string) error {
 	positional, archive := splitAttachTransferArgs(args)
-	if len(positional) != 2 {
-		return fmt.Errorf("usage: /download <workspace-path> <local-file> [--archive]")
+	if len(positional) < 1 || len(positional) > 2 {
+		return fmt.Errorf("usage: /download <workspace-path> [local-file] [--archive]")
 	}
-	return runWorkspaceDownload(c, svc, sessionID, positional[0], positional[1], archive)
+	workspacePath := positional[0]
+	localFile := ""
+	if len(positional) == 2 {
+		localFile = positional[1]
+	} else {
+		// Workspace paths are POSIX (remote Linux sandbox) regardless of the
+		// host OS running doctl, so use path.Base rather than filepath.Base.
+		base := path.Base(strings.TrimSuffix(workspacePath, "/"))
+		if base == "" || base == "." || base == "/" {
+			return fmt.Errorf("usage: /download <workspace-path> <local-file> [--archive]  (couldn't infer a local filename from %q)", workspacePath)
+		}
+		localFile = base
+	}
+	return runWorkspaceDownload(c, svc, sessionID, workspacePath, localFile, archive)
 }
 
 // listPendingHITLs renders the current HITL queue. The head is marked with
@@ -4708,6 +5129,10 @@ const runSeparator = "───────────────────�
 
 type tokenChunkPayload struct {
 	Text string `json:"text"`
+	// IsReasoning is true when this chunk is model reasoning/"thinking"
+	// rather than the user-visible answer (SPI TokenChunk.is_reasoning). The
+	// final answer begins at the first chunk where this is false.
+	IsReasoning bool `json:"is_reasoning"`
 }
 
 type runStartedPayload struct {
@@ -4895,6 +5320,23 @@ func renderEvent(w io.Writer, ev godo.HostedAgentEvent) {
 	}
 }
 
+// hitlOutcomeStatus returns the bold "<icon> <Verb>" status matching
+// renderApprovalLine's "● Approval required" segment, so the resolved line
+// reads as the same entry, just updated — approve green, reject red, defer
+// yellow.
+func hitlOutcomeStatus(code int32) string {
+	switch code {
+	case 1:
+		return boldColor("✓ Approved", colSuccess)
+	case 2:
+		return boldColor("✗ Rejected", colError)
+	case 3:
+		return boldColor("⏸ Deferred", colWarning)
+	default:
+		return boldColor("• "+hitlOutcomeLabel(code), colMuted)
+	}
+}
+
 // hitlOutcomeStyled renders a HITL outcome verb with a matching color:
 // approve green, reject red, defer yellow.
 func hitlOutcomeStyled(code int32) string {
@@ -4975,7 +5417,7 @@ func printAttachBanner(w io.Writer, sess *do.HostedAgentSession, bridgeNote stri
 	fmt.Fprintln(&body, colorize("Press Ctrl + D to detach locally", colMuted))
 
 	fmt.Fprintln(&body)
-	fmt.Fprintf(&body, "type a message and press %s\n", colorize("Enter", colHighlight))
+	fmt.Fprintf(&body, "type a message and press %s (%s for a new line)\n", colorize("Enter", colHighlight), colorize("Option/Alt + Enter", colHighlight))
 	yn := colorize("y", colSuccess) + colorize("/a", colSuccess) + " approve · " +
 		colorize("n", colError) + colorize("/r", colError) + " reject · " +
 		colorize("d", colWarning) + " defer"
@@ -5010,8 +5452,8 @@ func printAttachHelp(w io.Writer) {
 	writeHelpSection(&body, "Session controls", []helpRow{
 		{"/pause", "pause the session"},
 		{"/resume", "resume a paused session"},
-		{"/upload <file> <dest> [--archive]", "upload into the workspace"},
-		{"/download <src> <file> [--archive]", "download from the workspace"},
+		{"/upload <file> [dest] [--archive]", "upload into the workspace"},
+		{"/download <src> [file] [--archive]", "download from the workspace"},
 	})
 	fmt.Fprintln(&body)
 	writeHelpSection(&body, "Approvals pending (no Enter needed in a TTY)", []helpRow{
@@ -5025,6 +5467,7 @@ func printAttachHelp(w io.Writer) {
 	})
 	fmt.Fprintln(&body)
 	writeHelpSection(&body, "Other", []helpRow{
+		{"Option/Alt + Enter", "insert a newline (compose a multi-line message)"},
 		{"/ then Tab", "autocomplete a command"},
 		{agentCLI + " attach <session>", "reattach after detaching"},
 		{agentCLI + " remove <session>", "remove the session"},
@@ -5067,21 +5510,39 @@ func prettyAgentKind(k godo.HostedAgentKind) string {
 	return "agent"
 }
 
+// renderHITLStatusLine prints the shared "<status>  ·  <label>  ·  <id>"
+// structure behind both renderApprovalLine and renderApprovalResolvedLine, so
+// a resolution reads as an update to the request's line rather than an
+// unrelated one. fallback fills the label slot when label is empty; pass ""
+// to omit that segment entirely.
+func renderHITLStatusLine(w io.Writer, status, label, fallback, hitlID string) {
+	parts := []string{status}
+	switch {
+	case label != "":
+		parts = append(parts, boldColor(label, colHighlight))
+	case fallback != "":
+		parts = append(parts, colorize(fallback, colMuted))
+	}
+	parts = append(parts, colorize(hitlID, colMuted))
+	fmt.Fprintf(w, "\n%s\n", strings.Join(parts, colorize("  ·  ", colMuted)))
+}
+
 // renderApprovalLine prints the one-line approval prompt with an optional
 // command and the full HITL request id. The outcomes are shown by the
 // interactive menu.
 func renderApprovalLine(w io.Writer, hitlID, cmd string) {
-	parts := []string{boldColor("● Approval required", colWarning)}
-	if cmd != "" {
-		parts = append(parts, boldColor(cmd, colHighlight))
-	} else {
-		// The adapter didn't tell us what this approval is for (no command in
-		// the HITL payload and no paired tool call). Label it rather than
-		// leaving a bare id that reads as a glitch.
-		parts = append(parts, colorize("action pending", colMuted))
-	}
-	parts = append(parts, colorize(hitlID, colMuted))
-	fmt.Fprintf(w, "\n%s\n", strings.Join(parts, colorize("  ·  ", colMuted)))
+	// The adapter didn't tell us what this approval is for (no command in
+	// the HITL payload and no paired tool call). Label it rather than
+	// leaving a bare id that reads as a glitch.
+	renderHITLStatusLine(w, boldColor("● Approval required", colWarning), cmd, "action pending", hitlID)
+}
+
+// renderApprovalResolvedLine prints a HITL resolution using the exact same
+// layout as renderApprovalLine (status  ·  label  ·  id) with label carried
+// over from the original request, so it reads as that line updating in
+// place rather than a disconnected "<id> approve" receipt.
+func renderApprovalResolvedLine(w io.Writer, hitlID, label string, outcome int32) {
+	renderHITLStatusLine(w, hitlOutcomeStatus(outcome), label, "", hitlID)
 }
 
 // renderToolStart prints the "running a tool" line.

--- a/commands/agents.go
+++ b/commands/agents.go
@@ -4049,14 +4049,20 @@ func (s *attachState) insertNewlineAtCursor() {
 	s.mu.Unlock()
 }
 
+// newlineMarker stands in for an embedded newline in the flattened
+// single-row prompt display. Collapsing to a plain space (the original
+// behavior) made Option/Alt+Enter look like it had done nothing until the
+// message was actually sent — this makes the line break visible in place.
+const newlineMarker = " ↵ "
+
 func displayInputBuffer(buf []byte) string {
 	if len(buf) == 0 {
 		return ""
 	}
 	line := string(buf)
-	line = strings.ReplaceAll(line, "\r\n", " ")
-	line = strings.ReplaceAll(line, "\n", " ")
-	line = strings.ReplaceAll(line, "\r", " ")
+	line = strings.ReplaceAll(line, "\r\n", newlineMarker)
+	line = strings.ReplaceAll(line, "\n", newlineMarker)
+	line = strings.ReplaceAll(line, "\r", newlineMarker)
 	return line
 }
 

--- a/commands/agents_anthropic.go
+++ b/commands/agents_anthropic.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAnthropicAPIBase = "https://api.anthropic.com"
+	// anthropicBaseURLEnv mirrors the Anthropic SDKs' own override, so a key
+	// pointed at a proxy/gateway validates against that proxy too.
+	anthropicBaseURLEnv    = "ANTHROPIC_BASE_URL"
+	anthropicAPIVersion    = "2023-06-01"
+	anthropicModelsPath    = "/v1/models"
+	anthropicKeyCheckLabel = "Validating Anthropic API key…"
+)
+
+// validateAnthropicAPIKey is a var (not a plain func) so tests can stub it
+// out — mirrors createOpenAIAgentsSession. It calls GET /v1/models, a free,
+// side-effect-free endpoint that still requires a valid key, so a bogus
+// ANTHROPIC_API_KEY (empty check in ensureEnvVar only catches unset/blank)
+// is caught locally with a clear message instead of surfacing later as an
+// opaque failure deep inside the hosted claude-code sandbox.
+var validateAnthropicAPIKey = func(ctx context.Context, apiKey string) error {
+	return newHTTPAnthropicClient().checkAPIKey(ctx, apiKey)
+}
+
+type httpAnthropicClient struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func newHTTPAnthropicClient() *httpAnthropicClient {
+	return &httpAnthropicClient{
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+		baseURL:    resolveAnthropicBaseURL(),
+	}
+}
+
+func resolveAnthropicBaseURL() string {
+	if v := strings.TrimRight(strings.TrimSpace(os.Getenv(anthropicBaseURLEnv)), "/"); v != "" {
+		return v
+	}
+	return defaultAnthropicAPIBase
+}
+
+// checkAPIKey confirms apiKey is accepted by Anthropic before doctl ever
+// calls CreateSessionFromManifest. Any non-2xx response (401/403 for a bad
+// key, or anything else) fails the same way the OpenAI codex path already
+// fails fast on a bad OPENAI_API_KEY: locally, before a hosted session is
+// created that was never going to work.
+func (c *httpAnthropicClient) checkAPIKey(ctx context.Context, apiKey string) error {
+	url := c.baseURL + anthropicModelsPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", anthropicAPIVersion)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("validating %s: %w", anthropicAPIKeyEnv, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	detail := truncateForErr(raw)
+	if detail == "" {
+		detail = "(empty body)"
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("%s was rejected by Anthropic (HTTP %d): %s", anthropicAPIKeyEnv, resp.StatusCode, detail)
+	}
+	return fmt.Errorf("validating %s failed (HTTP %d) GET %s: %s", anthropicAPIKeyEnv, resp.StatusCode, url, detail)
+}

--- a/commands/agents_anthropic_test.go
+++ b/commands/agents_anthropic_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPAnthropicClient_CheckAPIKey(t *testing.T) {
+	t.Run("accepts a valid key", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/v1/models", r.URL.Path)
+			assert.Equal(t, "sk-ant-good", r.Header.Get("x-api-key"))
+			assert.Equal(t, anthropicAPIVersion, r.Header.Get("anthropic-version"))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		}))
+		defer srv.Close()
+
+		c := &httpAnthropicClient{httpClient: srv.Client(), baseURL: srv.URL}
+		require.NoError(t, c.checkAPIKey(context.Background(), "sk-ant-good"))
+	})
+
+	t.Run("rejects an invalid key with a clear message", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`))
+		}))
+		defer srv.Close()
+
+		c := &httpAnthropicClient{httpClient: srv.Client(), baseURL: srv.URL}
+		err := c.checkAPIKey(context.Background(), "sk-ant-bogus")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), anthropicAPIKeyEnv)
+		assert.Contains(t, err.Error(), "rejected by Anthropic")
+		assert.Contains(t, err.Error(), "invalid x-api-key")
+	})
+
+	t.Run("surfaces an unexpected status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`boom`))
+		}))
+		defer srv.Close()
+
+		c := &httpAnthropicClient{httpClient: srv.Client(), baseURL: srv.URL}
+		err := c.checkAPIKey(context.Background(), "sk-ant-good")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HTTP 500")
+	})
+}
+
+func TestResolveAnthropicBaseURL(t *testing.T) {
+	t.Run("defaults to the public API", func(t *testing.T) {
+		t.Setenv(anthropicBaseURLEnv, "")
+		assert.Equal(t, defaultAnthropicAPIBase, resolveAnthropicBaseURL())
+	})
+
+	t.Run("honors an override, trimming trailing slashes", func(t *testing.T) {
+		t.Setenv(anthropicBaseURLEnv, "https://proxy.example.com/anthropic/")
+		assert.Equal(t, "https://proxy.example.com/anthropic", resolveAnthropicBaseURL())
+	})
+}

--- a/commands/agents_errors.go
+++ b/commands/agents_errors.go
@@ -82,7 +82,7 @@ func (e *agentPrettyError) DisplayError() string {
 		reason = strings.TrimSpace(e.cause.Error())
 	}
 	if reason != "" && !strings.EqualFold(reason, title) {
-		b.WriteString(cardRow("Reason", reason))
+		fmt.Fprintf(&b, "  %s\n", reason)
 	}
 	if e.status > 0 {
 		b.WriteString(cardRow("Status", colorize(httpStatusLabel(e.status), colMuted)))
@@ -95,7 +95,7 @@ func (e *agentPrettyError) DisplayError() string {
 			if tip == "" {
 				continue
 			}
-			b.WriteString(cardRow("•", tip))
+			fmt.Fprintf(&b, "  %s\n", tip)
 		}
 	}
 	return strings.TrimRight(b.String(), "\n")

--- a/commands/agents_run.go
+++ b/commands/agents_run.go
@@ -353,10 +353,12 @@ func buildHarnessManifest(harness, repo, prompt, name string) ([]byte, error) {
 	case agent == claudeCodeAgentName:
 		// Claude Code needs its own inference key just like Codex needs
 		// OPENAI_API_KEY. Referencing it here (rather than baking in a
-		// literal) routes through expandManifestEnvCollect/ensureEnvVar so a
-		// missing key is caught — and prompted for on a TTY — before doctl
-		// ever calls CreateSessionFromManifest, instead of failing deep into
-		// a hosted session that was never going to work.
+		// literal) still routes through expandManifestEnvCollect/ensureEnvVar
+		// so a missing key is prompted for on a TTY, but a present-but-bogus
+		// key is caught too: prepareClaudeCodeStart validates it against
+		// Anthropic's API before doctl ever calls CreateSessionFromManifest,
+		// instead of failing deep into a hosted session that was never going
+		// to work.
 		doc.Env = map[string]string{
 			"ANTHROPIC_API_KEY": "${" + anthropicAPIKeyEnv + "}",
 		}
@@ -475,6 +477,11 @@ func startSessionFromRawManifest(c *CmdConfig, raw []byte, prog *creationProgres
 			prog.ok("OpenAI Agents environment ready")
 		}
 	}
+
+	if err := prepareClaudeCodeStart(context.Background(), raw, prog); err != nil {
+		return nil, err
+	}
+
 	lookup := envLookupWithOverlay(envOverlay)
 	manifest, err := expandManifestEnvCollect(raw, lookup)
 	if err != nil {
@@ -504,6 +511,38 @@ func startSessionFromRawManifest(c *CmdConfig, raw []byte, prog *creationProgres
 		prog.ok(fmt.Sprintf("Session created · %s", displaySessionRef(sess)))
 	}
 	return sess, nil
+}
+
+// prepareClaudeCodeStart mirrors prepareOpenAISandboxStart for claude-code:
+// it resolves ANTHROPIC_API_KEY (prompting on a TTY if missing, exactly like
+// ensureEnvVar already did) and then confirms Anthropic actually accepts it
+// with a real, free API call — closing the gap where a bogus (but non-empty)
+// key used to sail through to CreateSessionFromManifest and only fail deep
+// inside the hosted sandbox. No-ops for every other harness.
+func prepareClaudeCodeStart(ctx context.Context, raw []byte, prog *creationProgress) error {
+	doc, err := parseAgentManifest(raw)
+	if err != nil {
+		return err
+	}
+	if doc.adapter() != claudeCodeAgentName {
+		return nil
+	}
+
+	apiKey, err := ensureEnvVar(anthropicAPIKeyEnv)
+	if err != nil {
+		return fmt.Errorf("%s is required to start a %s session: %w", anthropicAPIKeyEnv, claudeCodeAgentName, err)
+	}
+
+	if prog != nil {
+		prog.wait(anthropicKeyCheckLabel)
+	}
+	if err := validateAnthropicAPIKey(ctx, apiKey); err != nil {
+		return err
+	}
+	if prog != nil {
+		prog.ok("Anthropic API key OK")
+	}
+	return nil
 }
 
 func manifestNeedsOpenAIPrepare(raw []byte) (bool, error) {

--- a/commands/agents_run.go
+++ b/commands/agents_run.go
@@ -21,12 +21,14 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/commands/charm/confirm"
 	"github.com/digitalocean/doctl/do"
 	"github.com/digitalocean/godo"
+	"golang.org/x/term"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -82,6 +84,9 @@ func maybeOfferGitHubAuth(c *CmdConfig) error {
 const (
 	defaultCodexRunModel = "gpt-5.6-sol"
 	defaultRunWait       = 5 * time.Minute
+
+	claudeCodeAgentName = "claude-code"
+	anthropicAPIKeyEnv  = "ANTHROPIC_API_KEY"
 )
 
 var (
@@ -100,6 +105,33 @@ var harnessAgentNames = map[string]string{
 	"codex":          openAIAgentsAdapter,
 	"codex-agentapi": openAIAgentsAdapter,
 	"openai-codex":   openAIAgentsAdapter,
+}
+
+// harnessDisplayNames maps canonical flat-manifest agent keys (the values of
+// harnessAgentNames) to their proper display name, matching the casing used
+// by prettyAgentKind (e.g. "opencode" -> "OpenCode").
+var harnessDisplayNames = map[string]string{
+	"opencode":          "OpenCode",
+	"claude-code":       "Claude Code",
+	openAIAgentsAdapter: "Codex",
+}
+
+// prettyHarnessName returns the display name for a raw --harness value or
+// alias (case-insensitive), matching agentKindDisplayNames' casing. Falls
+// back to the trimmed input when the harness isn't recognized.
+func prettyHarnessName(h string) string {
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return ""
+	}
+	canon, ok := harnessAgentNames[strings.ToLower(h)]
+	if !ok {
+		canon = strings.ToLower(h)
+	}
+	if name, ok := harnessDisplayNames[canon]; ok {
+		return name
+	}
+	return h
 }
 
 // RunAgentsRun creates a hosted agent session from --harness/--gh-repo/--prompt
@@ -174,6 +206,7 @@ func RunAgentsRun(c *CmdConfig) error {
 	}
 
 	prog := newCreationProgress(c.Out)
+	defer prog.stop()
 	prog.header("Launching agent session")
 
 	var (
@@ -310,12 +343,23 @@ func buildHarnessManifest(harness, repo, prompt, name string) ([]byte, error) {
 		doc.Name = name
 	}
 
-	if isOpenAISandboxAdapter(agent) {
+	switch {
+	case isOpenAISandboxAdapter(agent):
 		doc.Env = map[string]string{
 			"CODEX_ENVIRONMENT_ID": "${ENV_ID}",
 			"CODEX_API_KEY":        "${OPENAI_API_KEY}",
 		}
 		doc.Config = defaultCodexRunConfig(prompt)
+	case agent == claudeCodeAgentName:
+		// Claude Code needs its own inference key just like Codex needs
+		// OPENAI_API_KEY. Referencing it here (rather than baking in a
+		// literal) routes through expandManifestEnvCollect/ensureEnvVar so a
+		// missing key is caught — and prompted for on a TTY — before doctl
+		// ever calls CreateSessionFromManifest, instead of failing deep into
+		// a hosted session that was never going to work.
+		doc.Env = map[string]string{
+			"ANTHROPIC_API_KEY": "${" + anthropicAPIKeyEnv + "}",
+		}
 	}
 
 	out, err := yaml.Marshal(doc)
@@ -468,20 +512,45 @@ func manifestNeedsOpenAIPrepare(raw []byte) (bool, error) {
 	return isOpenAISandboxAdapter(doc.adapter()) || hasOpenAICreateBody(doc), nil
 }
 
+// creationSpinnerInterval controls how often the live spinner frame advances
+// while creationProgress.wait animates a line on a real terminal.
+var creationSpinnerInterval = 120 * time.Millisecond
+
 // creationProgress prints Plano-style lifecycle lines during session create/wait.
+// On a real terminal, wait() animates a single overwritten line (spinner +
+// ticking elapsed time) instead of a static "…" line, so a slow blocking call
+// (e.g. the initial create-session round trip) still looks alive. Piped or
+// non-TTY output (including tests) keeps the old one-line-per-call behavior.
 type creationProgress struct {
 	out   io.Writer
 	start time.Time
+	spin  *lineSpinner
 }
 
 func newCreationProgress(out io.Writer) *creationProgress {
 	return &creationProgress{out: out, start: creationClock()}
 }
 
+func (p *creationProgress) stopSpin() {
+	if p == nil || p.spin == nil {
+		return
+	}
+	p.spin.stopAndClear()
+	p.spin = nil
+}
+
+// stop ends any in-flight spinner animation, leaving the cursor on a clean
+// line. Callers should defer this right after newCreationProgress so an
+// early return (error path) never leaves a half-drawn spinner line behind.
+func (p *creationProgress) stop() {
+	p.stopSpin()
+}
+
 func (p *creationProgress) header(msg string) {
 	if p == nil {
 		return
 	}
+	p.stopSpin()
 	fmt.Fprintln(p.out, boldColor(msg, colHighlight))
 }
 
@@ -489,20 +558,33 @@ func (p *creationProgress) step(msg string) {
 	if p == nil {
 		return
 	}
+	p.stopSpin()
 	fmt.Fprintf(p.out, "%s %s\n", colorize("•", colHighlight), colorize(msg, colHighlight))
 }
 
+// wait announces a step that involves waiting on a network call. On a TTY it
+// animates in place; repeated calls while already animating just relabel the
+// spinner (e.g. periodic provisioning hints) instead of printing new lines.
 func (p *creationProgress) wait(msg string) {
 	if p == nil {
 		return
 	}
-	fmt.Fprintf(p.out, "%s %s\n", colorize("…", colWarning), colorize(msg, colWarning))
+	if p.spin != nil {
+		p.spin.setLabel(msg)
+		return
+	}
+	if isTerminalWriter(p.out) {
+		p.spin = newLineSpinner(p.out, msg, p.start)
+		return
+	}
+	fmt.Fprintf(p.out, "%s %s %s\n", colorize("…", colWarning), colorize(msg, colWarning), colorize(fmt.Sprintf("(%s)", p.elapsed()), colMuted))
 }
 
 func (p *creationProgress) ok(msg string) {
 	if p == nil {
 		return
 	}
+	p.stopSpin()
 	fmt.Fprintf(p.out, "%s %s\n", colorize("✓", colSuccess), boldColor(msg, colSuccess))
 }
 
@@ -515,6 +597,90 @@ func (p *creationProgress) elapsed() time.Duration {
 		return 0
 	}
 	return d.Truncate(time.Second)
+}
+
+// isTerminalWriter reports whether w is a real terminal doctl can safely
+// animate a spinner on (as opposed to a pipe, file, or in-memory buffer).
+func isTerminalWriter(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
+}
+
+// lineSpinner animates a single overwritten status line
+// ("\r<frame> <label> (<elapsed>)") while a blocking call is in flight.
+// Only meaningful when writing to a real terminal — isTerminalWriter gates
+// construction so piped/non-TTY output (including tests) never sees ANSI
+// cursor codes.
+type lineSpinner struct {
+	out   io.Writer
+	start time.Time
+
+	mu    sync.Mutex
+	label string
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+func newLineSpinner(out io.Writer, label string, start time.Time) *lineSpinner {
+	s := &lineSpinner{
+		out:   out,
+		start: start,
+		label: label,
+		stop:  make(chan struct{}),
+		done:  make(chan struct{}),
+	}
+	go s.run()
+	return s
+}
+
+func (s *lineSpinner) setLabel(label string) {
+	s.mu.Lock()
+	s.label = label
+	s.mu.Unlock()
+}
+
+func (s *lineSpinner) currentLabel() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.label
+}
+
+func (s *lineSpinner) run() {
+	defer close(s.done)
+	ticker := time.NewTicker(creationSpinnerInterval)
+	defer ticker.Stop()
+
+	frame := 0
+	s.paint(frame)
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-ticker.C:
+			frame = (frame + 1) % len(spinnerFrames)
+			s.paint(frame)
+		}
+	}
+}
+
+func (s *lineSpinner) paint(frame int) {
+	elapsed := time.Since(s.start).Truncate(time.Second)
+	fmt.Fprintf(s.out, "\r\x1b[K%s %s %s",
+		colorize(spinnerFrames[frame], colWarning),
+		colorize(s.currentLabel(), colWarning),
+		colorize(fmt.Sprintf("(%s)", elapsed), colMuted))
+}
+
+// stopAndClear halts the animation goroutine and clears the spinner line so
+// the next print starts fresh at column 0.
+func (s *lineSpinner) stopAndClear() {
+	close(s.stop)
+	<-s.done
+	fmt.Fprint(s.out, "\r\x1b[K")
 }
 
 // provisioningHints keep a long PROVISIONING wait feeling alive. Later lines
@@ -594,7 +760,7 @@ func waitForSessionReady(ctx context.Context, svc do.HostedAgentsService, sessio
 			if sawBitsReady {
 				hint = "Waiting for agent…"
 			}
-			prog.wait(fmt.Sprintf("%s (%s)", hint, prog.elapsed()))
+			prog.wait(hint)
 			hintIdx++
 			nextHint = creationClock().Add(creationHintInterval)
 		}
@@ -681,16 +847,16 @@ func printRunReadySummary(w io.Writer, sum runReadySummary) {
 	ref := displaySessionRef(sum.Session)
 	agent := prettyAgentKind(sum.Session.AgentKind)
 	if agent == "agent" && strings.TrimSpace(sum.Harness) != "" {
-		agent = strings.TrimSpace(sum.Harness)
+		agent = prettyHarnessName(sum.Harness)
 	}
 
 	var body strings.Builder
 	body.WriteString(cardRow("Session", ref))
-	if sum.Session != nil && sum.Session.SessionID != "" && sum.Session.SessionID != ref {
+	if Verbose && sum.Session != nil && sum.Session.SessionID != "" && sum.Session.SessionID != ref {
 		body.WriteString(cardRow("ID", colorize(sum.Session.SessionID, colMuted)))
 	}
 	body.WriteString(cardRow("Agent", agent))
-	if sum.Repo != "" {
+	if Verbose && sum.Repo != "" {
 		body.WriteString(cardRow("Repo", sum.Repo))
 	}
 	if prompt := strings.TrimSpace(sum.Prompt); prompt != "" {
@@ -752,14 +918,16 @@ func printSessionListItem(w io.Writer, sess *do.HostedAgentSession) {
 	fmt.Fprintf(w, "%s %s\n", sessionStatusGlyph(sess.Status), boldColor(ref, colHighlight))
 	meta := []string{agent, colorizeSessionStatus(sess.Status)}
 	if !sess.CreatedAt.Time.IsZero() {
-		meta = append(meta, colorize(sess.CreatedAt.Time.UTC().Format("2006-01-02 15:04"), colMuted))
+		meta = append(meta, colorize(createdAgo(sess.CreatedAt.Time), colMuted))
 	}
 	fmt.Fprintf(w, "  %s\n", strings.Join(meta, colorize(" · ", colMuted)))
-	if id := strings.TrimSpace(sess.SessionID); id != "" && id != ref {
-		fmt.Fprintf(w, "  %s\n", colorize(id, colMuted))
-	}
-	if repo := strings.TrimSpace(sess.RepoHint); repo != "" {
-		fmt.Fprintf(w, "  %s %s\n", colorize("repo", colMuted), repo)
+	if Verbose {
+		if id := strings.TrimSpace(sess.SessionID); id != "" && id != ref {
+			fmt.Fprintf(w, "  %s\n", colorize(id, colMuted))
+		}
+		if repo := strings.TrimSpace(sess.RepoHint); repo != "" {
+			fmt.Fprintf(w, "  %s %s\n", colorize("repo", colMuted), repo)
+		}
 	}
 }
 
@@ -774,19 +942,23 @@ func printSessionShowCard(w io.Writer, sess *do.HostedAgentSession) {
 
 	var body strings.Builder
 	body.WriteString(cardRow("Session", ref))
-	if id := strings.TrimSpace(sess.SessionID); id != "" && id != ref {
-		body.WriteString(cardRow("ID", colorize(id, colMuted)))
+	if Verbose {
+		if id := strings.TrimSpace(sess.SessionID); id != "" && id != ref {
+			body.WriteString(cardRow("ID", colorize(id, colMuted)))
+		}
 	}
 	body.WriteString(cardRow("Agent", agent))
 	body.WriteString(cardRow("Status", sessionStatusGlyph(sess.Status)+" "+colorizeSessionStatus(sess.Status)))
-	if repo := strings.TrimSpace(sess.RepoHint); repo != "" {
-		body.WriteString(cardRow("Repo", repo))
+	if Verbose {
+		if repo := strings.TrimSpace(sess.RepoHint); repo != "" {
+			body.WriteString(cardRow("Repo", repo))
+		}
 	}
 	if parent := strings.TrimSpace(sess.ParentSessionID); parent != "" {
 		body.WriteString(cardRow("Parent", colorize(parent, colMuted)))
 	}
 	if !sess.CreatedAt.Time.IsZero() {
-		body.WriteString(cardRow("Created", colorize(sess.CreatedAt.Time.UTC().Format("2006-01-02 15:04 UTC"), colMuted)))
+		body.WriteString(cardRow("Created", colorize(formatCreatedAt(sess.CreatedAt.Time), colMuted)))
 	}
 
 	switch sess.Status {

--- a/commands/agents_run_test.go
+++ b/commands/agents_run_test.go
@@ -16,6 +16,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -94,6 +95,28 @@ func TestBuildHarnessManifest(t *testing.T) {
 		input, ok := cfg["input"].([]any)
 		require.True(t, ok)
 		require.Len(t, input, 1)
+	})
+
+	t.Run("claude-code references ANTHROPIC_API_KEY", func(t *testing.T) {
+		raw, err := buildHarnessManifest("claude-code", "", "", "")
+		require.NoError(t, err)
+
+		var doc map[string]any
+		require.NoError(t, yaml.Unmarshal(raw, &doc))
+		assert.Equal(t, "claude-code", doc["agent"])
+		env, ok := doc["env"].(map[any]any)
+		require.True(t, ok)
+		assert.Equal(t, "${ANTHROPIC_API_KEY}", env["ANTHROPIC_API_KEY"])
+		assert.NotContains(t, doc, "config")
+	})
+
+	t.Run("opencode has no injected key requirement", func(t *testing.T) {
+		raw, err := buildHarnessManifest("opencode", "", "", "")
+		require.NoError(t, err)
+
+		var doc map[string]any
+		require.NoError(t, yaml.Unmarshal(raw, &doc))
+		assert.NotContains(t, doc, "env")
 	})
 }
 
@@ -275,7 +298,82 @@ func TestRunAgentsRun_NoAttachHarness(t *testing.T) {
 		assert.Contains(t, out, "Agent is ready")
 		assert.NotContains(t, out, "SESSION_STATUS_")
 		assert.Contains(t, out, "doctl open-harness-runtime attach demo")
+		assert.NotContains(t, out, "katanemo/plano", "repo is hidden by default; only shown with -v/--verbose")
+	})
+}
+
+// TestRunAgentsRun_ClaudeCodeMissingAnthropicKey ensures a missing inference
+// key is caught locally (no CreateSessionFromManifest/GetSession
+// expectations set below — gomock fails the test if either is called) rather
+// than letting the harness fail once it's already hosted.
+func TestRunAgentsRun_ClaudeCodeMissingAnthropicKey(t *testing.T) {
+	_ = os.Unsetenv(anthropicAPIKeyEnv)
+	prevInteractive := Interactive
+	Interactive = false
+	t.Cleanup(func() {
+		Interactive = prevInteractive
+		_ = os.Unsetenv(anthropicAPIKeyEnv)
+	})
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		var buf bytes.Buffer
+		config.Out = &buf
+		config.Doit.Set(config.NS, doctl.ArgAgentHarness, "claude-code")
+		config.Doit.Set(config.NS, doctl.ArgAgentName, "demo-claude")
+		config.Doit.Set(config.NS, doctl.ArgAgentNoAttach, true)
+
+		err := RunAgentsRun(config)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), anthropicAPIKeyEnv)
+	})
+}
+
+func TestRunAgentsRun_NoAttachHarness_VerboseShowsRepoAndID(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().
+			CreateSessionFromManifest(gomock.Any(), nil).
+			DoAndReturn(func(manifest []byte, opt *godo.HostedAgentManifestCreateOptions) (*do.HostedAgentSession, error) {
+				return &do.HostedAgentSession{
+					HostedAgentSession: &godo.HostedAgentSession{
+						SessionID: "sess_run_2",
+						Name:      "demo-verbose",
+						Status:    godo.HostedAgentSessionStatusProvisioning,
+					},
+				}, nil
+			})
+		tm.hostedAgents.EXPECT().
+			GetSession("sess_run_2").
+			Return(&do.HostedAgentSession{
+				HostedAgentSession: &godo.HostedAgentSession{
+					SessionID: "sess_run_2",
+					Name:      "demo-verbose",
+					Status:    godo.HostedAgentSessionStatusReady,
+				},
+			}, nil)
+
+		prev := sessionReadyPollInterval
+		sessionReadyPollInterval = time.Millisecond
+		defer func() { sessionReadyPollInterval = prev }()
+
+		prevVerbose := Verbose
+		Verbose = true
+		defer func() { Verbose = prevVerbose }()
+
+		var buf bytes.Buffer
+		config.Out = &buf
+		config.Doit.Set(config.NS, doctl.ArgAgentHarness, "opencode")
+		config.Doit.Set(config.NS, doctl.ArgAgentRepo, "https://github.com/katanemo/plano")
+		config.Doit.Set(config.NS, doctl.ArgAgentName, "demo-verbose")
+		config.Doit.Set(config.NS, doctl.ArgAgentNoAttach, true)
+
+		tm.hostedAgents.EXPECT().
+			StartProviderAuth("github").
+			Return(&godo.HostedAgentProviderAuthStart{Provider: "github", Status: "success"}, nil)
+
+		require.NoError(t, RunAgentsRun(config))
+		out := buf.String()
 		assert.Contains(t, out, "katanemo/plano")
+		assert.Contains(t, out, "sess_run_2")
 	})
 }
 
@@ -291,11 +389,12 @@ func TestPrintAttachBanner(t *testing.T) {
 
 	got := out.String()
 	assert.Contains(t, got, "Connected")
-	assert.Contains(t, got, "smoke-test")
-	assert.Contains(t, got, "Quick help")
-	assert.Contains(t, got, "Ctrl-D")
-	assert.Contains(t, got, "session keeps running")
-	assert.Contains(t, got, "doctl open-harness-runtime remove smoke-test")
+	assert.Contains(t, got, "Agent OpenCode")
+	assert.Contains(t, got, "Session smoke-test")
+	assert.Contains(t, got, "Press Ctrl + D to detach locally")
+	assert.Contains(t, got, "type a message and press Enter")
+	assert.Contains(t, got, "use /help for full command list")
+	assert.NotContains(t, got, "Quick help")
 }
 
 func TestPrintDetachNotice(t *testing.T) {
@@ -306,10 +405,8 @@ func TestPrintDetachNotice(t *testing.T) {
 	var buf bytes.Buffer
 	printDetachNotice(&buf, "my-session")
 	out := buf.String()
-	assert.Contains(t, out, "Disconnected")
-	assert.Contains(t, out, "still running")
-	assert.Contains(t, out, "doctl open-harness-runtime attach my-session")
-	assert.Contains(t, out, "doctl open-harness-runtime remove my-session")
+	assert.Contains(t, out, "Disconnected from session locally")
+	assert.Contains(t, out, "still active in the cloud")
 }
 
 func TestMaybeOfferGitHubAuth_AlreadyConnected(t *testing.T) {

--- a/commands/agents_run_test.go
+++ b/commands/agents_run_test.go
@@ -16,6 +16,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -325,6 +326,60 @@ func TestRunAgentsRun_ClaudeCodeMissingAnthropicKey(t *testing.T) {
 		err := RunAgentsRun(config)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), anthropicAPIKeyEnv)
+	})
+}
+
+// TestPrepareClaudeCodeStart_ValidatesKey confirms the key resolved via
+// ensureEnvVar is the one handed to validateAnthropicAPIKey, and that
+// non-claude-code manifests skip validation entirely (no network call).
+func TestPrepareClaudeCodeStart_ValidatesKey(t *testing.T) {
+	t.Setenv(anthropicAPIKeyEnv, "sk-ant-test")
+	orig := validateAnthropicAPIKey
+	t.Cleanup(func() { validateAnthropicAPIKey = orig })
+
+	var gotKey string
+	calls := 0
+	validateAnthropicAPIKey = func(ctx context.Context, apiKey string) error {
+		calls++
+		gotKey = apiKey
+		return nil
+	}
+
+	raw, err := buildHarnessManifest("claude-code", "", "", "")
+	require.NoError(t, err)
+	require.NoError(t, prepareClaudeCodeStart(context.Background(), raw, nil))
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "sk-ant-test", gotKey)
+
+	// A non-claude-code manifest must not trigger validation.
+	raw, err = buildHarnessManifest("opencode", "", "", "")
+	require.NoError(t, err)
+	require.NoError(t, prepareClaudeCodeStart(context.Background(), raw, nil))
+	assert.Equal(t, 1, calls, "opencode manifest should not call validateAnthropicAPIKey")
+}
+
+// TestRunAgentsRun_ClaudeCodeBogusAnthropicKey ensures a present-but-invalid
+// ANTHROPIC_API_KEY is caught locally too — not just a missing one. No
+// CreateSessionFromManifest expectation is set below, so gomock fails the
+// test if the bogus key is not rejected before that call.
+func TestRunAgentsRun_ClaudeCodeBogusAnthropicKey(t *testing.T) {
+	t.Setenv(anthropicAPIKeyEnv, "sk-ant-bogus")
+	orig := validateAnthropicAPIKey
+	t.Cleanup(func() { validateAnthropicAPIKey = orig })
+	validateAnthropicAPIKey = func(ctx context.Context, apiKey string) error {
+		return fmt.Errorf("%s was rejected by Anthropic (HTTP 401): invalid x-api-key", anthropicAPIKeyEnv)
+	}
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		var buf bytes.Buffer
+		config.Out = &buf
+		config.Doit.Set(config.NS, doctl.ArgAgentHarness, "claude-code")
+		config.Doit.Set(config.NS, doctl.ArgAgentName, "demo-claude")
+		config.Doit.Set(config.NS, doctl.ArgAgentNoAttach, true)
+
+		err := RunAgentsRun(config)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rejected by Anthropic")
 	})
 }
 

--- a/commands/agents_style.go
+++ b/commands/agents_style.go
@@ -17,10 +17,48 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/digitalocean/doctl/do"
 	"github.com/digitalocean/godo"
 )
+
+// relativeTimeAgo renders t as a short relative duration ("just now", "5m
+// ago", "3h ago", "2d ago"). Falls back to a plain date once it's more than
+// 30 days old, where "Nd ago" stops being a useful measure.
+func relativeTimeAgo(t time.Time) string {
+	d := time.Since(t)
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d/time.Minute))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d/time.Hour))
+	case d < 30*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d/(24*time.Hour)))
+	default:
+		return t.UTC().Format("2006-01-02")
+	}
+}
+
+// formatCreatedAt renders a resource's creation time: a short relative
+// duration by default ("5m ago"), or the full UTC timestamp with -v/--verbose.
+func formatCreatedAt(t time.Time) string {
+	if Verbose {
+		return t.UTC().Format("2006-01-02 15:04")
+	}
+	return relativeTimeAgo(t)
+}
+
+// createdAgo renders "Created <formatCreatedAt(t)>" for inline meta lines
+// that don't have their own "Created" row label.
+func createdAgo(t time.Time) string {
+	return "Created " + formatCreatedAt(t)
+}
 
 // printAgentSuccess prints a compact success line used by side-effect verbs.
 func printAgentSuccess(w io.Writer, msg string) {
@@ -71,7 +109,7 @@ func printCheckpointListItem(w io.Writer, cp *godo.HostedAgentCheckpoint) {
 		meta = append(meta, colorize(humanBytes(cp.SizeBytes), colMuted))
 	}
 	if !cp.CreatedAt.Time.IsZero() {
-		meta = append(meta, colorize(cp.CreatedAt.Time.UTC().Format("2006-01-02 15:04"), colMuted))
+		meta = append(meta, colorize(createdAgo(cp.CreatedAt.Time), colMuted))
 	}
 	fmt.Fprintf(w, "  %s\n", strings.Join(meta, colorize(" · ", colMuted)))
 	if id := strings.TrimSpace(cp.CheckpointID); id != "" && id != title {
@@ -104,7 +142,7 @@ func printCheckpointCard(w io.Writer, cp *godo.HostedAgentCheckpoint, created bo
 		body.WriteString(cardRow("Size", colorize(humanBytes(cp.SizeBytes), colMuted)))
 	}
 	if !cp.CreatedAt.Time.IsZero() {
-		body.WriteString(cardRow("Created", colorize(cp.CreatedAt.Time.UTC().Format("2006-01-02 15:04 UTC"), colMuted)))
+		body.WriteString(cardRow("Created", colorize(formatCreatedAt(cp.CreatedAt.Time), colMuted)))
 	}
 	if errMsg := strings.TrimSpace(cp.ErrorMessage); errMsg != "" {
 		body.WriteString(cardRow("Error", colorize(errMsg, colError)))
@@ -184,7 +222,7 @@ func printTriggerListItem(w io.Writer, t *do.HostedAgentTrigger) {
 		meta = append(meta, colorize(agent, colMuted))
 	}
 	if !t.CreatedAt.Time.IsZero() {
-		meta = append(meta, colorize(t.CreatedAt.Time.UTC().Format("2006-01-02 15:04"), colMuted))
+		meta = append(meta, colorize(createdAgo(t.CreatedAt.Time), colMuted))
 	}
 	fmt.Fprintf(w, "  %s\n", strings.Join(meta, colorize(" · ", colMuted)))
 	if id := strings.TrimSpace(t.TriggerID); id != "" && id != name {
@@ -245,7 +283,7 @@ func printTriggerCard(w io.Writer, t *do.HostedAgentTrigger, created bool) {
 		}
 	}
 	if !t.CreatedAt.Time.IsZero() {
-		body.WriteString(cardRow("Created", colorize(t.CreatedAt.Time.UTC().Format("2006-01-02 15:04 UTC"), colMuted)))
+		body.WriteString(cardRow("Created", colorize(formatCreatedAt(t.CreatedAt.Time), colMuted)))
 	}
 	renderAgentCard(w, body.String())
 }
@@ -325,7 +363,7 @@ func printTriggerExecutionListItem(w io.Writer, e *do.HostedAgentTriggerExecutio
 		meta = append(meta, colorize(sess, colMuted))
 	}
 	if !e.CreatedAt.Time.IsZero() {
-		meta = append(meta, colorize(e.CreatedAt.Time.UTC().Format("2006-01-02 15:04"), colMuted))
+		meta = append(meta, colorize(createdAgo(e.CreatedAt.Time), colMuted))
 	}
 	fmt.Fprintf(w, "  %s\n", strings.Join(meta, colorize(" · ", colMuted)))
 	if reason := strings.TrimSpace(e.FailureReason); reason != "" {
@@ -354,7 +392,7 @@ func printTriggerExecutionCard(w io.Writer, e *do.HostedAgentTriggerExecution) {
 		body.WriteString(cardRow("Failure", colorize(reason, colError)))
 	}
 	if !e.CreatedAt.Time.IsZero() {
-		body.WriteString(cardRow("Created", colorize(e.CreatedAt.Time.UTC().Format("2006-01-02 15:04 UTC"), colMuted)))
+		body.WriteString(cardRow("Created", colorize(formatCreatedAt(e.CreatedAt.Time), colMuted)))
 	}
 	renderAgentCard(w, body.String())
 
@@ -423,11 +461,13 @@ func printReusableSessionsList(w io.Writer, sessions []do.HostedAgentReusableSes
 		fmt.Fprintf(w, "%s %s\n", sessionStatusGlyph(s.Status), boldColor(ref, colHighlight))
 		meta := []string{prettyAgentKind(s.AgentKind), colorizeSessionStatus(s.Status)}
 		if !s.CreatedAt.Time.IsZero() {
-			meta = append(meta, colorize(s.CreatedAt.Time.UTC().Format("2006-01-02 15:04"), colMuted))
+			meta = append(meta, colorize(createdAgo(s.CreatedAt.Time), colMuted))
 		}
 		fmt.Fprintf(w, "  %s\n", strings.Join(meta, colorize(" · ", colMuted)))
-		if id := strings.TrimSpace(s.SessionID); id != "" && id != ref {
-			fmt.Fprintf(w, "  %s\n", colorize(id, colMuted))
+		if Verbose {
+			if id := strings.TrimSpace(s.SessionID); id != "" && id != ref {
+				fmt.Fprintf(w, "  %s\n", colorize(id, colMuted))
+			}
 		}
 	}
 }
@@ -502,14 +542,8 @@ func humanBytes(n uint64) string {
 // connection — the hosted session keeps running until explicitly removed.
 func printDetachNotice(w io.Writer, sessionRef string) {
 	fmt.Fprintln(w)
-	fmt.Fprintf(w, "%s %s\n", colorize("✓", colSuccess), boldColor("Disconnected", colHighlight))
-	fmt.Fprintln(w, colorize("Your session is still running — this only closed the local connection.", colMuted))
-	ref := strings.TrimSpace(sessionRef)
-	if ref == "" {
-		ref = "<session>"
-	}
-	fmt.Fprintf(w, "  %s %s\n", colorize("reattach", colMuted), "doctl open-harness-runtime attach "+ref)
-	fmt.Fprintf(w, "  %s %s\n", colorize("remove  ", colMuted), "doctl open-harness-runtime remove "+ref)
+	fmt.Fprintf(w, "%s\n", boldColor("✓ Disconnected from session locally", colSuccess))
+	fmt.Fprintln(w, colorize("Your session is still active in the cloud.", colMuted))
 }
 
 // printSessionEndedNotice is shown when the remote run can no longer accept input.

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -260,6 +260,10 @@ func TestRunAgentsStart(t *testing.T) {
 
 func TestRunAgentsStart_FromHarness(t *testing.T) {
 	t.Setenv(anthropicAPIKeyEnv, "sk-ant-test")
+	origValidate := validateAnthropicAPIKey
+	t.Cleanup(func() { validateAnthropicAPIKey = origValidate })
+	validateAnthropicAPIKey = func(ctx context.Context, apiKey string) error { return nil }
+
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.hostedAgents.EXPECT().
 			CreateSessionFromManifest(gomock.Any(), nil).
@@ -1745,6 +1749,16 @@ func TestInsertNewlineAtCursor(t *testing.T) {
 	s.insertNewlineAtCursor()
 	assert.Equal(t, "ab\ncd", string(s.lineBuf))
 	assert.Equal(t, 3, s.cursor)
+}
+
+// TestDisplayInputBufferShowsNewlineMarker is a regression test: the
+// flattened single-row prompt used to collapse an embedded newline to a
+// plain space, which made Option/Alt+Enter look like a no-op until the
+// message was actually submitted. It must render a visible marker instead.
+func TestDisplayInputBufferShowsNewlineMarker(t *testing.T) {
+	assert.Equal(t, "first line ↵ second line", displayInputBuffer([]byte("first line\nsecond line")))
+	assert.Equal(t, "first line ↵ second line", displayInputBuffer([]byte("first line\r\nsecond line")))
+	assert.Equal(t, "", displayInputBuffer(nil))
 }
 
 // TestHandleAttachEscapeSequenceOptionEnterInsertsNewline pins Option/Alt+

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -1575,7 +1575,7 @@ func TestHandleAttachByteCursorMovement(t *testing.T) {
 	typewrite := func(t *testing.T, state *attachState, s string) {
 		t.Helper()
 		for i := 0; i < len(s); i++ {
-			stop, err := handleAttachByte(nil, nil, "sess", s[i], state, nil)
+			stop, err := handleAttachByte(nil, nil, "sess", s[i], state, nil, nil)
 			assert.NoError(t, err)
 			assert.False(t, stop)
 		}
@@ -1583,7 +1583,7 @@ func TestHandleAttachByteCursorMovement(t *testing.T) {
 	arrow := func(t *testing.T, state *attachState, dir byte) {
 		t.Helper()
 		for _, b := range []byte{0x1b, '[', dir} {
-			stop, err := handleAttachByte(nil, nil, "sess", b, state, nil)
+			stop, err := handleAttachByte(nil, nil, "sess", b, state, nil, nil)
 			assert.NoError(t, err)
 			assert.False(t, stop)
 		}
@@ -1627,7 +1627,7 @@ func TestHandleAttachByteCursorMovement(t *testing.T) {
 		typewrite(t, state, "abcd")
 		arrow(t, state, 'D')
 		arrow(t, state, 'D') // caret before 'c'
-		stop, err := handleAttachByte(nil, nil, "sess", 0x7f, state, nil)
+		stop, err := handleAttachByte(nil, nil, "sess", 0x7f, state, nil, nil)
 		assert.NoError(t, err)
 		assert.False(t, stop)
 		assert.Equal(t, "acd", string(state.lineBuf))
@@ -1643,7 +1643,7 @@ func TestHandleAttachByteCursorMovement(t *testing.T) {
 			state := newAttachState(io.Discard, &pendingHITL{})
 			state.display.setRaw(true)
 			typewrite(t, state, "hi")
-			stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, nil)
+			stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, nil, nil)
 			assert.NoError(t, err)
 			assert.False(t, stop)
 			assert.Equal(t, "", string(state.lineBuf))
@@ -1660,13 +1660,13 @@ func TestHandleAttachByteCursorMovement(t *testing.T) {
 			state := newAttachState(io.Discard, &pendingHITL{})
 			state.display.setRaw(true)
 			for _, b := range []byte("\x1b[200~first line\r\nsecond line\x1b[201~") {
-				stop, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, nil)
+				stop, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, nil, nil)
 				assert.NoError(t, err)
 				assert.False(t, stop)
 			}
 			assert.Equal(t, "first line\nsecond line", string(state.lineBuf))
 
-			stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, nil)
+			stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, nil, nil)
 			assert.NoError(t, err)
 			assert.False(t, stop)
 			assert.Equal(t, "", string(state.lineBuf))
@@ -1684,17 +1684,17 @@ func TestHandleAttachByteCursorMovement(t *testing.T) {
 			state := newAttachState(io.Discard, &pendingHITL{})
 			state.display.setRaw(true)
 			for _, b := range []byte("\x1b[200~Line 1\r\nLine 2\r\nLine 3\r\nLine 4\r\nLine 5\r\nLine 6\x1b[201~") {
-				stop, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, nil)
+				stop, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, nil, nil)
 				assert.NoError(t, err)
 				assert.False(t, stop)
 			}
 
-			stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, nil)
+			stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, nil, nil)
 			assert.NoError(t, err)
 			assert.False(t, stop)
 			require.NotNil(t, state.largePasteConfirmation())
 
-			stop, err = handleAttachByte(config, tm.hostedAgents, "sess", 'y', state, nil)
+			stop, err = handleAttachByte(config, tm.hostedAgents, "sess", 'y', state, nil, nil)
 			assert.NoError(t, err)
 			assert.False(t, stop)
 			assert.Nil(t, state.largePasteConfirmation())
@@ -1712,22 +1712,112 @@ func TestHandleAttachByteCursorMovement(t *testing.T) {
 			state := newAttachState(io.Discard, &pendingHITL{})
 			state.display.setRaw(true)
 			for _, b := range []byte("\x1b[200~Line 1\r\nLine 2\r\nLine 3\r\nLine 4\r\nLine 5\r\nLine 6\x1b[201~") {
-				stop, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, nil)
+				stop, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, nil, nil)
 				assert.NoError(t, err)
 				assert.False(t, stop)
 			}
 
-			stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, nil)
+			stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, nil, nil)
 			assert.NoError(t, err)
 			assert.False(t, stop)
 			require.NotNil(t, state.largePasteConfirmation())
 
-			stop, err = handleAttachByte(config, tm.hostedAgents, "sess", 'n', state, nil)
+			stop, err = handleAttachByte(config, tm.hostedAgents, "sess", 'n', state, nil, nil)
 			assert.NoError(t, err)
 			assert.False(t, stop)
 			assert.Nil(t, state.largePasteConfirmation())
 		})
 	})
+}
+
+// TestInsertNewlineAtCursor covers appending at the end of the buffer and
+// splicing in the middle, mirroring the character-insert splice used
+// elsewhere for regular typed bytes.
+func TestInsertNewlineAtCursor(t *testing.T) {
+	s := &attachState{lineBuf: []byte("abcd"), cursor: 4}
+	s.insertNewlineAtCursor()
+	assert.Equal(t, "abcd\n", string(s.lineBuf))
+	assert.Equal(t, 5, s.cursor)
+
+	s = &attachState{lineBuf: []byte("abcd"), cursor: 2}
+	s.insertNewlineAtCursor()
+	assert.Equal(t, "ab\ncd", string(s.lineBuf))
+	assert.Equal(t, 3, s.cursor)
+}
+
+// TestHandleAttachEscapeSequenceOptionEnterInsertsNewline pins Option/Alt+
+// Enter (ESC followed by CR, the standard meta-key encoding used by iTerm2
+// and Terminal.app's default settings) as "insert a newline, don't submit" —
+// so a multi-line message can be composed and sent as one input, the same
+// way a pasted multi-line block already works.
+func TestHandleAttachEscapeSequenceOptionEnterInsertsNewline(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().
+			SendInput("sess", &godo.HostedAgentSendInputRequest{Text: "first line\nsecond line"}).
+			Return(&godo.HostedAgentSendInputResponse{RunID: "run_1"}, nil)
+
+		state := newAttachState(io.Discard, &pendingHITL{})
+		state.display.setRaw(true)
+		send := func(bs ...byte) {
+			for _, b := range bs {
+				stop, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, nil, nil)
+				assert.NoError(t, err)
+				assert.False(t, stop)
+			}
+		}
+		send([]byte("first line")...)
+		send(0x1b, 0x0d) // Option/Alt+Enter
+		send([]byte("second line")...)
+		assert.Equal(t, "first line\nsecond line", string(state.lineBuf))
+
+		// A real Enter submits the whole multi-line buffer as one message.
+		send(0x0d)
+		assert.Equal(t, "", string(state.lineBuf))
+	})
+}
+
+// TestHandleAttachEscapeSequenceOptionEnterIgnoredDuringHITL confirms
+// Option/Alt+Enter is swallowed (not left to fall through as stray bytes)
+// but does nothing while a HITL approval is pending — there's no text input
+// to insert a newline into at that point.
+func TestHandleAttachEscapeSequenceOptionEnterIgnoredDuringHITL(t *testing.T) {
+	state := newAttachState(io.Discard, &pendingHITL{})
+	state.display.setRaw(true)
+	state.pending.set("req-1", "approve something")
+
+	for _, b := range []byte{0x1b, 0x0d} {
+		stop, err := handleAttachByte(nil, nil, "sess", b, state, nil, nil)
+		assert.NoError(t, err)
+		assert.False(t, stop)
+	}
+	assert.Equal(t, "", string(state.lineBuf))
+}
+
+// TestHandlePastedByteOnlyRedrawsOnceAtEnd is a regression test for a bug
+// where every single pasted byte triggered its own full prompt repaint.
+// paintPromptLocked only erases the terminal's *current* row (\x1b[K); once
+// the growing pasted line got long enough to wrap, each of those hundreds of
+// incremental repaints left the previous, shorter wrapped block behind as a
+// stale duplicate instead of clearing it — turning one paste into dozens of
+// near-identical truncated lines in the scrollback. Buffering silently and
+// painting once when the paste ends fixes it.
+func TestHandlePastedByteOnlyRedrawsOnceAtEnd(t *testing.T) {
+	var buf bytes.Buffer
+	state := newAttachState(&buf, &pendingHITL{})
+	state.display.setRaw(true)
+
+	pasted := strings.Repeat("x", 300)
+	input := "\x1b[200~" + pasted + "\x1b[201~"
+	for _, b := range []byte(input) {
+		stop, err := handleAttachByte(nil, nil, "sess", b, state, nil, nil)
+		assert.NoError(t, err)
+		assert.False(t, stop)
+	}
+
+	assert.Equal(t, pasted, string(state.lineBuf))
+	// The clear-and-repaint escape must appear exactly once — for the single
+	// redraw when the paste ends — not once per pasted byte.
+	assert.Equal(t, 1, strings.Count(buf.String(), "\x1b[K"))
 }
 
 // TestAttachStateHITLSelection covers the arrow-key selection wrap-around and
@@ -1775,6 +1865,188 @@ func TestMsgAccumulatorPlain(t *testing.T) {
 	assert.Equal(t, "", buf.String())
 }
 
+// TestReasoningStreamer confirms the shared reasoning-block printer: a
+// leading label appears once per block, stop/start bracket the thinking
+// spinner around the block, end() is a no-op if nothing is active, and empty
+// chunks never trigger the leading label on their own.
+func TestReasoningStreamer(t *testing.T) {
+	var buf bytes.Buffer
+	thinking := newThinkingState(&buf)
+	r := &reasoningStreamer{out: &buf, thinking: thinking}
+
+	r.end() // no-op: nothing streamed yet
+	assert.Equal(t, "", buf.String())
+
+	r.stream("")
+	assert.Equal(t, "", buf.String(), "empty chunks don't open a block")
+
+	r.stream("thinking about it")
+	r.stream(" some more")
+	out := buf.String()
+	assert.Contains(t, out, "reasoning")
+	assert.Contains(t, out, "thinking about it some more")
+
+	buf.Reset()
+	r.end()
+	// end() closes the block with a trailing newline, then resumes the
+	// thinking spinner — for a non-promptDisplay writer that's a one-shot
+	// "(Run in progress)" line.
+	assert.Equal(t, "\n(Run in progress)\n", buf.String())
+	thinking.stop()
+
+	// A second end() without an intervening stream() is a no-op.
+	buf.Reset()
+	r.end()
+	assert.Equal(t, "", buf.String())
+}
+
+// TestTokenChunkPayloadIsReasoning confirms the SPI TokenChunk.is_reasoning
+// field round-trips through doctl's local payload struct, including the
+// common case where a harness never sets it (defaults to false, i.e. final
+// answer).
+func TestTokenChunkPayloadIsReasoning(t *testing.T) {
+	var p tokenChunkPayload
+	require.NoError(t, json.Unmarshal([]byte(`{"text":"hmm","is_reasoning":true}`), &p))
+	assert.True(t, p.IsReasoning)
+	assert.Equal(t, "hmm", p.Text)
+
+	var q tokenChunkPayload
+	require.NoError(t, json.Unmarshal([]byte(`{"text":"answer"}`), &q))
+	assert.False(t, q.IsReasoning)
+}
+
+// TestMsgAccumulatorPreviewTail confirms the bounded tail used for the live
+// "thinking" preview tracks the most recent content and stays bounded
+// regardless of how many small chunks built up the message, and that flush
+// clears it for the next turn.
+func TestMsgAccumulatorPreviewTail(t *testing.T) {
+	acc := &msgAccumulator{}
+	assert.Equal(t, "", acc.previewTail())
+
+	acc.add("hello ")
+	acc.add("world")
+	assert.Equal(t, "hello world", acc.previewTail())
+
+	// Feed enough chunks to exceed previewTailMaxRunes; only the tail survives.
+	long := strings.Repeat("x", previewTailMaxRunes+50)
+	acc.add(long)
+	assert.Len(t, []rune(acc.previewTail()), previewTailMaxRunes)
+	assert.True(t, strings.HasSuffix(acc.previewTail(), "xxxx"))
+
+	var buf bytes.Buffer
+	acc.flush(&buf)
+	assert.Equal(t, "", acc.previewTail())
+}
+
+func TestTrimTailRunes(t *testing.T) {
+	assert.Equal(t, "abc", trimTailRunes("abc", 5))
+	assert.Equal(t, "abc", trimTailRunes("abc", 3))
+	assert.Equal(t, "bc", trimTailRunes("abc", 2))
+	assert.Equal(t, "", trimTailRunes("abc", 0))
+	// Multi-byte runes must not be split.
+	assert.Equal(t, "🎉b", trimTailRunes("a🎉b", 2))
+}
+
+func TestThinkingPreviewLabel(t *testing.T) {
+	assert.Equal(t, "", thinkingPreviewLabel(""))
+	assert.Equal(t, "", thinkingPreviewLabel("   \n\t "))
+	assert.Equal(t, "hello world", thinkingPreviewLabel("hello  world"))
+	// Embedded newlines collapse to single spaces so the label stays one line.
+	assert.Equal(t, "line one line two", thinkingPreviewLabel("line one\nline two"))
+
+	long := strings.Repeat("a", thinkingPreviewMaxRunes+20)
+	got := thinkingPreviewLabel(long)
+	assert.True(t, strings.HasPrefix(got, "…"))
+	assert.Equal(t, thinkingPreviewMaxRunes+1, len([]rune(got))) // +1 for the ellipsis
+}
+
+// TestThinkingStateLivePreview confirms setLabel changes what the animated
+// spinner shows (falling back to defaultThinkingLabel until the first
+// preview arrives), and that a fresh start() clears any label left over from
+// a previous turn.
+func TestThinkingStateLivePreview(t *testing.T) {
+	var buf bytes.Buffer
+	pending := &pendingHITL{}
+	s := newAttachState(&buf, pending)
+	s.display.setRaw(true)
+
+	thinking := newThinkingState(s.display)
+	assert.Equal(t, defaultThinkingLabel, thinking.currentLabel())
+
+	thinking.setLabel("some text stream")
+	assert.Equal(t, "some text stream", thinking.currentLabel())
+
+	thinking.start()
+	defer thinking.stop()
+	// start() resets any stale label from a prior turn.
+	assert.Equal(t, defaultThinkingLabel, thinking.currentLabel())
+
+	thinking.setLabel("…streaming preview")
+	assert.Equal(t, "…streaming preview", thinking.currentLabel())
+}
+
+// TestThinkingStateTurnRunning confirms turnRunning is a distinct signal from
+// active: it's what the input loop checks to warn a user their message will
+// be queued behind an already-running turn, and it must not be perturbed by
+// stop()/start() cycling for sub-turn events like tool calls.
+func TestThinkingStateTurnRunning(t *testing.T) {
+	var buf bytes.Buffer
+	thinking := newThinkingState(&buf)
+	assert.False(t, thinking.isTurnRunning())
+
+	thinking.setTurnRunning(true)
+	assert.True(t, thinking.isTurnRunning())
+
+	// A tool call mid-turn stops/starts the spinner but the turn is still running.
+	thinking.start()
+	thinking.stop()
+	assert.True(t, thinking.isTurnRunning())
+
+	thinking.setTurnRunning(false)
+	assert.False(t, thinking.isTurnRunning())
+}
+
+// TestPrintAttachSendAck pins the three messages a user can see after
+// sending: queued behind warm-up, queued behind an already-running turn, or
+// (the common case) just waiting for the first response. There's no
+// server-side "queued" signal (see OHR queueing research — a queued send
+// returns the same response as one that starts immediately), so the "queued
+// behind a running turn" case is inferred entirely from local state.
+func TestPrintAttachSendAck(t *testing.T) {
+	t.Run("no warmup, no run active: generic waiting message", func(t *testing.T) {
+		var buf bytes.Buffer
+		printAttachSendAck(&buf, nil, nil)
+		assert.Contains(t, buf.String(), "waiting for the agent")
+	})
+
+	t.Run("run already active: queued-behind-run message, not the generic one", func(t *testing.T) {
+		var buf bytes.Buffer
+		thinking := newThinkingState(&buf)
+		thinking.setTurnRunning(true)
+		printAttachSendAck(&buf, nil, thinking)
+		assert.Contains(t, buf.String(), "queued")
+		assert.NotContains(t, buf.String(), "waiting for the agent")
+	})
+
+	t.Run("run not active: generic waiting message even with thinking wired up", func(t *testing.T) {
+		var buf bytes.Buffer
+		thinking := newThinkingState(&buf)
+		printAttachSendAck(&buf, nil, thinking)
+		assert.Contains(t, buf.String(), "waiting for the agent")
+	})
+
+	t.Run("warm-up takes priority over run-active", func(t *testing.T) {
+		var buf bytes.Buffer
+		warmup := newWarmupState(&buf, time.Now())
+		warmup.start()
+		thinking := newThinkingState(&buf)
+		thinking.setTurnRunning(true)
+		printAttachSendAck(&buf, warmup, thinking)
+		assert.Contains(t, buf.String(), "will send when agent is ready")
+		assert.NotContains(t, buf.String(), "queued behind")
+	})
+}
+
 // TestAttachLoopAcknowledgesSend: a successful submit prints a "waiting"
 // acknowledgement immediately so the multi-second wait for the first token
 // doesn't read as a hang.
@@ -1787,7 +2059,7 @@ func TestAttachLoopAcknowledgesSend(t *testing.T) {
 			Return(&godo.HostedAgentSendInputResponse{RunID: "run-abc"}, nil)
 
 		err := attachLoop(config, config.HostedAgents(), "sess_x",
-			strings.NewReader("What is the capital of France?\n"), testAttachStateFromPending(nil))
+			strings.NewReader("What is the capital of France?\n"), testAttachStateFromPending(nil), nil)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "waiting for the agent")
 	})
@@ -1806,7 +2078,7 @@ func TestAttachLoopBatchesRapidMultilineInput(t *testing.T) {
 			Return(&godo.HostedAgentSendInputResponse{RunID: "run-abc"}, nil)
 
 		err := attachLoop(config, config.HostedAgents(), "sess_x",
-			strings.NewReader("Line A\nLine B\nLine C\n"), testAttachStateFromPending(nil))
+			strings.NewReader("Line A\nLine B\nLine C\n"), testAttachStateFromPending(nil), nil)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Detected rapid multiline input")
 		assert.Contains(t, buf.String(), "waiting for the agent")
@@ -1868,7 +2140,7 @@ func TestAttachLoopHITLLetterShortcut(t *testing.T) {
 					}).Return(nil)
 
 				err := attachLoop(config, config.HostedAgents(), "sess_x",
-					strings.NewReader(tc.input), testAttachStateFromPending(pending))
+					strings.NewReader(tc.input), testAttachStateFromPending(pending), nil)
 				assert.NoError(t, err)
 				assert.Contains(t, buf.String(), "[y/n/d] > ")
 			})
@@ -1896,7 +2168,7 @@ func TestAttachLoopClearsPendingAfterResolve(t *testing.T) {
 		// Line-mode `y\n` exercises the same resolve+clear path; the raw-mode
 		// branch shares the clearIf call.
 		err := attachLoop(config, config.HostedAgents(), "sess_x",
-			strings.NewReader("y\n"), testAttachStateFromPending(pending))
+			strings.NewReader("y\n"), testAttachStateFromPending(pending), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "", pending.get(), "pending must be cleared after successful resolve")
 	})
@@ -1918,7 +2190,7 @@ func TestAttachLoopKeepsPendingOnResolveError(t *testing.T) {
 			}).Return(errors.New("boom"))
 
 		err := attachLoop(config, config.HostedAgents(), "sess_x",
-			strings.NewReader("y\n"), testAttachStateFromPending(pending))
+			strings.NewReader("y\n"), testAttachStateFromPending(pending), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "hitl_42", pending.get(), "pending must survive a failed resolve")
 		assert.Contains(t, buf.String(), "resolve failed: boom")
@@ -1936,7 +2208,7 @@ func TestAttachLoopHITLShortcutIgnoredWithoutPending(t *testing.T) {
 			Return(&godo.HostedAgentSendInputResponse{RunID: "run-1"}, nil)
 
 		err := attachLoop(config, config.HostedAgents(), "sess_x",
-			strings.NewReader("y\n"), testAttachStateFromPending(&pendingHITL{}))
+			strings.NewReader("y\n"), testAttachStateFromPending(&pendingHITL{}), nil)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "waiting for the agent")
 	})
@@ -2090,7 +2362,7 @@ func TestSingleKeystrokeAdvancesQueue(t *testing.T) {
 		}).Return(nil)
 
 		err := attachLoop(config, config.HostedAgents(), "sess_x",
-			strings.NewReader("y\nn\n"), testAttachStateFromPending(pending))
+			strings.NewReader("y\nn\n"), testAttachStateFromPending(pending), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, pending.len(), "both HITLs must be drained after two keystrokes")
 
@@ -2107,7 +2379,7 @@ func TestHandleAttachByteTabCompletion(t *testing.T) {
 	typewrite := func(t *testing.T, state *attachState, s string) {
 		t.Helper()
 		for i := 0; i < len(s); i++ {
-			stop, err := handleAttachByte(nil, nil, "sess", s[i], state, nil)
+			stop, err := handleAttachByte(nil, nil, "sess", s[i], state, nil, nil)
 			assert.NoError(t, err)
 			assert.False(t, stop)
 		}
@@ -2118,7 +2390,7 @@ func TestHandleAttachByteTabCompletion(t *testing.T) {
 		state.display.setRaw(true)
 		typewrite(t, state, "/pa")
 
-		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil)
+		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil, nil)
 		assert.NoError(t, err)
 		assert.False(t, stop)
 		assert.Equal(t, "/pause ", string(state.lineBuf))
@@ -2132,7 +2404,7 @@ func TestHandleAttachByteTabCompletion(t *testing.T) {
 		typewrite(t, state, "/")
 
 		config := &CmdConfig{Out: state.display}
-		stop, err := handleAttachByte(config, nil, "sess", 0x09, state, nil)
+		stop, err := handleAttachByte(config, nil, "sess", 0x09, state, nil, nil)
 		assert.NoError(t, err)
 		assert.False(t, stop)
 		assert.Equal(t, "/", string(state.lineBuf))
@@ -2146,7 +2418,7 @@ func TestHandleAttachByteTabCompletion(t *testing.T) {
 		state.display.setRaw(true)
 		typewrite(t, state, "/e")
 
-		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil)
+		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil, nil)
 		assert.NoError(t, err)
 		assert.False(t, stop)
 		assert.Equal(t, "/exit ", string(state.lineBuf))
@@ -2157,7 +2429,7 @@ func TestHandleAttachByteTabCompletion(t *testing.T) {
 		state.display.setRaw(true)
 		typewrite(t, state, "/zz")
 
-		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil)
+		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil, nil)
 		assert.NoError(t, err)
 		assert.False(t, stop)
 		assert.Equal(t, "/zz", string(state.lineBuf))
@@ -2168,7 +2440,7 @@ func TestHandleAttachByteTabCompletion(t *testing.T) {
 		state.display.setRaw(true)
 		typewrite(t, state, "/a foo")
 
-		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil)
+		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil, nil)
 		assert.NoError(t, err)
 		assert.False(t, stop)
 		assert.Equal(t, "/a foo", string(state.lineBuf))
@@ -2217,7 +2489,7 @@ func TestAttachLoopExitCommand(t *testing.T) {
 		state.sessionRef = "my-session"
 
 		err := attachLoop(config, config.HostedAgents(), "sess_x",
-			strings.NewReader("/exit\n"), state)
+			strings.NewReader("/exit\n"), state, nil)
 		assert.NoError(t, err)
 		out := buf.String()
 		assert.Contains(t, out, "Disconnected from session locally")
@@ -2234,7 +2506,7 @@ func TestProcessAttachLineExitCommand(t *testing.T) {
 		state.sessionRef = "my-session"
 		config.Out = state.display
 
-		detach := processAttachLine(config, config.HostedAgents(), "sess_x", "/exit", state, nil)
+		detach := processAttachLine(config, config.HostedAgents(), "sess_x", "/exit", state, nil, nil)
 		assert.True(t, detach)
 		assert.Contains(t, buf.String(), "Disconnected from session locally")
 	})
@@ -2378,12 +2650,49 @@ func TestHandleAttachCommandUpload(t *testing.T) {
 	})
 }
 
-// TestHandleAttachCommandUpload_UsageError requires exactly two positional args.
+// TestHandleAttachCommandUpload_UsageError requires one or two positional args
+// (workspace-path is optional — see TestHandleAttachCommandUpload_DefaultsWorkspacePath).
 func TestHandleAttachCommandUpload_UsageError(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, _ *tcMocks) {
-		err := handleAttachCommand(config, config.HostedAgents(), "sess_x", "/upload only-one-arg", &pendingHITL{})
+		err := handleAttachCommand(config, config.HostedAgents(), "sess_x", "/upload", &pendingHITL{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "usage: /upload")
+
+		err = handleAttachCommand(config, config.HostedAgents(), "sess_x", "/upload a b c", &pendingHITL{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "usage: /upload")
+	})
+}
+
+// TestHandleAttachCommandUpload_DefaultsWorkspacePath confirms omitting
+// workspace-path uploads to the local file's basename at the workspace root —
+// like `curl -O`, retyping an identical filename twice is just noise.
+func TestHandleAttachCommandUpload_DefaultsWorkspacePath(t *testing.T) {
+	prevPoll := workspaceTransferPollInterval
+	workspaceTransferPollInterval = 0
+	defer func() { workspaceTransferPollInterval = prevPoll }()
+
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "main.go")
+	contents := []byte("package main\n\nfunc main() {}\n")
+	assert.NoError(t, os.WriteFile(localPath, contents, 0o644))
+	sha := sha256Hex(contents)
+
+	partServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer partServer.Close()
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		// Only the basename ("main.go"), not the full local path, must be used
+		// as the workspace destination.
+		expectWorkspaceTransferUpload(t, tm, "sess_x", "main.go", int64(len(contents)), sha, false, partServer.URL)
+
+		var buf bytes.Buffer
+		config.Out = &buf
+		line := fmt.Sprintf("/upload %s", localPath)
+		assert.NoError(t, handleAttachCommand(config, config.HostedAgents(), "sess_x", line, &pendingHITL{}))
+		assert.Contains(t, buf.String(), "Upload complete")
 	})
 }
 
@@ -2431,6 +2740,71 @@ func TestHandleAttachCommandDownload(t *testing.T) {
 		assert.Contains(t, buf.String(), "Downloaded")
 
 		got, err := os.ReadFile(saveTo)
+		assert.NoError(t, err)
+		assert.Equal(t, contents, got)
+	})
+}
+
+// TestHandleAttachCommandDownload_UsageError requires one or two positional
+// args (local-file is optional — see TestHandleAttachCommandDownload_DefaultsLocalFile).
+func TestHandleAttachCommandDownload_UsageError(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, _ *tcMocks) {
+		err := handleAttachCommand(config, config.HostedAgents(), "sess_x", "/download", &pendingHITL{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "usage: /download")
+
+		err = handleAttachCommand(config, config.HostedAgents(), "sess_x", "/download a b c", &pendingHITL{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "usage: /download")
+	})
+}
+
+// TestHandleAttachCommandDownload_DefaultsLocalFile reproduces the reported
+// devex bug: `/download /workspace/Plano-One-Pager.pdf` (one positional arg)
+// used to fail with a usage error even though the intent — save it under
+// that same name in the current directory — was unambiguous. Like `curl -O`,
+// omitting local-file now defaults to the workspace path's basename.
+func TestHandleAttachCommandDownload_DefaultsLocalFile(t *testing.T) {
+	prevPoll := workspaceTransferPollInterval
+	workspaceTransferPollInterval = 0
+	defer func() { workspaceTransferPollInterval = prevPoll }()
+
+	t.Chdir(t.TempDir())
+
+	contents := []byte("%PDF-1.4 fake one-pager\n")
+	wantSum := sha256Hex(contents)
+
+	objServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(contents)
+	}))
+	defer objServer.Close()
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().
+			CreateWorkspaceTransfer("sess_x", gomock.Any()).
+			DoAndReturn(func(sessionID string, create *godo.HostedAgentWorkspaceTransferCreateRequest) (*godo.HostedAgentWorkspaceTransfer, error) {
+				assert.Equal(t, "/workspace/Plano-One-Pager.pdf", create.Path)
+				return &godo.HostedAgentWorkspaceTransfer{
+					TransferID: "xfer_dl2",
+					Status:     godo.HostedAgentWorkspaceTransferStatusPending,
+				}, nil
+			})
+		tm.hostedAgents.EXPECT().
+			GetWorkspaceTransfer("sess_x", "xfer_dl2").
+			Return(&godo.HostedAgentWorkspaceTransfer{
+				TransferID:  "xfer_dl2",
+				Status:      godo.HostedAgentWorkspaceTransferStatusCompleted,
+				SHA256:      wantSum,
+				DownloadURL: objServer.URL,
+			}, nil)
+
+		var buf bytes.Buffer
+		config.Out = &buf
+		err := handleAttachCommand(config, config.HostedAgents(), "sess_x", "/download /workspace/Plano-One-Pager.pdf", &pendingHITL{})
+		assert.NoError(t, err)
+		assert.Contains(t, buf.String(), "Downloaded")
+
+		got, err := os.ReadFile("Plano-One-Pager.pdf")
 		assert.NoError(t, err)
 		assert.Equal(t, contents, got)
 	})
@@ -3169,6 +3543,252 @@ func TestDrainStream_HITLReattachShowsCommand(t *testing.T) {
 	assert.Equal(t, hitlID, pending.get())
 }
 
+// TestRenderApprovalResolvedLine confirms the resolved line shares
+// renderApprovalLine's exact "status  ·  label  ·  id" structure (just with a
+// different status), for every outcome, and degrades to omitting the label
+// segment (rather than "action pending", which no longer applies once
+// resolved) when no label was ever captured.
+func TestRenderApprovalResolvedLine(t *testing.T) {
+	cases := []struct {
+		outcome int32
+		want    string
+	}{
+		{1, "Approved"},
+		{2, "Rejected"},
+		{3, "Deferred"},
+	}
+	for _, tc := range cases {
+		var buf bytes.Buffer
+		renderApprovalResolvedLine(&buf, "hitl-123", "tool_permission", tc.outcome)
+		out := buf.String()
+		assert.Contains(t, out, tc.want)
+		assert.Contains(t, out, "tool_permission")
+		assert.Contains(t, out, "hitl-123")
+	}
+
+	var buf bytes.Buffer
+	renderApprovalResolvedLine(&buf, "hitl-123", "", 1)
+	assert.NotContains(t, buf.String(), "action pending")
+	assert.Contains(t, buf.String(), "hitl-123")
+}
+
+// TestDrainStream_HITLResolvedReprintsRequestLabel reproduces a devex bug: the
+// resolution of a HITL approval used to print a disconnected "<id> approve"
+// line with no relation to the "● Approval required · <label> · <id>" line
+// above it, leaving that line looking stale. The resolution must now reuse
+// the same label and read as that line updating (status  ·  label  ·  id),
+// not a brand new unrelated entry.
+func TestDrainStream_HITLResolvedReprintsRequestLabel(t *testing.T) {
+	const hitlID = "01a025a0-e622-7153-a23d-d18b4dde462f"
+	body := sseFrame("evt-1", string(godo.HostedAgentEventKindRunStarted), `{"agent":"claude-code"}`) +
+		sseFrame("evt-2", string(godo.HostedAgentEventKindHITLRequested), fmt.Sprintf(`{"hitl_id":%q,"action":"tool_permission"}`, hitlID)) +
+		// No paired tool_call_started arrives for this generic permission
+		// check; the next discrete event flushes the unpaired approval line.
+		sseFrame("evt-3", string(godo.HostedAgentEventKindSessionUpdated), `{}`) +
+		sseFrame("evt-4", string(godo.HostedAgentEventKindHITLResolved), fmt.Sprintf(`{"hitl_id":%q,"outcome":1}`, hitlID))
+	srv := httptest.NewServer(hostedAgentSSEHandler(body, nil))
+	t.Cleanup(srv.Close)
+
+	client, err := godo.New(nil, godo.SetBaseURL(srv.URL+"/"))
+	assert.NoError(t, err)
+	stream := openHostedAgentStream(t, client, nil)
+	defer stream.Close()
+
+	var buf bytes.Buffer
+	drainStream(stream, &buf, &pendingHITL{}, &eventCursor{}, newThinkingState(&buf), nil, &tokenDeduper{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Approval required")
+	assert.Contains(t, out, "tool_permission")
+	assert.Contains(t, out, "Approved")
+	// The resolved line must carry the same label forward and use the id — but
+	// never as the old bare "<id> approve" pairing with no shared structure.
+	assert.NotContains(t, out, hitlID+" approve")
+	idx := strings.Index(out, "Approved")
+	require.GreaterOrEqual(t, idx, 0)
+	lineEnd := idx + strings.Index(out[idx:], "\n")
+	approvedLine := out[idx:lineEnd]
+	assert.Contains(t, approvedLine, "tool_permission")
+	assert.Contains(t, approvedLine, hitlID)
+}
+
+// TestDrainStream_TokenChunksUpdateThinkingPreview pins that drainStream feeds
+// each streamed final-answer token_delta chunk (is_reasoning omitted/false)
+// into the thinking spinner's live preview label, so the spinner reads as a
+// live typing indicator while the message is still buffering toward its
+// eventual markdown-rendered flush.
+func TestDrainStream_TokenChunksUpdateThinkingPreview(t *testing.T) {
+	body := sseFrame("evt-1", string(godo.HostedAgentEventKindRunStarted), `{"agent":"claude-code"}`) +
+		sseFrame("evt-2", string(godo.HostedAgentEventKindTokenChunk), `{"text":"Let me look "}`) +
+		sseFrame("evt-3", string(godo.HostedAgentEventKindTokenChunk), `{"text":"at the file."}`)
+	srv := httptest.NewServer(hostedAgentSSEHandler(body, nil))
+	t.Cleanup(srv.Close)
+
+	client, err := godo.New(nil, godo.SetBaseURL(srv.URL+"/"))
+	assert.NoError(t, err)
+	stream := openHostedAgentStream(t, client, nil)
+	defer stream.Close()
+
+	var buf bytes.Buffer
+	thinking := newThinkingState(&buf)
+	drainStream(stream, &buf, &pendingHITL{}, &eventCursor{}, thinking, nil, &tokenDeduper{})
+
+	assert.Equal(t, "Let me look at the file.", thinking.currentLabel())
+}
+
+// TestDrainStream_RunStaysStickyThroughToolCall pins that the "Run in
+// progress" spinner restarts after a discrete line (like a tool-call start)
+// prints, instead of staying off for the remainder of the run — a tool call
+// can take many seconds with no other output, and without this the run would
+// look identical to a hung session. Uses a *promptDisplay-backed thinking so
+// isSticky() is true and the restart actually takes effect.
+func TestDrainStream_RunStaysStickyThroughToolCall(t *testing.T) {
+	body := sseFrame("evt-1", string(godo.HostedAgentEventKindRunStarted), `{"agent":"claude-code"}`) +
+		sseFrame("evt-2", string(godo.HostedAgentEventKindToolCallStarted), `{"tool_call_id":"t1","name":"bash"}`) +
+		sseFrame("evt-3", string(godo.HostedAgentEventKindRunCompleted), `{}`)
+	srv := httptest.NewServer(hostedAgentSSEHandler(body, nil))
+	t.Cleanup(srv.Close)
+
+	client, err := godo.New(nil, godo.SetBaseURL(srv.URL+"/"))
+	assert.NoError(t, err)
+	stream := openHostedAgentStream(t, client, nil)
+	defer stream.Close()
+
+	var buf bytes.Buffer
+	pending := &pendingHITL{}
+	state := newAttachState(&buf, pending)
+	state.display.setRaw(true)
+	thinking := newThinkingState(state.display)
+	require.True(t, thinking.isSticky())
+
+	drainStream(stream, state.display, pending, &eventCursor{}, thinking, nil, &tokenDeduper{})
+
+	out := buf.String()
+	assert.Contains(t, out, "▸ bash")
+	// One spinnerInit right after RunStarted, and a second one after the
+	// tool-call line — proving the spinner came back instead of staying
+	// dark for the rest of the run.
+	assert.GreaterOrEqual(t, strings.Count(out, defaultThinkingLabel), 2,
+		"spinner should restart after the tool-call line, not just once at RunStarted")
+}
+
+// TestDrainStream_ReasoningTokensStreamDistinctlyFromFinalAnswer pins that
+// run.token_delta chunks flagged is_reasoning=true stream live and separately
+// (dim italic, via reasoningStreamer) from the buffered final answer, which
+// starts at the first is_reasoning=false chunk — mirroring the SPI
+// TokenChunk.is_reasoning contract.
+func TestDrainStream_ReasoningTokensStreamDistinctlyFromFinalAnswer(t *testing.T) {
+	body := sseFrame("evt-1", string(godo.HostedAgentEventKindRunStarted), `{"agent":"claude-code"}`) +
+		sseFrame("evt-2", string(godo.HostedAgentEventKindTokenChunk), `{"text":"Let me think... ","is_reasoning":true}`) +
+		sseFrame("evt-3", string(godo.HostedAgentEventKindTokenChunk), `{"text":"this looks right.","is_reasoning":true}`) +
+		sseFrame("evt-4", string(godo.HostedAgentEventKindTokenChunk), `{"text":"The answer is 42.","is_reasoning":false}`)
+	srv := httptest.NewServer(hostedAgentSSEHandler(body, nil))
+	t.Cleanup(srv.Close)
+
+	client, err := godo.New(nil, godo.SetBaseURL(srv.URL+"/"))
+	assert.NoError(t, err)
+	stream := openHostedAgentStream(t, client, nil)
+	defer stream.Close()
+
+	var buf bytes.Buffer
+	thinking := newThinkingState(&buf)
+	drainStream(stream, &buf, &pendingHITL{}, &eventCursor{}, thinking, nil, &tokenDeduper{})
+
+	out := buf.String()
+	assert.Contains(t, out, "reasoning", "reasoning block gets a leading label")
+	assert.Contains(t, out, "Let me think... this looks right.", "reasoning text streams live")
+	// The final answer is buffered and rendered as markdown, not streamed
+	// into the reasoning block or lost.
+	assert.Contains(t, out, "42")
+	// The live preview label only ever reflects the buffered final answer,
+	// never raw reasoning text — reasoning already has its own display.
+	assert.Equal(t, "The answer is 42.", thinking.currentLabel())
+}
+
+// TestDrainStream_ReasoningToAnswerTransitionDoesNotFlashDefaultLabel is a
+// regression test for the sticky spinner visibly showing "Run in progress"
+// twice per turn: once at RunStarted, and again for one frame every time a
+// reasoning block closes and the final answer's first chunk arrives — because
+// resuming the spinner reset its label to blank (falling back to the default
+// caption) before the very next setLabel call caught up. The fix seeds the
+// resumed spinner's first frame with the already-known preview instead
+// (reasoningStreamer.endWithLabel / thinkingState.startWithLabel), so
+// defaultThinkingLabel should only ever appear once — from RunStarted — not
+// a second time at the reasoning/answer boundary. Uses a *promptDisplay so
+// isSticky() is true and the literal spinnerInit text is observable.
+func TestDrainStream_ReasoningToAnswerTransitionDoesNotFlashDefaultLabel(t *testing.T) {
+	body := sseFrame("evt-1", string(godo.HostedAgentEventKindRunStarted), `{"agent":"claude-code"}`) +
+		sseFrame("evt-2", string(godo.HostedAgentEventKindTokenChunk), `{"text":"Let me think... ","is_reasoning":true}`) +
+		sseFrame("evt-3", string(godo.HostedAgentEventKindTokenChunk), `{"text":"The answer is 42.","is_reasoning":false}`) +
+		sseFrame("evt-4", string(godo.HostedAgentEventKindRunCompleted), `{}`)
+	srv := httptest.NewServer(hostedAgentSSEHandler(body, nil))
+	t.Cleanup(srv.Close)
+
+	client, err := godo.New(nil, godo.SetBaseURL(srv.URL+"/"))
+	assert.NoError(t, err)
+	stream := openHostedAgentStream(t, client, nil)
+	defer stream.Close()
+
+	var buf bytes.Buffer
+	pending := &pendingHITL{}
+	state := newAttachState(&buf, pending)
+	state.display.setRaw(true)
+	thinking := newThinkingState(state.display)
+	require.True(t, thinking.isSticky())
+
+	drainStream(stream, state.display, pending, &eventCursor{}, thinking, nil, &tokenDeduper{})
+
+	out := buf.String()
+	assert.Equal(t, 1, strings.Count(out, defaultThinkingLabel),
+		"the generic caption should only show once (RunStarted), not again when reasoning hands off to the final answer")
+	// The spinner resumed right at the reasoning/answer boundary with the
+	// answer's own preview text, not a blank/default frame.
+	assert.Contains(t, out, "The answer is 42.")
+}
+
+// TestDrainStream_StickySpinnerDoesNotInterruptReasoningStream is a
+// regression test for a bug where the sticky "Run in progress" restart (see
+// TestDrainStream_RunStaysStickyThroughToolCall) fired after every single
+// TokenChunk event, including the reasoning deltas that reasoningStreamer
+// deliberately leaves the spinner stopped for across a whole block. That
+// reinit landed mid-line, injecting a stray "Run in progress" line (and a
+// spurious newline) into the middle of the streamed reasoning text. Uses a
+// *promptDisplay-backed thinking (isSticky() true) — the bug never reproduced
+// against a plain io.Writer because the sticky restart is skipped when
+// !isSticky().
+func TestDrainStream_StickySpinnerDoesNotInterruptReasoningStream(t *testing.T) {
+	body := sseFrame("evt-1", string(godo.HostedAgentEventKindRunStarted), `{"agent":"claude-code"}`) +
+		sseFrame("evt-2", string(godo.HostedAgentEventKindTokenChunk), `{"text":"Let me think... ","is_reasoning":true}`) +
+		sseFrame("evt-3", string(godo.HostedAgentEventKindTokenChunk), `{"text":"this looks right.","is_reasoning":true}`) +
+		sseFrame("evt-4", string(godo.HostedAgentEventKindTokenChunk), `{"text":"The answer is 42.","is_reasoning":false}`) +
+		sseFrame("evt-5", string(godo.HostedAgentEventKindRunCompleted), `{}`)
+	srv := httptest.NewServer(hostedAgentSSEHandler(body, nil))
+	t.Cleanup(srv.Close)
+
+	client, err := godo.New(nil, godo.SetBaseURL(srv.URL+"/"))
+	assert.NoError(t, err)
+	stream := openHostedAgentStream(t, client, nil)
+	defer stream.Close()
+
+	var buf bytes.Buffer
+	pending := &pendingHITL{}
+	state := newAttachState(&buf, pending)
+	state.display.setRaw(true)
+	thinking := newThinkingState(state.display)
+	require.True(t, thinking.isSticky())
+
+	drainStream(stream, state.display, pending, &eventCursor{}, thinking, nil, &tokenDeduper{})
+
+	out := buf.String()
+	// The reasoning text must stay contiguous across both chunks. The bug
+	// this pins: the sticky restart used to fire after the first reasoning
+	// chunk too (thinking.active goes false the moment reasoningStreamer
+	// pauses it for the block), reiniting the spinner — and forcing a
+	// newline to do it, since the write landed mid-line — right between
+	// "Let me think... " and "this looks right.".
+	assert.Contains(t, out, "Let me think... this looks right.")
+}
+
 // TestDrainStream_skipsStreamStateControlFrames pins that a live stream.state
 // frame is transport bookkeeping: it renders nothing and must not become the
 // reconnect cursor, or a reconnect would resume from a position no event holds.
@@ -3502,7 +4122,7 @@ func TestWarmupState_noteQueuedUpdatesNotice(t *testing.T) {
 
 	// Further typing keeps the prompt in sync with the warm-up block.
 	buf.Reset()
-	stop, err := handleAttachByte(nil, nil, "sess", 'i', state, w)
+	stop, err := handleAttachByte(nil, nil, "sess", 'i', state, w, nil)
 	assert.NoError(t, err)
 	assert.False(t, stop)
 	assert.Contains(t, buf.String(), "> i")
@@ -3525,15 +4145,15 @@ func TestWarmupState_blocksDuplicateSubmit(t *testing.T) {
 		w.start()
 
 		for _, b := range []byte("2+2") {
-			_, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, w)
+			_, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, w, nil)
 			assert.NoError(t, err)
 		}
-		stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, w)
+		stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, w, nil)
 		assert.NoError(t, err)
 		assert.False(t, stop)
 		assert.True(t, w.inputAlreadyQueued())
 
-		stop, err = handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, w)
+		stop, err = handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, w, nil)
 		assert.NoError(t, err)
 		assert.False(t, stop)
 	})

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -27,10 +27,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/digitalocean/doctl"
 	"github.com/digitalocean/doctl/do"
@@ -255,6 +257,7 @@ func TestRunAgentsStart(t *testing.T) {
 }
 
 func TestRunAgentsStart_FromHarness(t *testing.T) {
+	t.Setenv(anthropicAPIKeyEnv, "sk-ant-test")
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.hostedAgents.EXPECT().
 			CreateSessionFromManifest(gomock.Any(), nil).
@@ -262,6 +265,9 @@ func TestRunAgentsStart_FromHarness(t *testing.T) {
 				var doc map[string]any
 				assert.NoError(t, yaml.Unmarshal(manifest, &doc))
 				assert.Equal(t, "claude-code", doc["agent"])
+				env, ok := doc["env"].(map[any]any)
+				assert.True(t, ok)
+				assert.Equal(t, "sk-ant-test", env["ANTHROPIC_API_KEY"])
 				return &do.HostedAgentSession{
 					HostedAgentSession: &godo.HostedAgentSession{
 						SessionID: "sess_harness",
@@ -2094,6 +2100,81 @@ func TestSingleKeystrokeAdvancesQueue(t *testing.T) {
 	})
 }
 
+// TestHandleAttachByteTabCompletion covers Tab-completion of slash commands:
+// a unique prefix fills in the verb, an ambiguous one lists candidates, and
+// completion never fires once an argument has started.
+func TestHandleAttachByteTabCompletion(t *testing.T) {
+	typewrite := func(t *testing.T, state *attachState, s string) {
+		t.Helper()
+		for i := 0; i < len(s); i++ {
+			stop, err := handleAttachByte(nil, nil, "sess", s[i], state, nil)
+			assert.NoError(t, err)
+			assert.False(t, stop)
+		}
+	}
+
+	t.Run("unique prefix completes with a trailing space", func(t *testing.T) {
+		state := newAttachState(io.Discard, &pendingHITL{})
+		state.display.setRaw(true)
+		typewrite(t, state, "/pa")
+
+		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil)
+		assert.NoError(t, err)
+		assert.False(t, stop)
+		assert.Equal(t, "/pause ", string(state.lineBuf))
+		assert.Equal(t, len("/pause "), state.cursor)
+	})
+
+	t.Run("ambiguous prefix lists matches without altering the buffer", func(t *testing.T) {
+		var buf bytes.Buffer
+		state := newAttachState(&buf, &pendingHITL{})
+		state.display.setRaw(true)
+		typewrite(t, state, "/")
+
+		config := &CmdConfig{Out: state.display}
+		stop, err := handleAttachByte(config, nil, "sess", 0x09, state, nil)
+		assert.NoError(t, err)
+		assert.False(t, stop)
+		assert.Equal(t, "/", string(state.lineBuf))
+		out := buf.String()
+		assert.Contains(t, out, "/help")
+		assert.Contains(t, out, "/download")
+	})
+
+	t.Run("/exit completes uniquely", func(t *testing.T) {
+		state := newAttachState(io.Discard, &pendingHITL{})
+		state.display.setRaw(true)
+		typewrite(t, state, "/e")
+
+		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil)
+		assert.NoError(t, err)
+		assert.False(t, stop)
+		assert.Equal(t, "/exit ", string(state.lineBuf))
+	})
+
+	t.Run("no match leaves the buffer untouched", func(t *testing.T) {
+		state := newAttachState(io.Discard, &pendingHITL{})
+		state.display.setRaw(true)
+		typewrite(t, state, "/zz")
+
+		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil)
+		assert.NoError(t, err)
+		assert.False(t, stop)
+		assert.Equal(t, "/zz", string(state.lineBuf))
+	})
+
+	t.Run("does not fire once an argument has started", func(t *testing.T) {
+		state := newAttachState(io.Discard, &pendingHITL{})
+		state.display.setRaw(true)
+		typewrite(t, state, "/a foo")
+
+		stop, err := handleAttachByte(nil, nil, "sess", 0x09, state, nil)
+		assert.NoError(t, err)
+		assert.False(t, stop)
+		assert.Equal(t, "/a foo", string(state.lineBuf))
+	})
+}
+
 // TestListPendingHITLs covers the /pending command output for empty, single,
 // and multi-entry queues.
 func TestListPendingHITLs(t *testing.T) {
@@ -2125,6 +2206,118 @@ func TestListPendingHITLs(t *testing.T) {
 	})
 }
 
+// TestAttachLoopExitCommand: /exit in line mode (piped input) detaches like
+// Ctrl-D / EOF — it prints the disconnect notice and returns without error,
+// leaving the hosted session untouched.
+func TestAttachLoopExitCommand(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, _ *tcMocks) {
+		var buf bytes.Buffer
+		config.Out = &buf
+		state := testAttachStateFromPending(nil)
+		state.sessionRef = "my-session"
+
+		err := attachLoop(config, config.HostedAgents(), "sess_x",
+			strings.NewReader("/exit\n"), state)
+		assert.NoError(t, err)
+		out := buf.String()
+		assert.Contains(t, out, "Disconnected from session locally")
+		assert.Contains(t, out, "still active in the cloud")
+	})
+}
+
+// TestProcessAttachLineExitCommand covers the TTY-mode dispatch: /exit must
+// report detach=true so the raw-mode loop stops reading bytes.
+func TestProcessAttachLineExitCommand(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, _ *tcMocks) {
+		var buf bytes.Buffer
+		state := newAttachState(&buf, &pendingHITL{})
+		state.sessionRef = "my-session"
+		config.Out = state.display
+
+		detach := processAttachLine(config, config.HostedAgents(), "sess_x", "/exit", state, nil)
+		assert.True(t, detach)
+		assert.Contains(t, buf.String(), "Disconnected from session locally")
+	})
+}
+
+// TestIsAttachExitCommand pins the exact-match contract: only a bare /exit
+// counts, not other slash commands or /exit with trailing arguments.
+func TestIsAttachExitCommand(t *testing.T) {
+	assert.True(t, isAttachExitCommand("/exit"))
+	assert.False(t, isAttachExitCommand("/exit now"))
+	assert.False(t, isAttachExitCommand("/exiting"))
+	assert.False(t, isAttachExitCommand("/help"))
+	assert.False(t, isAttachExitCommand(""))
+}
+
+// TestHandleAttachCommandHelp exercises the /help card, and pins the
+// tabwriter-aligned layout: every row's description column must start at the
+// same offset within its section (hand-counted spaces used to drift out of
+// alignment; tabwriter can't).
+func TestHandleAttachCommandHelp(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, _ *tcMocks) {
+		var buf bytes.Buffer
+		config.Out = &buf
+
+		assert.NoError(t, handleAttachCommand(config, config.HostedAgents(), "sess_x", "/help", &pendingHITL{}))
+		out := buf.String()
+
+		assert.Contains(t, out, "Attach help")
+		assert.Contains(t, out, "Detach (session keeps running)")
+		assert.Contains(t, out, "/exit")
+		assert.Contains(t, out, "Session controls")
+		assert.Contains(t, out, "/pause")
+		assert.Contains(t, out, "/upload")
+		assert.Contains(t, out, "/download")
+		assert.Contains(t, out, "Approvals pending")
+		assert.Contains(t, out, "/pending")
+		assert.Contains(t, out, "Tab")
+		assert.Contains(t, out, "attach <session>")
+		assert.Contains(t, out, "remove <session>")
+
+		sectionLines := func(header string) []string {
+			lines := strings.Split(out, "\n")
+			var section []string
+			started := false
+			for _, l := range lines {
+				if strings.Contains(l, header) {
+					started = true
+					continue
+				}
+				if !started {
+					continue
+				}
+				if strings.TrimSpace(l) == "" {
+					break
+				}
+				section = append(section, l)
+			}
+			return section
+		}
+
+		gapRE := regexp.MustCompile(`\S(\s{2,})\S`)
+		descColumn := func(line string) int {
+			// The first run of 2+ spaces between two non-space runs is the
+			// gap tabwriter inserted before the description column; report
+			// where the description text itself starts, in runes (tabwriter
+			// aligns by rune count, but FindStringSubmatchIndex is byte-based
+			// — some keys here contain multi-byte glyphs like "↑/↓").
+			loc := gapRE.FindStringSubmatchIndex(line)
+			require.NotNil(t, loc, "line %q has no column gap", line)
+			return utf8.RuneCountInString(line[:loc[3]])
+		}
+
+		for _, header := range []string{"Session controls", "Approvals pending"} {
+			lines := sectionLines(header)
+			require.NotEmpty(t, lines, "section %q not found", header)
+			want := descColumn(lines[0])
+			for _, l := range lines[1:] {
+				assert.Equal(t, want, descColumn(l), "misaligned row in %q section: %q", header, l)
+			}
+		}
+	})
+}
+
 // TestHandleAttachCommandPending exercises the /pending verb dispatch.
 func TestHandleAttachCommandPending(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, _ *tcMocks) {
@@ -2136,6 +2329,110 @@ func TestHandleAttachCommandPending(t *testing.T) {
 		assert.NoError(t, handleAttachCommand(config, config.HostedAgents(), "sess_x", "/pending", p))
 		assert.Contains(t, buf.String(), "1 HITL approval(s) pending")
 		assert.Contains(t, buf.String(), "* h1  (HITL_ACTION_BASH)")
+	})
+}
+
+// TestHandleAttachCommandPauseResume exercises the /pause and /resume verbs.
+func TestHandleAttachCommandPauseResume(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		var buf bytes.Buffer
+		config.Out = &buf
+
+		tm.hostedAgents.EXPECT().PauseSession("sess_x").Return(nil)
+		assert.NoError(t, handleAttachCommand(config, config.HostedAgents(), "sess_x", "/pause", &pendingHITL{}))
+		assert.Contains(t, buf.String(), "Session paused")
+
+		buf.Reset()
+		tm.hostedAgents.EXPECT().ResumeSession("sess_x").Return(nil)
+		assert.NoError(t, handleAttachCommand(config, config.HostedAgents(), "sess_x", "/resume", &pendingHITL{}))
+		assert.Contains(t, buf.String(), "Session resumed")
+	})
+}
+
+// TestHandleAttachCommandUpload exercises the /upload verb, mirroring
+// `doctl agents upload` but driven from the interactive attach REPL.
+func TestHandleAttachCommandUpload(t *testing.T) {
+	prevPoll := workspaceTransferPollInterval
+	workspaceTransferPollInterval = 0
+	defer func() { workspaceTransferPollInterval = prevPoll }()
+
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "main.go")
+	contents := []byte("package main\n\nfunc main() {}\n")
+	assert.NoError(t, os.WriteFile(localPath, contents, 0o644))
+	sha := sha256Hex(contents)
+
+	partServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer partServer.Close()
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		expectWorkspaceTransferUpload(t, tm, "sess_x", "src/main.go", int64(len(contents)), sha, false, partServer.URL)
+
+		var buf bytes.Buffer
+		config.Out = &buf
+		line := fmt.Sprintf("/upload %s src/main.go", localPath)
+		assert.NoError(t, handleAttachCommand(config, config.HostedAgents(), "sess_x", line, &pendingHITL{}))
+		assert.Contains(t, buf.String(), "Upload complete")
+	})
+}
+
+// TestHandleAttachCommandUpload_UsageError requires exactly two positional args.
+func TestHandleAttachCommandUpload_UsageError(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, _ *tcMocks) {
+		err := handleAttachCommand(config, config.HostedAgents(), "sess_x", "/upload only-one-arg", &pendingHITL{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "usage: /upload")
+	})
+}
+
+// TestHandleAttachCommandDownload exercises the /download verb, mirroring
+// `doctl agents download` but driven from the interactive attach REPL.
+func TestHandleAttachCommandDownload(t *testing.T) {
+	prevPoll := workspaceTransferPollInterval
+	workspaceTransferPollInterval = 0
+	defer func() { workspaceTransferPollInterval = prevPoll }()
+
+	dir := t.TempDir()
+	saveTo := filepath.Join(dir, "out.go")
+	contents := []byte("package main\n\nfunc main() {}\n")
+	wantSum := sha256Hex(contents)
+
+	objServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(contents)
+	}))
+	defer objServer.Close()
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().
+			CreateWorkspaceTransfer("sess_x", gomock.Any()).
+			DoAndReturn(func(sessionID string, create *godo.HostedAgentWorkspaceTransferCreateRequest) (*godo.HostedAgentWorkspaceTransfer, error) {
+				assert.Equal(t, godo.HostedAgentWorkspaceTransferDirectionDownload, create.Direction)
+				assert.Equal(t, "src/main.go", create.Path)
+				return &godo.HostedAgentWorkspaceTransfer{
+					TransferID: "xfer_dl",
+					Status:     godo.HostedAgentWorkspaceTransferStatusPending,
+				}, nil
+			})
+		tm.hostedAgents.EXPECT().
+			GetWorkspaceTransfer("sess_x", "xfer_dl").
+			Return(&godo.HostedAgentWorkspaceTransfer{
+				TransferID:  "xfer_dl",
+				Status:      godo.HostedAgentWorkspaceTransferStatusCompleted,
+				SHA256:      wantSum,
+				DownloadURL: objServer.URL,
+			}, nil)
+
+		var buf bytes.Buffer
+		config.Out = &buf
+		line := fmt.Sprintf("/download src/main.go %s", saveTo)
+		assert.NoError(t, handleAttachCommand(config, config.HostedAgents(), "sess_x", line, &pendingHITL{}))
+		assert.Contains(t, buf.String(), "Downloaded")
+
+		got, err := os.ReadFile(saveTo)
+		assert.NoError(t, err)
+		assert.Equal(t, contents, got)
 	})
 }
 

--- a/commands/openai_agents_test.go
+++ b/commands/openai_agents_test.go
@@ -503,3 +503,65 @@ func TestOpenAIAttachRenderer_PolishedOutput(t *testing.T) {
 	assert.Contains(t, out, "run complete")
 	assert.NotContains(t, out, `"event_id"`)
 }
+
+func TestOpenAIAttachRenderer_ReasoningStreamedViaDelta(t *testing.T) {
+	var buf strings.Builder
+	r := &openAIAttachRenderer{out: &buf}
+
+	r.handle(map[string]any{"type": "session.turn.created"})
+	r.handle(map[string]any{"type": "session.turn.reasoning_summary_text.delta", "delta": "Let's check "})
+	r.handle(map[string]any{"type": "session.turn.reasoning_summary_text.delta", "delta": "the file first."})
+	r.handle(map[string]any{"type": "session.turn.reasoning_summary_text.done", "text": "Let's check the file first."})
+	r.handle(map[string]any{"type": "session.turn.output_text.delta", "delta": "Done."})
+	r.handle(map[string]any{"type": "session.turn.completed"})
+
+	out := buf.String()
+	assert.Contains(t, out, "Let's check the file first.")
+	assert.Contains(t, out, "Done.")
+	// The .done fallback must not duplicate text already streamed via deltas.
+	assert.Equal(t, 1, strings.Count(out, "Let's check the file first."))
+}
+
+func TestOpenAIAttachRenderer_ReasoningItemDoneFallback(t *testing.T) {
+	var buf strings.Builder
+	r := &openAIAttachRenderer{out: &buf}
+
+	r.handle(map[string]any{"type": "session.turn.created"})
+	r.handle(map[string]any{
+		"type": "session.turn.item.added",
+		"item": map[string]any{"type": "reasoning"},
+	})
+	r.handle(map[string]any{
+		"type": "session.turn.item.done",
+		"item": map[string]any{
+			"type": "reasoning",
+			"summary": []any{
+				map[string]any{"type": "summary_text", "text": "Considering the best approach."},
+			},
+		},
+	})
+	r.handle(map[string]any{"type": "session.turn.output_text.delta", "delta": "Here's the plan."})
+	r.handle(map[string]any{"type": "session.turn.completed"})
+
+	out := buf.String()
+	assert.Contains(t, out, "Considering the best approach.")
+	assert.Contains(t, out, "Here's the plan.")
+}
+
+func TestOpenAIAttachRenderer_ReasoningDoesNotLeakIntoFinalAnswer(t *testing.T) {
+	var buf strings.Builder
+	r := &openAIAttachRenderer{out: &buf}
+
+	r.handle(map[string]any{"type": "session.turn.created"})
+	r.handle(map[string]any{"type": "session.turn.reasoning_summary_text.delta", "delta": "internal thoughts"})
+	r.handle(map[string]any{"type": "session.turn.reasoning_summary_text.done", "text": "internal thoughts"})
+	r.handle(map[string]any{"type": "session.turn.output_text.delta", "delta": "the actual answer"})
+	r.handle(map[string]any{"type": "session.turn.completed"})
+
+	out := buf.String()
+	// Reasoning is streamed directly to r.out, never through r.acc, so it must
+	// not appear inside the markdown-rendered final-answer block.
+	completedIdx := strings.Index(out, "the actual answer")
+	require.NotEqual(t, -1, completedIdx)
+	assert.NotContains(t, out[completedIdx:], "internal thoughts")
+}


### PR DESCRIPTION
## Summary

Follow-up UX pass on `doctl agent`/`doctl ohr` on top of `feat/agents-subcommands`, focused on making `attach` sessions legible in real time and tidying up display/validation along the way.

### Live run status & reasoning streaming (the core of this PR)

- Stream reasoning tokens live (dim italic, separate from the buffered final answer) instead of dropping them — for both the SPI protocol (`run.token_delta` with `is_reasoning=true`) and Codex's dedicated reasoning delta/done events.
- Keep a sticky "Run in progress" indicator visible for the *whole* run — tool calls, lifecycle events, not just the gap before the first token — so a multi-second tool call no longer looks identical to a hung session.
- Give accurate "message queued" feedback (distinct from the generic "Waiting for the agent...") when input is sent while a run is still in flight.
- Resolve HITL approvals in place ("Approval required" → "✓ Approved" / "✗ Rejected" / "⏸ Deferred" on the same line) instead of printing a disconnected receipt.

### Attach REPL input handling

- Fix a paste bug where pasting sufficiently long text corrupted the terminal with dozens of stale, truncated duplicate lines (the prompt was repainting on every pasted byte instead of once at the end).
- Add Option/Alt+Enter to insert a newline, so a message can be composed across multiple lines and sent as one input.
- Add `/pause`, `/resume`, `/upload`, `/download`, and `/exit` to the attach REPL, plus Tab-completion for slash commands. Make `/upload` and `/download`'s second argument optional, defaulting the local/workspace path to the other side's basename.
- Redesign the attach banner and detach notice to be left-aligned inside the green box, and rewrite `/help` as plain left-aligned text (no border) using `tabwriter` for column alignment.
- Animate session-creation waits with a live spinner + ticking elapsed time on a real terminal (replacing a static "Creating hosted session…" line that gave no feedback for the duration of the blocking API call). Piped/non-TTY output keeps the old one-line-per-step behavior.

### Display & validation cleanup

- Normalize hosted-agent kind/harness display names (`opencode` -> `OpenCode`, `claude-code` -> `Claude Code`, `codex` -> `Codex`, `cursor cli` -> `Cursor CLI`) so list/show/run output reads consistently.
- Hide session ID and repo by default; show both under `-v`/`--verbose`. Show `CreatedAt` as relative time ("5m ago") by default, full timestamp when verbose.
- Redesign agent error cards: drop the "Reason"/bullet labels and print the reason and next-step command directly, one line each.
- Validate that `ANTHROPIC_API_KEY` is set before creating a `claude-code` session (mirrors the existing `OPENAI_API_KEY`/codex check), so a missing key fails fast locally instead of erroring deep into hosted provisioning.

## Test plan

- [x] `go build ./commands/...`
- [x] `gofmt -l` / `go vet ./commands/...` clean
- [x] `go test ./commands/... ./do/...` (agents-related tests all pass; only pre-existing, unrelated `TestRegistryLogin`/`TestRegistryLogout` failures from macOS Keychain access in the sandbox)
- [x] Manually verified in a real terminal: live spinner animates and clears correctly during session creation
- [x] Manually verified: running `--harness claude-code` without `ANTHROPIC_API_KEY` fails fast with a clear local error, before any network call
- [x] Manually verified in `doctl agent attach`: reasoning streams live and distinctly from the final answer, the "Run in progress" indicator stays up through tool calls without corrupting the terminal, HITL approvals update in place, large pastes no longer duplicate lines, and Option/Alt+Enter composes multi-line messages