### PR TITLE
Rename open-harness-runtime command to harness-runtime

### DIFF
--- a/commands/agent_checkpoints.go
+++ b/commands/agent_checkpoints.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// AgentCheckpoints generates the `doctl open-harness-runtime checkpoint` subtree.
+// AgentCheckpoints generates the `doctl harness-runtime checkpoint` subtree.
 func AgentCheckpoints() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
@@ -41,7 +41,7 @@ func AgentCheckpoints() *Command {
 		Writer, agentPrettyErrors(), aliasOpt("save"),
 		displayerType(&displayers.HostedAgentCheckpoint{}))
 	AddStringFlag(cmdCreate, doctl.ArgAgentCheckpointLabel, "", "", "Optional label for the checkpoint")
-	cmdCreate.Example = `doctl open-harness-runtime checkpoint create sess_abc123 --label before-refactor`
+	cmdCreate.Example = `doctl harness-runtime checkpoint create sess_abc123 --label before-refactor`
 
 	cmdList := CmdBuilder(cmd, RunAgentsCheckpointList, "list <session>",
 		"List checkpoints for a session",
@@ -50,7 +50,7 @@ func AgentCheckpoints() *Command {
 		displayerType(&displayers.HostedAgentCheckpoint{}))
 	AddIntFlag(cmdList, doctl.ArgAgentPageSize, "", 0, "Maximum number of checkpoints to return per page")
 	AddStringFlag(cmdList, doctl.ArgAgentPageToken, "", "", "Pagination cursor from a previous list response")
-	cmdList.Example = `doctl open-harness-runtime checkpoint list sess_abc123`
+	cmdList.Example = `doctl harness-runtime checkpoint list sess_abc123`
 
 	CmdBuilder(cmd, RunAgentsCheckpointGet, "get <session> <checkpoint-id>",
 		"Get a checkpoint",

--- a/commands/agent_configs.go
+++ b/commands/agent_configs.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// AgentConfigs generates the `doctl open-harness-runtime config` subtree, which wraps the
+// AgentConfigs generates the `doctl harness-runtime config` subtree, which wraps the
 // godo Agent Configs API: immutable, team-scoped agent manifests that sessions
 // can be launched from by ID.
 func AgentConfigs() *Command {
@@ -55,7 +55,7 @@ func AgentConfigs() *Command {
 			displayerType(&displayers.HostedAgentConfig{}))...)
 	AddStringFlag(cmdCreate, doctl.ArgAgentSpec, "", "", `Path to an agent manifest in YAML or JSON. Prefer flat format (top-level name + agent), e.g. "name: my-config\nagent: opencode". Set to "-" to read from stdin. ${VAR} references are resolved from the local environment.`, requiredOpt())
 	AddStringFlag(cmdCreate, doctl.ArgAgentName, "", "", "Team-unique name for the config", requiredOpt())
-	cmdCreate.Example = `doctl open-harness-runtime config create --spec agent-spec.yaml --name my-config`
+	cmdCreate.Example = `doctl harness-runtime config create --spec agent-spec.yaml --name my-config`
 
 	cmdList := CmdBuilder(cmd, RunAgentsConfigList, "list",
 		"List agent configs",
@@ -64,7 +64,7 @@ func AgentConfigs() *Command {
 			displayerType(&displayers.HostedAgentConfigSummary{}))...)
 	AddIntFlag(cmdList, doctl.ArgAgentPageSize, "", 0, "Maximum number of configs to return per page")
 	AddStringFlag(cmdList, doctl.ArgAgentPageToken, "", "", "Pagination cursor from a previous list response")
-	cmdList.Example = `doctl open-harness-runtime config list --page-size 10`
+	cmdList.Example = `doctl harness-runtime config list --page-size 10`
 
 	CmdBuilder(cmd, RunAgentsConfigGet, "get <config-id>",
 		"Get an agent config",
@@ -86,7 +86,7 @@ func AgentConfigs() *Command {
 	AddStringFlag(cmdSessions, doctl.ArgAgentPageToken, "", "", "Pagination cursor from a previous list response")
 	AddStringFlag(cmdSessions, doctl.ArgAgentStatus, "", "", "Filter by session status (e.g. SESSION_STATUS_READY)")
 	AddStringFlag(cmdSessions, doctl.ArgAgentName, "", "", "Filter by session name")
-	cmdSessions.Example = `doctl open-harness-runtime config list-sessions cfg_abc123 --status SESSION_STATUS_READY`
+	cmdSessions.Example = `doctl harness-runtime config list-sessions cfg_abc123 --status SESSION_STATUS_READY`
 
 	cmdStartSession := CmdBuilder(cmd, RunAgentsConfigStartSession, "start-session <config-id>",
 		"Start a session from a config",
@@ -94,7 +94,7 @@ func AgentConfigs() *Command {
 		Writer, append(ns, aliasOpt("start"),
 			displayerType(&displayers.HostedAgentSession{}))...)
 	AddStringFlag(cmdStartSession, doctl.ArgAgentName, "", "", "Name for the new session", requiredOpt())
-	cmdStartSession.Example = `doctl open-harness-runtime config start-session cfg_abc123 --name my-session`
+	cmdStartSession.Example = `doctl harness-runtime config start-session cfg_abc123 --name my-session`
 
 	return cmd
 }
@@ -199,7 +199,7 @@ func RunAgentsConfigDelete(c *CmdConfig) error {
 	if err := c.HostedAgents().DeleteAgentConfig(configID); err != nil {
 		if agentConfigHasActiveSessionsErr(err) {
 			msg, _, _ := agentAPIError(err)
-			return fmt.Errorf("%s. List them with `doctl open-harness-runtime config list-sessions %s`, remove each with `doctl open-harness-runtime remove`, then retry", strings.TrimRight(msg, "."), configID)
+			return fmt.Errorf("%s. List them with `doctl harness-runtime config list-sessions %s`, remove each with `doctl harness-runtime remove`, then retry", strings.TrimRight(msg, "."), configID)
 		}
 		return err
 	}
@@ -360,7 +360,7 @@ func printAgentConfigCard(w io.Writer, cfg *godo.HostedAgentConfig, created bool
 	if id := strings.TrimSpace(cfg.ID); id != "" {
 		fmt.Fprintln(&body)
 		fmt.Fprintln(&body, colorize("Next step", colMuted))
-		body.WriteString(cardRow("run", "doctl open-harness-runtime run --config-id "+id+" --name my-session"))
+		body.WriteString(cardRow("run", "doctl harness-runtime run --config-id "+id+" --name my-session"))
 	}
 
 	renderAgentCard(w, body.String())

--- a/commands/agent_configs_test.go
+++ b/commands/agent_configs_test.go
@@ -150,7 +150,7 @@ func TestAgentConfigDelete_ActiveSessions(t *testing.T) {
 		err := RunAgentsConfigDelete(config)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "active sessions")
-		assert.Contains(t, err.Error(), "doctl open-harness-runtime remove")
+		assert.Contains(t, err.Error(), "doctl harness-runtime remove")
 	})
 }
 

--- a/commands/agent_sizes.go
+++ b/commands/agent_sizes.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// AgentSizes generates the `doctl open-harness-runtime sizes` subtree for the
+// AgentSizes generates the `doctl harness-runtime sizes` subtree for the
 // sandbox (microVM) size catalog returned by ListSandboxSizes.
 func AgentSizes() *Command {
 	cmd := &Command{
@@ -37,7 +37,7 @@ func AgentSizes() *Command {
 		agentsSizesListHelpMD,
 		Writer, append(ns, aliasOpt("ls"),
 			displayerType(&displayers.HostedAgentSandboxSize{}))...)
-	cmdList.Example = `doctl open-harness-runtime sizes list`
+	cmdList.Example = `doctl harness-runtime sizes list`
 
 	return cmd
 }

--- a/commands/agent_triggers.go
+++ b/commands/agent_triggers.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// AgentTriggers generates the `doctl open-harness-runtime triggers` subtree.
+// AgentTriggers generates the `doctl harness-runtime triggers` subtree.
 func AgentTriggers() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
@@ -46,7 +46,7 @@ func AgentTriggers() *Command {
 	AddStringFlag(cmdList, doctl.ArgAgentPageToken, "", "", "Pagination cursor from a previous list response")
 	AddStringFlag(cmdList, doctl.ArgAgentTriggerKind, "", "", "Filter by kind (webhook|cron)")
 	AddStringFlag(cmdList, doctl.ArgAgentStatus, "", "", "Filter by status (active|paused)")
-	cmdList.Example = `doctl open-harness-runtime triggers list --kind webhook --status active`
+	cmdList.Example = `doctl harness-runtime triggers list --kind webhook --status active`
 
 	cmdCreate := CmdBuilder(cmd, RunAgentTriggersCreate, "create",
 		"Create a webhook or cron trigger",
@@ -65,7 +65,7 @@ func AgentTriggers() *Command {
 	AddStringFlag(cmdCreate, doctl.ArgAgentTriggerProvider, "", "", "Webhook provider (github|gitlab|custom); default custom")
 	AddStringFlag(cmdCreate, doctl.ArgAgentTriggerCronExpr, "", "", "Cron expression when kind=cron")
 	AddStringFlag(cmdCreate, doctl.ArgAgentTriggerTimezone, "", "", "IANA timezone when kind=cron (e.g. America/New_York)")
-	cmdCreate.Example = `doctl open-harness-runtime triggers create --kind webhook --name gh-ci --session-mode fresh --prompt 'Review this PR: {{payload}}' --spec ./agent.yaml --provider github`
+	cmdCreate.Example = `doctl harness-runtime triggers create --kind webhook --name gh-ci --session-mode fresh --prompt 'Review this PR: {{payload}}' --spec ./agent.yaml --provider github`
 
 	CmdBuilder(cmd, RunAgentTriggersGet, "get <trigger-id>",
 		"Get a trigger",
@@ -88,14 +88,14 @@ func AgentTriggers() *Command {
 	AddStringFlag(cmdUpdate, doctl.ArgAgentTriggerBoundSessionID, "", "", "Updated bound session ID for reuse triggers")
 	AddStringFlag(cmdUpdate, doctl.ArgAgentTriggerCronExpr, "", "", "Updated cron expression")
 	AddStringFlag(cmdUpdate, doctl.ArgAgentTriggerTimezone, "", "", "Updated IANA timezone")
-	cmdUpdate.Example = `doctl open-harness-runtime triggers update TRIGGER_ID --status paused; doctl open-harness-runtime triggers update TRIGGER_ID --prompt 'New prompt'`
+	cmdUpdate.Example = `doctl harness-runtime triggers update TRIGGER_ID --status paused; doctl harness-runtime triggers update TRIGGER_ID --prompt 'New prompt'`
 
 	cmdDelete := CmdBuilder(cmd, RunAgentTriggersDelete, "delete <trigger-id>",
 		"Delete a trigger",
 		agentsTriggersDeleteHelpMD,
 		Writer, agentPrettyErrors(), aliasOpt("rm"))
 	AddBoolFlag(cmdDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Delete without confirmation")
-	cmdDelete.Example = `doctl open-harness-runtime triggers delete TRIGGER_ID --force`
+	cmdDelete.Example = `doctl harness-runtime triggers delete TRIGGER_ID --force`
 
 	CmdBuilder(cmd, RunAgentTriggersPause, "pause <trigger-id>",
 		"Pause a trigger",
@@ -122,7 +122,7 @@ func AgentTriggers() *Command {
 	AddIntFlag(cmdListExec, doctl.ArgAgentPageSize, "", 0, "Maximum number of executions to return per page")
 	AddStringFlag(cmdListExec, doctl.ArgAgentPageToken, "", "", "Pagination cursor from a previous list response")
 	AddStringFlag(cmdListExec, doctl.ArgAgentStatus, "", "", "Filter by execution status (pending|running|succeeded|failed)")
-	cmdListExec.Example = `doctl open-harness-runtime triggers list-executions TRIGGER_ID --status failed`
+	cmdListExec.Example = `doctl harness-runtime triggers list-executions TRIGGER_ID --status failed`
 
 	CmdBuilder(cmd, RunAgentTriggersGetExecution, "get-execution <trigger-id> <execution-id>",
 		"Get a single trigger execution",

--- a/commands/agents.go
+++ b/commands/agents.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// The `doctl open-harness-runtime` command (aliases: agent, agents, ohr) wraps the
+// The `doctl harness-runtime` command (aliases: agent, agents, ohr) wraps the
 // godo HostedAgents service for Managed Agents Runtime Services (M.A.R.S).
 // Wire types and the SSE iterator live in godo; this file handles CLI plumbing,
 // argument parsing, and human-readable rendering of streamed events.
@@ -299,7 +299,7 @@ func (r *reasoningStreamer) endWithLabel(label string) {
 	}
 }
 
-// Agents creates the `doctl open-harness-runtime` command tree (aliases: agent, agents, ohr).
+// Agents creates the `doctl harness-runtime` command tree (aliases: agent, agents, ohr).
 func Agents() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
@@ -400,19 +400,19 @@ func Agents() *Command {
 		"Remove a session",
 		agentsRemoveHelpMD,
 		Writer, agentsNS(aliasOpt("destroy", "rm"))...)
-	cmdRemove.Example = `doctl open-harness-runtime remove sess_abc123; doctl open-harness-runtime remove my-session; doctl open-harness-runtime destroy my-session`
+	cmdRemove.Example = `doctl harness-runtime remove sess_abc123; doctl harness-runtime remove my-session; doctl harness-runtime destroy my-session`
 
 	cmdPause := CmdBuilder(cmd, RunAgentsPause, "pause <session>",
 		"Pause a session",
 		agentsPauseHelpMD,
 		Writer, agentsNS()...)
-	cmdPause.Example = `doctl open-harness-runtime pause sess_abc123`
+	cmdPause.Example = `doctl harness-runtime pause sess_abc123`
 
 	cmdResume := CmdBuilder(cmd, RunAgentsResume, "resume <session>",
 		"Resume a paused session",
 		agentsResumeHelpMD,
 		Writer, agentsNS()...)
-	cmdResume.Example = `doctl open-harness-runtime resume sess_abc123`
+	cmdResume.Example = `doctl harness-runtime resume sess_abc123`
 
 	cmdUpload := CmdBuilder(cmd, RunAgentsUpload, "upload <session>",
 		"Upload a file into a session workspace",
@@ -422,7 +422,7 @@ func Agents() *Command {
 	AddStringFlag(cmdUpload, doctl.ArgAgentWorkspacePath, "", "", "Destination path inside the workspace root (/workspace)", requiredOpt())
 	AddStringFlag(cmdUpload, doctl.ArgAgentLocalFile, "", "", "Path to the local file to upload", requiredOpt())
 	AddBoolFlag(cmdUpload, doctl.ArgAgentArchive, "", false, "Treat the local file as an uncompressed tar archive to extract at the destination (not .tgz / .tar.gz)")
-	cmdUpload.Example = `doctl open-harness-runtime upload sess_abc123 --local-file ./main.go --workspace-path src/main.go`
+	cmdUpload.Example = `doctl harness-runtime upload sess_abc123 --local-file ./main.go --workspace-path src/main.go`
 
 	cmdDownload := CmdBuilder(cmd, RunAgentsDownload, "download <session>",
 		"Download a file from a session workspace",
@@ -431,7 +431,7 @@ func Agents() *Command {
 	AddStringFlag(cmdDownload, doctl.ArgAgentWorkspacePath, "", "", "Source path inside the workspace root (/workspace)", requiredOpt())
 	AddStringFlag(cmdDownload, doctl.ArgAgentSaveTo, "", "", "Local file path to write the download to", requiredOpt())
 	AddBoolFlag(cmdDownload, doctl.ArgAgentArchive, "", false, "Tar-stream the directory at the source path")
-	cmdDownload.Example = `doctl open-harness-runtime download sess_abc123 --workspace-path src/main.go --save-to ./main.go`
+	cmdDownload.Example = `doctl harness-runtime download sess_abc123 --workspace-path src/main.go --save-to ./main.go`
 
 	cmdExec := CmdBuilder(cmd, RunAgentsExec, "exec <session> -- <command> [args...]",
 		"Run a command in a session's sandbox",
@@ -440,7 +440,7 @@ func Agents() *Command {
 			displayerType(&displayers.HostedAgentSandboxExec{}))...)
 	AddStringFlag(cmdExec, doctl.ArgAgentExecWorkdir, "", "", "Absolute guest directory to run in (defaults to the workspace root)")
 	AddIntFlag(cmdExec, doctl.ArgAgentExecTimeout, "", 0, "Maximum seconds the command may run (0 uses the server default)")
-	cmdExec.Example = `doctl open-harness-runtime exec sess_abc123 -- ls -la; doctl open-harness-runtime exec my-session --workdir /workspace/src -- go test ./...`
+	cmdExec.Example = `doctl harness-runtime exec sess_abc123 -- ls -la; doctl harness-runtime exec my-session --workdir /workspace/src -- go test ./...`
 
 	cmdAuth := CmdBuilder(cmd, RunAgentsAuth, "auth <provider>",
 		"Connect an external provider (e.g. github) for agent git operations",
@@ -448,7 +448,7 @@ func Agents() *Command {
 		Writer, agentsNS()...)
 	AddBoolFlag(cmdAuth, doctl.ArgAgentAuthNoBrowser, "", false, "Print the authorization URL instead of opening a browser")
 	AddBoolFlag(cmdAuth, doctl.ArgAgentAuthNoWait, "", false, "Print the authorization URL and exit without waiting for authorization to complete")
-	cmdAuth.Example = `doctl open-harness-runtime auth github`
+	cmdAuth.Example = `doctl harness-runtime auth github`
 
 	cmdFork := CmdBuilder(cmd, RunAgentsFork, "fork <session>",
 		"Fork a session into independent child sessions",
@@ -457,7 +457,7 @@ func Agents() *Command {
 			displayerType(&displayers.HostedAgentSession{}))...)
 	AddStringFlag(cmdFork, doctl.ArgAgentFromCheckpoint, "", "", "Checkpoint ID to fork from (omit to checkpoint now first)")
 	AddIntFlag(cmdFork, doctl.ArgAgentForkCount, "", 1, "Number of child sessions to create (1–4)")
-	cmdFork.Example = `doctl open-harness-runtime fork sess_abc123 --from-checkpoint cp_9f2c1a4b --count 2`
+	cmdFork.Example = `doctl harness-runtime fork sess_abc123 --from-checkpoint cp_9f2c1a4b --count 2`
 
 	CmdBuilder(cmd, RunAgentsRollback, "rollback <session> <checkpoint-id>",
 		"Roll a session back to a checkpoint in place",
@@ -1051,7 +1051,7 @@ func resolveSessionRef(svc do.HostedAgentsService, ref string) (string, error) {
 
 	switch len(live) {
 	case 0:
-		return "", fmt.Errorf("no agent session goes by the name %q; pass a session ID or run `doctl open-harness-runtime list` to see available sessions", ref)
+		return "", fmt.Errorf("no agent session goes by the name %q; pass a session ID or run `doctl harness-runtime list` to see available sessions", ref)
 	case 1:
 		return live[0].SessionID, nil
 	default:
@@ -1090,7 +1090,7 @@ func RunAgentsShow(c *CmdConfig) error {
 	return nil
 }
 
-// RunAgentsDestroy tears down a session (CLI: `doctl open-harness-runtime remove`,
+// RunAgentsDestroy tears down a session (CLI: `doctl harness-runtime remove`,
 // with aliases `destroy` and `rm`).
 func RunAgentsDestroy(c *CmdConfig) error {
 	sessionID, err := sessionIDArg(c)
@@ -1151,7 +1151,7 @@ func RunAgentsAuth(c *CmdConfig) error {
 	}
 	provider := strings.ToLower(strings.TrimSpace(c.Args[0]))
 	if provider == "" {
-		return errors.New("a provider is required, e.g. `doctl open-harness-runtime auth github`")
+		return errors.New("a provider is required, e.g. `doctl harness-runtime auth github`")
 	}
 	noBrowser, err := c.Doit.GetBool(c.NS, doctl.ArgAgentAuthNoBrowser)
 	if err != nil {
@@ -1200,7 +1200,7 @@ func completeProviderAuth(c *CmdConfig, svc do.HostedAgentsService, provider str
 	}
 
 	if noWait || start.PollURL == "" {
-		printAgentSuccess(c.Out, fmt.Sprintf("Re-run `doctl open-harness-runtime auth %s` after authorizing to confirm the connection", provider))
+		printAgentSuccess(c.Out, fmt.Sprintf("Re-run `doctl harness-runtime auth %s` after authorizing to confirm the connection", provider))
 		return nil
 	}
 
@@ -1213,7 +1213,7 @@ func completeProviderAuth(c *CmdConfig, svc do.HostedAgentsService, provider str
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("stopped waiting; re-run `doctl open-harness-runtime auth %s` to check the connection later", provider)
+			return fmt.Errorf("stopped waiting; re-run `doctl harness-runtime auth %s` to check the connection later", provider)
 		case <-time.After(agentsAuthPollInterval):
 		}
 
@@ -3228,7 +3228,7 @@ func classifyStreamError(err error) (string, bool) {
 			if status == http.StatusConflict && ape.title == "Conflict" {
 				// V0 single-connection rejection; prefer a clearer title.
 				ape.title = "Session already attached elsewhere"
-				ape.tips = []string{"Detach on the other device, then re-run doctl open-harness-runtime attach"}
+				ape.tips = []string{"Detach on the other device, then re-run doctl harness-runtime attach"}
 			}
 			if status == http.StatusNotFound {
 				ape.title = "Session not found"

--- a/commands/agents_errors.go
+++ b/commands/agents_errors.go
@@ -154,10 +154,10 @@ func beautifyAgentError(err error) error {
 	switch {
 	case strings.Contains(lower, "limit of") && strings.Contains(lower, "active sessions"):
 		title = "Session limit reached"
-		tips = []string{"doctl open-harness-runtime list", "doctl open-harness-runtime remove <session>"}
+		tips = []string{"doctl harness-runtime list", "doctl harness-runtime remove <session>"}
 	case strings.Contains(lower, "active sessions"):
 		title = "Config still has active sessions"
-		tips = []string{"doctl open-harness-runtime config list-sessions <config-id>", "doctl open-harness-runtime remove <session>"}
+		tips = []string{"doctl harness-runtime config list-sessions <config-id>", "doctl harness-runtime remove <session>"}
 	case strings.Contains(lower, "mutually exclusive") || strings.Contains(lower, "is required") || strings.Contains(lower, "invalid --"):
 		title = "Invalid arguments"
 	case strings.Contains(lower, "not set locally") || strings.Contains(lower, "environment variable"):
@@ -168,13 +168,13 @@ func beautifyAgentError(err error) error {
 		tips = []string{"Check $OPENAI_API_KEY", "Retry in a moment"}
 	case strings.Contains(lower, "timed out"):
 		title = "Timed out"
-		tips = []string{"Retry with a longer --wait-timeout", "doctl open-harness-runtime show <session>"}
+		tips = []string{"Retry with a longer --wait-timeout", "doctl harness-runtime show <session>"}
 	case strings.Contains(lower, "no agent session goes by the name"):
 		title = "Session not found"
-		tips = []string{"doctl open-harness-runtime list"}
+		tips = []string{"doctl harness-runtime list"}
 	case strings.Contains(lower, "many agent sessions go by the name"):
 		title = "Ambiguous session name"
-		tips = []string{"Pass the session ID instead", "doctl open-harness-runtime list"}
+		tips = []string{"Pass the session ID instead", "doctl harness-runtime list"}
 	}
 
 	return &agentPrettyError{
@@ -193,17 +193,17 @@ func agentErrorTitleAndTips(msg string, status int) (title string, tips []string
 	case http.StatusForbidden:
 		return "Access denied", []string{"Check your token scopes or team permissions"}
 	case http.StatusNotFound:
-		return "Not found", []string{"doctl open-harness-runtime list", "Confirm the ID or name and try again"}
+		return "Not found", []string{"doctl harness-runtime list", "Confirm the ID or name and try again"}
 	case http.StatusConflict:
 		switch {
 		case strings.Contains(lower, "limit of") && strings.Contains(lower, "active sessions"):
-			return "Session limit reached", []string{"doctl open-harness-runtime list", "doctl open-harness-runtime remove <session>"}
+			return "Session limit reached", []string{"doctl harness-runtime list", "doctl harness-runtime remove <session>"}
 		case strings.Contains(lower, "active sessions"):
-			return "Config still has active sessions", []string{"doctl open-harness-runtime config list-sessions <config-id>", "doctl open-harness-runtime remove <session>"}
+			return "Config still has active sessions", []string{"doctl harness-runtime config list-sessions <config-id>", "doctl harness-runtime remove <session>"}
 		case strings.Contains(lower, "run is terminal"):
-			return "Session run has ended", []string{"doctl open-harness-runtime remove <session>", "doctl open-harness-runtime run --harness opencode --name new-session"}
+			return "Session run has ended", []string{"doctl harness-runtime remove <session>", "doctl harness-runtime run --harness opencode --name new-session"}
 		case strings.Contains(lower, "already attached") || strings.Contains(lower, "another device"):
-			return "Session already attached elsewhere", []string{"Detach on the other device, then re-run doctl open-harness-runtime attach"}
+			return "Session already attached elsewhere", []string{"Detach on the other device, then re-run doctl harness-runtime attach"}
 		default:
 			return "Conflict", nil
 		}

--- a/commands/agents_errors_test.go
+++ b/commands/agents_errors_test.go
@@ -67,7 +67,7 @@ func TestBeautifyAgentError_APIResponse(t *testing.T) {
 	assert.Equal(t, "Session limit reached", pretty.title)
 	assert.Equal(t, "team is at the limit of 4 active sessions", pretty.reason)
 	assert.Equal(t, http.StatusConflict, pretty.status)
-	assert.Contains(t, pretty.tips, "doctl open-harness-runtime list")
+	assert.Contains(t, pretty.tips, "doctl harness-runtime list")
 
 	display := pretty.DisplayError()
 	assert.Contains(t, display, "Session limit reached")

--- a/commands/agents_help.go
+++ b/commands/agents_help.go
@@ -25,7 +25,7 @@ import (
 // Primary cobra command name and user-facing CLI prefix for Managed Agents
 // Runtime Services (M.A.R.S). Viper keys stay under agents.* via agentsNS.
 const (
-	agentCmdName = "open-harness-runtime"
+	agentCmdName = "harness-runtime"
 	agentCLI     = "doctl " + agentCmdName
 )
 

--- a/commands/agents_run.go
+++ b/commands/agents_run.go
@@ -59,7 +59,7 @@ func maybeOfferGitHubAuth(c *CmdConfig) error {
 	svc := c.HostedAgents()
 	start, err := svc.StartProviderAuth(agentGitHubProvider)
 	if err != nil {
-		warn("could not check GitHub connection status: %v (continuing; use `doctl open-harness-runtime auth github` for private repos)", err)
+		warn("could not check GitHub connection status: %v (continuing; use `doctl harness-runtime auth github` for private repos)", err)
 		return nil
 	}
 	if start != nil && strings.EqualFold(start.Status, agentProviderAuthStatusSuccess) {
@@ -74,7 +74,7 @@ func maybeOfferGitHubAuth(c *CmdConfig) error {
 	if !connect {
 		fmt.Fprintf(c.Out, "%s %s\n",
 			colorize("•", colMuted),
-			colorize("Skipping GitHub connect — fine for public repos. Use `doctl open-harness-runtime auth github` later for private ones.", colMuted))
+			colorize("Skipping GitHub connect — fine for public repos. Use `doctl harness-runtime auth github` later for private ones.", colMuted))
 		return nil
 	}
 
@@ -226,7 +226,7 @@ func RunAgentsRun(c *CmdConfig) error {
 		}
 		if manifestUsesLegacyEnvelope(raw) {
 			warn("this manifest uses the deprecated apiVersion/kind/metadata/spec envelope format; " +
-				"switch to the flat format (top-level `agent:` key, no envelope — see `doctl open-harness-runtime start --help`). " +
+				"switch to the flat format (top-level `agent:` key, no envelope — see `doctl harness-runtime start --help`). " +
 				"The envelope is still accepted for now but will be rejected after the transition window")
 		}
 		raw, err = injectManifestName(raw, name)
@@ -290,7 +290,7 @@ func RunAgentsRun(c *CmdConfig) error {
 		ref := displaySessionRef(sess)
 		fmt.Fprintf(c.Out, "%s %s\n",
 			colorize("Tip:", colMuted),
-			colorize("For the native Codex TUI instead of doctl chat: doctl open-harness-runtime start-proxy --type codex --session "+ref+" --port 1144", colMuted))
+			colorize("For the native Codex TUI instead of doctl chat: doctl harness-runtime start-proxy --type codex --session "+ref+" --port 1144", colMuted))
 	}
 
 	return runAgentsAttachSession(c, sessionID)
@@ -503,7 +503,7 @@ func startSessionFromRawManifest(c *CmdConfig, raw []byte, prog *creationProgres
 	if err != nil {
 		if sessionLimitErr(err) {
 			msg, _, _ := agentAPIError(err)
-			return nil, fmt.Errorf("%s. Free a slot by removing one: run `doctl open-harness-runtime list` to find a session ID, then `doctl open-harness-runtime remove SESSION_ID`", strings.TrimRight(msg, "."))
+			return nil, fmt.Errorf("%s. Free a slot by removing one: run `doctl harness-runtime list` to find a session ID, then `doctl harness-runtime remove SESSION_ID`", strings.TrimRight(msg, "."))
 		}
 		return nil, err
 	}
@@ -910,9 +910,9 @@ func printRunReadySummary(w io.Writer, sum runReadySummary) {
 
 	fmt.Fprintln(&body)
 	fmt.Fprintln(&body, colorize("Next step", colMuted))
-	body.WriteString(cardRow("attach", "doctl open-harness-runtime attach "+ref))
+	body.WriteString(cardRow("attach", "doctl harness-runtime attach "+ref))
 	if isCodexReadyAgent(sum) {
-		body.WriteString(cardRow("proxy", "doctl open-harness-runtime start-proxy --type codex --session "+ref+" --port 1144"))
+		body.WriteString(cardRow("proxy", "doctl harness-runtime start-proxy --type codex --session "+ref+" --port 1144"))
 	}
 
 	renderAgentCard(w, body.String())
@@ -1007,7 +1007,7 @@ func printSessionShowCard(w io.Writer, sess *do.HostedAgentSession) {
 	case godo.HostedAgentSessionStatusReady, godo.HostedAgentSessionStatusDetached, godo.HostedAgentSessionStatusPaused:
 		fmt.Fprintln(&body)
 		fmt.Fprintln(&body, colorize("Next step", colMuted))
-		body.WriteString(cardRow("attach", "doctl open-harness-runtime attach "+ref))
+		body.WriteString(cardRow("attach", "doctl harness-runtime attach "+ref))
 	}
 
 	renderAgentCard(w, body.String())

--- a/commands/agents_run_test.go
+++ b/commands/agents_run_test.go
@@ -298,7 +298,7 @@ func TestRunAgentsRun_NoAttachHarness(t *testing.T) {
 		assert.Contains(t, out, "Session created")
 		assert.Contains(t, out, "Agent is ready")
 		assert.NotContains(t, out, "SESSION_STATUS_")
-		assert.Contains(t, out, "doctl open-harness-runtime attach demo")
+		assert.Contains(t, out, "doctl harness-runtime attach demo")
 		assert.NotContains(t, out, "katanemo/plano", "repo is hidden by default; only shown with -v/--verbose")
 	})
 }
@@ -588,7 +588,7 @@ func TestRunAgentsRun_FromConfigID_NoAttach(t *testing.T) {
 		got := buf.String()
 		assert.Contains(t, got, "Creating hosted session from config")
 		assert.Contains(t, got, "Agent is ready")
-		assert.Contains(t, got, "doctl open-harness-runtime attach demo")
+		assert.Contains(t, got, "doctl harness-runtime attach demo")
 	})
 }
 

--- a/commands/agents_style.go
+++ b/commands/agents_style.go
@@ -150,7 +150,7 @@ func printCheckpointCard(w io.Writer, cp *godo.HostedAgentCheckpoint, created bo
 	if sess := strings.TrimSpace(cp.SessionID); sess != "" {
 		fmt.Fprintln(&body)
 		fmt.Fprintln(&body, colorize("Next step", colMuted))
-		body.WriteString(cardRow("rollback", "doctl open-harness-runtime rollback "+sess+" "+cp.CheckpointID))
+		body.WriteString(cardRow("rollback", "doctl harness-runtime rollback "+sess+" "+cp.CheckpointID))
 	}
 	renderAgentCard(w, body.String())
 }
@@ -554,6 +554,6 @@ func printSessionEndedNotice(w io.Writer, sessionRef string) {
 	if ref == "" {
 		ref = "<session>"
 	}
-	fmt.Fprintf(w, "  %s %s\n", colorize("remove", colMuted), "doctl open-harness-runtime remove "+ref)
-	fmt.Fprintf(w, "  %s %s\n", colorize("start ", colMuted), "doctl open-harness-runtime run --harness opencode --name new-session")
+	fmt.Fprintf(w, "  %s %s\n", colorize("remove", colMuted), "doctl harness-runtime remove "+ref)
+	fmt.Fprintf(w, "  %s %s\n", colorize("start ", colMuted), "doctl harness-runtime run --harness opencode --name new-session")
 }

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -349,7 +349,7 @@ func TestAgentsStart_SpecNotRequiredForConfigID(t *testing.T) {
 	// LiveConfig.GetString is what the real CLI uses; TestConfig skips the
 	// required-flag check, so the FromConfigID runner tests cannot catch this.
 	require.False(t, viper.GetBool("required.agents.start.spec"),
-		"spec is still marked required; `doctl open-harness-runtime start --config-id` fails with (agents.start.spec) command is missing required arguments")
+		"spec is still marked required; `doctl harness-runtime start --config-id` fails with (agents.start.spec) command is missing required arguments")
 	_, err = (&doctl.LiveConfig{}).GetString("agents.start", doctl.ArgAgentSpec)
 	require.NoError(t, err)
 }
@@ -680,7 +680,7 @@ func TestRunAgentsShow(t *testing.T) {
 		got := buf.String()
 		assert.Contains(t, got, "demo")
 		assert.Contains(t, got, "ready")
-		assert.Contains(t, got, "doctl open-harness-runtime attach demo")
+		assert.Contains(t, got, "doctl harness-runtime attach demo")
 		assert.NotContains(t, got, "SESSION_STATUS_")
 	})
 }

--- a/commands/command_option.go
+++ b/commands/command_option.go
@@ -61,7 +61,7 @@ func agentPrettyErrors() cmdOption {
 }
 
 // agentsNS keeps viper keys under agents.* after the primary command became
-// `doctl open-harness-runtime` (with agent/agents/ohr aliases). Spread into CmdBuilder options.
+// `doctl harness-runtime` (with agent/agents/ohr aliases). Spread into CmdBuilder options.
 func agentsNS(opts ...cmdOption) []cmdOption {
 	return append([]cmdOption{agentPrettyErrors(), overrideCmdNS("agents")}, opts...)
 }

--- a/commands/displayers/hosted_agents.go
+++ b/commands/displayers/hosted_agents.go
@@ -21,7 +21,7 @@ import (
 )
 
 // HostedAgentSession wraps one or more hosted-agent sessions for display. The
-// same struct backs `doctl open-harness-runtime start`, `... show`, and `... list` — a slice
+// same struct backs `doctl harness-runtime start`, `... show`, and `... list` — a slice
 // of len 1 vs len N is the only difference between them.
 // Set Single=true for get/create verbs so JSON output is a bare object;
 // leave false (default) for list so JSON output is always an array.
@@ -137,7 +137,7 @@ func (h *HostedAgentCheckpoint) KV() []map[string]any {
 	return out
 }
 
-// HostedAgentWorkspaceUpload renders the result of `doctl open-harness-runtime upload`.
+// HostedAgentWorkspaceUpload renders the result of `doctl harness-runtime upload`.
 // Upload is single-file-only today (Uploads always has exactly one element),
 // so JSON() defaults to list semantics (always an array) like every other
 // list-shaped displayer; set Single=true if a future bare-object verb needs it
@@ -185,7 +185,7 @@ func (h *HostedAgentWorkspaceUpload) KV() []map[string]any {
 	return out
 }
 
-// HostedAgentSandboxExec renders the result of `doctl open-harness-runtime exec`
+// HostedAgentSandboxExec renders the result of `doctl harness-runtime exec`
 // under `-o json`. Text output never reaches this displayer: the command passes
 // the guest's stdout and stderr straight through instead, so it composes in a
 // pipeline.
@@ -237,7 +237,7 @@ func (h *HostedAgentSandboxExec) KV() []map[string]any {
 	return out
 }
 
-// HostedAgentConfig renders full Agent Configs, backing `doctl open-harness-runtime config
+// HostedAgentConfig renders full Agent Configs, backing `doctl harness-runtime config
 // get` and `... create`. Set Single=true so those verbs emit a bare JSON
 // object; the list verb uses HostedAgentConfigSummary instead.
 type HostedAgentConfig struct {
@@ -288,7 +288,7 @@ func (h *HostedAgentConfig) KV() []map[string]any {
 }
 
 // HostedAgentConfigSummary renders the list view of Agent Configs (no manifest
-// or credential slots), backing `doctl open-harness-runtime config list`.
+// or credential slots), backing `doctl harness-runtime config list`.
 type HostedAgentConfigSummary struct {
 	Configs []godo.HostedAgentConfigSummary
 }
@@ -333,7 +333,7 @@ func (h *HostedAgentConfigSummary) KV() []map[string]any {
 }
 
 // HostedAgentSandboxSize renders the sandbox size catalog for
-// `doctl open-harness-runtime sizes list`.
+// `doctl harness-runtime sizes list`.
 type HostedAgentSandboxSize struct {
 	Sizes []godo.HostedAgentSandboxSize
 }


### PR DESCRIPTION
## Summary
- Renames the primary CLI command for Managed Agents Runtime Services (M.A.R.S) from `open-harness-runtime` to `harness-runtime`, updating the `agentCmdName` constant, help text, error messages, and example command strings throughout `commands/`.
- No behavior changes beyond the command name; aliases (`agent`, `agents`, `ohr`) are unaffected.

## Test plan
- [x] `go build ./commands/...`
- [x] `go test ./commands/...` (agent-related tests pass; pre-existing failures in `TestRegistryLogin`/`TestRegistryLogout` are unrelated macOS keychain sandbox issues)