### PR TITLE
agents: add --revoke-previous to triggers rotate-secret

### DIFF
--- a/args.go
+++ b/args.go
@@ -969,6 +969,10 @@ const (
 	// ArgAgentStatus filters sessions by lifecycle status.
 	ArgAgentStatus = "status"
 
+	// ArgAgentAllowGrace opts into a grace window on rotate-secret so in-flight
+	// deliveries keep verifying. Never use after a secret is compromised.
+	ArgAgentAllowGrace = "allow-grace"
+
 	// ArgAgentWorkspacePath is the path inside the session workspace root (/workspace).
 	ArgAgentWorkspacePath = "workspace-path"
 

--- a/args.go
+++ b/args.go
@@ -969,9 +969,9 @@ const (
 	// ArgAgentStatus filters sessions by lifecycle status.
 	ArgAgentStatus = "status"
 
-	// ArgAgentAllowGrace opts into a grace window on rotate-secret so in-flight
-	// deliveries keep verifying. Never use after a secret is compromised.
-	ArgAgentAllowGrace = "allow-grace"
+	// ArgAgentRevokePrevious retires the old webhook secret on the rotate-secret
+	// call itself instead of granting the default grace window.
+	ArgAgentRevokePrevious = "revoke-previous"
 
 	// ArgAgentWorkspacePath is the path inside the session workspace root (/workspace).
 	ArgAgentWorkspacePath = "workspace-path"

--- a/commands/agent_triggers.go
+++ b/commands/agent_triggers.go
@@ -311,27 +311,33 @@ func RunAgentTriggersRotateSecret(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	secret, previousExpiresAt, err := c.HostedAgentTriggers().RotateSecret(c.Args[0], revokePrevious)
+	res, err := c.HostedAgentTriggers().RotateSecret(c.Args[0], revokePrevious)
 	if err != nil {
 		return err
 	}
 	if Output == "json" {
-		out := map[string]any{"webhook_secret": secret}
-		if previousExpiresAt != "" {
-			out["previous_secret_expires_at"] = previousExpiresAt
-		} else {
+		out := map[string]any{"webhook_secret": res.Secret}
+		if res.PreviousExpiresAt != "" {
+			out["previous_secret_expires_at"] = res.PreviousExpiresAt
+		}
+		if res.PreviousRevoked {
 			out["previous_secret_revoked"] = true
 		}
 		return json.NewEncoder(c.Out).Encode(out)
 	}
 	stylingEnabled = detectStyling()
-	printWebhookSecretCard(c.Out, secret, "")
-	// State the old secret's fate either way: "rotated" alone leaves an operator
-	// unable to tell whether a leaked secret still works.
-	if previousExpiresAt != "" {
-		fmt.Fprintf(c.Out, "Old secret stops working at: %s\n", previousExpiresAt)
-	} else {
+	printWebhookSecretCard(c.Out, res.Secret, "")
+	// State the old secret's fate, and only what the API actually reported. The
+	// server sets exactly one of these; if neither arrives, say so rather than
+	// picking one, because guessing "revoked" on a live secret is the reading an
+	// operator would act on and the one that gets someone hurt.
+	switch {
+	case res.PreviousRevoked:
 		fmt.Fprintln(c.Out, "Old secret revoked: deliveries still signed with it will fail.")
+	case res.PreviousExpiresAt != "":
+		fmt.Fprintf(c.Out, "Old secret stops working at: %s\n", res.PreviousExpiresAt)
+	default:
+		fmt.Fprintln(c.Out, "Old secret status not reported by the API; assume it is still valid until you can confirm.")
 	}
 	return nil
 }

--- a/commands/agent_triggers.go
+++ b/commands/agent_triggers.go
@@ -113,7 +113,7 @@ func AgentTriggers() *Command {
 		"Rotate a webhook trigger's secret",
 		agentsTriggersRotateSecretHelpMD,
 		Writer, agentPrettyErrors())
-	AddBoolFlag(cmdRotate, doctl.ArgAgentAllowGrace, "", false, "Preserve the old secret for a short grace window so in-flight deliveries keep verifying. Never use after a secret is compromised.")
+	AddBoolFlag(cmdRotate, doctl.ArgAgentRevokePrevious, "", false, "Retire the old secret immediately instead of granting the grace window. Deliveries still signed with it start failing at once; use this when the old secret is compromised.")
 
 	cmdListExec := CmdBuilder(cmd, RunAgentTriggersListExecutions, "list-executions <trigger-id>",
 		"List a trigger's execution history",
@@ -307,25 +307,31 @@ func RunAgentTriggersRotateSecret(c *CmdConfig) error {
 	if err := ensureOneArg(c); err != nil {
 		return err
 	}
-	allowGrace, err := c.Doit.GetBool(c.NS, doctl.ArgAgentAllowGrace)
+	revokePrevious, err := c.Doit.GetBool(c.NS, doctl.ArgAgentRevokePrevious)
 	if err != nil {
 		return err
 	}
-	secret, previousExpiresAt, err := c.HostedAgentTriggers().RotateSecret(c.Args[0], allowGrace)
+	secret, previousExpiresAt, err := c.HostedAgentTriggers().RotateSecret(c.Args[0], revokePrevious)
 	if err != nil {
 		return err
 	}
 	if Output == "json" {
-		out := map[string]string{"webhook_secret": secret}
+		out := map[string]any{"webhook_secret": secret}
 		if previousExpiresAt != "" {
 			out["previous_secret_expires_at"] = previousExpiresAt
+		} else {
+			out["previous_secret_revoked"] = true
 		}
 		return json.NewEncoder(c.Out).Encode(out)
 	}
 	stylingEnabled = detectStyling()
 	printWebhookSecretCard(c.Out, secret, "")
+	// State the old secret's fate either way: "rotated" alone leaves an operator
+	// unable to tell whether a leaked secret still works.
 	if previousExpiresAt != "" {
 		fmt.Fprintf(c.Out, "Old secret stops working at: %s\n", previousExpiresAt)
+	} else {
+		fmt.Fprintln(c.Out, "Old secret revoked: deliveries still signed with it will fail.")
 	}
 	return nil
 }

--- a/commands/agent_triggers.go
+++ b/commands/agent_triggers.go
@@ -130,10 +130,11 @@ Pause/re-enable via `+"`"+`--status paused|active`+"`"+`, or use the dedicated `
 		Writer, aliasOpt("activate", "enable"),
 		displayerType(&displayers.HostedAgentTrigger{}))
 
-	CmdBuilder(cmd, RunAgentTriggersRotateSecret, "rotate-secret <trigger-id>",
+	cmdRotate := CmdBuilder(cmd, RunAgentTriggersRotateSecret, "rotate-secret <trigger-id>",
 		"Rotate a webhook trigger's secret",
-		"Issues a new webhook secret (shown once). Webhook triggers only. The previous secret stays valid briefly so in-flight deliveries keep verifying.",
+		"Issues a new webhook secret (shown once) and immediately revokes the old one. Webhook triggers only. Update your external system with the new secret. Use --allow-grace only for routine key-hygiene rotations, never after a secret is compromised.",
 		Writer)
+	AddBoolFlag(cmdRotate, doctl.ArgAgentAllowGrace, "", false, "Preserve the old secret for a short grace window so in-flight deliveries keep verifying. Never use after a secret is compromised.")
 
 	cmdListExec := CmdBuilder(cmd, RunAgentTriggersListExecutions, "list-executions <trigger-id>",
 		"List a trigger's execution history",
@@ -301,14 +302,25 @@ func RunAgentTriggersRotateSecret(c *CmdConfig) error {
 	if err := ensureOneArg(c); err != nil {
 		return err
 	}
-	secret, err := c.HostedAgentTriggers().RotateSecret(c.Args[0])
+	allowGrace, err := c.Doit.GetBool(c.NS, doctl.ArgAgentAllowGrace)
+	if err != nil {
+		return err
+	}
+	secret, previousExpiresAt, err := c.HostedAgentTriggers().RotateSecret(c.Args[0], allowGrace)
 	if err != nil {
 		return err
 	}
 	if Output == "json" {
-		return json.NewEncoder(c.Out).Encode(map[string]string{"webhook_secret": secret})
+		out := map[string]string{"webhook_secret": secret}
+		if previousExpiresAt != "" {
+			out["previous_secret_expires_at"] = previousExpiresAt
+		}
+		return json.NewEncoder(c.Out).Encode(out)
 	}
 	fmt.Fprint(c.Out, displayers.FormatWebhookSecretNotice(secret))
+	if previousExpiresAt != "" {
+		fmt.Fprintf(c.Out, "Old secret stops working at: %s\n", previousExpiresAt)
+	}
 	return nil
 }
 

--- a/commands/agent_triggers_test.go
+++ b/commands/agent_triggers_test.go
@@ -194,9 +194,13 @@ func TestAgentTriggersGetUpdatePauseDelete(t *testing.T) {
 	})
 }
 
+// rotateExpiry is the previous-secret expiry the API returns on a default
+// (grace-window) rotation.
+const rotateExpiry = "2026-08-12T12:05:00Z"
+
 func TestAgentTriggersRotateSecretAndExecutions(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", "", nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", rotateExpiry, nil)
 		config.Args = []string{"tr_1"}
 		var buf bytes.Buffer
 		config.Out = &buf
@@ -368,7 +372,7 @@ func TestAgentTriggersCreateWebhook_JSONMode(t *testing.T) {
 //   - the banner is on neither stdout nor stderr
 func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", "", nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", rotateExpiry, nil)
 		config.Args = []string{"tr_1"}
 
 		var stdout bytes.Buffer
@@ -386,8 +390,35 @@ func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
 		var parsed map[string]any
 		require.NoError(t, json.Unmarshal([]byte(raw), &parsed), "stdout must be valid JSON in -o json mode, got: %q", raw)
 		assert.Equal(t, "new_sec", parsed["webhook_secret"], "JSON must contain webhook_secret field")
+		assert.Equal(t, rotateExpiry, parsed["previous_secret_expires_at"], "scripts need the expiry to schedule the provider-side update")
+		assert.NotContains(t, parsed, "previous_secret_revoked", "the old secret is still live during the grace window")
 		assert.NotContains(t, raw, "store it now", "banner must not appear on stdout in JSON mode")
 		assert.Empty(t, stderr, "nothing may be written to stderr in -o json mode")
+	})
+}
+
+// --revoke-previous is the breach path: the response reports the old secret as
+// already dead rather than giving an expiry to wait out.
+func TestAgentTriggersRotateSecret_RevokePrevious(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", true).Return("new_sec", "", nil)
+		config.Args = []string{"tr_1"}
+		config.Doit.Set(config.NS, doctl.ArgAgentRevokePrevious, true)
+
+		var stdout bytes.Buffer
+		config.Out = &stdout
+
+		prev := Output
+		Output = "json"
+		defer func() { Output = prev }()
+
+		require.NoError(t, RunAgentTriggersRotateSecret(config))
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &parsed))
+		assert.Equal(t, "new_sec", parsed["webhook_secret"])
+		assert.Equal(t, true, parsed["previous_secret_revoked"])
+		assert.NotContains(t, parsed, "previous_secret_expires_at", "there is no window left to report")
 	})
 }
 
@@ -395,7 +426,7 @@ func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
 // secret banner still appears on stdout (existing behaviour preserved).
 func TestAgentTriggersRotateSecret_TextMode(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", "", nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", rotateExpiry, nil)
 		config.Args = []string{"tr_1"}
 
 		var stdout bytes.Buffer
@@ -407,6 +438,7 @@ func TestAgentTriggersRotateSecret_TextMode(t *testing.T) {
 
 		require.NoError(t, RunAgentTriggersRotateSecret(config))
 		assert.Contains(t, stdout.String(), "new_sec", "secret must appear on stdout in text mode")
+		assert.Contains(t, stdout.String(), rotateExpiry, "an operator needs the exact instant the old secret dies")
 	})
 }
 

--- a/commands/agent_triggers_test.go
+++ b/commands/agent_triggers_test.go
@@ -195,7 +195,7 @@ func TestAgentTriggersGetUpdatePauseDelete(t *testing.T) {
 
 func TestAgentTriggersRotateSecretAndExecutions(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1").Return("new_sec", nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", "", nil)
 		config.Args = []string{"tr_1"}
 		var buf bytes.Buffer
 		config.Out = &buf
@@ -367,7 +367,7 @@ func TestAgentTriggersCreateWebhook_JSONMode(t *testing.T) {
 //   - the banner is on neither stdout nor stderr
 func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1").Return("new_sec", nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", "", nil)
 		config.Args = []string{"tr_1"}
 
 		var stdout bytes.Buffer
@@ -394,7 +394,7 @@ func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
 // secret banner still appears on stdout (existing behaviour preserved).
 func TestAgentTriggersRotateSecret_TextMode(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1").Return("new_sec", nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", "", nil)
 		config.Args = []string{"tr_1"}
 
 		var stdout bytes.Buffer

--- a/commands/agent_triggers_test.go
+++ b/commands/agent_triggers_test.go
@@ -200,7 +200,7 @@ const rotateExpiry = "2026-08-12T12:05:00Z"
 
 func TestAgentTriggersRotateSecretAndExecutions(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", rotateExpiry, nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousExpiresAt: rotateExpiry}, nil)
 		config.Args = []string{"tr_1"}
 		var buf bytes.Buffer
 		config.Out = &buf
@@ -372,7 +372,7 @@ func TestAgentTriggersCreateWebhook_JSONMode(t *testing.T) {
 //   - the banner is on neither stdout nor stderr
 func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", rotateExpiry, nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousExpiresAt: rotateExpiry}, nil)
 		config.Args = []string{"tr_1"}
 
 		var stdout bytes.Buffer
@@ -401,7 +401,7 @@ func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
 // already dead rather than giving an expiry to wait out.
 func TestAgentTriggersRotateSecret_RevokePrevious(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", true).Return("new_sec", "", nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", true).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousRevoked: true}, nil)
 		config.Args = []string{"tr_1"}
 		config.Doit.Set(config.NS, doctl.ArgAgentRevokePrevious, true)
 
@@ -422,11 +422,32 @@ func TestAgentTriggersRotateSecret_RevokePrevious(t *testing.T) {
 	})
 }
 
+// The API sets exactly one of the two fields, so neither arriving means
+// something went wrong upstream. Reporting "revoked" on that would tell an
+// operator a possibly-live secret is dead, which is the one error here anybody
+// acts on.
+func TestAgentTriggersRotateSecret_NeitherOutcomeReported(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).
+			Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec"}, nil)
+		config.Args = []string{"tr_1"}
+
+		var stdout bytes.Buffer
+		config.Out = &stdout
+
+		require.NoError(t, RunAgentTriggersRotateSecret(config))
+
+		out := stdout.String()
+		assert.Contains(t, out, "not reported")
+		assert.NotContains(t, out, "Old secret revoked", "an unreported outcome must never read as a dead secret")
+	})
+}
+
 // TestAgentTriggersRotateSecret_TextMode verifies that in text mode the
 // secret banner still appears on stdout (existing behaviour preserved).
 func TestAgentTriggersRotateSecret_TextMode(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return("new_sec", rotateExpiry, nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousExpiresAt: rotateExpiry}, nil)
 		config.Args = []string{"tr_1"}
 
 		var stdout bytes.Buffer

--- a/commands/agents_help.go
+++ b/commands/agents_help.go
@@ -183,7 +183,7 @@ const agentsTriggersPauseHelpMD = `Pause a trigger. New events or cron ticks are
 
 const agentsTriggersResumeHelpMD = `Resume a paused trigger.`
 
-const agentsTriggersRotateSecretHelpMD = `Issue a new webhook secret (shown once) and immediately revoke the old one. Webhook triggers only. Update your external system with the new secret. Use ` + "`--allow-grace`" + ` only for routine key-hygiene rotations, never after a secret is compromised.`
+const agentsTriggersRotateSecretHelpMD = `Issue a new webhook secret (shown once). Webhook triggers only. The old secret keeps verifying deliveries for a short grace window, so deliveries already in flight still succeed while you paste the new secret into your external system. Pass ` + "`--revoke-previous`" + ` to retire the old secret immediately instead — deliveries still signed with it start failing at once, so use it when the old secret is compromised.`
 
 const agentsTriggersListExecutionsHelpMD = `List firings for a trigger. Use ` + "`get-execution`" + ` for full payload and output.`
 

--- a/do/agent_triggers.go
+++ b/do/agent_triggers.go
@@ -54,7 +54,7 @@ type HostedAgentTriggersService interface {
 	Get(triggerID string) (*HostedAgentTrigger, error)
 	Update(triggerID string, update *godo.HostedAgentTriggerUpdateRequest) (*HostedAgentTrigger, error)
 	Delete(triggerID string) error
-	RotateSecret(triggerID string) (string, error)
+	RotateSecret(triggerID string, allowGrace bool) (secret, previousExpiresAt string, err error)
 	ListExecutions(triggerID string, opt *godo.HostedAgentTriggerExecutionListOptions) ([]HostedAgentTriggerExecution, string, error)
 	GetExecution(triggerID, executionID string) (*HostedAgentTriggerExecution, error)
 	GetBySession(sessionID string) (*HostedAgentTrigger, error)
@@ -119,12 +119,12 @@ func (s *hostedAgentTriggersService) Delete(triggerID string) error {
 	return err
 }
 
-func (s *hostedAgentTriggersService) RotateSecret(triggerID string) (string, error) {
-	resp, _, err := s.svc.RotateSecret(context.TODO(), triggerID)
+func (s *hostedAgentTriggersService) RotateSecret(triggerID string, allowGrace bool) (secret, previousExpiresAt string, err error) {
+	resp, _, err := s.svc.RotateSecret(context.TODO(), triggerID, allowGrace)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return resp.WebhookSecret, nil
+	return resp.WebhookSecret, resp.PreviousSecretExpiresAt, nil
 }
 
 func (s *hostedAgentTriggersService) ListExecutions(triggerID string, opt *godo.HostedAgentTriggerExecutionListOptions) ([]HostedAgentTriggerExecution, string, error) {

--- a/do/agent_triggers.go
+++ b/do/agent_triggers.go
@@ -15,6 +15,7 @@ package do
 
 import (
 	"context"
+	"time"
 
 	"github.com/digitalocean/godo"
 )
@@ -122,11 +123,20 @@ func (s *hostedAgentTriggersService) Delete(triggerID string) error {
 // RotateSecret returns the new secret and, unless revokePrevious retired the old
 // one outright, the instant the old one stops verifying deliveries.
 func (s *hostedAgentTriggersService) RotateSecret(triggerID string, revokePrevious bool) (secret, previousExpiresAt string, err error) {
-	resp, _, err := s.svc.RotateSecret(context.TODO(), triggerID, revokePrevious)
+	// Left nil for the default rotation so no revoke_previous parameter goes on
+	// the wire at all, rather than an explicit =false.
+	var opt *godo.HostedAgentTriggerRotateSecretOptions
+	if revokePrevious {
+		opt = &godo.HostedAgentTriggerRotateSecretOptions{RevokePrevious: true}
+	}
+	resp, _, err := s.svc.RotateSecret(context.TODO(), triggerID, opt)
 	if err != nil {
 		return "", "", err
 	}
-	return resp.WebhookSecret, resp.PreviousSecretExpiresAt, nil
+	if resp.PreviousSecretExpiresAt == nil {
+		return resp.WebhookSecret, "", nil
+	}
+	return resp.WebhookSecret, resp.PreviousSecretExpiresAt.UTC().Format(time.RFC3339), nil
 }
 
 func (s *hostedAgentTriggersService) ListExecutions(triggerID string, opt *godo.HostedAgentTriggerExecutionListOptions) ([]HostedAgentTriggerExecution, string, error) {

--- a/do/agent_triggers.go
+++ b/do/agent_triggers.go
@@ -47,6 +47,17 @@ type HostedAgentReusableSession struct {
 	*godo.HostedAgentReusableSession
 }
 
+// HostedAgentTriggerRotateSecretResult is the outcome of a secret rotation.
+// PreviousExpiresAt and PreviousRevoked are read straight from the API rather
+// than derived from each other: the server sets exactly one, and inferring the
+// other from a missing field would turn any unrelated omission into a false
+// "the old secret is dead".
+type HostedAgentTriggerRotateSecretResult struct {
+	Secret            string
+	PreviousExpiresAt string
+	PreviousRevoked   bool
+}
+
 // HostedAgentTriggersService is the doctl-facing wrapper around
 // godo.HostedAgentTriggersService.
 type HostedAgentTriggersService interface {
@@ -55,7 +66,7 @@ type HostedAgentTriggersService interface {
 	Get(triggerID string) (*HostedAgentTrigger, error)
 	Update(triggerID string, update *godo.HostedAgentTriggerUpdateRequest) (*HostedAgentTrigger, error)
 	Delete(triggerID string) error
-	RotateSecret(triggerID string, revokePrevious bool) (secret, previousExpiresAt string, err error)
+	RotateSecret(triggerID string, revokePrevious bool) (*HostedAgentTriggerRotateSecretResult, error)
 	ListExecutions(triggerID string, opt *godo.HostedAgentTriggerExecutionListOptions) ([]HostedAgentTriggerExecution, string, error)
 	GetExecution(triggerID, executionID string) (*HostedAgentTriggerExecution, error)
 	GetBySession(sessionID string) (*HostedAgentTrigger, error)
@@ -120,9 +131,9 @@ func (s *hostedAgentTriggersService) Delete(triggerID string) error {
 	return err
 }
 
-// RotateSecret returns the new secret and, unless revokePrevious retired the old
-// one outright, the instant the old one stops verifying deliveries.
-func (s *hostedAgentTriggersService) RotateSecret(triggerID string, revokePrevious bool) (secret, previousExpiresAt string, err error) {
+// RotateSecret issues a new webhook secret and reports what became of the old
+// one.
+func (s *hostedAgentTriggersService) RotateSecret(triggerID string, revokePrevious bool) (*HostedAgentTriggerRotateSecretResult, error) {
 	// Left nil for the default rotation so no revoke_previous parameter goes on
 	// the wire at all, rather than an explicit =false.
 	var opt *godo.HostedAgentTriggerRotateSecretOptions
@@ -131,12 +142,21 @@ func (s *hostedAgentTriggersService) RotateSecret(triggerID string, revokePrevio
 	}
 	resp, _, err := s.svc.RotateSecret(context.TODO(), triggerID, opt)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
-	if resp.PreviousSecretExpiresAt == nil {
-		return resp.WebhookSecret, "", nil
+	out := &HostedAgentTriggerRotateSecretResult{
+		Secret: resp.WebhookSecret,
+		// Read, never inferred from a missing expiry. The API guarantees exactly
+		// one of the two fields, so an absent expiry means "revoked" only if the
+		// response really said so — any other cause of a missing field (an older
+		// server, a proxy dropping it) would otherwise be reported to the
+		// operator as a dead secret while it is still live.
+		PreviousRevoked: resp.PreviousSecretRevoked,
 	}
-	return resp.WebhookSecret, resp.PreviousSecretExpiresAt.UTC().Format(time.RFC3339), nil
+	if resp.PreviousSecretExpiresAt != nil {
+		out.PreviousExpiresAt = resp.PreviousSecretExpiresAt.UTC().Format(time.RFC3339)
+	}
+	return out, nil
 }
 
 func (s *hostedAgentTriggersService) ListExecutions(triggerID string, opt *godo.HostedAgentTriggerExecutionListOptions) ([]HostedAgentTriggerExecution, string, error) {

--- a/do/agent_triggers.go
+++ b/do/agent_triggers.go
@@ -54,7 +54,7 @@ type HostedAgentTriggersService interface {
 	Get(triggerID string) (*HostedAgentTrigger, error)
 	Update(triggerID string, update *godo.HostedAgentTriggerUpdateRequest) (*HostedAgentTrigger, error)
 	Delete(triggerID string) error
-	RotateSecret(triggerID string, allowGrace bool) (secret, previousExpiresAt string, err error)
+	RotateSecret(triggerID string, revokePrevious bool) (secret, previousExpiresAt string, err error)
 	ListExecutions(triggerID string, opt *godo.HostedAgentTriggerExecutionListOptions) ([]HostedAgentTriggerExecution, string, error)
 	GetExecution(triggerID, executionID string) (*HostedAgentTriggerExecution, error)
 	GetBySession(sessionID string) (*HostedAgentTrigger, error)
@@ -119,8 +119,10 @@ func (s *hostedAgentTriggersService) Delete(triggerID string) error {
 	return err
 }
 
-func (s *hostedAgentTriggersService) RotateSecret(triggerID string, allowGrace bool) (secret, previousExpiresAt string, err error) {
-	resp, _, err := s.svc.RotateSecret(context.TODO(), triggerID, allowGrace)
+// RotateSecret returns the new secret and, unless revokePrevious retired the old
+// one outright, the instant the old one stops verifying deliveries.
+func (s *hostedAgentTriggersService) RotateSecret(triggerID string, revokePrevious bool) (secret, previousExpiresAt string, err error) {
+	resp, _, err := s.svc.RotateSecret(context.TODO(), triggerID, revokePrevious)
 	if err != nil {
 		return "", "", err
 	}

--- a/do/mocks/HostedAgentTriggersService.go
+++ b/do/mocks/HostedAgentTriggersService.go
@@ -179,18 +179,19 @@ func (mr *MockHostedAgentTriggersServiceMockRecorder) ListWebhookProviders() *go
 }
 
 // RotateSecret mocks base method.
-func (m *MockHostedAgentTriggersService) RotateSecret(triggerID string) (string, error) {
+func (m *MockHostedAgentTriggersService) RotateSecret(triggerID string, allowGrace bool) (string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RotateSecret", triggerID)
+	ret := m.ctrl.Call(m, "RotateSecret", triggerID, allowGrace)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // RotateSecret indicates an expected call of RotateSecret.
-func (mr *MockHostedAgentTriggersServiceMockRecorder) RotateSecret(triggerID any) *gomock.Call {
+func (mr *MockHostedAgentTriggersServiceMockRecorder) RotateSecret(triggerID, allowGrace any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecret", reflect.TypeOf((*MockHostedAgentTriggersService)(nil).RotateSecret), triggerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecret", reflect.TypeOf((*MockHostedAgentTriggersService)(nil).RotateSecret), triggerID, allowGrace)
 }
 
 // Update mocks base method.

--- a/do/mocks/HostedAgentTriggersService.go
+++ b/do/mocks/HostedAgentTriggersService.go
@@ -179,13 +179,12 @@ func (mr *MockHostedAgentTriggersServiceMockRecorder) ListWebhookProviders() *go
 }
 
 // RotateSecret mocks base method.
-func (m *MockHostedAgentTriggersService) RotateSecret(triggerID string, revokePrevious bool) (string, string, error) {
+func (m *MockHostedAgentTriggersService) RotateSecret(triggerID string, revokePrevious bool) (*do.HostedAgentTriggerRotateSecretResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RotateSecret", triggerID, revokePrevious)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(*do.HostedAgentTriggerRotateSecretResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // RotateSecret indicates an expected call of RotateSecret.

--- a/do/mocks/HostedAgentTriggersService.go
+++ b/do/mocks/HostedAgentTriggersService.go
@@ -179,9 +179,9 @@ func (mr *MockHostedAgentTriggersServiceMockRecorder) ListWebhookProviders() *go
 }
 
 // RotateSecret mocks base method.
-func (m *MockHostedAgentTriggersService) RotateSecret(triggerID string, allowGrace bool) (string, string, error) {
+func (m *MockHostedAgentTriggersService) RotateSecret(triggerID string, revokePrevious bool) (string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RotateSecret", triggerID, allowGrace)
+	ret := m.ctrl.Call(m, "RotateSecret", triggerID, revokePrevious)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -189,9 +189,9 @@ func (m *MockHostedAgentTriggersService) RotateSecret(triggerID string, allowGra
 }
 
 // RotateSecret indicates an expected call of RotateSecret.
-func (mr *MockHostedAgentTriggersServiceMockRecorder) RotateSecret(triggerID, allowGrace any) *gomock.Call {
+func (mr *MockHostedAgentTriggersServiceMockRecorder) RotateSecret(triggerID, revokePrevious any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecret", reflect.TypeOf((*MockHostedAgentTriggersService)(nil).RotateSecret), triggerID, allowGrace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecret", reflect.TypeOf((*MockHostedAgentTriggersService)(nil).RotateSecret), triggerID, revokePrevious)
 }
 
 // Update mocks base method.

--- a/vendor/github.com/digitalocean/godo/hosted_agent_triggers.go
+++ b/vendor/github.com/digitalocean/godo/hosted_agent_triggers.go
@@ -27,7 +27,7 @@ type HostedAgentTriggersService interface {
 	Get(context.Context, string) (*HostedAgentTrigger, *Response, error)
 	Update(context.Context, string, *HostedAgentTriggerUpdateRequest) (*HostedAgentTrigger, *Response, error)
 	Delete(context.Context, string) (*Response, error)
-	RotateSecret(context.Context, string, bool) (*HostedAgentTriggerRotateSecretResponse, *Response, error)
+	RotateSecret(context.Context, string, *HostedAgentTriggerRotateSecretOptions) (*HostedAgentTriggerRotateSecretResponse, *Response, error)
 	ListExecutions(context.Context, string, *HostedAgentTriggerExecutionListOptions) (*HostedAgentTriggerExecutionsListResponse, *Response, error)
 	GetExecution(context.Context, string, string) (*HostedAgentTriggerExecution, *Response, error)
 	GetBySession(context.Context, string) (*HostedAgentTrigger, *Response, error)
@@ -214,14 +214,26 @@ type HostedAgentTriggersListResponse struct {
 	NextPageToken string               `json:"next_page_token,omitempty"`
 }
 
+// HostedAgentTriggerRotateSecretOptions specifies optional rotation behaviour.
+// The zero value (or a nil pointer) selects the server default, which keeps the
+// outgoing secret verifying for a short grace window.
+type HostedAgentTriggerRotateSecretOptions struct {
+	// RevokePrevious retires the outgoing secret on this call instead of at the
+	// end of the grace window. Intended for a compromised secret: deliveries
+	// still signed with the old value start failing immediately.
+	RevokePrevious bool `url:"revoke_previous,omitempty"`
+}
+
 // HostedAgentTriggerRotateSecretResponse is returned by RotateSecret.
+// Exactly one of PreviousSecretExpiresAt and PreviousSecretRevoked is set, so a
+// caller never has to infer the outcome from a missing field.
 type HostedAgentTriggerRotateSecretResponse struct {
 	WebhookSecret string `json:"webhook_secret,omitempty"`
 	// PreviousSecretExpiresAt is when the outgoing secret stops verifying
-	// deliveries. Empty when PreviousSecretRevoked is set: exactly one of the two
-	// is present, so a caller never has to infer the outcome from a missing field.
-	PreviousSecretExpiresAt string `json:"previous_secret_expires_at,omitempty"`
-	PreviousSecretRevoked   bool   `json:"previous_secret_revoked,omitempty"`
+	// deliveries. Nil when the secret was revoked on the rotate call.
+	PreviousSecretExpiresAt *Timestamp `json:"previous_secret_expires_at,omitempty"`
+	// PreviousSecretRevoked reports that the outgoing secret is already dead.
+	PreviousSecretRevoked bool `json:"previous_secret_revoked,omitempty"`
 }
 
 // HostedAgentTriggerExecution is one row per firing.
@@ -398,18 +410,17 @@ func (s *HostedAgentTriggersServiceOp) Delete(ctx context.Context, triggerID str
 }
 
 // RotateSecret issues a new webhook secret (webhook triggers only).
-// By default the outgoing secret stays valid for a short server-configured
-// window so in-flight deliveries keep verifying, and PreviousSecretExpiresAt in
-// the response tells the caller when it dies. Set revokePrevious to retire it on
-// this call instead — intended for a compromised secret, since deliveries still
-// signed with the old value start failing immediately.
-func (s *HostedAgentTriggersServiceOp) RotateSecret(ctx context.Context, triggerID string, revokePrevious bool) (*HostedAgentTriggerRotateSecretResponse, *Response, error) {
+// By default the outgoing secret keeps verifying deliveries for a short
+// server-configured window, and PreviousSecretExpiresAt reports when it dies;
+// set opt.RevokePrevious to retire it on this call instead.
+func (s *HostedAgentTriggersServiceOp) RotateSecret(ctx context.Context, triggerID string, opt *HostedAgentTriggerRotateSecretOptions) (*HostedAgentTriggerRotateSecretResponse, *Response, error) {
 	if triggerID == "" {
 		return nil, nil, errors.New("hosted agent triggers: trigger id is required")
 	}
 	path := fmt.Sprintf(hostedAgentTriggerRotateSecretPath, triggerID)
-	if revokePrevious {
-		path += "?revoke_previous=true"
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
 	}
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, struct{}{})
 	if err != nil {

--- a/vendor/github.com/digitalocean/godo/hosted_agent_triggers.go
+++ b/vendor/github.com/digitalocean/godo/hosted_agent_triggers.go
@@ -216,8 +216,12 @@ type HostedAgentTriggersListResponse struct {
 
 // HostedAgentTriggerRotateSecretResponse is returned by RotateSecret.
 type HostedAgentTriggerRotateSecretResponse struct {
-	WebhookSecret           string `json:"webhook_secret,omitempty"`
+	WebhookSecret string `json:"webhook_secret,omitempty"`
+	// PreviousSecretExpiresAt is when the outgoing secret stops verifying
+	// deliveries. Empty when PreviousSecretRevoked is set: exactly one of the two
+	// is present, so a caller never has to infer the outcome from a missing field.
 	PreviousSecretExpiresAt string `json:"previous_secret_expires_at,omitempty"`
+	PreviousSecretRevoked   bool   `json:"previous_secret_revoked,omitempty"`
 }
 
 // HostedAgentTriggerExecution is one row per firing.
@@ -394,17 +398,18 @@ func (s *HostedAgentTriggersServiceOp) Delete(ctx context.Context, triggerID str
 }
 
 // RotateSecret issues a new webhook secret (webhook triggers only).
-// When allowGrace is true the outgoing secret stays valid for a short server-
-// configured window so in-flight deliveries keep verifying; PreviousSecretExpiresAt
-// in the response tells the caller when it dies. Use allowGrace=false (default)
-// when responding to a compromised secret.
-func (s *HostedAgentTriggersServiceOp) RotateSecret(ctx context.Context, triggerID string, allowGrace bool) (*HostedAgentTriggerRotateSecretResponse, *Response, error) {
+// By default the outgoing secret stays valid for a short server-configured
+// window so in-flight deliveries keep verifying, and PreviousSecretExpiresAt in
+// the response tells the caller when it dies. Set revokePrevious to retire it on
+// this call instead — intended for a compromised secret, since deliveries still
+// signed with the old value start failing immediately.
+func (s *HostedAgentTriggersServiceOp) RotateSecret(ctx context.Context, triggerID string, revokePrevious bool) (*HostedAgentTriggerRotateSecretResponse, *Response, error) {
 	if triggerID == "" {
 		return nil, nil, errors.New("hosted agent triggers: trigger id is required")
 	}
 	path := fmt.Sprintf(hostedAgentTriggerRotateSecretPath, triggerID)
-	if allowGrace {
-		path += "?allow_grace=true"
+	if revokePrevious {
+		path += "?revoke_previous=true"
 	}
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, struct{}{})
 	if err != nil {

--- a/vendor/github.com/digitalocean/godo/hosted_agent_triggers.go
+++ b/vendor/github.com/digitalocean/godo/hosted_agent_triggers.go
@@ -27,7 +27,7 @@ type HostedAgentTriggersService interface {
 	Get(context.Context, string) (*HostedAgentTrigger, *Response, error)
 	Update(context.Context, string, *HostedAgentTriggerUpdateRequest) (*HostedAgentTrigger, *Response, error)
 	Delete(context.Context, string) (*Response, error)
-	RotateSecret(context.Context, string) (*HostedAgentTriggerRotateSecretResponse, *Response, error)
+	RotateSecret(context.Context, string, bool) (*HostedAgentTriggerRotateSecretResponse, *Response, error)
 	ListExecutions(context.Context, string, *HostedAgentTriggerExecutionListOptions) (*HostedAgentTriggerExecutionsListResponse, *Response, error)
 	GetExecution(context.Context, string, string) (*HostedAgentTriggerExecution, *Response, error)
 	GetBySession(context.Context, string) (*HostedAgentTrigger, *Response, error)
@@ -216,7 +216,8 @@ type HostedAgentTriggersListResponse struct {
 
 // HostedAgentTriggerRotateSecretResponse is returned by RotateSecret.
 type HostedAgentTriggerRotateSecretResponse struct {
-	WebhookSecret string `json:"webhook_secret,omitempty"`
+	WebhookSecret           string `json:"webhook_secret,omitempty"`
+	PreviousSecretExpiresAt string `json:"previous_secret_expires_at,omitempty"`
 }
 
 // HostedAgentTriggerExecution is one row per firing.
@@ -393,11 +394,18 @@ func (s *HostedAgentTriggersServiceOp) Delete(ctx context.Context, triggerID str
 }
 
 // RotateSecret issues a new webhook secret (webhook triggers only).
-func (s *HostedAgentTriggersServiceOp) RotateSecret(ctx context.Context, triggerID string) (*HostedAgentTriggerRotateSecretResponse, *Response, error) {
+// When allowGrace is true the outgoing secret stays valid for a short server-
+// configured window so in-flight deliveries keep verifying; PreviousSecretExpiresAt
+// in the response tells the caller when it dies. Use allowGrace=false (default)
+// when responding to a compromised secret.
+func (s *HostedAgentTriggersServiceOp) RotateSecret(ctx context.Context, triggerID string, allowGrace bool) (*HostedAgentTriggerRotateSecretResponse, *Response, error) {
 	if triggerID == "" {
 		return nil, nil, errors.New("hosted agent triggers: trigger id is required")
 	}
 	path := fmt.Sprintf(hostedAgentTriggerRotateSecretPath, triggerID)
+	if allowGrace {
+		path += "?allow_grace=true"
+	}
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, struct{}{})
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary

Replaces the `--allow-grace` flag this branch previously carried. The server-side default is **not** changing after all, so the CLI shouldn't imply it does.

`rotate-secret` keeps its grace window by default: the provider side holds only one secret (a GitHub webhook has a single `Secret` field), so it keeps signing with the old value until a human pastes the new one in. Revoking on the call would turn every routine rotation into a delivery outage lasting as long as that handoff takes.

`--revoke-previous` is the breach path instead — it retires the old secret immediately and accepts that gap.

Either way the command now **states the outcome**: the expiry instant, or that the old secret is already dead. "Rotated" on its own leaves an operator unable to tell whether a leaked secret still works.

```
$ doctl agents triggers rotate-secret TRIGGER_ID
  Webhook secret ...
  Old secret stops working at: 2026-08-12T12:05:00Z

$ doctl agents triggers rotate-secret TRIGGER_ID --revoke-previous
  Webhook secret ...
  Old secret revoked: deliveries still signed with it will fail.
```

In `-o json`, exactly one of `previous_secret_expires_at` / `previous_secret_revoked` is present, so scripts never infer the outcome from a missing field.

## Depends on

Server-side contract: cthulhu#172453 (MARSOHS-1078), which is additive — `?revoke_previous=true` plus `previous_secret_revoked` in the response. The default response shape is unchanged.

## Testing

`go build ./...`, `go vet`, and `go test ./commands/... ./do/...` pass. New `TestAgentTriggersRotateSecret_RevokePrevious` covers the breach path; the existing rotate tests now assert the expiry is surfaced on the default path.

Made with [Cursor](https://cursor.com)