### PR TITLE
agents: print session create warnings (MARSOHS-1019)

### DIFF
--- a/commands/agent_configs.go
+++ b/commands/agent_configs.go
@@ -281,6 +281,9 @@ func RunAgentsConfigStartSession(c *CmdConfig) error {
 	}
 	stylingEnabled = detectStyling()
 	printSessionShowCard(c.Out, sess)
+	if sess != nil && sess.HostedAgentSession != nil {
+		printSessionCreateWarnings(sess.Warnings)
+	}
 	return nil
 }
 

--- a/commands/agents.go
+++ b/commands/agents.go
@@ -806,6 +806,9 @@ func createSessionFromConfig(c *CmdConfig, configID, name string, prog *creation
 	if prog != nil {
 		prog.ok(fmt.Sprintf("Session created · %s", displaySessionRef(sess)))
 	}
+	if sess != nil && sess.HostedAgentSession != nil {
+		printSessionCreateWarnings(sess.Warnings)
+	}
 	return sess, nil
 }
 

--- a/commands/agents_run.go
+++ b/commands/agents_run.go
@@ -516,6 +516,9 @@ func startSessionFromRawManifest(c *CmdConfig, raw []byte, prog *creationProgres
 	if prog != nil {
 		prog.ok(fmt.Sprintf("Session created · %s", displaySessionRef(sess)))
 	}
+	if sess != nil && sess.HostedAgentSession != nil {
+		printSessionCreateWarnings(sess.Warnings)
+	}
 	return sess, nil
 }
 

--- a/commands/agents_validate.go
+++ b/commands/agents_validate.go
@@ -597,6 +597,12 @@ func printAgentManifestValidation(w io.Writer, v *agentManifestValidation) {
 	}
 }
 
+// printSessionCreateWarnings prints server-returned create-time advisories
+// (manifest + policy) on stderr after a successful CreateSession call.
+func printSessionCreateWarnings(warnings []string) {
+	printAgentManifestWarnings(os.Stderr, warnings)
+}
+
 // printAgentManifestWarnings prints create-path warnings (stderr) with a yellow
 // Warning label so they stand out next to lifecycle progress lines.
 func printAgentManifestWarnings(w io.Writer, warnings []string) {

--- a/vendor/github.com/digitalocean/godo/hosted_agents.go
+++ b/vendor/github.com/digitalocean/godo/hosted_agents.go
@@ -360,6 +360,10 @@ type HostedAgentSession struct {
 	// Returned on create/get/list; omitted for sessions created before config
 	// references were stored.
 	ConfigID string `json:"config_id,omitempty"`
+	// Warnings carries non-fatal create-time advisories from the server
+	// (manifest parse + policy fidelity). Populated on the create response
+	// only; omitted on get/list.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // HostedAgentRun represents a single execution within a session.


### PR DESCRIPTION
Surface harness-api create-time policy advisories after session create for manifest, config, and config-start paths; vendor godo Warnings field.

<img width="1625" height="373" alt="image" src="https://github.com/user-attachments/assets/47ce54a5-731d-40e9-9905-8c5b0b4f9ca4" />
