### PR TITLE
agents proxy: opencode facade M0-M1 — attach renders against stubs

### DIFF
--- a/commands/agents.go
+++ b/commands/agents.go
@@ -53,6 +53,7 @@ import (
 	"github.com/digitalocean/doctl/do"
 	"github.com/digitalocean/doctl/internal/agentproxy"
 	"github.com/digitalocean/doctl/internal/agentproxy/codex"
+	"github.com/digitalocean/doctl/internal/agentproxy/opencode"
 	"github.com/digitalocean/godo"
 	"github.com/muesli/termenv"
 	"github.com/pkg/browser"
@@ -480,7 +481,7 @@ func Agents() *Command {
 		"Bridge the Codex CLI to a hosted session",
 		agentsStartProxyHelpMD,
 		Writer, agentsNS()...)
-	AddStringFlag(cmdStartProxy, doctl.ArgAgentProxyType, "", "codex", "Coding-agent protocol to bridge (v1: codex)")
+	AddStringFlag(cmdStartProxy, doctl.ArgAgentProxyType, "", "codex", "Coding-agent protocol to bridge (codex, opencode)")
 	AddStringFlag(cmdStartProxy, doctl.ArgAgentProxySession, "", "", "Session ID or name to bridge to", requiredOpt())
 	AddIntFlag(cmdStartProxy, doctl.ArgAgentProxyPort, "", 1144, "Local port to listen on")
 	AddBoolFlag(cmdStartProxy, doctl.ArgAgentProxyReplay, "", false, "Replay the session's event history into the first thread on connect")
@@ -1029,8 +1030,8 @@ func RunAgentsStartProxy(c *CmdConfig) error {
 	if err != nil {
 		return err
 	}
-	if proxyType != "codex" {
-		return fmt.Errorf("unsupported --type %q; v1 supports only \"codex\"", proxyType)
+	if proxyType != "codex" && proxyType != "opencode" {
+		return fmt.Errorf("unsupported --type %q; supported types are \"codex\" and \"opencode\"", proxyType)
 	}
 
 	sessionRef, err := c.Doit.GetString(c.NS, doctl.ArgAgentProxySession)
@@ -1056,12 +1057,26 @@ func RunAgentsStartProxy(c *CmdConfig) error {
 		return fmt.Errorf("session %q not found: %w", sessionRef, err)
 	}
 
+	// The two facades speak different transports, so the listen URL scheme
+	// and the connect command diverge per type. --replay is codex-only:
+	// opencode's attach fetches history itself (GET /session/{id}/message,
+	// served from M3 on), so there is nothing for the proxy to push.
+	listenURL := fmt.Sprintf("ws://127.0.0.1:%d", port)
+	connectCmd := fmt.Sprintf("codex --remote ws://127.0.0.1:%d", port)
+	if proxyType == "opencode" {
+		if replay {
+			return fmt.Errorf("--replay is codex-only; opencode's own `attach` replays history itself")
+		}
+		listenURL = fmt.Sprintf("http://127.0.0.1:%d", port)
+		connectCmd = fmt.Sprintf("opencode attach http://127.0.0.1:%d", port)
+	}
+
 	stylingEnabled = detectStyling()
 	var body strings.Builder
 	fmt.Fprintf(&body, "%s\n\n", boldColor("Proxy listening", colSuccess))
 	body.WriteString(cardRow("Session", displaySessionRef(sess)))
-	body.WriteString(cardRow("Listen", fmt.Sprintf("ws://127.0.0.1:%d", port)))
-	body.WriteString(cardRow("Connect", fmt.Sprintf("codex --remote ws://127.0.0.1:%d", port)))
+	body.WriteString(cardRow("Listen", listenURL))
+	body.WriteString(cardRow("Connect", connectCmd))
 	renderAgentCard(c.Out, body.String())
 
 	// SIGTERM alongside SIGINT: under a process manager or plain `kill` (not
@@ -1069,6 +1084,21 @@ func RunAgentsStartProxy(c *CmdConfig) error {
 	// ServeListener never triggered — the process just died abruptly instead.
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
+
+	// opencode's facade is an http.Handler over REST + SSE, not a JSON-RPC
+	// Facade — one instance for the listener lifetime; the single-consumer
+	// rule lives on its event stream instead of on a connection.
+	if proxyType == "opencode" {
+		dir, err := os.Getwd()
+		if err != nil {
+			dir = "/"
+		}
+		return agentproxy.ServeHTTP(ctx, port, &opencode.Facade{
+			SessionID: sessionID,
+			Sessions:  svc,
+			Dir:       dir,
+		})
+	}
 
 	// Fresh Facade per connection (see ServeListener): per-connection state
 	// (notifier, in-flight turns, event loop, --replay gate) must not leak

--- a/internal/agentproxy/httpproxy.go
+++ b/internal/agentproxy/httpproxy.go
@@ -1,0 +1,58 @@
+package agentproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// ServeHTTP binds a plain HTTP listener on 127.0.0.1:port — the same
+// loopback-only rule as Serve — and serves handler until ctx is canceled.
+//
+// This is the transport for facades whose native protocol is REST + SSE
+// (opencode) rather than JSON-RPC over a WebSocket (codex). There is no
+// framing to pump and no request/reply correlation to own at this layer, so
+// unlike Serve there is no Facade/Notifier machinery here: the facade IS the
+// http.Handler, and anything connection-scoped (like a single-consumer event
+// stream) is the facade's own concern, not the transport's.
+func ServeHTTP(ctx context.Context, port int, handler http.Handler) error {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return err
+	}
+	return ServeHTTPListener(ctx, ln, handler)
+}
+
+// ServeHTTPListener is ServeHTTP over an already-bound listener. It exists
+// for the same reason ServeListener does: tests that pick an ephemeral port
+// with net.Listen and must not race a separate re-bind of that port number.
+func ServeHTTPListener(ctx context.Context, ln net.Listener, handler http.Handler) error {
+	server := &http.Server{
+		Handler: handler,
+		// Root every request context in ctx: a long-lived SSE handler watches
+		// r.Context() to know when to stop, and Shutdown below only returns
+		// once handlers do. Without this, canceling ctx would leave the SSE
+		// handler blocked forever on a Background()-rooted request context and
+		// shutdown would hang until the 2s timeout force-closed it — the same
+		// class of bug ServeListener's connCtx comment records for WebSocket.
+		BaseContext: func(net.Listener) context.Context { return ctx },
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- server.Serve(ln) }()
+
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		return server.Shutdown(shutdownCtx)
+	}
+}

--- a/internal/agentproxy/httpproxy_test.go
+++ b/internal/agentproxy/httpproxy_test.go
@@ -1,0 +1,72 @@
+package agentproxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServeHTTPListenerServesAndShutsDown(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- ServeHTTPListener(ctx, ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "ok")
+		}))
+	}()
+
+	resp, err := http.Get("http://" + ln.Addr().String() + "/")
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeHTTPListener did not return after ctx cancel")
+	}
+}
+
+// A handler blocked on r.Context() (the SSE shape) must be released by
+// canceling the server ctx — that's what BaseContext is for; without it,
+// Shutdown would hang until its timeout force-closed the connection.
+func TestServeHTTPListenerCancelReleasesStreamingHandler(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	entered := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- ServeHTTPListener(ctx, ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.(http.Flusher).Flush()
+			close(entered)
+			<-r.Context().Done()
+		}))
+	}()
+
+	resp, err := http.Get("http://" + ln.Addr().String() + "/stream")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	<-entered
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("streaming handler was not released by ctx cancel")
+	}
+}

