### PR TITLE
feat(agents): accept the manifest as an argument, default to ./agents.yaml

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -57,6 +57,7 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/term"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -439,13 +440,14 @@ func Agents() *Command {
 		},
 	}
 
-	cmdStart := CmdBuilder(cmd, RunAgentsStart, "start",
+	cmdStart := CmdBuilder(cmd, RunAgentsStart, "start [<manifest>]",
 		"Start a new session",
 		agentsStartHelpMD,
 		Writer, agentsNS(aliasOpt("deploy"),
 			displayerType(&displayers.HostedAgentSession{}))...)
 	AddStringFlag(cmdStart, doctl.ArgAgentHarness, "", "", "Coding-agent harness (opencode, claude-code, codex). Builds the manifest for you. Mutually exclusive with --spec and --config-id.")
-	AddStringFlag(cmdStart, doctl.ArgAgentSpec, "", "", `Path to an agent manifest in YAML or JSON. Prefer flat format (top-level name + agent), e.g. "name: my-session\nagent: opencode". Legacy apiVersion/kind/metadata/spec envelopes still work. Set to "-" to read from stdin. ${VAR} references are resolved from the local environment. Mutually exclusive with --harness and --config-id.`)
+	AddStringFlag(cmdStart, doctl.ArgAgentSpec, "f", "", `Path to an agent manifest in YAML or JSON, equivalently given as a positional argument or --file. Defaults to ./agents.yaml when present. Prefer flat format (top-level name + agent), e.g. "name: my-session\nagent: opencode". Legacy apiVersion/kind/metadata/spec envelopes still work. Set to "-" to read from stdin. ${VAR} references are resolved from the local environment. Mutually exclusive with --harness and --config-id.`)
+	acceptFileAliasFor(cmdStart)
 	AddStringFlag(cmdStart, doctl.ArgAgentConfigID, "", "", "ID of an existing Agent Config to start the session from. Requires --name. Mutually exclusive with --harness and --spec.")
 	AddStringFlag(cmdStart, doctl.ArgAgentRepo, "", "", "GitHub repository to clone into the workspace (https://github.com/org/repo or org/repo). Only with --harness or --spec.")
 	AddStringFlag(cmdStart, doctl.ArgAgentTriggerPrompt, "", "", "Initial prompt to send once the session is ready")
@@ -454,21 +456,23 @@ func Agents() *Command {
 	cmdStart.MarkFlagsMutuallyExclusive(doctl.ArgAgentHarness, doctl.ArgAgentSpec)
 	cmdStart.MarkFlagsMutuallyExclusive(doctl.ArgAgentHarness, doctl.ArgAgentConfigID)
 	cmdStart.MarkFlagsMutuallyExclusive(doctl.ArgAgentSpec, doctl.ArgAgentConfigID)
-	cmdStart.Example = agentCLI + ` start --harness claude-code --gh-repo owner/repo --prompt "Review the README"; ` + agentCLI + ` start --spec agent-spec.yaml --name my-session; ` + agentCLI + ` start --config-id cfg_abc123 --name my-session`
+	cmdStart.Example = agentCLI + ` start; ` + agentCLI + ` start agent-spec.yaml --name my-session; ` + agentCLI + ` start --harness claude-code --gh-repo owner/repo --prompt "Review the README"; ` + agentCLI + ` start --config-id cfg_abc123 --name my-session`
 
-	cmdValidate := CmdBuilder(cmd, RunAgentsValidate, "validate",
+	cmdValidate := CmdBuilder(cmd, RunAgentsValidate, "validate [<manifest>]",
 		"Validate an agent manifest",
 		agentsValidateHelpMD,
 		Writer, agentsNS()...)
-	AddStringFlag(cmdValidate, doctl.ArgAgentSpec, "", "", `Path to an agent manifest in YAML or JSON (flat or legacy envelope). Set to "-" to read from stdin.`, requiredOpt())
-	cmdValidate.Example = agentCLI + ` validate --spec agent.yaml`
+	AddStringFlag(cmdValidate, doctl.ArgAgentSpec, "f", "", `Path to an agent manifest in YAML or JSON (flat or legacy envelope), equivalently given as a positional argument or --file. Defaults to ./agents.yaml when present. Set to "-" to read from stdin.`)
+	acceptFileAliasFor(cmdValidate)
+	cmdValidate.Example = agentCLI + ` validate; ` + agentCLI + ` validate agent.yaml`
 
-	cmdRun := CmdBuilder(cmd, RunAgentsRun, "run",
+	cmdRun := CmdBuilder(cmd, RunAgentsRun, "run [<manifest>]",
 		"Start one session and attach",
 		agentsRunHelpMD,
 		Writer, agentsNS(aliasOpt("up"))...)
 	AddStringFlag(cmdRun, doctl.ArgAgentHarness, "", "", "Coding-agent harness (opencode, claude-code, codex). Mutually exclusive with --spec and --config-id.")
-	AddStringFlag(cmdRun, doctl.ArgAgentSpec, "", "", `Optional manifest file instead of --harness or --config-id. Same format as start --spec (flat: top-level name + agent).`)
+	AddStringFlag(cmdRun, doctl.ArgAgentSpec, "f", "", `Optional manifest file instead of --harness or --config-id, equivalently given as a positional argument or --file. Defaults to ./agents.yaml when present. Same format as start --spec (flat: top-level name + agent).`)
+	acceptFileAliasFor(cmdRun)
 	AddStringFlag(cmdRun, doctl.ArgAgentConfigID, "", "", "ID of an existing Agent Config to run from, instead of --harness/--spec. Requires --name.")
 	AddStringFlag(cmdRun, doctl.ArgAgentRepo, "", "", "GitHub repository to clone into the workspace (https://github.com/org/repo or org/repo). Only with --harness or --spec.")
 	AddStringFlag(cmdRun, doctl.ArgAgentTriggerPrompt, "", "", "Initial prompt to send once the session is ready")
@@ -478,7 +482,7 @@ func Agents() *Command {
 	cmdRun.MarkFlagsMutuallyExclusive(doctl.ArgAgentHarness, doctl.ArgAgentSpec)
 	cmdRun.MarkFlagsMutuallyExclusive(doctl.ArgAgentHarness, doctl.ArgAgentConfigID)
 	cmdRun.MarkFlagsMutuallyExclusive(doctl.ArgAgentSpec, doctl.ArgAgentConfigID)
-	cmdRun.Example = agentCLI + ` run --harness opencode --gh-repo https://github.com/katanemo/plano --prompt "Review the README"; ` + agentCLI + ` run --config-id cfg_abc123 --name my-session --prompt "Review the README"`
+	cmdRun.Example = agentCLI + ` run; ` + agentCLI + ` run agent-spec.yaml; ` + agentCLI + ` run --harness opencode --gh-repo https://github.com/katanemo/plano --prompt "Review the README"; ` + agentCLI + ` run --config-id cfg_abc123 --name my-session --prompt "Review the README"`
 
 	cmdStartProxy := CmdBuilder(cmd, RunAgentsStartProxy, "start-proxy",
 		"Bridge the Codex CLI to a hosted session",
@@ -647,10 +651,15 @@ func RunAgentsStart(c *CmdConfig) error {
 	repo = strings.TrimSpace(repo)
 	prompt = strings.TrimSpace(prompt)
 
+	if len(c.Args) > 0 && (harness != "" || configID != "") {
+		return fmt.Errorf("a manifest path cannot be combined with --%s or --%s", doctl.ArgAgentHarness, doctl.ArgAgentConfigID)
+	}
+
 	// Never call GetString(--spec) when another source is selected: a stale
 	// required.agents.start.spec viper mark (or LiveConfig required check)
 	// would fail --harness / --config-id even though --spec is optional.
 	specPath := ""
+	discoveredSpec := false
 	switch {
 	case configID != "":
 		if c.Doit.IsSet(doctl.ArgAgentSpec) || c.Doit.IsSet(doctl.ArgAgentHarness) {
@@ -662,11 +671,10 @@ func RunAgentsStart(c *CmdConfig) error {
 		}
 	default:
 		var err error
-		specPath, err = c.Doit.GetString(c.NS, doctl.ArgAgentSpec)
+		specPath, err = namedManifestPath(c)
 		if err != nil {
 			return err
 		}
-		specPath = strings.TrimSpace(specPath)
 	}
 
 	sources := 0
@@ -679,7 +687,13 @@ func RunAgentsStart(c *CmdConfig) error {
 		return fmt.Errorf("--%s, --%s, and --%s are mutually exclusive; provide only one", doctl.ArgAgentHarness, doctl.ArgAgentSpec, doctl.ArgAgentConfigID)
 	}
 	if sources == 0 {
-		return fmt.Errorf("one of --%s, --%s, or --%s is required", doctl.ArgAgentHarness, doctl.ArgAgentSpec, doctl.ArgAgentConfigID)
+		// Nothing named and no other source selected, so an agents.yaml sitting
+		// in the working directory is unambiguously what the user meant.
+		if found := discoverManifestFile(); found != "" {
+			specPath, discoveredSpec = found, true
+		} else {
+			return missingManifestErr()
+		}
 	}
 	if configID != "" && repo != "" {
 		return fmt.Errorf("--%s cannot be used with --%s; put the repo in the Agent Config instead", doctl.ArgAgentRepo, doctl.ArgAgentConfigID)
@@ -693,6 +707,7 @@ func RunAgentsStart(c *CmdConfig) error {
 	if Output != "json" {
 		stylingEnabled = detectStyling()
 	}
+	noticeDiscoveredManifest(specPath, discoveredSpec)
 	if repo != "" {
 		if err := maybeOfferGitHubAuth(c); err != nil {
 			return err
@@ -908,6 +923,81 @@ func readManifest(stdin io.Reader, path string) ([]byte, error) {
 		return nil, err
 	}
 	return expandManifestEnv(raw)
+}
+
+// acceptFileAliasFor makes --file a second spelling of --spec on cmd. --spec
+// stays canonical in help output because it is doctl's word for a declarative
+// file (apps, dedicated-inference); --file and -f exist because kubectl,
+// compose and planoai trained that muscle memory.
+func acceptFileAliasFor(cmd *Command) {
+	cmd.Flags().SetNormalizeFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
+		if name == "file" {
+			name = doctl.ArgAgentSpec
+		}
+		return pflag.NormalizedName(name)
+	})
+}
+
+// manifestFileNames are the files start/run/validate look for in the working
+// directory when the manifest is not named explicitly. agents.yaml is the
+// conventional name used throughout the docs.
+var manifestFileNames = []string{"agents.yaml", "agents.yml"}
+
+// namedManifestPath returns the manifest the user named explicitly, either
+// with --spec (also spelled -f / --file) or as a positional path. An empty
+// result means they named none, which leaves the caller free to fall back to
+// discoverManifestFile — but only once it knows no other source (--harness,
+// --config-id) was selected.
+func namedManifestPath(c *CmdConfig) (string, error) {
+	spec, err := c.Doit.GetString(c.NS, doctl.ArgAgentSpec)
+	if err != nil {
+		return "", err
+	}
+	spec = strings.TrimSpace(spec)
+
+	if len(c.Args) > 1 {
+		return "", fmt.Errorf("expected at most one manifest path, got %d", len(c.Args))
+	}
+	arg := ""
+	if len(c.Args) == 1 {
+		arg = strings.TrimSpace(c.Args[0])
+	}
+
+	switch {
+	case spec != "" && arg != "":
+		return "", fmt.Errorf("manifest given twice, as --%s %s and as %s; pass it one way", doctl.ArgAgentSpec, spec, arg)
+	case spec != "":
+		return spec, nil
+	default:
+		return arg, nil
+	}
+}
+
+// discoverManifestFile returns the conventional manifest in the working
+// directory, or "" when there is none.
+func discoverManifestFile() string {
+	for _, name := range manifestFileNames {
+		if info, err := os.Stat(name); err == nil && info.Mode().IsRegular() {
+			return name
+		}
+	}
+	return ""
+}
+
+// noticeDiscoveredManifest names an implicitly chosen manifest, so a run never
+// reads a file the user did not mention. Suppressed under -o json, which must
+// stay parseable.
+func noticeDiscoveredManifest(path string, discovered bool) {
+	if discovered && Output != "json" {
+		notice("using %s", path)
+	}
+}
+
+// missingManifestErr is the "nothing to start from" message, listing every way
+// to name a manifest rather than only the flag.
+func missingManifestErr() error {
+	return fmt.Errorf("no manifest given: pass a path (or --%s), add %s to this directory, or use --%s / --%s",
+		doctl.ArgAgentSpec, manifestFileNames[0], doctl.ArgAgentHarness, doctl.ArgAgentConfigID)
 }
 
 // readManifestBytes loads the spec file without env expansion. Used by start

--- a/commands/agents_help.go
+++ b/commands/agents_help.go
@@ -48,11 +48,16 @@ const agentsStartHelpMD = `Create a hosted session and wait until it is ready (d
 
 Provide exactly one of:
 
+- a **manifest** — as a positional path, or with ` + "`--spec`" + ` / ` + "`-f`" + ` / ` + "`--file`" + ` (` + "`-`" + ` reads stdin). With none of these, ` + "`./agents.yaml`" + ` is used when it exists.
 - ` + "`--harness`" + ` — opencode, claude-code, or codex (builds the manifest for you)
-- ` + "`--spec`" + ` — path to an agents.yaml / JSON manifest (` + "`-`" + ` reads stdin)
 - ` + "`--config-id`" + ` — start from an existing Agent Config (` + "`--name`" + ` required)
 
-With ` + "`--harness`" + ` or ` + "`--spec`" + `, optionally pass ` + "`--gh-repo`" + ` and ` + "`--prompt`" + `. Example:
+These four are equivalent:
+` + "```bash\n" + agentCLI + ` start                       # uses ./agents.yaml
+` + agentCLI + ` start agents.yaml
+` + agentCLI + ` start -f agents.yaml
+` + agentCLI + ` start --spec agents.yaml
+` + "```\n\n" + `With a manifest or ` + "`--harness`" + `, optionally pass ` + "`--gh-repo`" + ` and ` + "`--prompt`" + `. Example:
 ` + "```bash\n" + agentCLI + ` start --harness claude-code --gh-repo owner/repo --prompt "Review the README"
 ` + "```\n\n" + `Flat manifests use a top-level ` + "`name`" + ` (or pass ` + "`--name`" + `, which writes that field). Minimal example:
 ` + "```yaml\n" + `name: my-session
@@ -65,13 +70,16 @@ const agentsValidateHelpMD = `Check an agents.yaml / JSON manifest client-side w
 
 Catches missing ` + "`agent`" + `/` + "`spec.runtime.adapter`" + `, unknown adapters, reserved env keys, credentials placed in ` + "`env`" + ` instead of ` + "`secrets`" + `, and conflicting model env keys (` + "`MODEL`" + ` / ` + "`HARNESS_INFERENCE_MODEL`" + ` / ` + "`ANTHROPIC_MODEL`" + `). The API remains the authoritative validator for the full contract.
 
+Name the manifest as a positional path or with ` + "`--spec`" + ` / ` + "`-f`" + ` / ` + "`--file`" + ` (` + "`-`" + ` reads stdin); with none of these, ` + "`./agents.yaml`" + ` is used when it exists.
+
 Example:
-` + "```bash\n" + agentCLI + ` validate --spec agent.yaml
+` + "```bash\n" + agentCLI + ` validate            # checks ./agents.yaml
+` + agentCLI + ` validate agent.yaml
 ` + "```"
 
 const agentsRunHelpMD = `Create a session, wait until ready, optionally send ` + "`--prompt`" + `, then open the interactive TUI.
 
-Provide exactly one of ` + "`--harness`" + `, ` + "`--spec`" + `, or ` + "`--config-id`" + `. With ` + "`--harness`" + ` / ` + "`--spec`" + `, use ` + "`--gh-repo`" + ` to clone a repository. Pass ` + "`--no-attach`" + ` to stop at the ready summary.
+Provide exactly one of a manifest, ` + "`--harness`" + `, or ` + "`--config-id`" + `. The manifest is a positional path or ` + "`--spec`" + ` / ` + "`-f`" + ` / ` + "`--file`" + `, defaulting to ` + "`./agents.yaml`" + ` when present. With a manifest or ` + "`--harness`" + `, use ` + "`--gh-repo`" + ` to clone a repository. Pass ` + "`--no-attach`" + ` to stop at the ready summary.
 
 For the native Codex desktop/CLI UI instead of doctl chat, see ` + "`" + agentCLI + " start-proxy --help`" + `.`
 

--- a/commands/agents_run.go
+++ b/commands/agents_run.go
@@ -142,7 +142,7 @@ func RunAgentsRun(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	specPath, err := c.Doit.GetString(c.NS, doctl.ArgAgentSpec)
+	specPath, err := namedManifestPath(c)
 	if err != nil {
 		return err
 	}
@@ -177,6 +177,10 @@ func RunAgentsRun(c *CmdConfig) error {
 	repo = strings.TrimSpace(repo)
 	prompt = strings.TrimSpace(prompt)
 
+	if len(c.Args) > 0 && (harness != "" || configID != "") {
+		return fmt.Errorf("a manifest path cannot be combined with --%s or --%s", doctl.ArgAgentHarness, doctl.ArgAgentConfigID)
+	}
+
 	sources := 0
 	for _, s := range []string{harness, specPath, configID} {
 		if s != "" {
@@ -186,8 +190,15 @@ func RunAgentsRun(c *CmdConfig) error {
 	if sources > 1 {
 		return fmt.Errorf("--%s, --%s, and --%s are mutually exclusive; provide only one", doctl.ArgAgentHarness, doctl.ArgAgentSpec, doctl.ArgAgentConfigID)
 	}
+	discoveredSpec := false
 	if sources == 0 {
-		return fmt.Errorf("one of --%s, --%s, or --%s is required", doctl.ArgAgentHarness, doctl.ArgAgentSpec, doctl.ArgAgentConfigID)
+		// Nothing named and no other source selected, so an agents.yaml sitting
+		// in the working directory is unambiguously what the user meant.
+		if found := discoverManifestFile(); found != "" {
+			specPath, discoveredSpec = found, true
+		} else {
+			return missingManifestErr()
+		}
 	}
 	if configID != "" && repo != "" {
 		return fmt.Errorf("--%s cannot be used with --%s; put the repo in the Agent Config instead", doctl.ArgAgentRepo, doctl.ArgAgentConfigID)
@@ -199,6 +210,7 @@ func RunAgentsRun(c *CmdConfig) error {
 	}
 
 	stylingEnabled = detectStyling()
+	noticeDiscoveredManifest(specPath, discoveredSpec)
 	if repo != "" {
 		if err := maybeOfferGitHubAuth(c); err != nil {
 			return err

--- a/commands/agents_run_test.go
+++ b/commands/agents_run_test.go
@@ -573,10 +573,11 @@ func TestMaybeOfferGitHubAuth_ConnectsWhenAccepted(t *testing.T) {
 }
 
 func TestRunAgentsRun_RequiresHarnessOrSpec(t *testing.T) {
+	t.Chdir(t.TempDir()) // no agents.yaml to discover
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		err := RunAgentsRun(config)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "one of --harness, --spec, or --config-id is required")
+		assert.Contains(t, err.Error(), "no manifest given")
 	})
 }
 

--- a/commands/agents_test.go
+++ b/commands/agents_test.go
@@ -139,6 +139,124 @@ func TestAgents_helpers(t *testing.T) {
 	})
 }
 
+func TestNamedManifestPath(t *testing.T) {
+	t.Run("flag wins when it is the only source", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			config.Doit.Set(config.NS, doctl.ArgAgentSpec, "from-flag.yaml")
+			path, err := namedManifestPath(config)
+			assert.NoError(t, err)
+			assert.Equal(t, "from-flag.yaml", path)
+		})
+	})
+
+	t.Run("positional path is accepted", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			config.Args = []string{"from-arg.yaml"}
+			path, err := namedManifestPath(config)
+			assert.NoError(t, err)
+			assert.Equal(t, "from-arg.yaml", path)
+		})
+	})
+
+	t.Run("flag and positional together are rejected", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			config.Doit.Set(config.NS, doctl.ArgAgentSpec, "from-flag.yaml")
+			config.Args = []string{"from-arg.yaml"}
+			_, err := namedManifestPath(config)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "given twice")
+		})
+	})
+
+	t.Run("more than one positional is rejected", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			config.Args = []string{"a.yaml", "b.yaml"}
+			_, err := namedManifestPath(config)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "at most one manifest path")
+		})
+	})
+
+	t.Run("nothing named returns empty", func(t *testing.T) {
+		withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+			path, err := namedManifestPath(config)
+			assert.NoError(t, err)
+			assert.Empty(t, path)
+		})
+	})
+}
+
+func TestDiscoverManifestFile(t *testing.T) {
+	t.Run("finds agents.yaml in the working directory", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "agents.yaml"), []byte(sampleFlatManifest), 0o644))
+		t.Chdir(dir)
+		assert.Equal(t, "agents.yaml", discoverManifestFile())
+	})
+
+	t.Run("falls back to the .yml spelling", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "agents.yml"), []byte(sampleFlatManifest), 0o644))
+		t.Chdir(dir)
+		assert.Equal(t, "agents.yml", discoverManifestFile())
+	})
+
+	t.Run("ignores a directory of that name", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "agents.yaml"), 0o755))
+		t.Chdir(dir)
+		assert.Empty(t, discoverManifestFile())
+	})
+
+	t.Run("empty when there is nothing to find", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		assert.Empty(t, discoverManifestFile())
+	})
+}
+
+func TestRunAgentsStart_DiscoversAgentsYAML(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "agents.yaml"), []byte(sampleFlatManifest), 0o644))
+	t.Chdir(dir)
+
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().
+			CreateSessionFromManifest(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(manifest []byte, opt *godo.HostedAgentManifestCreateOptions) (*do.HostedAgentSession, error) {
+				assert.Contains(t, string(manifest), "agent: opencode")
+				return &do.HostedAgentSession{
+					HostedAgentSession: &godo.HostedAgentSession{
+						SessionID: "sess-discovered",
+						Name:      "test-agent",
+						Status:    godo.HostedAgentSessionStatusProvisioning,
+					},
+				}, nil
+			})
+		tm.hostedAgents.EXPECT().
+			GetSession("sess-discovered").
+			Return(&do.HostedAgentSession{
+				HostedAgentSession: &godo.HostedAgentSession{
+					SessionID: "sess-discovered",
+					Name:      "test-agent",
+					Status:    godo.HostedAgentSessionStatusReady,
+				},
+			}, nil).
+			AnyTimes()
+
+		assert.NoError(t, RunAgentsStart(config))
+	})
+}
+
+func TestRunAgentsStart_RejectsManifestArgWithHarness(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		config.Args = []string{"agents.yaml"}
+		config.Doit.Set(config.NS, doctl.ArgAgentHarness, "opencode")
+		err := RunAgentsStart(config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be combined with")
+	})
+}
+
 func TestReadManifest(t *testing.T) {
 	t.Run("from file", func(t *testing.T) {
 		dir := t.TempDir()
@@ -409,10 +527,11 @@ func TestRunAgentsStart_SpecAndConfigIDMutuallyExclusive(t *testing.T) {
 }
 
 func TestRunAgentsStart_RequiresSource(t *testing.T) {
+	t.Chdir(t.TempDir()) // no agents.yaml to discover
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		err := RunAgentsStart(config)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "one of --harness, --spec, or --config-id is required")
+		assert.Contains(t, err.Error(), "no manifest given")
 	})
 }
 

