### PR TITLE
fix(agents): keep warm-up input visible and queue every message

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -2445,10 +2445,11 @@ func printAttachSendAck(out io.Writer, warmup *warmupState, thinking *thinkingSt
 	fmt.Fprintln(out, colorize("… waiting for the agent", colMuted))
 }
 
-func echoAttachSubmitNewline(display *promptDisplay, warmup *warmupState, visual string) {
-	if warmup != nil && warmup.isBannerVisible() {
-		return
-	}
+// echoAttachSubmitNewline commits the submitted line to scrollback. During
+// warm-up it lands above the banner rather than being dropped: the buffer is
+// already cleared by then, so skipping it erased every record of what the user
+// queued while they waited.
+func echoAttachSubmitNewline(display *promptDisplay, visual string) {
 	display.finishInputLine(visual)
 }
 
@@ -2518,12 +2519,7 @@ func handleOpenAIAttachByte(c *CmdConfig, ctx context.Context, client openAIAgen
 		visual := displayInputBuffer(state.lineBuf)
 		state.mu.Unlock()
 		line := readSubmittedInput(state)
-		if line != "" && warmup.inputAlreadyQueued() {
-			fmt.Fprintln(c.Out, colorize("Message already queued — waiting for agent to start", colMuted))
-			state.display.redraw()
-			return false, nil
-		}
-		echoAttachSubmitNewline(state.display, warmup, visual)
+		echoAttachSubmitNewline(state.display, visual)
 		if line != "" {
 			if n, ok := needsLargePasteConfirmation(line); ok {
 				state.setLargePasteConfirmation(line, n)
@@ -2539,6 +2535,7 @@ func handleOpenAIAttachByte(c *CmdConfig, ctx context.Context, client openAIAgen
 						thinking.stop()
 					}
 					fmt.Fprintf(c.Out, "send failed: %v\n", err)
+					restoreInput(state, line)
 				} else if warmup.isActive() {
 					warmup.markInputQueued()
 					printAttachSendAck(c.Out, warmup, thinking)
@@ -2665,6 +2662,20 @@ const (
 	msgAgentWarmup       = "Agent is warming up… please wait"
 	msgAgentWarmupQueued = "Input queued until agent is ready"
 )
+
+// warmupQueuedLabel replaces the generic queued notice once messages have
+// actually been accepted, so the banner reflects how many are waiting rather
+// than implying a single one.
+func warmupQueuedLabel(n int) string {
+	switch {
+	case n < 1:
+		return msgAgentWarmupQueued
+	case n == 1:
+		return "1 message queued until agent is ready"
+	default:
+		return fmt.Sprintf("%d messages queued until agent is ready", n)
+	}
+}
 
 var (
 	warmupDuration       = 60 * time.Second
@@ -2885,7 +2896,7 @@ type warmupState struct {
 	active        bool
 	dismissed     bool
 	queued        bool
-	inputQueued   bool
+	queuedCount   int
 	phase         string
 	timeout       time.Duration // when > 0, overrides warmupDuration (tests)
 	getSession    func() (*do.HostedAgentSession, error)
@@ -2923,22 +2934,37 @@ func (w *warmupState) isActive() bool {
 	return w.active && !w.dismissed
 }
 
-func (w *warmupState) inputAlreadyQueued() bool {
+// queuedMessages is how many messages the backend has accepted while the
+// session warms up.
+func (w *warmupState) queuedMessages() int {
 	if w == nil {
-		return false
+		return 0
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	return w.inputQueued
+	return w.queuedCount
 }
 
+// markInputQueued records another accepted message and updates the banner to
+// show the running total.
+//
+// There is no cap here: a send only succeeds once the guest run accepts
+// messages, and from that point OHR queues turns in order (it answers a full
+// queue with a plain "agent is busy" error), so counting is honest and the
+// backend stays the single authority on capacity.
 func (w *warmupState) markInputQueued() {
 	if w == nil {
 		return
 	}
 	w.mu.Lock()
-	w.inputQueued = true
+	w.queuedCount++
+	w.queued = true
+	n := w.queuedCount
+	display, ok := w.out.(*promptDisplay)
 	w.mu.Unlock()
+	if ok {
+		display.warmupSetQueued(warmupQueuedLabel(n))
+	}
 }
 
 func (w *warmupState) isBannerVisible() bool {
@@ -3215,7 +3241,7 @@ func (w *warmupState) clear() {
 		return
 	}
 	w.active = false
-	w.inputQueued = false
+	w.queuedCount = 0
 	w.queued = false
 	timeoutCancel := w.timeoutCancel
 	animCancel := w.animCancel
@@ -4627,6 +4653,20 @@ func appendBufferedInput(state *attachState, chunk []byte) bool {
 	return true
 }
 
+// restoreInput puts a submitted line back on the input line after a failed
+// send, so the user can retry or edit it instead of losing what they typed.
+// Anything typed in the meantime is kept ahead of the restored text.
+func restoreInput(state *attachState, line string) {
+	if line == "" {
+		return
+	}
+	state.mu.Lock()
+	state.lineBuf = append([]byte(line), state.lineBuf...)
+	state.cursor = len(line)
+	state.mu.Unlock()
+	state.display.redraw()
+}
+
 func readSubmittedInput(state *attachState) string {
 	state.mu.Lock()
 	line := submittedInput(state.lineBuf)
@@ -4942,13 +4982,22 @@ func promptRowCount(prompt, line string, cols int) int {
 // clearPromptRowsLocked erases every terminal row occupied by the last painted
 // prompt, ending with the cursor on a blank row ready for a replacement paint.
 func (p *promptDisplay) clearPromptRowsLocked() {
+	var b strings.Builder
+	p.appendClearPromptRows(&b)
+	io.WriteString(p.out, b.String())
+}
+
+// appendClearPromptRows is clearPromptRowsLocked into a builder, so callers
+// that repaint a multi-row block can emit the whole escape burst as one write.
+// It leaves the cursor at column 0 of the topmost row the prompt occupied.
+func (p *promptDisplay) appendClearPromptRows(b *strings.Builder) {
 	rows := p.promptRows
 	if rows < 1 {
 		rows = 1
 	}
-	fmt.Fprint(p.out, "\r\x1b[K")
+	b.WriteString("\r\x1b[K")
 	for i := 1; i < rows; i++ {
-		fmt.Fprint(p.out, "\x1b[A\r\x1b[K")
+		b.WriteString("\x1b[A\r\x1b[K")
 	}
 	p.promptRows = 0
 }
@@ -4965,6 +5014,16 @@ func (p *promptDisplay) Write(b []byte) (int, error) {
 
 	startsWithNL := b[0] == '\n'
 	endsWithNL := b[len(b)-1] == '\n'
+
+	if p.warmupStatusLines > 0 {
+		if endsWithNL {
+			p.writeAboveWarmupLocked(string(b))
+			return len(b), nil
+		}
+		// A tokenless write means the agent is streaming: the wait is over, so
+		// retire the banner instead of interleaving frames with the tokens.
+		p.warmupStopLocked()
+	}
 
 	if p.midLine {
 		// Inject a separator only for discrete events that don't already
@@ -5040,6 +5099,12 @@ func (p *promptDisplay) finishInputLine(visual string) {
 	defer p.mu.Unlock()
 	if !p.raw {
 		fmt.Fprint(p.out, "\r\n")
+		return
+	}
+	if p.warmupStatusLines > 0 {
+		// Keep the banner pinned below the committed line so the user can still
+		// see what they queued while the agent boots.
+		p.writeAboveWarmupLocked(p.prompt() + visual + "\n")
 		return
 	}
 	p.clearPromptRowsLocked()
@@ -5181,21 +5246,17 @@ func (p *promptDisplay) warmupSetQueued(text string) {
 }
 
 // warmupEnsureRowsLocked grows reserved status rows to fit spinner + phase + queued.
+// Each new row is claimed by pushing the prompt down one line; the block itself
+// is painted afterwards by warmupPaintLocked, which clears every row it touches.
 func (p *promptDisplay) warmupEnsureRowsLocked() {
-	want := 1
-	if p.warmupPhaseLabel != "" {
-		want++
-	}
-	if p.warmupQueuedLabel != "" {
-		want++
-	}
-	for p.warmupStatusLines < want {
+	for p.warmupStatusLines < len(p.warmupBlockLinesLocked()) {
 		if p.midLine {
 			fmt.Fprint(p.out, "\r\n")
 			p.midLine = false
 		}
+		p.clearPromptRowsLocked()
 		fmt.Fprint(p.out, "\r\n")
-		p.paintPromptLocked(false)
+		p.promptRows = 1
 		p.warmupStatusLines++
 	}
 }
@@ -5211,9 +5272,11 @@ func (p *promptDisplay) warmupSetFrame(frame string) {
 	p.warmupPaintLocked()
 }
 
-// warmupPaintLocked redraws the warm-up spinner, optional grey phase / queued
-// lines, and prompt+input atomically from the prompt row. Caller must hold p.mu.
-func (p *promptDisplay) warmupPaintLocked() {
+// warmupBlockLinesLocked renders the banner's status rows top to bottom: the
+// spinner, then the optional grey backend-phase and queued-input notices. Its
+// length is the row count the block occupies above the prompt, so row
+// accounting and painting can never disagree.
+func (p *promptDisplay) warmupBlockLinesLocked() []string {
 	frame := p.warmupSpinnerFrame
 	if frame == "" {
 		frame = spinnerFrames[0]
@@ -5222,43 +5285,93 @@ func (p *promptDisplay) warmupPaintLocked() {
 	if label == "" {
 		label = msgAgentWarmup
 	}
+	lines := []string{fmt.Sprintf("%s %s", frame, label)}
+	if p.warmupPhaseLabel != "" {
+		lines = append(lines, colorize(p.warmupPhaseLabel, colMuted))
+	}
+	if p.warmupQueuedLabel != "" {
+		lines = append(lines, colorize(p.warmupQueuedLabel, colMuted))
+	}
+	return lines
+}
+
+// appendWarmupBlock paints the status rows and the prompt+input row downward
+// from the cursor's current row, clearing each row as it goes, and leaves the
+// cursor on the prompt row at the input caret.
+//
+// It deliberately does not save/restore the cursor: DECRC would override the
+// caret column computed here, which is the whole point of the repaint — during
+// warm-up nothing echoes keystrokes, so this is the only thing that advances
+// the caret as the user types.
+func (p *promptDisplay) appendWarmupBlock(b *strings.Builder) {
+	lines := p.warmupBlockLinesLocked()
+	for _, l := range lines {
+		b.WriteString("\r\x1b[K")
+		b.WriteString(l)
+		b.WriteString("\r\n")
+	}
+	b.WriteString("\r\x1b[K")
+
+	prompt := p.prompt()
 	line := ""
 	if p.lineBuf != nil && !p.freezeLine {
 		line = p.lineBuf()
 	}
-	cur := len(line)
-	if p.cursorPos != nil && !p.freezeLine {
-		cur = p.cursorPos()
-		if cur < 0 {
-			cur = 0
-		}
-		if cur > len(line) {
-			cur = len(line)
-		}
-	}
-
-	n := p.warmupStatusLines
-	var b strings.Builder
-	fmt.Fprintf(&b, "\x1b7\x1b[%dA\r\x1b[K", n)
-	fmt.Fprintf(&b, "%s %s", frame, label)
-	if p.warmupPhaseLabel != "" {
-		b.WriteString("\r\n\r\x1b[K")
-		b.WriteString(colorize(p.warmupPhaseLabel, colMuted))
-	}
-	if p.warmupQueuedLabel != "" {
-		b.WriteString("\r\n\r\x1b[K")
-		b.WriteString(colorize(p.warmupQueuedLabel, colMuted))
-	}
-	b.WriteString("\r\n\r\x1b[K")
-	prompt := p.prompt()
 	b.WriteString(prompt)
 	b.WriteString(line)
-	if back := len(line) - cur; back > 0 {
-		fmt.Fprintf(&b, "\x1b[%dD", back)
+	if back := len(line) - p.caretLocked(line); back > 0 {
+		fmt.Fprintf(b, "\x1b[%dD", back)
 	}
-	b.WriteString("\x1b8")
-	io.WriteString(p.out, b.String())
+
+	p.warmupStatusLines = len(lines)
 	p.promptRows = promptRowCount(prompt, line, p.columnsLocked())
+}
+
+// caretLocked clamps the input caret to line, defaulting to end-of-line.
+func (p *promptDisplay) caretLocked(line string) int {
+	if p.cursorPos == nil || p.freezeLine {
+		return len(line)
+	}
+	cur := p.cursorPos()
+	if cur < 0 {
+		return 0
+	}
+	if cur > len(line) {
+		return len(line)
+	}
+	return cur
+}
+
+// warmupPaintLocked redraws the warm-up spinner, optional grey phase / queued
+// lines, and prompt+input atomically. Caller must hold p.mu.
+func (p *promptDisplay) warmupPaintLocked() {
+	if p.warmupStatusLines < 1 {
+		return
+	}
+	var b strings.Builder
+	p.appendClearPromptRows(&b)
+	fmt.Fprintf(&b, "\x1b[%dA", p.warmupStatusLines)
+	p.appendWarmupBlock(&b)
+	io.WriteString(p.out, b.String())
+}
+
+// writeAboveWarmupLocked commits newline-terminated output to scrollback above
+// the pinned warm-up banner, then repaints the banner and prompt below it.
+//
+// Writing through the normal path instead would land the text on the prompt
+// row and push the prompt down without the block knowing, so every later frame
+// would repaint the spinner one row lower and leave a trail of stale spinner
+// rows. Caller must hold p.mu.
+func (p *promptDisplay) writeAboveWarmupLocked(text string) {
+	var b strings.Builder
+	p.appendClearPromptRows(&b)
+	for i := 0; i < p.warmupStatusLines; i++ {
+		b.WriteString("\x1b[A\r\x1b[K")
+	}
+	b.WriteString(strings.ReplaceAll(text, "\n", "\r\n"))
+	p.appendWarmupBlock(&b)
+	io.WriteString(p.out, b.String())
+	p.midLine = false
 }
 
 // warmupStopLocked erases the warm-up banner rows entirely. Caller must hold p.mu.
@@ -5270,20 +5383,20 @@ func (p *promptDisplay) warmupStopLocked() {
 		fmt.Fprint(p.out, "\r\n")
 		p.midLine = false
 	}
-	n := p.warmupStatusLines
+	// Blanking the status rows in place would leave one empty line per row
+	// wedged above the prompt, so delete the rows themselves (DL) and let the
+	// prompt row shift up into their place before repainting it there.
 	var b strings.Builder
-	b.WriteString("\x1b7")
-	for i := 0; i < n; i++ {
-		b.WriteString("\x1b[A\r\x1b[K")
-	}
-	b.WriteString("\x1b8")
+	p.appendClearPromptRows(&b)
+	fmt.Fprintf(&b, "\x1b[%dA\x1b[%dM", p.warmupStatusLines, p.warmupStatusLines)
 	io.WriteString(p.out, b.String())
+
 	p.warmupStatusLines = 0
 	p.warmupSpinnerFrame = ""
 	p.warmupSpinnerLabel = ""
 	p.warmupPhaseLabel = ""
 	p.warmupQueuedLabel = ""
-	p.paintPromptLocked(true)
+	p.paintPromptLocked(false)
 }
 
 // warmupStop erases the warm-up banner rows entirely.
@@ -5499,12 +5612,7 @@ func handleAttachByte(c *CmdConfig, svc do.HostedAgentsService, sessionID string
 		visual := displayInputBuffer(state.lineBuf)
 		state.mu.Unlock()
 		line := readSubmittedInput(state)
-		if line != "" && warmup.inputAlreadyQueued() {
-			fmt.Fprintln(c.Out, colorize("Message already queued — waiting for agent to start", colMuted))
-			state.display.redraw()
-			return false, nil
-		}
-		echoAttachSubmitNewline(state.display, warmup, visual)
+		echoAttachSubmitNewline(state.display, visual)
 		if line != "" {
 			if n, ok := needsLargePasteConfirmation(line); ok {
 				state.setLargePasteConfirmation(line, n)
@@ -5667,6 +5775,7 @@ func processAttachLine(c *CmdConfig, svc do.HostedAgentsService, sessionID, line
 			return true
 		}
 		fmt.Fprintf(c.Out, "send failed: %v\n", err)
+		restoreInput(state, line)
 		return false
 	}
 	if warmup != nil && warmup.isActive() {

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -4740,7 +4740,45 @@ func TestWarmupState_noteQueuedUpdatesNotice(t *testing.T) {
 	assert.Contains(t, buf.String(), "> i")
 }
 
-func TestWarmupState_blocksDuplicateSubmit(t *testing.T) {
+// Every message typed during warm-up is sent and counted: the guest queues
+// turns in order once it accepts input, so dropping later lines only lost the
+// user's typing.
+func TestWarmupState_queuesEverySubmittedMessage(t *testing.T) {
+	oldClock := warmupClock
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	warmupClock = func() time.Time { return now }
+	t.Cleanup(func() { warmupClock = oldClock })
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		for _, text := range []string{"hello", "hello again"} {
+			tm.hostedAgents.EXPECT().
+				SendInput("sess", &godo.HostedAgentSendInputRequest{Text: text}).
+				Return(&godo.HostedAgentSendInputResponse{RunID: "run_" + text}, nil)
+		}
+
+		state := newAttachState(io.Discard, &pendingHITL{})
+		state.display.setRaw(true)
+		w := newWarmupState(state.display, now.Add(-30*time.Second))
+		w.start()
+
+		typeLine := func(text string) {
+			for _, b := range append([]byte(text), 0x0d) {
+				stop, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, w, nil)
+				assert.NoError(t, err)
+				assert.False(t, stop)
+			}
+		}
+
+		typeLine("hello")
+		assert.Equal(t, 1, w.queuedMessages())
+
+		typeLine("hello again")
+		assert.Equal(t, 2, w.queuedMessages())
+	})
+}
+
+// A failed send must hand the text back rather than swallowing it.
+func TestWarmupState_failedSendRestoresInput(t *testing.T) {
 	oldClock := warmupClock
 	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
 	warmupClock = func() time.Time { return now }
@@ -4748,27 +4786,31 @@ func TestWarmupState_blocksDuplicateSubmit(t *testing.T) {
 
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		tm.hostedAgents.EXPECT().
-			SendInput("sess", &godo.HostedAgentSendInputRequest{Text: "2+2"}).
-			Return(&godo.HostedAgentSendInputResponse{RunID: "run_1"}, nil)
+			SendInput("sess", &godo.HostedAgentSendInputRequest{Text: "hello"}).
+			Return(nil, errors.New("boom"))
 
 		state := newAttachState(io.Discard, &pendingHITL{})
 		state.display.setRaw(true)
 		w := newWarmupState(state.display, now.Add(-30*time.Second))
 		w.start()
 
-		for _, b := range []byte("2+2") {
+		for _, b := range append([]byte("hello"), 0x0d) {
 			_, err := handleAttachByte(config, tm.hostedAgents, "sess", b, state, w, nil)
 			assert.NoError(t, err)
 		}
-		stop, err := handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, w, nil)
-		assert.NoError(t, err)
-		assert.False(t, stop)
-		assert.True(t, w.inputAlreadyQueued())
 
-		stop, err = handleAttachByte(config, tm.hostedAgents, "sess", 0x0d, state, w, nil)
-		assert.NoError(t, err)
-		assert.False(t, stop)
+		assert.Equal(t, 0, w.queuedMessages())
+		state.mu.Lock()
+		defer state.mu.Unlock()
+		assert.Equal(t, "hello", string(state.lineBuf), "failed send should restore the typed text")
+		assert.Equal(t, len("hello"), state.cursor)
 	})
+}
+
+func TestWarmupQueuedLabel(t *testing.T) {
+	assert.Equal(t, msgAgentWarmupQueued, warmupQueuedLabel(0))
+	assert.Equal(t, "1 message queued until agent is ready", warmupQueuedLabel(1))
+	assert.Equal(t, "3 messages queued until agent is ready", warmupQueuedLabel(3))
 }
 
 func TestHandleOpenAIAttachByte_warmupQueuedNotice(t *testing.T) {
@@ -4804,9 +4846,10 @@ func TestWarmupState_markInputQueuedDismissesBanner(t *testing.T) {
 	assert.True(t, w.isBannerVisible())
 
 	w.markInputQueued()
-	assert.True(t, w.inputAlreadyQueued())
+	assert.Equal(t, 1, w.queuedMessages())
 	assert.True(t, w.isBannerVisible())
 	assert.True(t, w.isActive())
+	assert.Contains(t, buf.String(), warmupQueuedLabel(1))
 }
 
 func TestWarmupState_clearsOnTimeout(t *testing.T) {

--- a/commands/agents_warmup_render_test.go
+++ b/commands/agents_warmup_render_test.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeScreen is a minimal ANSI terminal model — enough of CSI to replay what
+// the attach display writes and then assert what the user would actually see.
+// The warm-up banner bugs it guards against are only visible in the composed
+// effect of cursor moves, erases and wraps, which a raw byte-stream assertion
+// cannot express.
+type fakeScreen struct {
+	rows           [][]rune
+	row, col       int
+	cols           int
+	savedR, savedC int
+}
+
+func newFakeScreen(rows, cols int) *fakeScreen {
+	s := &fakeScreen{cols: cols, rows: make([][]rune, rows)}
+	for i := range s.rows {
+		s.rows[i] = blankRow(cols)
+	}
+	return s
+}
+
+func blankRow(cols int) []rune {
+	r := make([]rune, cols)
+	for i := range r {
+		r[i] = ' '
+	}
+	return r
+}
+
+func (s *fakeScreen) newline() {
+	if s.row == len(s.rows)-1 {
+		s.rows = append(s.rows[1:], blankRow(s.cols))
+		return
+	}
+	s.row++
+}
+
+func (s *fakeScreen) Write(p []byte) (int, error) {
+	runes := []rune(string(p))
+	for i := 0; i < len(runes); i++ {
+		switch r := runes[i]; r {
+		case '\r':
+			s.col = 0
+		case '\n':
+			s.newline()
+		case '\x1b':
+			i += s.escape(runes[i+1:])
+		default:
+			if s.col >= s.cols {
+				s.col = 0
+				s.newline()
+			}
+			s.rows[s.row][s.col] = r
+			s.col++
+		}
+	}
+	return len(p), nil
+}
+
+// escape applies one escape sequence and reports how many runes it consumed
+// past the leading ESC.
+func (s *fakeScreen) escape(rest []rune) int {
+	if len(rest) == 0 {
+		return 0
+	}
+	switch rest[0] {
+	case '7':
+		s.savedR, s.savedC = s.row, s.col
+		return 1
+	case '8':
+		s.row, s.col = s.savedR, s.savedC
+		return 1
+	case '[':
+		// CSI: parameters, then a final letter.
+		end := 1
+		for end < len(rest) && (rest[end] == ';' || (rest[end] >= '0' && rest[end] <= '9')) {
+			end++
+		}
+		if end >= len(rest) {
+			return end
+		}
+		n, err := strconv.Atoi(string(rest[1:end]))
+		if err != nil || n < 1 {
+			n = 1
+		}
+		s.csi(rest[end], n)
+		return end + 1 // params plus the final letter
+	}
+	return 1
+}
+
+func (s *fakeScreen) csi(final rune, n int) {
+	switch final {
+	case 'A':
+		if s.row -= n; s.row < 0 {
+			s.row = 0
+		}
+	case 'B':
+		if s.row += n; s.row > len(s.rows)-1 {
+			s.row = len(s.rows) - 1
+		}
+	case 'C':
+		s.col += n
+	case 'D':
+		if s.col -= n; s.col < 0 {
+			s.col = 0
+		}
+	case 'K':
+		for c := s.col; c < s.cols; c++ {
+			s.rows[s.row][c] = ' '
+		}
+	case 'M':
+		for i := 0; i < n; i++ {
+			s.rows = append(append(s.rows[:s.row:s.row], s.rows[s.row+1:]...), blankRow(s.cols))
+		}
+	}
+	// SGR ('m') and anything else leaves the grid untouched.
+}
+
+// lines returns the non-blank screen rows, right-trimmed.
+func (s *fakeScreen) lines() []string {
+	var out []string
+	for _, r := range s.rows {
+		if l := strings.TrimRight(string(r), " "); l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// trimmedLines is lines() with trailing blanks removed from each row, for
+// whole-screen equality assertions.
+func trimmedLines(s *fakeScreen) []string {
+	out := s.lines()
+	for i, l := range out {
+		out[i] = strings.TrimRight(l, " ")
+	}
+	return out
+}
+
+func (s *fakeScreen) countLines(substr string) int {
+	n := 0
+	for _, l := range s.lines() {
+		if strings.Contains(l, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// warmupScreen wires an attachState to a fakeScreen with the warm-up banner up.
+func warmupScreen(t *testing.T) (*fakeScreen, *attachState) {
+	t.Helper()
+	scr := newFakeScreen(12, 80)
+	state := newAttachState(scr, &pendingHITL{})
+	state.display.termCols = 80
+	state.display.setRaw(true)
+	state.display.warmupInit(spinnerFrames[0], msgAgentWarmup)
+	return scr, state
+}
+
+// typeDuringWarmup mirrors handleAttachByte's warm-up path: buffer the byte,
+// then repaint the whole banner (warm-up never echoes keystrokes).
+func typeDuringWarmup(state *attachState, text string) {
+	for _, b := range []byte(text) {
+		state.mu.Lock()
+		state.lineBuf = append(state.lineBuf, b)
+		state.cursor++
+		state.mu.Unlock()
+		state.display.redraw()
+	}
+}
+
+func TestWarmupBannerCaretFollowsTypedInput(t *testing.T) {
+	scr, state := warmupScreen(t)
+	typeDuringWarmup(state, "hello")
+
+	require.Contains(t, scr.lines(), "> hello")
+	// The caret must sit after the final "o", not back at the prompt: warm-up
+	// suppresses echo, so this repaint is the only thing that moves it.
+	assert.Equal(t, len("> hello"), scr.col, "caret column should follow the typed text")
+	assert.Equal(t, "> hello", strings.TrimRight(string(scr.rows[scr.row]), " "),
+		"caret should rest on the prompt row")
+}
+
+func TestWarmupBannerCaretHonoursMidLineEditing(t *testing.T) {
+	scr, state := warmupScreen(t)
+	typeDuringWarmup(state, "hello")
+
+	state.mu.Lock()
+	state.cursor = 2 // caret before the first "l"
+	state.mu.Unlock()
+	state.display.redraw()
+
+	assert.Equal(t, len("> he"), scr.col)
+}
+
+func TestWarmupBannerKeepsOneSpinnerRowAcrossEvents(t *testing.T) {
+	scr, state := warmupScreen(t)
+	typeDuringWarmup(state, "hello")
+	state.display.warmupSetPhase("sandbox ready · starting agent")
+	state.display.warmupSetQueued(msgAgentWarmupQueued)
+
+	// A plain event write mid-warm-up used to land on the prompt row and push
+	// the prompt down without the banner knowing, so every later frame painted
+	// a fresh spinner row.
+	fmt.Fprintln(state.display, "sandbox provisioned")
+	state.display.warmupSetFrame(spinnerFrames[1])
+	state.display.warmupSetFrame(spinnerFrames[2])
+
+	assert.Equal(t, 1, scr.countLines(msgAgentWarmup), "exactly one spinner row should remain")
+	assert.Equal(t, 1, scr.countLines("sandbox ready · starting agent"))
+	assert.Equal(t, 1, scr.countLines(msgAgentWarmupQueued))
+
+	lines := scr.lines()
+	assert.Equal(t, "sandbox provisioned", lines[0], "event text belongs above the pinned banner")
+	assert.Contains(t, lines[1], msgAgentWarmup)
+	assert.Equal(t, "> hello", lines[len(lines)-1], "prompt and input stay at the bottom")
+}
+
+func TestWarmupBannerCommitsSubmittedLineAboveBanner(t *testing.T) {
+	scr, state := warmupScreen(t)
+	typeDuringWarmup(state, "hello")
+	state.display.warmupSetQueued(msgAgentWarmupQueued)
+
+	visual := displayInputBuffer(state.lineBuf)
+	require.Equal(t, "hello", readSubmittedInput(state))
+	echoAttachSubmitNewline(state.display, visual)
+
+	lines := scr.lines()
+	assert.Equal(t, "> hello", lines[0], "the queued message must stay visible in scrollback")
+	assert.Contains(t, lines[1], msgAgentWarmup, "banner stays pinned under the committed line")
+	assert.Equal(t, 1, scr.countLines(msgAgentWarmup))
+	assert.Equal(t, ">", strings.TrimRight(lines[len(lines)-1], " "), "prompt is left empty for the next message")
+}
+
+// The reported case: two messages typed while the agent boots. Both must stay
+// on screen, in order, with a single banner reporting the running total.
+func TestWarmupBannerShowsEveryQueuedMessage(t *testing.T) {
+	scr, state := warmupScreen(t)
+
+	queue := func(text string, total int) {
+		typeDuringWarmup(state, text)
+		visual := displayInputBuffer(state.lineBuf)
+		require.Equal(t, text, readSubmittedInput(state))
+		echoAttachSubmitNewline(state.display, visual)
+		state.display.warmupSetQueued(warmupQueuedLabel(total))
+	}
+
+	queue("hello", 1)
+	queue("hello again", 2)
+
+	assert.Equal(t, []string{
+		"> hello",
+		"> hello again",
+		spinnerFrames[0] + " " + msgAgentWarmup,
+		warmupQueuedLabel(2),
+		">",
+	}, trimmedLines(scr))
+}
+
+func TestWarmupBannerStopLeavesNoBlankRows(t *testing.T) {
+	scr, state := warmupScreen(t)
+	typeDuringWarmup(state, "hello")
+	state.display.warmupSetPhase("sandbox ready · starting agent")
+	state.display.warmupSetQueued(msgAgentWarmupQueued)
+	state.display.warmupStop()
+
+	assert.Equal(t, []string{"> hello"}, scr.lines(),
+		"clearing the banner should delete its rows, not blank them in place")
+	assert.Equal(t, len("> hello"), scr.col)
+}


### PR DESCRIPTION
Follow-up to MARSOHS-972. Attaching to a session that is still booting mishandled input in three ways.

## What was wrong

**The caret never moved while typing.** `warmupPaintLocked` computed the correct caret column and then discarded it by ending with `\x1b8` (DECRC), restoring the cursor saved at the top of that same paint. Warm-up deliberately suppresses echo and repaints instead, so that paint was the only thing that could advance the caret — it stayed pinned just after `> ` no matter how much you typed.

**Submitted messages vanished.** On Enter the buffer is cleared first, then `echoAttachSubmitNewline` skipped the commit to scrollback whenever the banner was visible. The typed text was gone with no record of what had been queued.

**Only the first message was ever sent.** A second Enter hit the `inputAlreadyQueued` guard and was dropped outright — not sent, not shown, not returned to the input line:

```
> hello
Message already queued — waiting for agent to start   <- "hello again" silently lost
```

The guard was also unnecessary. It is only set after a *successful* send, which means the guest run was already accepting input; from that point OHR queues turns in order on a 64-slot channel and answers a full queue with a clean "agent is busy" error.

**Stale spinner rows.** `Write` ignored `warmupStatusLines`, so any plain output during warm-up landed on the prompt row and pushed the prompt down without the banner's row accounting knowing. Every subsequent frame then painted its spinner one row lower, stranding the previous one:

```
⠋ Agent is warming up… please wait
⠙ Agent is warming up… please wait
```

## What changed

- The banner renders top-down from a known anchor via `appendWarmupBlock` and stops at the computed caret — no DECSC/DECRC to override it. Row count is derived from `warmupBlockLinesLocked()`, so accounting and painting cannot disagree.
- Scrollback writes and submitted lines go above the pinned banner (`writeAboveWarmupLocked`); clearing the banner deletes its rows (DL) rather than blanking them in place, which used to leave empty lines behind.
- Every message typed during warm-up is sent and committed to scrollback in order. `markInputQueued` counts instead of latching, and the banner reports the running total.
- A failed send calls `restoreInput`, putting the text back on the input line with the caret at its end, on both the hosted and OpenAI attach paths.

Result for the reported case:

```
> hello
> hello again
⠋ Agent is warming up… please wait
2 messages queued until agent is ready
>
```

No client-side cap was added: the backend stays the single authority on capacity, so the count stays honest.

## Test plan

- [x] `go test ./commands/` — no new failures (`TestRegistryLogin`/`TestRegistryLogout` fail identically on a clean checkout of the base branch; unrelated and environment-dependent)
- [x] New `commands/agents_warmup_render_test.go` replays the real escape-sequence stream through a small terminal model and asserts the resulting screen — the only way to express "exactly one spinner row" or "caret in column 7". Covers caret tracking (end and mid-line), one spinner row across events, committed lines above the banner, the two-message case above, and no blank rows after teardown.
- [x] Each new test was confirmed non-vacuous by reverting the corresponding fix and watching it fail in the reported way.
- [x] `TestWarmupState_blocksDuplicateSubmit` replaced by `TestWarmupState_queuesEverySubmittedMessage` and `TestWarmupState_failedSendRestoresInput`.
- [x] `gofmt` / `go vet` clean.
- [x] Caret tracking and the visible queued message were confirmed in a live `doctl agents attach` session against a warming-up sandbox.
- [ ] Multi-message queueing is covered by tests but has not yet been exercised against a live session — worth a reviewer sanity check.

Made with [Cursor](https://cursor.com)
