### PR TITLE
agents: accept hermes as a known adapter

### DIFF
--- a/commands/agents_validate.go
+++ b/commands/agents_validate.go
@@ -36,6 +36,7 @@ var knownAgentAdapters = map[string]struct{}{
 	"opencode":         {},
 	"codex":            {},
 	"codex-agentapi":   {},
+	"hermes":           {}, // runnable, but outside the default server-side agent-kind set
 	"custom":           {},
 	"codex-cli":        {}, // deprecated alias
 	"openai-agents":    {}, // declared, not yet runnable
@@ -346,6 +347,7 @@ func validateAdapterModelEnv(adapter string, env map[string]string, envPath stri
 	_, hasHarnessKey := env["HARNESS_INFERENCE_API_KEY"]
 	_, hasAnthropicModel := env["ANTHROPIC_MODEL"]
 	_, hasAnthropicKey := env["ANTHROPIC_API_KEY"]
+	_, hasOpenAIModel := env["OPENAI_MODEL"]
 
 	// Incident follow-up: MODEL vs HARNESS_INFERENCE_MODEL produce different
 	// session-create outcomes when harness inference env is partially set.
@@ -366,6 +368,14 @@ func validateAdapterModelEnv(adapter string, env map[string]string, envPath stri
 		if hasAnthropicKey && !hasAnthropicModel && (hasModel || hasHarnessModel) {
 			out.Warnings = append(out.Warnings, fmt.Sprintf("%s.ANTHROPIC_API_KEY: set without %s.ANTHROPIC_MODEL; set ANTHROPIC_MODEL explicitly for claude-code", envPath, envPath))
 		}
+	}
+
+	// hermes renders its gateway config from env at guest boot, resolving the
+	// model as OPENAI_MODEL -> HARNESS_INFERENCE_MODEL -> MODEL. With none of
+	// them set the session still creates and the gateway still starts; the
+	// first turn is what fails.
+	if adapter == "hermes" && !hasOpenAIModel && !hasHarnessModel && !hasModel {
+		out.Warnings = append(out.Warnings, fmt.Sprintf("%s: adapter hermes has no model env var (OPENAI_MODEL, HARNESS_INFERENCE_MODEL, or MODEL); the session will start but its first turn will fail", envPath))
 	}
 }
 

--- a/commands/agents_validate_test.go
+++ b/commands/agents_validate_test.go
@@ -60,7 +60,7 @@ func TestValidateAgentManifest_UnknownAdapter(t *testing.T) {
 }
 
 func TestValidateAgentManifest_RemovedAdaptersRejected(t *testing.T) {
-	for _, adapter := range []string{"cursor", "hermes", "cursor-cli"} {
+	for _, adapter := range []string{"cursor", "cursor-cli"} {
 		t.Run(adapter, func(t *testing.T) {
 			v := validateAgentManifest([]byte("agent: " + adapter + "\n"))
 			require.False(t, v.ok())
@@ -68,6 +68,24 @@ func TestValidateAgentManifest_RemovedAdaptersRejected(t *testing.T) {
 			assert.Contains(t, v.Errors[0], adapter)
 		})
 	}
+}
+
+func TestValidateAgentManifest_HermesAccepted(t *testing.T) {
+	const manifest = `name: hermes-smoke
+agent: hermes
+env:
+  OPENAI_MODEL: openai-gpt-4o
+`
+	v := validateAgentManifest([]byte(manifest))
+	assert.True(t, v.ok(), "errors=%v", v.Errors)
+	assert.Empty(t, v.Warnings)
+}
+
+func TestValidateAgentManifest_HermesWithoutModelWarns(t *testing.T) {
+	v := validateAgentManifest([]byte("agent: hermes\n"))
+	require.True(t, v.ok(), "errors=%v", v.Errors)
+	require.Len(t, v.Warnings, 1)
+	assert.Contains(t, v.Warnings[0], "OPENAI_MODEL")
 }
 
 func TestValidateAgentManifest_CredentialPlaceholderNoWarn(t *testing.T) {


### PR DESCRIPTION
## Summary

`doctl agents validate` currently rejects `agent: hermes`, because hermes was dropped from the known-adapter set back when it was unrunnable (8e2d640). It runs now, so the client is rejecting a manifest the server accepts. Whether hermes is available is a server-side decision (`HARNESS_SUPPORTED_AGENT_KINDS`), so the only thing the client-side rejection accomplishes is blocking the deployments that have it turned on.

This adds hermes back to `knownAgentAdapters`, and adds one hermes-specific warning: a manifest with no model env var.

## Why the model warning

The hermes guest renders its gateway config at boot, resolving the model as `OPENAI_MODEL` → `HARNESS_INFERENCE_MODEL` → `MODEL`. With none of them set, everything downstream still looks healthy — the session creates, the sandbox boots, the gateway starts and serves. Only the first turn fails, which is far enough from the cause to be annoying to attribute. Validate is the cheapest place to say so, and it stays a warning rather than an error because the value can legitimately arrive from a source validate cannot see.

This mirrors the existing claude-code checks in `validateAdapterModelEnv`.

## Test plan

- [x] `go test ./commands/ -run TestValidateAgentManifest` — passes
- [x] New `TestValidateAgentManifest_HermesAccepted` (valid hermes manifest is accepted with no warnings) and `TestValidateAgentManifest_HermesWithoutModelWarns`
- [x] `TestValidateAgentManifest_RemovedAdaptersRejected` keeps asserting `cursor` / `cursor-cli` are still rejected; only hermes moves out of that set
- [x] Validated a real hermes manifest end to end against a local stack (session creates, attach reaches the gateway)

Made with [Cursor](https://cursor.com)