--- a/internal/agentproxy/opencode/facade.go
+++ b/internal/agentproxy/opencode/facade.go
@@ -1,0 +1,312 @@
+// Package opencode implements the local HTTP facade that lets an unmodified
+// opencode CLI drive a hosted MARS session as if the session were a local
+// `opencode serve` backend.
+//
+// Unlike codex (a JSON-RPC-over-WebSocket app-server), opencode's TUI is
+// natively a remote-capable HTTP client: `opencode attach <url>` points it at
+// any server speaking the opencode REST + SSE surface. The facade implements
+// exactly the slice of that surface a real attach exercises — captured live
+// against `opencode serve` (see TestedVersion) — and will bridge prompts and
+// events to the hosted session through do.HostedAgentsService in later
+// milestones. M1 scope: the TUI attaches, renders, and idles cleanly.
+package opencode
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/digitalocean/doctl/do"
+)
+
+// TestedVersion is the opencode CLI version the route inventory and response
+// shapes below were captured against (`opencode serve` + `opencode attach`
+// through a logging relay). opencode releases near-daily and a v2 API surface
+// is rolling out alongside v1, so re-capture on upgrades rather than assuming
+// stability; the unhandled-route log below is the drift detector.
+const TestedVersion = "1.18.25"
+
+// Facade impersonates an opencode server for one hosted session. It is the
+// http.Handler ServeHTTP-transport variant of the codex Facade: dispatch is
+// by method+path instead of JSON-RPC method, and server→client traffic is a
+// single SSE stream instead of WebSocket frames.
+//
+// One Facade serves the whole listener lifetime — HTTP has no "connection" to
+// scope state to the way the WebSocket transport does. The one genuinely
+// connection-like resource, the /global/event stream, guards itself with a
+// single-consumer slot instead (mirroring the WS transport's one-client rule).
+type Facade struct {
+	// SessionID is the hosted session this facade bridges to (already
+	// resolved and validated by the command layer).
+	SessionID string
+	// Sessions is the harness bridge. Unused in M1 (stubs only); the event
+	// loop and prompt path arrive in M2.
+	Sessions do.HostedAgentsService
+	// Dir is the directory advertised to the TUI as the workspace root
+	// (opencode renders it in the footer and scopes requests to it). The
+	// hosted workspace isn't locally mounted, so this is presentational —
+	// the proxy's own working directory.
+	Dir string
+
+	eventSeq atomic.Uint64
+	// eventSlot: at most one /global/event consumer at a time, same rule as
+	// the WebSocket transport's one-client slot and for the same reason —
+	// the harness allows one attached device per session, and two TUIs
+	// racing one facade would each see half the stream.
+	eventSlot   sync.Mutex
+	eventInUse  bool
+	handlerOnce sync.Once
+	mux         *http.ServeMux
+}
+
+// ServeHTTP implements http.Handler.
+func (f *Facade) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.handlerOnce.Do(f.buildMux)
+	f.mux.ServeHTTP(w, r)
+}
+
+// buildMux registers the attach-burst surface captured from a real
+// `opencode attach` (TestedVersion): ~30 routes, almost all read-only
+// bootstrap lookups. Anything not captured falls through to the unhandled
+// logger — the discovery mechanism for TUI versions that ask for more, same
+// role as the codex facade's "unhandled: <method>" log.
+func (f *Facade) buildMux() {
+	mux := http.NewServeMux()
+
+	// Liveness preflight: `opencode attach` checks this before starting the
+	// TUI. The version reported is this facade's tested-protocol version, not
+	// the client's; attach does not require them to match.
+	mux.HandleFunc("GET /global/health", f.json(map[string]any{
+		"healthy": true, "version": TestedVersion,
+	}))
+
+	// The server→client event stream. The 1.18.x TUI subscribes to the
+	// GLOBAL stream (/global/event), whose frames wrap the instance-stream
+	// shape in a payload envelope: {"payload":{id,type,properties},...} —
+	// not the bare {type,properties} the in-sandbox OHR adapter consumes
+	// from /event. Both captured live; don't conflate them.
+	mux.HandleFunc("GET /global/event", f.handleGlobalEvent)
+	mux.HandleFunc("GET /event", f.handleGlobalEvent)
+
+	// Workspace/project identity. All presentational in M1.
+	mux.HandleFunc("GET /path", func(w http.ResponseWriter, r *http.Request) {
+		home := f.Dir
+		f.writeJSON(w, map[string]any{
+			"home": home, "state": home, "config": home,
+			"worktree": f.Dir, "directory": f.Dir,
+		})
+	})
+	mux.HandleFunc("GET /project/current", f.json(map[string]any{
+		"id": "global", "worktree": f.Dir, "vcs": "git",
+		"time": map[string]any{"created": 0, "updated": 0}, "sandboxes": []any{},
+	}))
+	mux.HandleFunc("GET /project/global/directories", f.json([]any{}))
+	mux.HandleFunc("GET /vcs", f.json(map[string]any{"branch": "hosted", "default_branch": nil}))
+
+	// Config and the provider/model catalog. The facade advertises exactly
+	// one synthetic provider/model pair representing the hosted session, so
+	// the TUI has a selected model and never opens its own /connect flow —
+	// model choice is a session-create-time decision on the hosted side, not
+	// something this proxy can change.
+	mux.HandleFunc("GET /config", f.json(map[string]any{
+		"$schema": "https://opencode.ai/config.json",
+		"command": map[string]any{}, "plugin": []any{},
+		"mode": map[string]any{}, "agent": map[string]any{},
+	}))
+	mux.HandleFunc("GET /config/providers", f.json(map[string]any{
+		"default":   map[string]any{providerID: modelID},
+		"providers": []any{catalogProvider()},
+	}))
+	mux.HandleFunc("GET /provider", f.json(map[string]any{
+		"all":       []any{catalogProvider()},
+		"connected": []any{providerID},
+		"default":   map[string]any{providerID: modelID},
+	}))
+	mux.HandleFunc("GET /provider/auth", f.json(map[string]any{}))
+
+	// Agents (opencode's build/plan/... modes, not MARS agents). One primary
+	// agent whose permissions claim nothing: enforcement lives in the hosted
+	// session's policy, and overstating it here would only mislead the TUI.
+	mux.HandleFunc("GET /agent", f.json([]any{map[string]any{
+		"name": "build", "description": "Hosted MARS session",
+		"mode": "primary", "native": true,
+		"permission": []any{map[string]any{"permission": "*", "pattern": "*", "action": "allow"}},
+		"options":    map[string]any{},
+	}}))
+
+	// Empty-but-present bootstrap lookups, verbatim from the capture.
+	mux.HandleFunc("GET /command", f.json([]any{}))
+	mux.HandleFunc("GET /lsp", f.json([]any{}))
+	mux.HandleFunc("GET /mcp", f.json(map[string]any{}))
+	mux.HandleFunc("GET /formatter", f.json([]any{}))
+	mux.HandleFunc("GET /session/status", f.json(map[string]any{}))
+	mux.HandleFunc("GET /experimental/capabilities", f.json(map[string]any{"backgroundSubagents": false}))
+	mux.HandleFunc("GET /experimental/console", f.json(map[string]any{
+		"consoleManagedProviders": []any{}, "switchableOrgCount": 0,
+	}))
+	mux.HandleFunc("GET /experimental/resource", f.json(map[string]any{}))
+	mux.HandleFunc("GET /experimental/workspace", f.json([]any{}))
+	mux.HandleFunc("GET /experimental/workspace/status", f.json([]any{}))
+
+	// Session listing: empty until M3 serves history. The TUI treats an
+	// empty list as "fresh session, create lazily on first prompt" — exactly
+	// the M1 empty-ready-conversation state.
+	mux.HandleFunc("GET /session", f.json([]any{}))
+
+	// The /api/* surface (new in recent opencode versions; sits alongside
+	// the older paths above — the TUI queries both). Wrapped responses:
+	// {"location": ..., "data": [...]}.
+	mux.HandleFunc("GET /api/location", func(w http.ResponseWriter, r *http.Request) {
+		f.writeJSON(w, f.apiLocation())
+	})
+	for _, p := range []string{"skill", "reference", "integration", "command", "agent"} {
+		mux.HandleFunc("GET /api/"+p, func(w http.ResponseWriter, r *http.Request) {
+			f.writeJSON(w, map[string]any{"location": f.apiLocation(), "data": []any{}})
+		})
+	}
+	mux.HandleFunc("GET /api/provider", func(w http.ResponseWriter, r *http.Request) {
+		f.writeJSON(w, map[string]any{"location": f.apiLocation(), "data": []any{apiProvider()}})
+	})
+	mux.HandleFunc("GET /api/model", func(w http.ResponseWriter, r *http.Request) {
+		f.writeJSON(w, map[string]any{"location": f.apiLocation(), "data": []any{apiModel()}})
+	})
+
+	// Share syncs conversation history to opencode's public share
+	// infrastructure — never appropriate for a hosted session. Refuse
+	// loudly rather than 404-ing quietly.
+	mux.HandleFunc("POST /session/{id}/share", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "sharing a hosted session is disabled", http.StatusForbidden)
+	})
+
+	// Everything else: honest 404 plus the drift log. opencode's TUI
+	// tolerates 404s on optional lookups; anything it *requires* will show
+	// up here first when a new client version asks for it.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("unhandled: %s %s", r.Method, r.URL.Path)
+		http.NotFound(w, r)
+	})
+
+	f.mux = mux
+}
+
+// handleGlobalEvent serves the SSE event stream: server.connected first (the
+// TUI's liveness signal), then blocks until the client disconnects or the
+// server shuts down. M2 wires the harness event loop in here.
+func (f *Facade) handleGlobalEvent(w http.ResponseWriter, r *http.Request) {
+	f.eventSlot.Lock()
+	if f.eventInUse {
+		f.eventSlot.Unlock()
+		http.Error(w, "an event-stream client is already connected", http.StatusConflict)
+		return
+	}
+	f.eventInUse = true
+	f.eventSlot.Unlock()
+	defer func() {
+		f.eventSlot.Lock()
+		f.eventInUse = false
+		f.eventSlot.Unlock()
+	}()
+
+	fl, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	if err := f.sendEvent(w, "server.connected", map[string]any{}); err != nil {
+		return
+	}
+	fl.Flush()
+
+	// r.Context() is rooted in the transport's ctx (ServeHTTPListener's
+	// BaseContext), so both a client disconnect and a proxy shutdown land
+	// here — no separate signal plumbing needed.
+	<-r.Context().Done()
+}
+
+// sendEvent writes one global-stream SSE frame. Envelope shape per the
+// capture: data: {"payload":{"id":"evt_<n>","type":T,"properties":P}}
+func (f *Facade) sendEvent(w http.ResponseWriter, eventType string, properties any) error {
+	frame, err := json.Marshal(map[string]any{
+		"payload": map[string]any{
+			"id":         fmt.Sprintf("evt_%d", f.eventSeq.Add(1)),
+			"type":       eventType,
+			"properties": properties,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "data: %s\n\n", frame)
+	return err
+}
+
+// json returns a handler that writes a fixed JSON body. For bodies that
+// depend on request or facade state, write inline handlers instead.
+func (f *Facade) json(v any) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) { f.writeJSON(w, v) }
+}
+
+func (f *Facade) writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("agentproxy/opencode: encode response: %v", err)
+	}
+}
+
+func (f *Facade) apiLocation() map[string]any {
+	return map[string]any{
+		"directory": f.Dir,
+		"project":   map[string]any{"id": "global", "directory": f.Dir},
+	}
+}
+
+// The synthetic provider/model catalog entry. The hosted session already has
+// its model pinned at create time; this exists so the TUI has something to
+// display and select, not to offer a real choice.
+const (
+	providerID   = "digitalocean"
+	providerName = "DigitalOcean"
+	modelID      = "hosted"
+	modelName    = "Hosted Session"
+)
+
+func catalogProvider() map[string]any {
+	return map[string]any{
+		"id": providerID, "name": providerName, "api": nil, "env": []any{},
+		"models": map[string]any{modelID: map[string]any{
+			"id": modelID, "name": modelName, "providerID": providerID,
+			"family": "hosted", "status": "active",
+			"capabilities": map[string]any{"tools": true, "input": []any{"text"}, "output": []any{"text"}},
+			"limit":        map[string]any{"context": 262144, "output": 32768},
+			"options":      map[string]any{}, "variants": []any{},
+		}},
+	}
+}
+
+func apiProvider() map[string]any {
+	return map[string]any{
+		"id": providerID, "name": providerName,
+		"api":     map[string]any{"type": "aisdk", "package": "@ai-sdk/openai-compatible", "url": "http://127.0.0.1"},
+		"request": map[string]any{"headers": map[string]any{}, "body": map[string]any{}},
+	}
+}
+
+func apiModel() map[string]any {
+	return map[string]any{
+		"id": modelID, "providerID": providerID, "family": "hosted", "name": modelName,
+		"api":          map[string]any{"id": modelID, "type": "aisdk", "package": "@ai-sdk/openai-compatible", "url": "http://127.0.0.1"},
+		"capabilities": map[string]any{"tools": true, "input": []any{"text"}, "output": []any{"text"}},
+		"request":      map[string]any{"headers": map[string]any{}, "body": map[string]any{}},
+		"variants":     []any{}, "time": map[string]any{"released": 0},
+		"cost":   []any{map[string]any{"input": 0, "output": 0, "cache": map[string]any{"read": 0, "write": 0}}},
+		"status": "active", "enabled": true,
+		"limit": map[string]any{"context": 262144, "output": 32768},
+	}
+}

