### PR TITLE
fix(agents): keep attach interruptible while a request is in flight

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -3932,11 +3932,14 @@ type attachState struct {
 	hitlSel    int // highlighted HITL menu option: 0 approve, 1 reject, 2 defer
 	escSeq     []byte
 	pasting    bool
-	confirm    *largePasteConfirmation
+	confirm *largePasteConfirmation
 	// Input history for bash-style ↑/↓ recall within this attach session.
 	history   []string
 	histIndex int    // len(history) means draft/new line; 0..len-1 browses history
 	histDraft []byte // saved draft when ↑ is first pressed
+	// dispatch, when set, runs a blocking API request off the input loop; see
+	// call. attachLoopTTY installs it. Set once before the loop starts.
+	dispatch func(func() (detach bool))
 }
 
 type largePasteConfirmation struct {
@@ -3969,6 +3972,23 @@ func newAttachState(out io.Writer, pending *pendingHITL) *attachState {
 		},
 	}
 	return s
+}
+
+// call runs fn, which performs a blocking API request.
+//
+// In raw mode Ctrl-C is a byte the input loop has to read, not a signal, so a
+// request made from inside that loop makes the session uninterruptible for as
+// long as the server takes to answer — and these requests carry no deadline.
+// With a dispatcher installed, fn is handed to attachLoopTTY's worker and this
+// returns immediately; fn's detach verdict reaches the loop by its own route.
+// Without one (line mode, unit tests) fn runs inline and its result is passed
+// straight back, so nothing about the synchronous paths changes.
+func (s *attachState) call(fn func() (detach bool)) (detach bool) {
+	if s.dispatch == nil {
+		return fn()
+	}
+	s.dispatch(fn)
+	return false
 }
 
 // promptString is the raw-mode prompt. With no pending approval it's the plain
@@ -4986,6 +5006,25 @@ func attachLoopTTY(c *CmdConfig, svc do.HostedAgentsService, sessionID string, f
 		}
 	}()
 