--- a/commands/agents_validate.go
+++ b/commands/agents_validate.go
@@ -527,13 +527,19 @@ func RunAgentsValidate(c *CmdConfig) error {
 	if Output != "json" {
 		stylingEnabled = detectStyling()
 	}
-	specPath, err := c.Doit.GetString(c.NS, doctl.ArgAgentSpec)
+	specPath, err := namedManifestPath(c)
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(specPath) == "" {
-		return fmt.Errorf("--%s is required", doctl.ArgAgentSpec)
+	discovered := false
+	if specPath == "" {
+		if specPath = discoverManifestFile(); specPath == "" {
+			return fmt.Errorf("no manifest given: pass a path (or --%s), or add %s to this directory",
+				doctl.ArgAgentSpec, manifestFileNames[0])
+		}
+		discovered = true
 	}
+	noticeDiscoveredManifest(specPath, discovered)
 	raw, err := readManifest(os.Stdin, specPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Naming a manifest required a flag for the most common invocation. The thing everyone types first — `doctl agents start agents.yaml` — was silently ignored and fell through to `one of --harness, --spec, or --config-id is required`.

`start`, `run` and `validate` now resolve the manifest most-explicit-first: `--spec` beats a positional path, which beats an `agents.yaml` discovered in the working directory. All four of these are now equivalent:

```bash
doctl agents start                          # uses ./agents.yaml
doctl agents start agents.yaml
doctl agents start -f agents.yaml
doctl agents start --spec agents.yaml       # unchanged
```

`--spec` stays canonical in help output because it is doctl's existing word for a declarative file (`apps create/update/propose`, `dedicated-inference create/update`). `-f` and `--file` are added as aliases for the kubectl / compose / planoai muscle memory — `--file` is a pflag normalize alias rather than a second flag, so there is no duplicate to keep in sync.

## Behavior notes

- **Implicit sources are never silent.** A discovered file is announced (`Notice: using agents.yaml`), suppressed under `-o json` so machine output stays parseable.
- **Discovery only runs when no other source was selected**, so `--harness opencode` in a directory holding an `agents.yaml` stays unambiguous.
- **Pairing a positional path with `--harness` / `--config-id` is an error**, not a silent winner; so is passing both `--spec` and a positional.
- `validate` loses `requiredOpt()` on `--spec`, since requiring the flag would defeat the point.
- `-` (stdin) and `${VAR}` expansion are unchanged.

## Test plan

- [x] `go build`, `go vet`, `gofmt` clean
- [x] `go test ./commands/...` — passes except pre-existing `TestRegistryLogin` / `TestRegistryLogout`, which fail identically on an unmodified tree (local docker credential helper / keychain)
- [x] New unit tests: `TestNamedManifestPath` (flag, positional, both-given, >1 positional, neither), `TestDiscoverManifestFile` (`.yaml`, `.yml`, ignores a *directory* of that name, absent), `TestRunAgentsStart_DiscoversAgentsYAML`, `TestRunAgentsStart_RejectsManifestArgWithHarness`
- [x] Updated the two tests asserting the old required-flag message; both now `t.Chdir` to a temp dir so a stray `agents.yaml` cannot make them flaky
- [x] Manually exercised all five spellings plus `--file=x` and stdin against a built binary, and confirmed `start` still reaches session creation via the `--file` alias

Made with [Cursor](https://cursor.com)