### PR TITLE
feat(agents): add `exec` to run a command in a session's sandbox

### DIFF
--- a/args.go
+++ b/args.go
@@ -981,6 +981,12 @@ const (
 	// ArgAgentArchive treats the workspace payload as a tar archive.
 	ArgAgentArchive = "archive"
 
+	// ArgAgentExecWorkdir is the guest directory a sandbox exec runs in.
+	ArgAgentExecWorkdir = "workdir"
+
+	// ArgAgentExecTimeout bounds a sandbox exec, in seconds.
+	ArgAgentExecTimeout = "timeout"
+
 	// ArgAgentProxyType selects which coding-agent protocol `start-proxy` impersonates.
 	ArgAgentProxyType = "type"
 

--- a/commands/agent_exec.go
+++ b/commands/agent_exec.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/commands/displayers"
+	"github.com/digitalocean/doctl/do"
+	"github.com/digitalocean/godo"
+)
+
+// execStderr is where a guest command's stderr is mirrored. c.Out only covers
+// stdout, and the two streams must stay separate for redirection to behave; a
+// var so tests can capture it.
+var execStderr io.Writer = os.Stderr
+
+// execExit ends doctl with the guest command's status. Exiting here rather than
+// returning an error is deliberate: doctl's shared checkErr can only ever exit
+// 1, and teaching it a second status would change behaviour for every other
+// command. A var so tests can observe the code instead of ending the test
+// binary.
+var execExit = os.Exit
+
+// RunAgentsExec runs one command in the session's sandbox and reproduces its
+// result locally: guest stdout and stderr are passed through unchanged and the
+// guest's exit code becomes doctl's, so the command composes in a pipeline or an
+// `&&` chain.
+func RunAgentsExec(c *CmdConfig) error {
+	// args[0] is the session; everything after it is the guest command. Callers
+	// separate the two with `--`, without which cobra would try to parse the
+	// guest command's own flags (`ls -la`) as doctl flags.
+	if len(c.Args) < 2 {
+		return doctl.NewMissingArgsErr(c.NS)
+	}
+	sessionID, err := resolveSessionRef(c.HostedAgents(), c.Args[0])
+	if err != nil {
+		return err
+	}
+	argv := c.Args[1:]
+
+	// Resolution above is a plain GET and keeps the shared retrying client; the
+	// exec itself must not.
+	if err := disableRetriesForExec(c); err != nil {
+		return err
+	}
+
+	workdir, err := c.Doit.GetString(c.NS, doctl.ArgAgentExecWorkdir)
+	if err != nil {
+		return err
+	}
+	timeout, err := c.Doit.GetInt(c.NS, doctl.ArgAgentExecTimeout)
+	if err != nil {
+		return err
+	}
+
+	// SIGTERM alongside SIGINT so Ctrl-C or a plain `kill` stops the wait
+	// instead of hanging until the server's own timeout. Giving up locally does
+	// NOT yet stop the guest process — it runs on until its timeout.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	resp, err := c.HostedAgents().ExecInSandbox(ctx, sessionID, &godo.HostedAgentSandboxExecRequest{
+		Argv:           argv,
+		Workdir:        workdir,
+		TimeoutSeconds: int64(timeout),
+	})
+	if err != nil {
+		return err
+	}
+
+	if Output == "json" {
+		if err := c.Display(&displayers.HostedAgentSandboxExec{
+			Execs:  []*godo.HostedAgentSandboxExecResponse{resp},
+			Single: true,
+		}); err != nil {
+			return err
+		}
+		return exitWithGuestStatus(resp.ExitCode)
+	}
+
+	// Verbatim, and with no added newline: the guest's bytes are the output
+	// contract, so anything appended here would corrupt a piped payload.
+	if _, err := io.WriteString(c.Out, resp.Stdout); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(execStderr, resp.Stderr); err != nil {
+		return err
+	}
+	return exitWithGuestStatus(resp.ExitCode)
+}
+
+// disableRetriesForExec swaps in a client that does not retry, following the
+// same pattern as `doctl account ratelimit`.
+//
+// doctl retries 429s and 5xx up to --http-retry-max (5 by default). That is
+// right for the idempotent calls it was written for and wrong for exec: a retry
+// runs the guest command a second time, so a `make install` answered with a 5xx
+// would be replayed up to six times. Losing the retry costs little here, since
+// the caller sees the failure and can re-run deliberately.
+func disableRetriesForExec(c *CmdConfig) error {
+	if RetryMax <= 0 {
+		return nil
+	}
+	godoClient, err := c.Doit.GetGodoClient(Trace, false, c.getContextAccessToken())
+	if err != nil {
+		return fmt.Errorf("unable to initialize DigitalOcean API client: %s", err)
+	}
+	c.HostedAgents = func() do.HostedAgentsService { return do.NewHostedAgentsService(godoClient) }
+	return nil
+}
+
+// exitWithGuestStatus reproduces the guest's exit code as doctl's own, so the
+// command composes in `&&` chains and `if` tests. A command that ran and failed
+// is not a doctl error, so nothing is printed on top of the output the guest
+// already produced.
+//
+// The guest's stdout and stderr have been written to file descriptors by this
+// point, so os.Exit cannot truncate them.
+func exitWithGuestStatus(code int) error {
+	if code == 0 {
+		return nil
+	}
+	execExit(code)
+	// Unreachable in a real run — os.Exit does not return. Under test the stub
+	// does, and the sentinel keeps the runner honest about having failed
+	// without printing a second error on top of the guest's.
+	return ErrExitSilently
+}

