### PR TITLE
agents: replace --revoke-previous with --grace-period (MARSOHS-1078)

### DIFF
--- a/args.go
+++ b/args.go
@@ -969,9 +969,11 @@ const (
 	// ArgAgentStatus filters sessions by lifecycle status.
 	ArgAgentStatus = "status"
 
-	// ArgAgentRevokePrevious retires the old webhook secret on the rotate-secret
-	// call itself instead of granting the default grace window.
-	ArgAgentRevokePrevious = "revoke-previous"
+	// ArgAgentGracePeriod is the rotate-secret handoff window in seconds.
+	// Omit (or leave unset) for the server default of 5 minutes; 0 retires the
+	// old secret immediately; positive values set a custom window up to the
+	// server max (default 1 hour).
+	ArgAgentGracePeriod = "grace-period"
 
 	// ArgAgentWorkspacePath is the path inside the session workspace root (/workspace).
 	ArgAgentWorkspacePath = "workspace-path"

--- a/commands/agent_triggers.go
+++ b/commands/agent_triggers.go
@@ -113,7 +113,7 @@ func AgentTriggers() *Command {
 		"Rotate a webhook trigger's secret",
 		agentsTriggersRotateSecretHelpMD,
 		Writer, agentPrettyErrors())
-	AddBoolFlag(cmdRotate, doctl.ArgAgentRevokePrevious, "", false, "Retire the old secret immediately instead of granting the grace window. Deliveries still signed with it start failing at once; use this when the old secret is compromised.")
+	AddIntFlag(cmdRotate, doctl.ArgAgentGracePeriod, "", 0, "Seconds the old secret keeps verifying (omit for 5m default; 0 revokes immediately; max 1h). Use 0 when the old secret is compromised.")
 
 	cmdListExec := CmdBuilder(cmd, RunAgentTriggersListExecutions, "list-executions <trigger-id>",
 		"List a trigger's execution history",
@@ -308,11 +308,20 @@ func RunAgentTriggersRotateSecret(c *CmdConfig) error {
 	if err := ensureOneArg(c); err != nil {
 		return err
 	}
-	revokePrevious, err := c.Doit.GetBool(c.NS, doctl.ArgAgentRevokePrevious)
-	if err != nil {
-		return err
+	// Unset flag → omit the query parameter (server 5m default). Explicit 0
+	// and positive values are sent as-is.
+	var gracePtr *int
+	if c.Doit.IsSet(doctl.ArgAgentGracePeriod) {
+		grace, err := c.Doit.GetInt(c.NS, doctl.ArgAgentGracePeriod)
+		if err != nil {
+			return err
+		}
+		if grace < 0 {
+			return fmt.Errorf("--%s must be a non-negative integer", doctl.ArgAgentGracePeriod)
+		}
+		gracePtr = &grace
 	}
-	res, err := c.HostedAgentTriggers().RotateSecret(c.Args[0], revokePrevious)
+	res, err := c.HostedAgentTriggers().RotateSecret(c.Args[0], gracePtr)
 	if err != nil {
 		return err
 	}

--- a/commands/agent_triggers_test.go
+++ b/commands/agent_triggers_test.go
@@ -200,7 +200,7 @@ const rotateExpiry = "2026-08-12T12:05:00Z"
 
 func TestAgentTriggersRotateSecretAndExecutions(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousExpiresAt: rotateExpiry}, nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", nil).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousExpiresAt: rotateExpiry}, nil)
 		config.Args = []string{"tr_1"}
 		var buf bytes.Buffer
 		config.Out = &buf
@@ -372,7 +372,7 @@ func TestAgentTriggersCreateWebhook_JSONMode(t *testing.T) {
 //   - the banner is on neither stdout nor stderr
 func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousExpiresAt: rotateExpiry}, nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", nil).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousExpiresAt: rotateExpiry}, nil)
 		config.Args = []string{"tr_1"}
 
 		var stdout bytes.Buffer
@@ -397,13 +397,14 @@ func TestAgentTriggersRotateSecret_JSONMode(t *testing.T) {
 	})
 }
 
-// --revoke-previous is the breach path: the response reports the old secret as
+// --grace-period 0 is the breach path: the response reports the old secret as
 // already dead rather than giving an expiry to wait out.
-func TestAgentTriggersRotateSecret_RevokePrevious(t *testing.T) {
+func TestAgentTriggersRotateSecret_ZeroGrace(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", true).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousRevoked: true}, nil)
+		zero := 0
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", gomock.Eq(&zero)).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousRevoked: true}, nil)
 		config.Args = []string{"tr_1"}
-		config.Doit.Set(config.NS, doctl.ArgAgentRevokePrevious, true)
+		config.Doit.Set(config.NS, doctl.ArgAgentGracePeriod, 0)
 
 		var stdout bytes.Buffer
 		config.Out = &stdout
@@ -428,7 +429,7 @@ func TestAgentTriggersRotateSecret_RevokePrevious(t *testing.T) {
 // acts on.
 func TestAgentTriggersRotateSecret_NeitherOutcomeReported(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", nil).
 			Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec"}, nil)
 		config.Args = []string{"tr_1"}
 
@@ -447,7 +448,7 @@ func TestAgentTriggersRotateSecret_NeitherOutcomeReported(t *testing.T) {
 // secret banner still appears on stdout (existing behaviour preserved).
 func TestAgentTriggersRotateSecret_TextMode(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
-		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", false).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousExpiresAt: rotateExpiry}, nil)
+		tm.hostedAgentTriggers.EXPECT().RotateSecret("tr_1", nil).Return(&do.HostedAgentTriggerRotateSecretResult{Secret: "new_sec", PreviousExpiresAt: rotateExpiry}, nil)
 		config.Args = []string{"tr_1"}
 
 		var stdout bytes.Buffer

--- a/commands/agents_help.go
+++ b/commands/agents_help.go
@@ -183,7 +183,7 @@ const agentsTriggersPauseHelpMD = `Pause a trigger. New events or cron ticks are
 
 const agentsTriggersResumeHelpMD = `Resume a paused trigger.`
 
-const agentsTriggersRotateSecretHelpMD = `Issue a new webhook secret (shown once). Webhook triggers only. The old secret keeps verifying deliveries for a short grace window, so deliveries already in flight still succeed while you paste the new secret into your external system. Pass ` + "`--revoke-previous`" + ` to retire the old secret immediately instead — deliveries still signed with it start failing at once, so use it when the old secret is compromised.`
+const agentsTriggersRotateSecretHelpMD = `Issue a new webhook secret (shown once). Webhook triggers only. By default the old secret keeps verifying deliveries for 5 minutes, so deliveries already in flight still succeed while you paste the new secret into your external system. Pass ` + "`--grace-period 0`" + ` to retire the old secret immediately — deliveries still signed with it start failing at once, so use it when the old secret is compromised. Pass a positive value (seconds, up to the server max of 1 hour) for a custom handoff window.`
 
 const agentsTriggersListExecutionsHelpMD = `List firings for a trigger. Use ` + "`get-execution`" + ` for full payload and output.`
 

--- a/do/agent_triggers.go
+++ b/do/agent_triggers.go
@@ -66,7 +66,7 @@ type HostedAgentTriggersService interface {
 	Get(triggerID string) (*HostedAgentTrigger, error)
 	Update(triggerID string, update *godo.HostedAgentTriggerUpdateRequest) (*HostedAgentTrigger, error)
 	Delete(triggerID string) error
-	RotateSecret(triggerID string, revokePrevious bool) (*HostedAgentTriggerRotateSecretResult, error)
+	RotateSecret(triggerID string, gracePeriodSeconds *int) (*HostedAgentTriggerRotateSecretResult, error)
 	ListExecutions(triggerID string, opt *godo.HostedAgentTriggerExecutionListOptions) ([]HostedAgentTriggerExecution, string, error)
 	GetExecution(triggerID, executionID string) (*HostedAgentTriggerExecution, error)
 	GetBySession(sessionID string) (*HostedAgentTrigger, error)
@@ -132,13 +132,13 @@ func (s *hostedAgentTriggersService) Delete(triggerID string) error {
 }
 
 // RotateSecret issues a new webhook secret and reports what became of the old
-// one.
-func (s *hostedAgentTriggersService) RotateSecret(triggerID string, revokePrevious bool) (*HostedAgentTriggerRotateSecretResult, error) {
-	// Left nil for the default rotation so no revoke_previous parameter goes on
-	// the wire at all, rather than an explicit =false.
+// one. gracePeriodSeconds nil selects the server default; 0 revokes now.
+func (s *hostedAgentTriggersService) RotateSecret(triggerID string, gracePeriodSeconds *int) (*HostedAgentTriggerRotateSecretResult, error) {
+	// Left nil for the default rotation so no grace_period_seconds parameter
+	// goes on the wire at all.
 	var opt *godo.HostedAgentTriggerRotateSecretOptions
-	if revokePrevious {
-		opt = &godo.HostedAgentTriggerRotateSecretOptions{RevokePrevious: true}
+	if gracePeriodSeconds != nil {
+		opt = &godo.HostedAgentTriggerRotateSecretOptions{GracePeriodSeconds: gracePeriodSeconds}
 	}
 	resp, _, err := s.svc.RotateSecret(context.TODO(), triggerID, opt)
 	if err != nil {

--- a/do/mocks/HostedAgentTriggersService.go
+++ b/do/mocks/HostedAgentTriggersService.go
@@ -179,18 +179,18 @@ func (mr *MockHostedAgentTriggersServiceMockRecorder) ListWebhookProviders() *go
 }
 
 // RotateSecret mocks base method.
-func (m *MockHostedAgentTriggersService) RotateSecret(triggerID string, revokePrevious bool) (*do.HostedAgentTriggerRotateSecretResult, error) {
+func (m *MockHostedAgentTriggersService) RotateSecret(triggerID string, gracePeriodSeconds *int) (*do.HostedAgentTriggerRotateSecretResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RotateSecret", triggerID, revokePrevious)
+	ret := m.ctrl.Call(m, "RotateSecret", triggerID, gracePeriodSeconds)
 	ret0, _ := ret[0].(*do.HostedAgentTriggerRotateSecretResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RotateSecret indicates an expected call of RotateSecret.
-func (mr *MockHostedAgentTriggersServiceMockRecorder) RotateSecret(triggerID, revokePrevious any) *gomock.Call {
+func (mr *MockHostedAgentTriggersServiceMockRecorder) RotateSecret(triggerID, gracePeriodSeconds any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecret", reflect.TypeOf((*MockHostedAgentTriggersService)(nil).RotateSecret), triggerID, revokePrevious)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecret", reflect.TypeOf((*MockHostedAgentTriggersService)(nil).RotateSecret), triggerID, gracePeriodSeconds)
 }
 
 // Update mocks base method.

--- a/vendor/github.com/digitalocean/godo/hosted_agent_triggers.go
+++ b/vendor/github.com/digitalocean/godo/hosted_agent_triggers.go
@@ -215,13 +215,14 @@ type HostedAgentTriggersListResponse struct {
 }
 
 // HostedAgentTriggerRotateSecretOptions specifies optional rotation behaviour.
-// The zero value (or a nil pointer) selects the server default, which keeps the
-// outgoing secret verifying for a short grace window.
+// A nil options pointer, or GracePeriodSeconds left nil, selects the server
+// default (5 minutes). Pass a pointer to 0 to revoke the outgoing secret
+// immediately; any positive value is a custom handoff window in seconds
+// (server-enforced max, default 1 hour).
 type HostedAgentTriggerRotateSecretOptions struct {
-	// RevokePrevious retires the outgoing secret on this call instead of at the
-	// end of the grace window. Intended for a compromised secret: deliveries
-	// still signed with the old value start failing immediately.
-	RevokePrevious bool `url:"revoke_previous,omitempty"`
+	// GracePeriodSeconds is how long the outgoing secret keeps verifying.
+	// Nil omits the query parameter (server default). Non-nil 0 revokes now.
+	GracePeriodSeconds *int `url:"grace_period_seconds,omitempty"`
 }
 
 // HostedAgentTriggerRotateSecretResponse is returned by RotateSecret.
@@ -410,9 +411,10 @@ func (s *HostedAgentTriggersServiceOp) Delete(ctx context.Context, triggerID str
 }
 
 // RotateSecret issues a new webhook secret (webhook triggers only).
-// By default the outgoing secret keeps verifying deliveries for a short
-// server-configured window, and PreviousSecretExpiresAt reports when it dies;
-// set opt.RevokePrevious to retire it on this call instead.
+// By default (nil options, or GracePeriodSeconds left nil) the outgoing secret
+// keeps verifying for the server default window (5 minutes) and
+// PreviousSecretExpiresAt reports when it dies. Pass GracePeriodSeconds pointing
+// at 0 to revoke it on this call, or at a positive value for a custom window.
 func (s *HostedAgentTriggersServiceOp) RotateSecret(ctx context.Context, triggerID string, opt *HostedAgentTriggerRotateSecretOptions) (*HostedAgentTriggerRotateSecretResponse, *Response, error) {
 	if triggerID == "" {
 		return nil, nil, errors.New("hosted agent triggers: trigger id is required")


### PR DESCRIPTION
## Summary

Replaces `--revoke-previous` with `--grace-period <seconds>` on `doctl agents triggers rotate-secret`, matching the server contract in cthulhu#172453.

```
doctl agents triggers rotate-secret TRIGGER_ID                 # 5m default
doctl agents triggers rotate-secret TRIGGER_ID --grace-period 0
doctl agents triggers rotate-secret TRIGGER_ID --grace-period 120
```

Vendors the matching godo `GracePeriodSeconds *int` options shape (godo#1093).

## Related

- Server: digitalocean/cthulhu#172453
- godo: digitalocean/godo#1093
- pydo: digitalocean/pydo#715

## Test plan

- [x] `go test ./commands/ ./do/ -run 'AgentTriggersRotate|RotateSecret'`

Made with [Cursor](https://cursor.com)