--- a/internal/agentproxy/opencode/facade_test.go
+++ b/internal/agentproxy/opencode/facade_test.go
@@ -1,0 +1,171 @@
+package opencode
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestFacade() *Facade {
+	return &Facade{SessionID: "sess-1", Dir: "/tmp/ws"}
+}
+
+// The attach burst captured from a real `opencode attach` (TestedVersion).
+// Every route the TUI hits at startup must answer 200 with valid JSON —
+// a 404 here is exactly the "new client version wants more" drift signal.
+func TestAttachBurstRoutesAnswer(t *testing.T) {
+	srv := httptest.NewServer(newTestFacade())
+	defer srv.Close()
+
+	routes := []string{
+		"/global/health",
+		"/path",
+		"/project/current",
+		"/project/global/directories",
+		"/config",
+		"/config/providers",
+		"/provider",
+		"/provider/auth",
+		"/agent",
+		"/command",
+		"/lsp",
+		"/mcp",
+		"/formatter",
+		"/vcs",
+		"/session/status",
+		"/session?start=1785667630974&path=",
+		"/experimental/capabilities",
+		"/experimental/console",
+		"/experimental/resource",
+		"/experimental/workspace",
+		"/experimental/workspace/status",
+		"/api/location",
+		"/api/skill",
+		"/api/reference",
+		"/api/provider",
+		"/api/integration",
+		"/api/model",
+		"/api/command",
+		"/api/agent",
+	}
+	for _, route := range routes {
+		resp, err := http.Get(srv.URL + route)
+		require.NoError(t, err, route)
+		assert.Equal(t, http.StatusOK, resp.StatusCode, route)
+		var v any
+		assert.NoError(t, json.NewDecoder(resp.Body).Decode(&v), route)
+		resp.Body.Close()
+	}
+}
+
+func TestHealthReportsTestedVersion(t *testing.T) {
+	srv := httptest.NewServer(newTestFacade())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/global/health")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var health struct {
+		Healthy bool   `json:"healthy"`
+		Version string `json:"version"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&health))
+	assert.True(t, health.Healthy)
+	assert.Equal(t, TestedVersion, health.Version)
+}
+
+// The global stream's first frame must be server.connected in the wrapped
+// payload envelope — the TUI treats it as the liveness signal.
+func TestGlobalEventStreamsServerConnectedFirst(t *testing.T) {
+	srv := httptest.NewServer(newTestFacade())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/global/event")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	line, err := bufio.NewReader(resp.Body).ReadString('\n')
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(line, "data: "), "SSE frame: %q", line)
+
+	var frame struct {
+		Payload struct {
+			ID         string         `json:"id"`
+			Type       string         `json:"type"`
+			Properties map[string]any `json:"properties"`
+		} `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimPrefix(strings.TrimSpace(line), "data: ")), &frame))
+	assert.Equal(t, "server.connected", frame.Payload.Type)
+	assert.NotEmpty(t, frame.Payload.ID)
+}
+
+// One event-stream consumer at a time: same rule as the WebSocket
+// transport's single-client slot, enforced on the stream rather than the
+// listener since plain REST requests may overlap freely.
+func TestSecondEventStreamConsumerConflicts(t *testing.T) {
+	srv := httptest.NewServer(newTestFacade())
+	defer srv.Close()
+
+	first, err := http.Get(srv.URL + "/global/event")
+	require.NoError(t, err)
+	defer first.Body.Close()
+	// Wait for the stream to actually be established before racing it.
+	_, err = bufio.NewReader(first.Body).ReadString('\n')
+	require.NoError(t, err)
+
+	second, err := http.Get(srv.URL + "/global/event")
+	require.NoError(t, err)
+	defer second.Body.Close()
+	assert.Equal(t, http.StatusConflict, second.StatusCode)
+}
+
+func TestShareIsRefused(t *testing.T) {
+	srv := httptest.NewServer(newTestFacade())
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/session/sess-1/share", "application/json", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestUnknownRouteIs404(t *testing.T) {
+	srv := httptest.NewServer(newTestFacade())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/no/such/route")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// The synthetic catalog must agree with itself: the default selection in
+// /config/providers points at the one provider/model pair every other
+// catalog route advertises.
+func TestSyntheticCatalogIsConsistent(t *testing.T) {
+	srv := httptest.NewServer(newTestFacade())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/config/providers")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var cfg struct {
+		Default   map[string]string `json:"default"`
+		Providers []struct {
+			ID     string                    `json:"id"`
+			Models map[string]map[string]any `json:"models"`
+		} `json:"providers"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&cfg))
+	require.Len(t, cfg.Providers, 1)
+	assert.Equal(t, providerID, cfg.Providers[0].ID)
+	assert.Contains(t, cfg.Providers[0].Models, cfg.Default[providerID])
+}


### PR DESCRIPTION
First slice of `doctl agents start-proxy --type opencode`: an unmodified `opencode` CLI attaches to the proxy as if it were a local `opencode serve` backend. This PR covers M0 (protocol capture) + M1 (attach renders against stubs); prompt/event bridging to the hosted session lands in the next PR.

## Why opencode is codex-shaped

opencode's TUI is natively a remote-capable HTTP client: `opencode attach <url>` points it at any server speaking the opencode REST + SSE surface — no client modification, same product shape as `codex --remote`. The transport differs: HTTP REST + SSE instead of JSON-RPC over WebSocket.

## M0 — capture

Ran a real `opencode serve` + `opencode attach` pair (both v1.18.25) through a logging relay. Key findings, encoded in the code:

- The TUI subscribes to `/global/event`, whose SSE frames wrap the instance-stream shape in a payload envelope (`{"payload":{id,type,properties}}`) — not the bare `{type,properties}` shape.
- First frame must be `server.connected` (the TUI's liveness signal).
- The attach burst is ~30 parallel read-only GET routes, spanning the classic surface (`/config`, `/provider`, `/agent`, `/session`, ...) and a newer wrapped `/api/*` surface.

## M1 — implementation

- `internal/agentproxy/httpproxy.go`: `ServeHTTP`/`ServeHTTPListener`, the REST+SSE sibling of the WS transport. Same loopback-only rule and shutdown pattern; `BaseContext` roots request contexts in the server ctx so a blocked SSE handler is released on shutdown (the same bug class the WS transport's connCtx comment records).
- `internal/agentproxy/opencode/facade.go`: an `http.Handler` facade answering the captured burst, streaming `server.connected` first, enforcing one event-stream consumer at a time (409), refusing `POST /session/{id}/share` (403 — share syncs history to opencode's public infra), and logging + 404ing unknown routes as the protocol-drift detector. A synthetic single provider/model catalog gives the TUI a selected model, since model choice is a session-create-time decision on the hosted side.
- `commands/agents.go`: `--type opencode` accepted; per-type listen/connect strings; `--replay` rejected for opencode (its attach fetches history itself — that endpoint is a later milestone).

## Testing

- Unit tests: the full attach-burst route inventory answers 200/valid JSON, SSE envelope shape, single-consumer conflict, share refusal, catalog self-consistency, and transport shutdown release.
- Live: against both a stub harness and the local dev stack, a real `opencode attach http://127.0.0.1:1144` renders the full empty-session TUI with **zero unhandled routes** at v1.18.25.

## Next (separate PRs)

M2 `prompt_async` → `SendInput` + event-stream bridging (first demo checkpoint), M3 message history, M4 tool calls + usage, M5 permission round-trip, M6 hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)