+	// API requests run here rather than inline in the loop below, so the loop
+	// keeps reading while one is in flight — raw mode turned Ctrl-C into a byte
+	// only this loop can act on, and the requests have no deadline. A single
+	// worker rather than a goroutine per call keeps sends in the order typed.
+	work := make(chan func() (detach bool), 64)
+	defer close(work)
+	detachCh := make(chan struct{}, 1)
+	go func() {
+		for fn := range work {
+			if fn() {
+				select {
+				case detachCh <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+	state.dispatch = func(fn func() (detach bool)) { work <- fn }
+
 	// 50ms ticker so HITL arrival reflows the prompt even when the user idles.
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
@@ -5005,6 +5044,10 @@ func attachLoopTTY(c *CmdConfig, svc do.HostedAgentsService, sessionID string, f
 			if stop {
 				return nil
 			}
+		case <-detachCh:
+			// A queued request found the session unable to take more input;
+			// it has already printed why.
+			return nil
 		case <-ticker.C:
 			state.handlePendingEscTimeout()
 		case err := <-readErrCh:
@@ -5025,7 +5068,9 @@ func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string
 		case 'y', 'Y':
 			state.display.echo([]byte{b, '\r', '\n'})
 			state.takeLargePasteConfirmation()
-			if detach := processAttachLine(c, svc, sessionID, confirm.text, state, nil, thinking); detach {
+			if detach := state.call(func() bool {
+				return processAttachLine(c, svc, sessionID, confirm.text, state, nil, thinking)
+			}); detach {
 				return true, nil
 			}
 			state.display.redraw()
@@ -5033,10 +5078,18 @@ func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string
 		case 'n', 'N', 0x0d, 0x0a:
 			state.display.echo([]byte("\r\n"))
 			state.takeLargePasteConfirmation()
-			for _, part := range splitSubmittedLines(confirm.text) {
-				if detach := processAttachLine(c, svc, sessionID, part, state, nil, thinking); detach {
-					return true, nil
+			parts := splitSubmittedLines(confirm.text)
+			// One unit of work, not one per part: the parts are separate sends
+			// and have to reach the session in the pasted order.
+			if detach := state.call(func() bool {
+				for _, part := range parts {
+					if processAttachLine(c, svc, sessionID, part, state, nil, thinking) {
+						return true
+					}
 				}
+				return false
+			}); detach {
+				return true, nil
 			}
 			state.display.redraw()
 			return false, nil
@@ -5091,14 +5144,19 @@ func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string
 		} else {
 			state.display.echo([]byte{b, '\r', '\n'})
 		}
-		if err := svc.ResolveHITL(sessionID, id, &godo.HostedAgentResolveHITLRequest{
-			Outcome: outcome,
-			Source:  godo.HostedAgentResolutionSourceInlineKeystroke,
-		}); err != nil {
-			fmt.Fprintf(c.Out, "resolve failed: %v\n", err)
-		} else {
-			state.pending.clearIf(id)
-		}
+		// No redraw once the resolve lands: clearing the pending id is a change
+		// attachLoopTTY notices on its next tick and redraws for.
+		state.call(func() bool {
+			if err := svc.ResolveHITL(sessionID, id, &godo.HostedAgentResolveHITLRequest{
+				Outcome: outcome,
+				Source:  godo.HostedAgentResolutionSourceInlineKeystroke,
+			}); err != nil {
+				fmt.Fprintf(c.Out, "resolve failed: %v\n", err)
+			} else {
+				state.pending.clearIf(id)
+			}
+			return false
+		})
 		state.resetHITLSelection()
 		state.display.redraw()
 		return false, nil
@@ -5123,7 +5181,9 @@ func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string
 				state.display.redraw()
 				return false, nil
 			}
-			if detach := processAttachLine(c, svc, sessionID, line, state, warmup, thinking); detach {
+			if detach := state.call(func() bool {
+				return processAttachLine(c, svc, sessionID, line, state, warmup, thinking)
+			}); detach {
 				return true, nil
 			}
 		}

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -2007,6 +2007,55 @@ func TestAttachStateHITLSelection(t *testing.T) {
 	assert.Equal(t, 0, s.hitlSelection())
 }
 
+// TestHandleAttachByteCtrlCDuringRequest pins the reason attachLoopTTY runs API
+// calls on a worker: raw mode makes Ctrl-C a byte the input loop has to read,
+// so a request in flight must not be holding that loop hostage.
+func TestHandleAttachByteCtrlCDuringRequest(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		inFlight := make(chan struct{})
+		release := make(chan struct{})
+		tm.hostedAgents.EXPECT().
+			SendInput("sess", &godo.HostedAgentSendInputRequest{Text: "hi"}).
+			DoAndReturn(func(string, *godo.HostedAgentSendInputRequest) (*godo.HostedAgentSendInputResponse, error) {
+				close(inFlight)
+				<-release
+				return &godo.HostedAgentSendInputResponse{RunID: "run_1"}, nil
+			})
+
+		state := newAttachState(io.Discard, &pendingHITL{})
+		state.display.setRaw(true)
+
+		// Stand-in for attachLoopTTY's worker.
+		work := make(chan func() (detach bool), 1)
+		state.dispatch = func(fn func() (detach bool)) { work <- fn }
+		workerDone := make(chan struct{})
+		go func() {
+			defer close(workerDone)
+			for fn := range work {
+				fn()
+			}
+		}()
+
+		for _, b := range []byte("hi") {
+			_, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, nil, nil)
+			require.NoError(t, err)
+		}
+		stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, nil, nil)
+		require.NoError(t, err)
+		require.False(t, stop)
+
+		<-inFlight
+
+		stop, err = handleAttachByte(config, tm.hostedAgents, "sess", 0x03, state, nil, nil)
+		require.NoError(t, err)
+		assert.True(t, stop, "Ctrl-C must detach while a request is still in flight")
+
+		close(release)
+		close(work)
+		<-workerDone
+	})
+}
+
 // TestMsgAccumulatorPlain confirms buffered tokens flush as-is when styling is
 // off (no markdown rewriting) and that flush resets the buffer.
 func TestMsgAccumulatorPlain(t *testing.T) {


### PR DESCRIPTION
## Summary

`doctl agents attach` could not be interrupted while it was waiting on the API.
Ctrl-C did nothing, and the only way out was to kill the terminal.

Raw mode is what makes this a bug. It suppresses the kernel's Ctrl-C, so `0x03`
arrives as an ordinary byte that only the input loop can act on — and that same
loop was making the API calls, synchronously and without a deadline. A send
against a slow or wedged control plane therefore took Ctrl-C with it: the byte
sat unread in the tty buffer until the request finished, which for an unbounded
request could be never.

Calls now go to a worker the loop hands work to, so the loop keeps reading while
one is outstanding:

- **One worker, not a goroutine per call** — consecutive sends have to reach the
  session in the order they were typed. A multi-line paste is enqueued as a
  single unit for the same reason.
- A queued call that finds the session unable to take more input reports the
  detach back over a channel the loop already selects on, so the existing
  "session can't take input" exits still work.
- Line mode (no TTY) and the unit tests install no dispatcher and keep running
  calls inline, so nothing about the synchronous paths changes.

Affects the two calls the attach loop makes: `SendInput` and the inline HITL
`ResolveHITL`.

## Test

New `TestHandleAttachByteCtrlCDuringRequest` holds a `SendInput` open, feeds
Ctrl-C while it is still in flight, and asserts the byte detaches instead of
being swallowed — it fails against the old loop.

Manually A/B'd against a proxy that stalls `POST /v2/agents/sessions/{id}/input`
forever: the old binary ignores Ctrl-C indefinitely, the new one detaches
immediately.

- [x] `go test ./commands/ -run 'Attach|HITL|Agents'`

Made with [Cursor](https://cursor.com)