### PR TITLE
fix(databases): preserve database firewall descriptions on append and remove (#1869)

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -2535,6 +2535,7 @@ func RunDatabaseFirewallRulesAppend(c *CmdConfig) error {
 		firewallRule.Value = rule.Value
 		firewallRule.ClusterUUID = rule.ClusterUUID
 		firewallRule.UUID = rule.UUID
+		firewallRule.Description = rule.Description
 
 		allRules = append(allRules, firewallRule)
 	}
@@ -2581,6 +2582,7 @@ func RunDatabaseFirewallRulesRemove(c *CmdConfig) error {
 				ClusterUUID: rule.ClusterUUID,
 				Type:        rule.Type,
 				Value:       rule.Value,
+				Description: rule.Description,
 			})
 		}
 	}

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -1985,3 +1985,93 @@ func TestDatabaseConfigurationUpdate(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestDatabaseFirewallRulesAppend(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		existingRules := do.DatabaseFirewallRules{
+			{
+				DatabaseFirewallRule: &godo.DatabaseFirewallRule{
+					UUID:        "rule-1-uuid",
+					ClusterUUID: testDBCluster.ID,
+					Type:        "ip_addr",
+					Value:       "10.0.0.5",
+					Description: "Staging App",
+				},
+			},
+		}
+
+		tm.databases.EXPECT().GetFirewallRules(testDBCluster.ID).Return(existingRules, nil).Times(2)
+
+		expectedRequest := &godo.DatabaseUpdateFirewallRulesRequest{
+			Rules: []*godo.DatabaseFirewallRule{
+				{
+					Type:        "ip_addr",
+					Value:       "1.2.3.4",
+					ClusterUUID: testDBCluster.ID,
+				},
+				{
+					UUID:        "rule-1-uuid",
+					ClusterUUID: testDBCluster.ID,
+					Type:        "ip_addr",
+					Value:       "10.0.0.5",
+					Description: "Staging App",
+				},
+			},
+		}
+
+		tm.databases.EXPECT().UpdateFirewallRules(testDBCluster.ID, expectedRequest).Return(nil)
+
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseFirewallRule, "ip_addr:1.2.3.4")
+
+		err := RunDatabaseFirewallRulesAppend(config)
+		assert.NoError(t, err)
+	})
+}
+
+func TestDatabaseFirewallRulesRemove(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		existingRules := do.DatabaseFirewallRules{
+			{
+				DatabaseFirewallRule: &godo.DatabaseFirewallRule{
+					UUID:        "rule-1-uuid",
+					ClusterUUID: testDBCluster.ID,
+					Type:        "ip_addr",
+					Value:       "10.0.0.5",
+					Description: "Staging App",
+				},
+			},
+			{
+				DatabaseFirewallRule: &godo.DatabaseFirewallRule{
+					UUID:        "rule-2-uuid",
+					ClusterUUID: testDBCluster.ID,
+					Type:        "ip_addr",
+					Value:       "10.0.0.6",
+					Description: "Prod App",
+				},
+			},
+		}
+
+		tm.databases.EXPECT().GetFirewallRules(testDBCluster.ID).Return(existingRules, nil).Times(2)
+
+		expectedRequest := &godo.DatabaseUpdateFirewallRulesRequest{
+			Rules: []*godo.DatabaseFirewallRule{
+				{
+					UUID:        "rule-2-uuid",
+					ClusterUUID: testDBCluster.ID,
+					Type:        "ip_addr",
+					Value:       "10.0.0.6",
+					Description: "Prod App",
+				},
+			},
+		}
+
+		tm.databases.EXPECT().UpdateFirewallRules(testDBCluster.ID, expectedRequest).Return(nil)
+
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgDatabaseFirewallRuleUUID, "rule-1-uuid")
+
+		err := RunDatabaseFirewallRulesRemove(config)
+		assert.NoError(t, err)
+	})
+}

--- a/commands/displayers/database.go
+++ b/commands/displayers/database.go
@@ -736,6 +736,7 @@ func (dr *DatabaseFirewallRules) Cols() []string {
 		"ClusterUUID",
 		"Type",
 		"Value",
+		"Description",
 	}
 }
 
@@ -746,6 +747,7 @@ func (dr *DatabaseFirewallRules) ColMap() map[string]string {
 		"ClusterUUID": "ClusterUUID",
 		"Type":        "Type",
 		"Value":       "Value",
+		"Description": "Description",
 	}
 }
 
@@ -758,6 +760,7 @@ func (dr *DatabaseFirewallRules) KV() []map[string]any {
 			"ClusterUUID": r.ClusterUUID,
 			"Type":        r.Type,
 			"Value":       r.Value,
+			"Description": r.Description,
 		}
 		out = append(out, o)
 	}

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -584,6 +584,7 @@ type DatabaseFirewallRule struct {
 	ClusterUUID string    `json:"cluster_uuid"`
 	Type        string    `json:"type"`
 	Value       string    `json:"value"`
+	Description string    `json:"description,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
 }
 


### PR DESCRIPTION
### Summary

Fixes #1869: Database firewall rule descriptions were erased when appending or removing rules via `doctl databases firewalls append` or `doctl databases firewalls remove`.

### Cause
When reconstructing existing firewall rules prior to invoking `UpdateFirewallRules`, `doctl` copied `UUID`, `ClusterUUID`, `Type`, and `Value`, but omitted `Description`. Additionally, the vendored `godo.DatabaseFirewallRule` struct was missing the `Description` field (`json:"description,omitempty"`).

### Solution
1. **Added `Description` field** to `godo.DatabaseFirewallRule` in the vendored `godo` package.
2. **Preserved `Description` in `RunDatabaseFirewallRulesAppend`**: Copied `firewallRule.Description = rule.Description` during rule reconstruction.
3. **Preserved `Description` in `RunDatabaseFirewallRulesRemove`**: Copied `Description: rule.Description` during rule reconstruction.
4. **Updated `DatabaseFirewallRules` displayer**: Added `Description` to `Cols()`, `ColMap()`, and `KV()` so descriptions render in CLI output.
5. **Added Regression Tests**: Added `TestDatabaseFirewallRulesAppend` and `TestDatabaseFirewallRulesRemove` to verify that existing firewall rule descriptions are preserved in the payload sent to DigitalOcean API.

### Verification

Ran unit tests:
```bash
go test -v ./commands -run TestDatabaseFirewallRules
