### PR TITLE
agents: stop the codex facade rendering reasoning as the reply (MARSOHS-1012)

### DIFF
--- a/internal/agentproxy/codex/facade_test.go
+++ b/internal/agentproxy/codex/facade_test.go
@@ -348,6 +348,45 @@ func TestFacade_TurnStart_SendInputError(t *testing.T) {
 // translated into the turn/started, item/started, item/agentMessage/delta*,
 // item/completed, turn/completed notification sequence the design doc's
 // event-mapping table calls for.
+// TestFacade_TurnStart_SkipsReasoning pins MARSOHS-1012: a token chunk marked
+// is_reasoning is the model's thinking trace, not the answer, and the facade
+// has no reasoning item to route it to — so it must not surface as
+// agentMessage text. The reasoning chunk here leads the turn, which also pins
+// that no item/started is announced on its behalf: the first notification
+// after turn/started belongs to the answer.
+func TestFacade_TurnStart_SkipsReasoning(t *testing.T) {
+	f, h, rec := newTestFacade(t)
+
+	h.QueueRun("run-1",
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindRunStarted)},
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindTokenChunk), Data: json.RawMessage(`{"text":"let me think","is_reasoning":true}`)},
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindTokenChunk), Data: json.RawMessage(`{"text":"Paris","is_reasoning":false}`)},
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindRunCompleted)},
+	)
+
+	_, err := dispatch(t, f, "turn/start", turnStartParams{
+		ThreadID: testSessionID,
+		Input:    []userInputItem{{Type: "text", Text: "hi"}},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "turn/started", rec.next(t).method)
+	require.Equal(t, "item/started", rec.next(t).method)
+
+	delta := rec.next(t)
+	require.Equal(t, "item/agentMessage/delta", delta.method)
+	assert.Equal(t, "Paris", delta.params.(agentMessageDeltaNotification).Delta,
+		"reasoning must not be forwarded as an agentMessage delta")
+
+	itemCompleted := rec.next(t)
+	require.Equal(t, "item/completed", itemCompleted.method)
+	completedItem, ok := itemCompleted.params.(itemCompletedNotification).Item.(agentMessageItem)
+	require.True(t, ok, "item/completed's Item should be agentMessageItem, got %T", itemCompleted.params.(itemCompletedNotification).Item)
+	assert.Equal(t, "Paris", completedItem.Text, "reasoning must not accumulate into the completed item")
+
+	require.Equal(t, "turn/completed", rec.next(t).method)
+}
+
 func TestFacade_TurnStart_StreamsToCompletion(t *testing.T) {
 	f, h, rec := newTestFacade(t)
 

--- a/internal/agentproxy/codex/translate.go
+++ b/internal/agentproxy/codex/translate.go
@@ -72,8 +72,27 @@ func (f *Facade) translateEvent(ctx context.Context, ev godo.HostedAgentEvent, t
 	case godo.HostedAgentEventKindTokenChunk:
 		var payload struct {
 			Text string `json:"text"`
+			// IsReasoning marks model reasoning rather than the user-visible
+			// answer (SPI TokenChunk.is_reasoning). The answer begins at the
+			// first chunk where this is false.
+			IsReasoning bool `json:"is_reasoning"`
 		}
 		if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+			return false
+		}
+		// Reasoning is not the answer, and this protocol has nowhere to put
+		// it: item/agentMessage/delta is the only text channel the facade
+		// speaks, so forwarding a thought there makes the client render the
+		// thinking trace AS the reply (MARSOHS-1012). Codex sessions never
+		// reach this line for reasoning — raw.go forwards their native
+		// frames, which carry reasoning as its own item — so this path is
+		// what non-codex runtimes (cursor) fall back to, and dropping is the
+		// only faithful option until the protocol gains a reasoning item.
+		//
+		// Skipped ahead of the item/started below on purpose: opening an
+		// agentMessage item for a turn that leads with reasoning would
+		// announce an item whose only content we then refuse to send.
+		if payload.IsReasoning {
 			return false
 		}
 		// A canonical delta on a turn whose run.started went raw (or was


### PR DESCRIPTION
Fixes [MARSOHS-1012](https://do-internal.atlassian.net/browse/MARSOHS-1012) (p2, "Cursor showing thinking process as response"). Targets `feat/agents-subcommands` because the agents surface is not on `main` yet.

## The bug

`translateEvent`'s `TokenChunk` case decoded only `text`:

```go
var payload struct {
    Text string `json:"text"`
}
```

so a chunk marked `is_reasoning` was forwarded as `item/agentMessage/delta` — the exact same channel as the answer. The client concatenates that channel into the visible reply, so the model's thinking trace rendered *as* the response.

This is the path that matters for the reported case. `raw.go` only forwards native frames when the hosted runtime is codex itself, so a **cursor** session always falls back to this canonical translator.

## Confirmed on production

A real cursor session on prod returned 25 token deltas, **all 25 carrying the field: 4 `true`, 21 `false`**. The raw SSE shows the provenance:

```
"source_event_type":"session/update:agent_thought_chunk",  "data":{"text":"This is a classic riddle.","is_reasoning":true}
"source_event_type":"session/update:agent_message_chunk",  "data":{"text":"“","is_reasoning":false}
```

The server side has been correct since [cthulhu#172482](https://github.internal.digitalocean.com/digitalocean/cthulhu/pull/172482) ("OHS: forward is_reasoning on token chunks to consumers"), whose commit `299c38e6` is what production runs today. Before it, both proto→SPI mappings dropped the flag, which is why it previously looked absent. The remaining defect was entirely client-side.

## Why drop rather than re-route

`item/agentMessage/delta` is the only text channel this facade speaks and the protocol has no reasoning item, so there is nowhere faithful to put a thought. Codex sessions don't lose anything — `raw.go` forwards their native frames, which carry reasoning as its own item. Dropping is the only honest option for the non-codex fallback until the protocol gains somewhere to put it.

The skip sits **ahead of** the `item/started` block on purpose: a turn that leads with reasoning would otherwise announce an `agentMessage` item whose only content we then refuse to send.

## Deliberately not touching `commands/agents.go`

This branch already handles reasoning there, and handles it *better* — `reasoningStreamer` renders the trace in a separate muted channel rather than discarding it. That is the right treatment where a channel exists, and it is left alone. Only the facade, which has no such channel, changes here.

## Test plan

- New `TestFacade_TurnStart_SkipsReasoning` pins that a reasoning delta produces no notification and stays out of the completed item. The reasoning chunk leads the turn, so it also pins that no `item/started` is announced on its behalf.
- **Verified the test guards the fix**: removing the skip makes it fail, with the reasoning text leaking through as a second `item/agentMessage/delta`.
- `go test ./internal/agentproxy/... ./commands/` all pass.

Made with [Cursor](https://cursor.com)

[MARSOHS-1012]: https://do-internal.atlassian.net/browse/MARSOHS-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