--- a/commands/agent_exec_test.go
+++ b/commands/agent_exec_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/godo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// A UUID-shaped ref so resolveSessionRef short-circuits instead of listing.
+const testExecSessionID = "01a01e58-6209-7c75-8b31-6cb80f7301ff"
+
+// noExit is the sentinel a stubbed execExit records when the runner never asked
+// to terminate.
+const noExit = -1
+
+// captureExec points stdout, stderr, and the exit call at the test instead of
+// the process, and returns the recorded exit code by pointer.
+func captureExec(t *testing.T, config *CmdConfig) (stdout, stderr *bytes.Buffer, exitCode *int) {
+	t.Helper()
+	stdout, stderr = &bytes.Buffer{}, &bytes.Buffer{}
+	config.Out = stdout
+
+	prevErr, prevExit := execStderr, execExit
+	execStderr = stderr
+	code := noExit
+	execExit = func(c int) { code = c }
+	t.Cleanup(func() { execStderr, execExit = prevErr, prevExit })
+
+	// Registering the root flags sets RetryMax to its default as a side effect,
+	// which would make the runner swap the mock for a live no-retry client. The
+	// swap has its own test below; here the mock has to survive.
+	prevRetry := RetryMax
+	RetryMax = 0
+	t.Cleanup(func() { RetryMax = prevRetry })
+
+	return stdout, stderr, &code
+}
+
+// exec is a flat verb like upload/download, not a nested group: it is a
+// session-scoped action, and the tree reserves subcommands for sub-resources
+// with their own CRUD (checkpoint, triggers, config).
+func TestAgentsExecIsAFlatVerb(t *testing.T) {
+	cmd := Agents()
+	require.NotNil(t, cmd)
+
+	var exec *cobra.Command
+	for _, c := range cmd.Commands() {
+		if c.Name() == "exec" {
+			exec = c
+		}
+	}
+	require.NotNil(t, exec, "agents exec must be registered on the root tree")
+	assert.False(t, exec.HasSubCommands(), "exec takes a command to run, not subcommands")
+}
+
+func TestAgentsExec(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		stdout, stderr, exitCode := captureExec(t, config)
+
+		tm.hostedAgents.EXPECT().
+			ExecInSandbox(gomock.Any(), testExecSessionID, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, req *godo.HostedAgentSandboxExecRequest) (*godo.HostedAgentSandboxExecResponse, error) {
+				assert.Equal(t, []string{"ls", "-la"}, req.Argv, "everything after the session is the guest command")
+				assert.Equal(t, "/workspace/src", req.Workdir)
+				assert.Equal(t, int64(30), req.TimeoutSeconds)
+				return &godo.HostedAgentSandboxExecResponse{Stdout: "total 0\n"}, nil
+			})
+
+		config.Args = []string{testExecSessionID, "ls", "-la"}
+		config.Doit.Set(config.NS, doctl.ArgAgentExecWorkdir, "/workspace/src")
+		config.Doit.Set(config.NS, doctl.ArgAgentExecTimeout, 30)
+
+		require.NoError(t, RunAgentsExec(config))
+		assert.Equal(t, "total 0\n", stdout.String())
+		assert.Empty(t, stderr.String())
+		assert.Equal(t, noExit, *exitCode, "a successful command must not force an exit status")
+	})
+}
+
+// Guest output is the contract: it must arrive byte-for-byte, with the streams
+// kept apart and no newline added by doctl.
+func TestAgentsExecPassesOutputThroughVerbatim(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		stdout, stderr, _ := captureExec(t, config)
+
+		tm.hostedAgents.EXPECT().
+			ExecInSandbox(gomock.Any(), testExecSessionID, gomock.Any()).
+			Return(&godo.HostedAgentSandboxExecResponse{
+				Stdout: "no trailing newline",
+				Stderr: "warning: careful\n",
+			}, nil)
+
+		config.Args = []string{testExecSessionID, "echo", "-n", "no trailing newline"}
+		require.NoError(t, RunAgentsExec(config))
+
+		assert.Equal(t, "no trailing newline", stdout.String())
+		assert.Equal(t, "warning: careful\n", stderr.String())
+	})
+}
+
+// A command that ran and failed is not a doctl error: the output still comes
+// through, and the guest's code becomes doctl's exit status so `&&` chains and
+// `if` tests behave.
+func TestAgentsExecPropagatesGuestExitCode(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		stdout, stderr, exitCode := captureExec(t, config)
+
+		tm.hostedAgents.EXPECT().
+			ExecInSandbox(gomock.Any(), testExecSessionID, gomock.Any()).
+			Return(&godo.HostedAgentSandboxExecResponse{
+				ExitCode: 2,
+				Stdout:   "partial work\n",
+				Stderr:   "make: *** Error 2\n",
+			}, nil)
+
+		config.Args = []string{testExecSessionID, "make"}
+		err := RunAgentsExec(config)
+
+		assert.Equal(t, 2, *exitCode)
+		// Silent: the guest already explained itself on stderr, so doctl must
+		// not print an error of its own on top.
+		assert.ErrorIs(t, err, ErrExitSilently)
+		assert.Equal(t, "partial work\n", stdout.String())
+		assert.Equal(t, "make: *** Error 2\n", stderr.String())
+	})
+}
+
+func TestAgentsExecJSONOutput(t *testing.T) {
+	prev := Output
+	Output = "json"
+	t.Cleanup(func() { Output = prev })
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		stdout, _, exitCode := captureExec(t, config)
+
+		tm.hostedAgents.EXPECT().
+			ExecInSandbox(gomock.Any(), testExecSessionID, gomock.Any()).
+			Return(&godo.HostedAgentSandboxExecResponse{
+				ExitCode: 7,
+				Stdout:   "out\n",
+				Stderr:   "err\n",
+			}, nil)
+
+		config.Args = []string{testExecSessionID, "false"}
+		_ = RunAgentsExec(config)
+
+		// The exit code still propagates under -o json, so a script can branch
+		// on status without parsing the body.
+		assert.Equal(t, 7, *exitCode)
+
+		var got godo.HostedAgentSandboxExecResponse
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &got), "body: %q", stdout.String())
+		assert.Equal(t, 7, got.ExitCode)
+		assert.Equal(t, "out\n", got.Stdout)
+		assert.Equal(t, "err\n", got.Stderr)
+	})
+}
+
+func TestAgentsExecRequiresACommand(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		config.Out = io.Discard
+		// A session with no argv cannot be run, so the API is never called.
+		config.Args = []string{testExecSessionID}
+		assert.Error(t, RunAgentsExec(config))
+
+		config.Args = []string{}
+		assert.Error(t, RunAgentsExec(config))
+	})
+}
+
+// Retrying an exec would run the guest command again, so the call must go
+// through a client with retries off whenever doctl's shared client has them on.
+func TestAgentsExecDoesNotRetry(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		prev := RetryMax
+		t.Cleanup(func() { RetryMax = prev })
+
+		RetryMax = 0
+		mocked := config.HostedAgents()
+		require.NoError(t, disableRetriesForExec(config))
+		assert.Same(t, mocked, config.HostedAgents(),
+			"with retries already off there is nothing to swap")
+
+		RetryMax = 5
+		require.NoError(t, disableRetriesForExec(config))
+		assert.NotSame(t, mocked, config.HostedAgents(),
+			"exec must not run against the retrying client")
+	})
+}
+
+func TestAgentsExecSurfacesTransportErrors(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		_, _, exitCode := captureExec(t, config)
+
+		tm.hostedAgents.EXPECT().
+			ExecInSandbox(gomock.Any(), testExecSessionID, gomock.Any()).
+			Return(nil, errors.New("session is not operable"))
+
+		config.Args = []string{testExecSessionID, "true"}
+		err := RunAgentsExec(config)
+
+		require.Error(t, err)
+		// A real failure keeps its message and the default status, unlike a
+		// non-zero guest exit.
+		assert.Contains(t, err.Error(), "session is not operable")
+		assert.NotErrorIs(t, err, ErrExitSilently)
+		assert.Equal(t, noExit, *exitCode)
+	})
+}

