### PR TITLE
secrets: add kvs flag for secrets get

### DIFF
--- a/args.go
+++ b/args.go
@@ -732,6 +732,11 @@ const (
 	ArgSecretVersion = "version"
 	// ArgSecretShow reveals secret values instead of masking them on get.
 	ArgSecretShow = "show"
+	// ArgSecretShowKV reveals secret values instead of masking them on get,
+	// formatted as:
+	//
+	//	KEY=VALUE
+	ArgSecretShowKV = "kvs"
 	// ArgSecretRaw writes a single secret value to stdout with no formatting.
 	ArgSecretRaw = "raw"
 	// ArgSecretReplace replaces all key-value pairs in a secret on update.

--- a/commands/secrets.go
+++ b/commands/secrets.go
@@ -16,7 +16,9 @@ package commands
 import (
 	"fmt"
 	"io"
+	"maps"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -95,6 +97,7 @@ Secret values are masked by default. Use --show to reveal them, or --key with --
 	AddStringFlag(cmdGet, doctl.ArgRegionSlug, "", "", secretRegionFlagDesc)
 	AddStringFlag(cmdGet, doctl.ArgKey, "", "", "Return only the value for this key.")
 	AddBoolFlag(cmdGet, doctl.ArgSecretShow, "", false, "Reveal secret values instead of masking them.")
+	AddBoolFlag(cmdGet, doctl.ArgSecretShowKV, "", false, "Reveal secret values instead of masking them, displayed as KEY=VALUE pairs.")
 	AddBoolFlag(cmdGet, doctl.ArgSecretRaw, "", false, "Write the value for --key to stdout with no formatting.")
 	cmdGet.Example = `The following example retrieves a secret: doctl secrets get ` + exampleSecretName + ` --region nyc3 --key ` + exampleSecretKey + ` --raw`
 
@@ -207,8 +210,28 @@ func RunCmdSecretsGet(c *CmdConfig) error {
 		return fmt.Errorf("--%s requires --%s", doctl.ArgSecretRaw, doctl.ArgKey)
 	}
 
+	// The `kvs` flag is a special flag to output KEY=VALUE pairs, and therefore
+	// takes precendence over a number of other flags.
+	kvs, err := c.Doit.GetBool(c.NS, doctl.ArgSecretShowKV)
+	if err != nil {
+		return err
+	}
+
 	secret, err := c.Secrets().Get(name, region)
 	if err != nil {
+		return err
+	}
+
+	if kvs {
+		var b strings.Builder
+		keys := slices.Sorted(maps.Keys(secret.Values))
+		for _, key := range keys {
+			b.WriteString(strings.ToUpper(key))
+			b.WriteString("=")
+			b.WriteString(secret.Values[key])
+			b.WriteString("\n")
+		}
+		_, err := c.Out.Write([]byte(b.String()))
 		return err
 	}
 

--- a/commands/secrets.go
+++ b/commands/secrets.go
@@ -211,7 +211,7 @@ func RunCmdSecretsGet(c *CmdConfig) error {
 	}
 
 	// The `kvs` flag is a special flag to output KEY=VALUE pairs, and therefore
-	// takes precendence over a number of other flags.
+	// takes precedence over a number of other flags.
 	kvs, err := c.Doit.GetBool(c.NS, doctl.ArgSecretShowKV)
 	if err != nil {
 		return err

--- a/commands/secrets.go
+++ b/commands/secrets.go
@@ -92,7 +92,9 @@ If no `+"`"+`--value`+"`"+` or `+"`"+`--from-env-file`+"`"+` flags are provided,
 
 	cmdGet := CmdBuilder(cmd, RunCmdSecretsGet, "get <name>", "Get a secret", `Retrieves a secret container and its key-value pairs.
 
-Secret values are masked by default. Use --show to reveal them, or --key with --raw to print a single value for scripting.`, Writer,
+Secret values are masked by default. Use --show to reveal them, or --key with --raw to print a single value for scripting.
+
+To print the key-value pairs in an .env file-style format, set the --kvs flag. Note that this flag takes precedence over others.`, Writer,
 		aliasOpt("g"), displayerType(&displayers.Secret{}))
 	AddStringFlag(cmdGet, doctl.ArgRegionSlug, "", "", secretRegionFlagDesc)
 	AddStringFlag(cmdGet, doctl.ArgKey, "", "", "Return only the value for this key.")
@@ -206,15 +208,15 @@ func RunCmdSecretsGet(c *CmdConfig) error {
 		return err
 	}
 
-	if raw && key == "" {
-		return fmt.Errorf("--%s requires --%s", doctl.ArgSecretRaw, doctl.ArgKey)
-	}
-
 	// The `kvs` flag is a special flag to output KEY=VALUE pairs, and therefore
 	// takes precedence over a number of other flags.
 	kvs, err := c.Doit.GetBool(c.NS, doctl.ArgSecretShowKV)
 	if err != nil {
 		return err
+	}
+
+	if (raw && key == "") && !kvs {
+		return fmt.Errorf("--%s requires --%s", doctl.ArgSecretRaw, doctl.ArgKey)
 	}
 
 	secret, err := c.Secrets().Get(name, region)

--- a/commands/secrets_test.go
+++ b/commands/secrets_test.go
@@ -34,6 +34,7 @@ var (
 	testSecretVal2         = "value-2"
 	testSecretVal3         = "value-3"
 	testSecretValNew       = "value-new"
+	testSecretValKVPair    = "KEY=value\nOTHER-KEY=value-2\n"
 	testSecretValFromFile  = "file-value"
 	testSecretValFromStdin = "stdin-value"
 
@@ -361,6 +362,22 @@ func TestRunCmdSecretsGetRaw(t *testing.T) {
 	})
 }
 
+func TestRunCmdSecretsGetKV(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		secret := cloneSecret(testSecret)
+		tm.secrets.EXPECT().Get(testSecretName, "nyc3").Return(&secret, nil)
+
+		config.Args = []string{testSecretName}
+		config.Doit.Set(config.NS, doctl.ArgRegionSlug, "nyc3")
+		config.Doit.Set(config.NS, doctl.ArgKey, testSecretKey)
+		config.Doit.Set(config.NS, doctl.ArgSecretShowKV, true)
+		config.Out = &bytes.Buffer{}
+
+		err := RunCmdSecretsGet(config)
+		assert.NoError(t, err)
+		assert.Equal(t, testSecretValKVPair, config.Out.(*bytes.Buffer).String())
+	})
+}
 func TestRunCmdSecretsGetRawRequiresKey(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		config.Args = []string{testSecretName}

--- a/commands/secrets_test.go
+++ b/commands/secrets_test.go
@@ -378,6 +378,25 @@ func TestRunCmdSecretsGetKV(t *testing.T) {
 		assert.Equal(t, testSecretValKVPair, config.Out.(*bytes.Buffer).String())
 	})
 }
+
+func TestRunCmdSecretsGetKVSucceedsEvenWithRawFlag(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		secret := cloneSecret(testSecret)
+		tm.secrets.EXPECT().Get(testSecretName, "nyc3").Return(&secret, nil)
+
+		config.Args = []string{testSecretName}
+		config.Doit.Set(config.NS, doctl.ArgRegionSlug, "nyc3")
+		config.Doit.Set(config.NS, doctl.ArgKey, testSecretKey)
+		config.Doit.Set(config.NS, doctl.ArgSecretRaw, true)
+		config.Doit.Set(config.NS, doctl.ArgSecretShowKV, true)
+		config.Out = &bytes.Buffer{}
+
+		err := RunCmdSecretsGet(config)
+		assert.NoError(t, err)
+		assert.Equal(t, testSecretValKVPair, config.Out.(*bytes.Buffer).String())
+	})
+}
+
 func TestRunCmdSecretsGetRawRequiresKey(t *testing.T) {
 	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
 		config.Args = []string{testSecretName}


### PR DESCRIPTION
Adds a new `--kvs` flag for the `doctl secrets get` command which prints the secret values as `KEY=VALUE` pairs.

For example, running:

```sh
$ doctl secrets get --region tor1 --kvs my-secret
```

will output something like:

```
KEY=b-value
OTHER_KEY=a-value
```

These will always print in alphabetical order.