--- a/commands/agents.go
+++ b/commands/agents.go
@@ -349,6 +349,15 @@ func Agents() *Command {
 	AddBoolFlag(cmdDownload, doctl.ArgAgentArchive, "", false, "Tar-stream the directory at the source path")
 	cmdDownload.Example = `doctl open-harness-runtime download sess_abc123 --workspace-path src/main.go --save-to ./main.go`
 
+	cmdExec := CmdBuilder(cmd, RunAgentsExec, "exec <session> -- <command> [args...]",
+		"Run a command in a session's sandbox",
+		agentsExecHelpMD,
+		Writer, agentsNS(
+			displayerType(&displayers.HostedAgentSandboxExec{}))...)
+	AddStringFlag(cmdExec, doctl.ArgAgentExecWorkdir, "", "", "Absolute guest directory to run in (defaults to the workspace root)")
+	AddIntFlag(cmdExec, doctl.ArgAgentExecTimeout, "", 0, "Maximum seconds the command may run (0 uses the server default)")
+	cmdExec.Example = `doctl open-harness-runtime exec sess_abc123 -- ls -la; doctl open-harness-runtime exec my-session --workdir /workspace/src -- go test ./...`
+
 	cmdAuth := CmdBuilder(cmd, RunAgentsAuth, "auth <provider>",
 		"Connect an external provider (e.g. github) for agent git operations",
 		agentsAuthHelpMD,

--- a/commands/agents_help.go
+++ b/commands/agents_help.go
@@ -128,6 +128,16 @@ const agentsConfigListSessionsHelpMD = `List sessions started from a config. Fil
 
 const agentsConfigStartSessionHelpMD = `Start a new session from a config ID. ` + "`--name`" + ` is required and must be unique among active sessions.`
 
+const agentsExecHelpMD = `Run one command in a session's sandbox and print its output.
+
+Drives the sandbox directly rather than through its agent, so it works on a bare sandbox started with ` + "`--agent none`" + ` as well as on a managed-agent session.
+
+Separate the guest command from doctl's own flags with ` + "`--`" + `, or flags meant for the guest (` + "`ls -la`" + `) are parsed as doctl flags.
+
+Guest stdout and stderr pass through unchanged and the guest's exit code becomes doctl's, so this composes in pipelines and ` + "`&&`" + ` chains. Each call is independent: there is no shell session between calls, so ` + "`cd`" + ` does not carry over — use ` + "`--workdir`" + `, or run a shell explicitly (` + "`-- sh -c 'cd src && make'`" + `).
+
+Output is buffered until the command finishes, and capped at 1 MiB per stream. With ` + "`-o json`" + ` the full response is emitted instead of the raw streams.`
+
 const agentsCheckpointRootHelpMD = `Save points for a hosted agent session. Fork into new sessions or rollback the same session in place.`
 
 const agentsCheckpointCreateHelpMD = `Create a checkpoint for a session. Can only be taken between agent turns. Optional ` + "`--label`" + ` for a human-readable name.`

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -68,7 +68,7 @@ func TestAgentsCommand(t *testing.T) {
 	cmd := Agents()
 	assert.NotNil(t, cmd)
 
-	assertCommandNames(t, cmd, "start", "run", "attach", "list", "show", "logs", "approve", "remove", "pause", "resume", "upload", "download", "start-proxy", "auth", "fork", "rollback", "checkpoint", "triggers", "config")
+	assertCommandNames(t, cmd, "start", "run", "attach", "list", "show", "logs", "approve", "remove", "pause", "resume", "upload", "download", "start-proxy", "auth", "fork", "rollback", "checkpoint", "triggers", "config", "exec")
 }
 
 func TestAgentsPrimaryNameIsOpenHarnessRuntime(t *testing.T) {

--- a/commands/displayers/hosted_agents.go
+++ b/commands/displayers/hosted_agents.go
@@ -185,6 +185,58 @@ func (h *HostedAgentWorkspaceUpload) KV() []map[string]any {
 	return out
 }
 
+// HostedAgentSandboxExec renders the result of `doctl open-harness-runtime exec`
+// under `-o json`. Text output never reaches this displayer: the command passes
+// the guest's stdout and stderr straight through instead, so it composes in a
+// pipeline.
+//
+// Single is always set by the exec verb (one command, one result), but the field
+// is kept explicit rather than unwrapping on len==1, so the JSON container type
+// never changes with the row count (MARSOHS-869/887).
+type HostedAgentSandboxExec struct {
+	Execs  []*godo.HostedAgentSandboxExecResponse
+	Single bool
+}
+
+var _ Displayable = &HostedAgentSandboxExec{}
+
+func (h *HostedAgentSandboxExec) JSON(out io.Writer) error {
+	if h.Single && len(h.Execs) == 1 {
+		return writeJSON(h.Execs[0], out)
+	}
+	return writeJSON(h.Execs, out)
+}
+
+func (h *HostedAgentSandboxExec) Cols() []string {
+	return []string{"ExitCode", "Stdout", "Stderr"}
+}
+
+func (h *HostedAgentSandboxExec) ColMap() map[string]string {
+	return map[string]string{
+		"ExitCode": "ExitCode",
+		"Stdout":   "Stdout",
+		"Stderr":   "Stderr",
+	}
+}
+
+func (h *HostedAgentSandboxExec) KV() []map[string]any {
+	if h == nil {
+		return []map[string]any{}
+	}
+	out := make([]map[string]any, 0, len(h.Execs))
+	for _, e := range h.Execs {
+		if e == nil {
+			continue
+		}
+		out = append(out, map[string]any{
+			"ExitCode": e.ExitCode,
+			"Stdout":   e.Stdout,
+			"Stderr":   e.Stderr,
+		})
+	}
+	return out
+}
+
 // HostedAgentConfig renders full Agent Configs, backing `doctl open-harness-runtime config
 // get` and `... create`. Set Single=true so those verbs emit a bare JSON
 // object; the list verb uses HostedAgentConfigSummary instead.

--- a/do/agents.go
+++ b/do/agents.go
@@ -46,6 +46,12 @@ type HostedAgentsService interface {
 	// context.TODO(): the caller is a proxy answering a client that is itself
 	// blocked, and it needs to be able to give up.
 	RelayRequest(ctx context.Context, sessionID string, body *godo.HostedAgentRelayRequest) (*godo.HostedAgentRelayResponse, error)
+	// ExecInSandbox runs one command inside the session's sandbox and returns
+	// the buffered result. Like RelayRequest it takes its own context rather
+	// than the package-wide context.TODO(): the call blocks for as long as the
+	// guest command runs, so the caller needs to be able to give up. A non-zero
+	// ExitCode is a successful call — only transport failure is an error.
+	ExecInSandbox(ctx context.Context, sessionID string, body *godo.HostedAgentSandboxExecRequest) (*godo.HostedAgentSandboxExecResponse, error)
 	ResolveHITL(sessionID, requestID string, body *godo.HostedAgentResolveHITLRequest) error
 	// StartProviderAuth begins (or resumes) the team-scoped connect flow for an
 	// external provider (e.g. "github"). The team is taken from the
@@ -142,6 +148,11 @@ func (s *hostedAgentsService) SendInput(sessionID string, input *godo.HostedAgen
 
 func (s *hostedAgentsService) RelayRequest(ctx context.Context, sessionID string, body *godo.HostedAgentRelayRequest) (*godo.HostedAgentRelayResponse, error) {
 	resp, _, err := s.client.HostedAgents.RelayRequest(ctx, sessionID, body)
+	return resp, err
+}
+
+func (s *hostedAgentsService) ExecInSandbox(ctx context.Context, sessionID string, body *godo.HostedAgentSandboxExecRequest) (*godo.HostedAgentSandboxExecResponse, error) {
+	resp, _, err := s.client.HostedAgents.ExecInSandbox(ctx, sessionID, body)
 	return resp, err
 }
 

--- a/do/mocks/HostedAgentsService.go
+++ b/do/mocks/HostedAgentsService.go
@@ -205,6 +205,21 @@ func (mr *MockHostedAgentsServiceMockRecorder) DestroySession(sessionID any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroySession", reflect.TypeOf((*MockHostedAgentsService)(nil).DestroySession), sessionID)
 }
 
+// ExecInSandbox mocks base method.
+func (m *MockHostedAgentsService) ExecInSandbox(ctx context.Context, sessionID string, body *godo.HostedAgentSandboxExecRequest) (*godo.HostedAgentSandboxExecResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExecInSandbox", ctx, sessionID, body)
+	ret0, _ := ret[0].(*godo.HostedAgentSandboxExecResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExecInSandbox indicates an expected call of ExecInSandbox.
+func (mr *MockHostedAgentsServiceMockRecorder) ExecInSandbox(ctx, sessionID, body any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecInSandbox", reflect.TypeOf((*MockHostedAgentsService)(nil).ExecInSandbox), ctx, sessionID, body)
+}
+
 // ForkSession mocks base method.
 func (m *MockHostedAgentsService) ForkSession(sessionID string, fork *godo.HostedAgentForkSessionRequest) ([]do.HostedAgentSession, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

**Stacked on #1853** — targets `feat/agents-subcommands`, so the diff here is just the new verb.

Adds `doctl agents exec`, which runs one command inside a hosted session's sandbox:

```
doctl agents exec my-session -- go test ./...
doctl agents exec my-session --workdir /workspace/src -- make build
doctl agents exec my-session -o json -- ls -la
```

The design goal is that it behaves like a local command, so it can be dropped into a script:

- Guest stdout and stderr are written to doctl's own stdout and stderr **byte-for-byte**, with nothing appended — piping the output does not corrupt it, and redirecting the two streams separately works.
- The guest's exit code becomes doctl's exit code, so `&&` chains and `if` tests behave. A command that ran and failed is not a doctl error, so nothing is printed on top of what the guest already said.
- The session argument accepts an id or a name, via the existing `resolveSessionRef`.
- Everything after `--` is the guest command. Without the separator, cobra would try to parse the guest command's own flags (`ls -la`) as doctl flags.

Server side is `POST /v2/agents/sessions/:id/sandbox/exec`, whose godo client types already shipped; `do/agents.go` just wraps it. The call takes its own context rather than `context.TODO()` because it blocks for as long as the guest command runs, and it honours SIGINT/SIGTERM so Ctrl-C stops the wait.

### Two decisions worth reviewer attention

**Exit codes bypass `checkErr`.** doctl's shared error path can only ever exit 1, and teaching it a second status would change behaviour for every other command. Instead the runner calls `os.Exit` through a package-level var that tests stub. The guest's output is already written to file descriptors by then, so nothing is truncated.

**The exec call does not retry.** doctl retries 5xx up to `--http-retry-max` (**5 by default**), which is right for the idempotent calls it was written for and wrong here — a retry runs the guest command a second time. Testing against a real session, a command that timed out server-side was replayed **six times** (230 s instead of 33 s); on a `make install` that would be six installs. `exec` therefore builds a non-retrying client, following the same pattern as `account ratelimit`. Session resolution above it is a plain GET and keeps the retrying client.

### Known gaps (server-side work, not CLI)

- **No `--stdin`.** The API accepts one-shot stdin and it works, but `godo.HostedAgentSandboxExecRequest` has no `Stdin` field yet, so piping needs a godo change first.
- **Output is buffered**, not streamed: a long build prints nothing until it finishes. The streaming endpoint is the next piece of server-side work; this command is written to be swapped onto it without changing its user-facing contract.
- `--timeout` is honoured, but the guest currently stops the process at the budget plus a grace period rather than exactly at it.

## Testing

`go test ./commands/... ./do/...` — pass. New unit tests cover verbatim passthrough, stream separation, exit-code propagation, JSON output, the no-retry swap, and usage errors. (`TestRegistryLogout` fails on this base with and without these changes — pre-existing, keychain-related.)

Verified end to end against a live session with a real guest — 15 assertions:

- `echo hello` returns on stdout; a name resolves to a session id
- exit 7 becomes doctl's status while stdout and stderr stay separate, with no doctl error text added on top
- `--workdir` and `--timeout` are forwarded and take effect
- composes in an `&&` chain; output is byte-exact through a pipe (no added newline)
- `-o json` carries the full record and still sets the exit status
- oversized output is capped at 1 MiB by the server
- a guest flag without `--` is refused rather than misparsed; an unknown session and a missing command both fail with a message

Made with [Cursor](https://cursor.com)