### PR TITLE
agents: add `config generate` to author manifests locally

### DIFF
--- a/args.go
+++ b/args.go
@@ -1083,6 +1083,134 @@ const (
 	// every approval request during an unattended `agents create`.
 	ArgAgentOnHITL = "on-hitl"
 
+	// Hosted Agents `config generate` args
+	//
+	// These name the flat agent-manifest fields (agent.flat.yaml) that
+	// `harness-runtime config generate` writes. Every one has a matching
+	// wizard question, so an interactive run is always reproducible as a
+	// single non-interactive command.
+
+	// The manifest's free-form description reuses ArgAgentDescription
+	// ("description"), declared with the Gradient AI agent args above.
+
+	// ArgAgentLabel is a repeatable KEY=VALUE manifest label.
+	ArgAgentLabel = "label"
+
+	// ArgAgentImage is the digest-pinned container image for `agent: custom`.
+	ArgAgentImage = "image"
+
+	// ArgAgentEntrypoint is the argv entrypoint for `agent: custom`.
+	ArgAgentEntrypoint = "entrypoint"
+
+	// ArgAgentEnv is a repeatable KEY=VALUE non-secret guest environment entry.
+	ArgAgentEnv = "env"
+
+	// ArgAgentInlineSecret writes a literal credential straight into the
+	// generated manifest, instead of the default ${VAR} placeholder.
+	ArgAgentInlineSecret = "inline-secret"
+
+	// ArgAgentInference selects where the agent gets inference from: its own
+	// vendor (native), DigitalOcean Serverless Inference (do), or another
+	// OpenAI-compatible endpoint (custom).
+	ArgAgentInference = "inference"
+
+	// ArgAgentInferenceURL is the OpenAI-compatible base URL used with
+	// --inference custom.
+	ArgAgentInferenceURL = "inference-url"
+
+	// ArgAgentModel sets the manifest's model (model.default in object form).
+	ArgAgentModel = "model"
+
+	// ArgAgentModelRouting sets model.routing.
+	ArgAgentModelRouting = "model-routing"
+
+	// ArgAgentSize is the sandbox size slug from `sizes list`.
+	ArgAgentSize = "size"
+
+	// ArgAgentTemplate pins a sandbox template instead of deriving it from the
+	// agent.
+	ArgAgentTemplate = "template"
+
+	// ArgAgentPersistentWorkspace keeps /workspace across idle suspend/resume.
+	ArgAgentPersistentWorkspace = "persistent-workspace"
+
+	// ArgAgentIdleTimeout is the per-session idle suspend duration (e.g. 10m).
+	ArgAgentIdleTimeout = "idle-timeout"
+
+	// ArgAgentMaxLifetime is the absolute session lifetime ceiling (e.g. 8h).
+	ArgAgentMaxLifetime = "max-lifetime"
+
+	// ArgAgentEgress is a repeatable egress allowlist host.
+	ArgAgentEgress = "egress"
+
+	// ArgAgentGitHubAccess declares the brokered GitHub OAuth secret slot and
+	// opens GitHub egress in one flag.
+	ArgAgentGitHubAccess = "github-access"
+
+	// ArgAgentPermissionDefault is permissions.default (allow|ask|deny).
+	ArgAgentPermissionDefault = "permission-default"
+
+	// ArgAgentAllowTool, ArgAgentAskTool, and ArgAgentDenyTool are repeatable
+	// TOOL[:match] permission rules.
+	ArgAgentAllowTool = "allow-tool"
+	ArgAgentAskTool   = "ask-tool"
+	ArgAgentDenyTool  = "deny-tool"
+
+	// ArgAgentToolsPreset attaches a curated DO tool bundle (none|default).
+	ArgAgentToolsPreset = "tools-preset"
+
+	// ArgAgentTool is a repeatable catalog tool attachment, e.g.
+	// do.actions or do.actions:web_search,execute_code.
+	ArgAgentTool = "tool"
+
+	// ArgAgentMCPServer is a repeatable inline MCP server as NAME=URL.
+	ArgAgentMCPServer = "mcp-server"
+
+	// ArgAgentMCPTools selects tools on an inline MCP server as NAME:tool,tool.
+	ArgAgentMCPTools = "mcp-tools"
+
+	// ArgAgentMCPAuthSecret points an inline MCP server at a declared secrets
+	// slot, as NAME=SECRET_SLOT.
+	ArgAgentMCPAuthSecret = "mcp-auth-secret"
+
+	// ArgAgentSkill is a repeatable inline skill as NAME=path/to/SKILL.md.
+	ArgAgentSkill = "skill"
+
+	// ArgAgentSkillDescription overrides a skill's derived description, as
+	// NAME=description.
+	ArgAgentSkillDescription = "skill-description"
+
+	// ArgAgentMode is the lifecycle mode (interactive|served).
+	ArgAgentMode = "mode"
+
+	// ArgAgentServingMin, ArgAgentServingMax, ArgAgentServingConcurrency, and
+	// ArgAgentServingScaleToZeroIdle describe a served fleet.
+	ArgAgentServingMin             = "serving-min"
+	ArgAgentServingMax             = "serving-max"
+	ArgAgentServingConcurrency     = "serving-concurrency"
+	ArgAgentServingScaleToZeroIdle = "serving-scale-to-zero-idle"
+
+	// ArgAgentOut is the file the generated manifest is written to. Empty
+	// prints to stdout.
+	ArgAgentOut = "out"
+
+	// ArgAgentManifestFormat is the generated manifest encoding (yaml|json).
+	ArgAgentManifestFormat = "manifest-format"
+
+	// ArgAgentOverwrite allows `config generate --out` to replace an existing
+	// file.
+	ArgAgentOverwrite = "overwrite"
+
+	// ArgAgentSkipValidate skips the client-side manifest check that otherwise
+	// runs before the manifest is emitted.
+	ArgAgentSkipValidate = "skip-validate"
+
+	// ArgAgentNoInteractive answers every `config generate` question with its
+	// default instead of prompting. Spelled positively as its own flag because
+	// the global escape hatch, `--interactive=false`, is neither discoverable
+	// from the command's own --help nor memorable.
+	ArgAgentNoInteractive = "no-interactive"
+
 	// Gradient AI simulation args
 
 	// ArgGenAISearch filters a Gradient AI list by a free-text search term.

--- a/commands/agent_config_generate.go
+++ b/commands/agent_config_generate.go
@@ -1,0 +1,709 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/digitalocean/doctl"
+)
+
+// `harness-runtime config generate` writes an agent manifest and nothing else:
+// no session, no durable config, no API write of any kind. The generated file is
+// the input to `config create` / `create --spec`, so authoring it is separable
+// from deciding when to run it.
+//
+// Every field is reachable two ways — a flag, or a wizard prompt — and the two
+// converge on the same generateAnswers value, so an interactive run is always
+// reproducible as a single scripted command.
+
+// addAgentConfigGenerateFlags registers the manifest-authoring flags. They are
+// grouped in the same order as the manifest sections they write, so `--help`
+// reads like the file it produces.
+func addAgentConfigGenerateFlags(cmd *Command) {
+	// Identity.
+	AddStringFlag(cmd, doctl.ArgAgentName, "", "", "Session name written to the manifest. Team-unique among live sessions; omit to let the server generate one.")
+	AddStringFlag(cmd, doctl.ArgAgentDescription, "", "", "Free-form description stored with the manifest")
+	AddStringSliceFlag(cmd, doctl.ArgAgentLabel, "", nil, "Manifest label as KEY=VALUE. Repeatable.")
+
+	// Agent.
+	AddStringFlag(cmd, doctl.ArgAgentHarness, "", "", "Coding-agent harness the manifest runs: "+generateHarnessIDList()+". Prompted for when omitted on a terminal.")
+	AddStringFlag(cmd, doctl.ArgAgentImage, "", "", "Digest-pinned container image. Only with --"+doctl.ArgAgentHarness+" custom.")
+	AddStringSliceFlag(cmd, doctl.ArgAgentEntrypoint, "", nil, "Container entrypoint argv. Only with --"+doctl.ArgAgentHarness+" custom.")
+	AddStringFlag(cmd, doctl.ArgAgentTriggerPrompt, "", "", "Initial prompt embedded in the runtime config. Only with --"+doctl.ArgAgentHarness+" codex-agentapi.")
+
+	// Workspace.
+	AddStringSliceFlag(cmd, doctl.ArgAgentRepo, "", nil, "GitHub repository the session works against (owner/repo or an https://github.com URL). Repeatable; the first is the session's repo hint.")
+	AddBoolFlag(cmd, doctl.ArgAgentGitHubAccess, "", false, "Declare the brokered GitHub credential slot ("+generateGitHubOAuthSlot+": "+generateGitHubOAuthValue+") and allow GitHub egress")
+	AddStringFlag(cmd, doctl.ArgAgentTemplate, "", "", "Pin a sandbox template. Omit to derive it from the harness (recommended).")
+	AddBoolFlag(cmd, doctl.ArgAgentPersistentWorkspace, "", false, "Keep /workspace across idle suspend and resume")
+	AddStringFlag(cmd, doctl.ArgAgentSize, "", "", "Sandbox size slug, from "+agentCLI+" sizes list. Omit for the service default.")
+
+	// Environment and credentials.
+	AddStringSliceFlag(cmd, doctl.ArgAgentEnv, "", nil, "Non-secret guest environment entry as KEY=VALUE. Repeatable. The guest environment is debug-readable — put credentials in --"+doctl.ArgAgentSecret+" instead.")
+	AddStringSliceFlag(cmd, doctl.ArgAgentSecret, "", nil, "Declare a credential slot: NAME for a ${NAME} placeholder doctl expands at create time, or NAME=oauth/<provider> for a brokered slot. Repeatable. Values are never written to the manifest, so the file stays committable — supply them with "+agentCLI+" config create --"+doctl.ArgAgentSecret+" NAME=VALUE.")
+	AddStringSliceFlag(cmd, doctl.ArgAgentInlineSecret, "", nil, "Write a literal credential into the manifest as NAME=VALUE (also NAME=@path and NAME=-). Repeatable. Prefer --"+doctl.ArgAgentSecret+": an inlined value lands in plaintext in the generated file.")
+
+	// Inference and model.
+	AddStringFlag(cmd, doctl.ArgAgentInference, "", "", "Where the agent gets inference: "+inferenceProviderDO+" (DigitalOcean Serverless Inference, recommended), "+inferenceProviderNative+" (its own vendor's API), or "+inferenceProviderCustom+" (any other OpenAI-compatible endpoint, with --"+doctl.ArgAgentInferenceURL+"). Anything but "+inferenceProviderNative+" also requires --"+doctl.ArgAgentModel+", so "+inferenceProviderNative+" is the default when not prompting.")
+	AddStringFlag(cmd, doctl.ArgAgentInferenceURL, "", "", "OpenAI-compatible base URL, usually ending in /v1. Implies --"+doctl.ArgAgentInference+" "+inferenceProviderCustom+", and adds the host to egress.")
+	AddStringFlag(cmd, doctl.ArgAgentModel, "", "", "Model id, written to the environment variables this harness reads. Required unless --"+doctl.ArgAgentInference+" is "+inferenceProviderNative+", where omitting it uses the agent's own default. Ids are provider-specific: anthropic-claude-4.5-sonnet at DigitalOcean ("+doInferenceModelsCmd+"), claude-sonnet-4-5 at Anthropic.")
+	AddStringFlag(cmd, doctl.ArgAgentModelRouting, "", "", "Model routing profile recorded in the manifest's model block. Requires --"+doctl.ArgAgentModel+".")
+
+	// Lifecycle.
+	AddStringFlag(cmd, doctl.ArgAgentIdleTimeout, "", "", "Idle suspend for the session as a duration (10m, 90s, 1h30m). Omit for the team default.")
+	AddStringFlag(cmd, doctl.ArgAgentMaxLifetime, "", "", "Absolute session lifetime ceiling as a duration (e.g. 8h), regardless of activity")
+
+	// Network, tools, permissions.
+	AddStringSliceFlag(cmd, doctl.ArgAgentEgress, "", nil, "Host the session may reach. Repeatable. Intersected server-side with team and platform policy.")
+	AddStringFlag(cmd, doctl.ArgAgentToolsPreset, "", "", "Attach a curated DO tool bundle: default ("+strings.Join(generateDefaultToolsPreset, ", ")+"), or none to attach nothing. Defaults to default.")
+	AddStringSliceFlag(cmd, doctl.ArgAgentTool, "", nil, "DO catalog tool attachment: do.actions for everything it advertises, or do.actions:web_search,execute_code to select. Repeatable.")
+	AddStringSliceFlag(cmd, doctl.ArgAgentMCPServer, "", nil, "Inline MCP server as NAME=https://host/mcp. Repeatable. Its host is added to egress for you.")
+	AddStringSliceFlag(cmd, doctl.ArgAgentMCPTools, "", nil, "Tools to select on an inline MCP server, as NAME:tool[,tool]. Repeatable.")
+	AddStringSliceFlag(cmd, doctl.ArgAgentMCPAuthSecret, "", nil, "Credential slot an inline MCP server authenticates with, as NAME=SECRET_SLOT. The slot must also be declared with --"+doctl.ArgAgentSecret+".")
+	AddStringFlag(cmd, doctl.ArgAgentPermissionDefault, "", "", "Disposition for tool calls no rule matches: allow, ask, or deny")
+	AddStringSliceFlag(cmd, doctl.ArgAgentAllowTool, "", nil, "Allow a tool, as TOOL or TOOL:command-match (e.g. bash:\"git status\"). Repeatable.")
+	AddStringSliceFlag(cmd, doctl.ArgAgentAskTool, "", nil, "Require approval for a tool, as TOOL or TOOL:command-match. Repeatable.")
+	AddStringSliceFlag(cmd, doctl.ArgAgentDenyTool, "", nil, "Deny a tool, as TOOL or TOOL:command-match (e.g. bash:\"rm -rf *\"). Repeatable.")
+
+	// Skills.
+	AddStringSliceFlag(cmd, doctl.ArgAgentSkill, "", nil, "Inline a skill from a markdown file, as NAME=path/to/SKILL.md. Repeatable.")
+	AddStringSliceFlag(cmd, doctl.ArgAgentSkillDescription, "", nil, "Override a skill's description, as NAME=description. Repeatable. Defaults to the file's first heading.")
+
+	// Serving mode.
+	AddStringFlag(cmd, doctl.ArgAgentMode, "", "", "Lifecycle mode: interactive (one session, one machine) or served (an autoscaled fleet)")
+	AddIntFlag(cmd, doctl.ArgAgentServingMin, "", 0, "Minimum fleet replicas. Only with --"+doctl.ArgAgentMode+" served.")
+	AddIntFlag(cmd, doctl.ArgAgentServingMax, "", 0, "Maximum fleet replicas. Only with --"+doctl.ArgAgentMode+" served.")
+	AddIntFlag(cmd, doctl.ArgAgentServingConcurrency, "", 0, "Target concurrent runs per replica. Only with --"+doctl.ArgAgentMode+" served.")
+	AddStringFlag(cmd, doctl.ArgAgentServingScaleToZeroIdle, "", "", "Idle duration before the fleet scales to zero (e.g. 10m). Only with --"+doctl.ArgAgentMode+" served.")
+
+	// Output.
+	AddStringFlag(cmd, doctl.ArgAgentOut, "", "", "Write the manifest to this path instead of stdout")
+	AddStringFlag(cmd, doctl.ArgAgentManifestFormat, "", "", "Manifest encoding: yaml (default) or json")
+	AddBoolFlag(cmd, doctl.ArgAgentOverwrite, "", false, "Replace the file at --"+doctl.ArgAgentOut+" if it already exists")
+	AddBoolFlag(cmd, doctl.ArgAgentSkipValidate, "", false, "Skip the client-side manifest check that otherwise runs before the manifest is written")
+	AddBoolFlag(cmd, doctl.ArgAgentNoInteractive, "", false, "Do not prompt. Every question not answered by a flag takes its default. Unlike the wizard, nothing is inferred from the working directory, so the same flags always produce the same manifest.")
+}
+
+// RunAgentsConfigGenerate authors a manifest from flags, prompts, or both, and
+// writes it to stdout or a file. It performs no API writes.
+func RunAgentsConfigGenerate(c *CmdConfig) error {
+	answers, err := agentGenerateAnswersFromFlags(c)
+	if err != nil {
+		return err
+	}
+
+	outPath, err := c.Doit.GetString(c.NS, doctl.ArgAgentOut)
+	if err != nil {
+		return err
+	}
+	outPath = strings.TrimSpace(outPath)
+
+	format, err := resolveGenerateFormat(c)
+	if err != nil {
+		return err
+	}
+
+	// Chrome (the review card, warnings, next steps) must never mix with the
+	// manifest itself: when the manifest goes to stdout, notes go to stderr, so
+	// `generate > agents.yaml` yields a clean file either way.
+	dest := &generateDestination{path: outPath, format: format}
+	notes := c.Out
+	if dest.path == "" {
+		notes = os.Stderr
+	}
+
+	noInteractive, err := c.Doit.GetBool(c.NS, doctl.ArgAgentNoInteractive)
+	if err != nil {
+		return err
+	}
+
+	if !noInteractive && agentGenerateCanPrompt() {
+		if err := runAgentGenerateWizard(c, answers, dest, notes); err != nil {
+			if isPromptCanceled(err) {
+				fmt.Fprintf(notes, "%s\n", colorize("Canceled — nothing was written.", colMuted))
+				return nil
+			}
+			return err
+		}
+	} else {
+		// The harness is the one question with no sensible default, so it is
+		// also the only flag that is ever required.
+		if strings.TrimSpace(answers.Harness) == "" {
+			return fmt.Errorf("--%s is required when not prompting; pass one of %s", doctl.ArgAgentHarness, generateHarnessIDList())
+		}
+		applyGenerateEnterDefaults(answers)
+	}
+
+	if err := applyGenerateDerivations(answers); err != nil {
+		return err
+	}
+
+	manifest, err := buildGeneratedManifest(answers)
+	if err != nil {
+		return err
+	}
+	encoded, err := encodeGeneratedManifest(manifest, dest.format)
+	if err != nil {
+		return err
+	}
+
+	skipValidate, err := c.Doit.GetBool(c.NS, doctl.ArgAgentSkipValidate)
+	if err != nil {
+		return err
+	}
+	if !skipValidate {
+		// Validation is advisory here by design: `generate` writes a draft, and a
+		// warning about a field the server accepts-but-does-not-yet-enforce should
+		// not stop a user from saving it. Hard errors still fail.
+		v := validateAgentManifest(encoded)
+		if !v.ok() {
+			return v.error()
+		}
+		printAgentManifestWarnings(notes, v.Warnings)
+	}
+
+	return writeGeneratedManifest(c, answers, manifest, encoded, dest, notes)
+}
+
+// generateDestination is where the manifest lands. The wizard may set it, so it
+// is threaded through rather than re-read from flags after prompting.
+type generateDestination struct {
+	path      string
+	format    string
+	overwrite bool
+}
+
+// agentGenerateAnswersFromFlags reads every manifest flag. Unset flags leave
+// their field zero, which is what the wizard treats as "still to ask" and what
+// the builder treats as "omit, and let the server default apply".
+func agentGenerateAnswersFromFlags(c *CmdConfig) (*generateAnswers, error) {
+	a := &generateAnswers{}
+
+	str := func(flag string) (string, error) {
+		v, err := c.Doit.GetString(c.NS, flag)
+		return strings.TrimSpace(v), err
+	}
+
+	var err error
+	if a.Name, err = str(doctl.ArgAgentName); err != nil {
+		return nil, err
+	}
+	if a.Description, err = str(doctl.ArgAgentDescription); err != nil {
+		return nil, err
+	}
+	labels, err := c.Doit.GetStringSlice(c.NS, doctl.ArgAgentLabel)
+	if err != nil {
+		return nil, err
+	}
+	if a.Labels, err = parseGenerateKeyValues(doctl.ArgAgentLabel, labels); err != nil {
+		return nil, err
+	}
+
+	if a.Harness, err = str(doctl.ArgAgentHarness); err != nil {
+		return nil, err
+	}
+	if a.Harness != "" {
+		// Fail on a bad harness now rather than after a dozen prompts.
+		if a.Harness, err = resolveGenerateHarness(a.Harness); err != nil {
+			return nil, err
+		}
+	}
+	if a.Image, err = str(doctl.ArgAgentImage); err != nil {
+		return nil, err
+	}
+	if a.Entrypoint, err = c.Doit.GetStringSlice(c.NS, doctl.ArgAgentEntrypoint); err != nil {
+		return nil, err
+	}
+	if a.Prompt, err = str(doctl.ArgAgentTriggerPrompt); err != nil {
+		return nil, err
+	}
+
+	repos, err := c.Doit.GetStringSlice(c.NS, doctl.ArgAgentRepo)
+	if err != nil {
+		return nil, err
+	}
+	for _, repo := range repos {
+		ref, err := normalizeHarnessRepoRef(repo)
+		if err != nil {
+			return nil, err
+		}
+		if ref != "" {
+			a.Repos = append(a.Repos, ref)
+		}
+	}
+	if a.GitHubAccess, err = c.Doit.GetBool(c.NS, doctl.ArgAgentGitHubAccess); err != nil {
+		return nil, err
+	}
+	if a.Template, err = str(doctl.ArgAgentTemplate); err != nil {
+		return nil, err
+	}
+	if a.PersistentWorkspace, err = c.Doit.GetBoolPtr(c.NS, doctl.ArgAgentPersistentWorkspace); err != nil {
+		return nil, err
+	}
+	if a.Size, err = str(doctl.ArgAgentSize); err != nil {
+		return nil, err
+	}
+
+	env, err := c.Doit.GetStringSlice(c.NS, doctl.ArgAgentEnv)
+	if err != nil {
+		return nil, err
+	}
+	if a.Env, err = parseGenerateKeyValues(doctl.ArgAgentEnv, env); err != nil {
+		return nil, err
+	}
+	if err := rejectCredentialLookingEnv(a.Env); err != nil {
+		return nil, err
+	}
+
+	if err := readGenerateSecretFlags(c, a); err != nil {
+		return nil, err
+	}
+
+	if a.InferenceProvider, err = str(doctl.ArgAgentInference); err != nil {
+		return nil, err
+	}
+	if a.InferenceURL, err = str(doctl.ArgAgentInferenceURL); err != nil {
+		return nil, err
+	}
+	if a.InferenceURL != "" && a.InferenceProvider == "" {
+		// A URL says everything the provider flag would.
+		a.InferenceProvider = inferenceProviderCustom
+	}
+	if a.Model, err = str(doctl.ArgAgentModel); err != nil {
+		return nil, err
+	}
+	if a.ModelRouting, err = str(doctl.ArgAgentModelRouting); err != nil {
+		return nil, err
+	}
+	if a.IdleTimeout, err = str(doctl.ArgAgentIdleTimeout); err != nil {
+		return nil, err
+	}
+	if a.MaxLifetime, err = str(doctl.ArgAgentMaxLifetime); err != nil {
+		return nil, err
+	}
+
+	if a.Egress, err = c.Doit.GetStringSlice(c.NS, doctl.ArgAgentEgress); err != nil {
+		return nil, err
+	}
+	if a.ToolsPreset, err = str(doctl.ArgAgentToolsPreset); err != nil {
+		return nil, err
+	}
+	if err := validateToolsPreset(a.ToolsPreset); err != nil {
+		return nil, err
+	}
+	if a.Tools, err = c.Doit.GetStringSlice(c.NS, doctl.ArgAgentTool); err != nil {
+		return nil, err
+	}
+
+	mcpServers, err := c.Doit.GetStringSlice(c.NS, doctl.ArgAgentMCPServer)
+	if err != nil {
+		return nil, err
+	}
+	mcpTools, err := c.Doit.GetStringSlice(c.NS, doctl.ArgAgentMCPTools)
+	if err != nil {
+		return nil, err
+	}
+	mcpAuth, err := c.Doit.GetStringSlice(c.NS, doctl.ArgAgentMCPAuthSecret)
+	if err != nil {
+		return nil, err
+	}
+	if a.MCPServers, err = parseGenerateMCPServers(mcpServers, mcpTools, mcpAuth); err != nil {
+		return nil, err
+	}
+
+	if a.PermissionDefault, err = str(doctl.ArgAgentPermissionDefault); err != nil {
+		return nil, err
+	}
+	if a.PermissionDefault != "" {
+		if _, ok := validPermissionDefaults[a.PermissionDefault]; !ok {
+			return nil, fmt.Errorf("--%s must be allow, ask, or deny (got %q)", doctl.ArgAgentPermissionDefault, a.PermissionDefault)
+		}
+	}
+	if err := readGeneratePermissionRules(c, a); err != nil {
+		return nil, err
+	}
+
+	skills, err := c.Doit.GetStringSlice(c.NS, doctl.ArgAgentSkill)
+	if err != nil {
+		return nil, err
+	}
+	skillDescriptions, err := c.Doit.GetStringSlice(c.NS, doctl.ArgAgentSkillDescription)
+	if err != nil {
+		return nil, err
+	}
+	if a.Skills, err = parseGenerateSkills(skills, skillDescriptions); err != nil {
+		return nil, err
+	}
+
+	if a.Mode, err = str(doctl.ArgAgentMode); err != nil {
+		return nil, err
+	}
+	if a.Serving, err = readGenerateServing(c); err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}
+
+// readGenerateSecretFlags turns --secret and --inline-secret into ordered slot
+// declarations.
+//
+// --secret carries no value into the file on purpose: the manifest is a file
+// people commit, and the create-time --secret flag already exists to supply
+// values. --inline-secret is the explicit opt-out for a throwaway local file.
+func readGenerateSecretFlags(c *CmdConfig, a *generateAnswers) error {
+	slots, err := c.Doit.GetStringSlice(c.NS, doctl.ArgAgentSecret)
+	if err != nil {
+		return err
+	}
+	for _, raw := range slots {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		name, value, hasValue := strings.Cut(raw, "=")
+		name = strings.TrimSpace(name)
+		value = strings.TrimSpace(value)
+		switch {
+		case !hasValue || value == "":
+			a.addSecretSlot(generateSecretSlot{Name: name, Value: secretPlaceholder(name)})
+		case strings.HasPrefix(value, "oauth/"):
+			a.addSecretSlot(generateSecretSlot{Name: name, Value: value})
+		default:
+			return fmt.Errorf("--%s %s=… carries a credential value, which is never written to a generated manifest. Declare the slot with `--%s %s` and pass the value at create time, or use `--%s %s=VALUE` to embed it deliberately",
+				doctl.ArgAgentSecret, name, doctl.ArgAgentSecret, name, doctl.ArgAgentInlineSecret, name)
+		}
+	}
+
+	inline, err := c.Doit.GetStringSlice(c.NS, doctl.ArgAgentInlineSecret)
+	if err != nil {
+		return err
+	}
+	// Inline values do reach the file, so they get the full grammar: a literal,
+	// @path, or - for stdin, exactly as `create --secret` spells it.
+	values, err := parseKeyValueInputs(inline)
+	if err != nil {
+		return fmt.Errorf("--%s: %w", doctl.ArgAgentInlineSecret, err)
+	}
+	for _, name := range sortedKeys(values) {
+		if a.hasSecret(name) {
+			return fmt.Errorf("secret slot %q is declared twice (--%s and --%s)", name, doctl.ArgAgentSecret, doctl.ArgAgentInlineSecret)
+		}
+		a.addSecretSlot(generateSecretSlot{Name: name, Value: values[name], Inline: true})
+	}
+	return nil
+}
+
+func readGeneratePermissionRules(c *CmdConfig, a *generateAnswers) error {
+	for _, spec := range []struct {
+		flag   string
+		action string
+	}{
+		{doctl.ArgAgentAllowTool, "allow"},
+		{doctl.ArgAgentAskTool, "ask"},
+		{doctl.ArgAgentDenyTool, "deny"},
+	} {
+		values, err := c.Doit.GetStringSlice(c.NS, spec.flag)
+		if err != nil {
+			return err
+		}
+		rules, err := parseGeneratePermissionRules(spec.flag, spec.action, values)
+		if err != nil {
+			return err
+		}
+		a.PermissionRules = append(a.PermissionRules, rules...)
+	}
+	return nil
+}
+
+// readGenerateServing collects the fleet flags, returning nil when none were
+// given so `mode: interactive` never sprouts an empty serving block.
+func readGenerateServing(c *CmdConfig) (*generatedServing, error) {
+	min, err := c.Doit.GetIntPtr(c.NS, doctl.ArgAgentServingMin)
+	if err != nil {
+		return nil, err
+	}
+	max, err := c.Doit.GetIntPtr(c.NS, doctl.ArgAgentServingMax)
+	if err != nil {
+		return nil, err
+	}
+	concurrency, err := c.Doit.GetIntPtr(c.NS, doctl.ArgAgentServingConcurrency)
+	if err != nil {
+		return nil, err
+	}
+	idle, err := c.Doit.GetString(c.NS, doctl.ArgAgentServingScaleToZeroIdle)
+	if err != nil {
+		return nil, err
+	}
+	idle = strings.TrimSpace(idle)
+	if min == nil && max == nil && concurrency == nil && idle == "" {
+		return nil, nil
+	}
+	if err := validateGenerateDuration(doctl.ArgAgentServingScaleToZeroIdle, idle); err != nil {
+		return nil, err
+	}
+	serving := &generatedServing{Min: min, Max: max, TargetConcurrency: concurrency}
+	if idle != "" {
+		serving.ScaleToZero = &generatedScaleToZero{Idle: idle}
+	}
+	if min != nil && max != nil && *max < *min {
+		return nil, fmt.Errorf("--%s must be greater than or equal to --%s", doctl.ArgAgentServingMax, doctl.ArgAgentServingMin)
+	}
+	return serving, nil
+}
+
+// rejectCredentialLookingEnv refuses a credential in `env`, reusing the same
+// detector `validate` warns with. Here it is an error rather than a warning:
+// the file has not been written yet, so the fix is free.
+func rejectCredentialLookingEnv(env map[string]string) error {
+	for _, key := range sortedKeys(env) {
+		if _, reserved := reservedAgentEnvKeys[strings.ToUpper(key)]; reserved {
+			return fmt.Errorf("--%s %s: reserved platform environment key", doctl.ArgAgentEnv, key)
+		}
+		value := env[key]
+		if isCredentialLookingEnvKey(key) || hasCredentialPrefix(value) {
+			return fmt.Errorf("--%s %s looks like a credential; declare it with --%s %s instead (the guest environment is debug-readable and stored as-is)", doctl.ArgAgentEnv, key, doctl.ArgAgentSecret, key)
+		}
+	}
+	return nil
+}
+
+func validateToolsPreset(preset string) error {
+	switch strings.ToLower(strings.TrimSpace(preset)) {
+	case "", generateToolsPresetNone, generateToolsPresetDefault:
+		return nil
+	default:
+		return fmt.Errorf("--%s must be %s or %s (got %q)", doctl.ArgAgentToolsPreset, generateToolsPresetNone, generateToolsPresetDefault, preset)
+	}
+}
+
+// resolveGenerateFormat picks the manifest encoding: the explicit flag first,
+// then doctl's global -o json, then YAML.
+func resolveGenerateFormat(c *CmdConfig) (string, error) {
+	format, err := c.Doit.GetString(c.NS, doctl.ArgAgentManifestFormat)
+	if err != nil {
+		return "", err
+	}
+	format = strings.ToLower(strings.TrimSpace(format))
+	switch format {
+	case generateFormatYAML, "yml", generateFormatJSON:
+		return format, nil
+	case "":
+		if Output == "json" {
+			return generateFormatJSON, nil
+		}
+		return generateFormatYAML, nil
+	default:
+		return "", fmt.Errorf("--%s must be %s or %s (got %q)", doctl.ArgAgentManifestFormat, generateFormatYAML, generateFormatJSON, format)
+	}
+}
+
+// --- output -----------------------------------------------------------------
+
+// writeGeneratedManifest emits the manifest and, when a human is watching, the
+// review card and the commands to run next.
+func writeGeneratedManifest(c *CmdConfig, a *generateAnswers, m *generatedManifest, encoded []byte, dest *generateDestination, notes io.Writer) error {
+	overwrite, err := c.Doit.GetBool(c.NS, doctl.ArgAgentOverwrite)
+	if err != nil {
+		return err
+	}
+	overwrite = overwrite || dest.overwrite
+
+	if dest.path == "" {
+		stylingEnabled = detectStyling()
+		// The label goes to stderr with the rest of the chrome, so stdout still
+		// carries nothing but the manifest.
+		if isTerminalWriter(notes) {
+			fmt.Fprintf(notes, "\n%s\n", colorize("Manifest · "+dest.format, colMuted))
+		}
+		if _, err := io.WriteString(c.Out, highlightManifest(encoded)); err != nil {
+			return err
+		}
+		if isTerminalWriter(notes) {
+			printGenerateNextSteps(notes, a, m, "")
+		}
+		return nil
+	}
+
+	path := filepath.Clean(dest.path)
+	if !overwrite {
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("%s already exists; pass --%s to replace it, or choose another --%s", path, doctl.ArgAgentOverwrite, doctl.ArgAgentOut)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	if err := os.WriteFile(path, encoded, 0600); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+
+	stylingEnabled = detectStyling()
+	printAgentSuccess(notes, fmt.Sprintf("Wrote %s", path))
+	printGenerateNextSteps(notes, a, m, path)
+	return nil
+}
+
+// highlightManifest colors the document's structure — keys against values,
+// sequence markers, and the placeholders still waiting on a value.
+//
+// Color is the only decoration used here, and deliberately so: this block
+// exists to be copied, and a border or an added indent would come along with
+// it. ANSI codes do not, since a terminal keeps only plain text in its
+// selection buffer.
+//
+// It applies solely when stdout is a terminal, so `generate > agents.yaml` and
+// `generate | config create --spec -` still receive the exact bytes that were
+// validated.
+func highlightManifest(encoded []byte) string {
+	if !stylingEnabled {
+		return string(encoded)
+	}
+	lines := strings.Split(string(encoded), "\n")
+	for i, line := range lines {
+		lines[i] = highlightManifestLine(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func highlightManifestLine(line string) string {
+	indent := line[:len(line)-len(strings.TrimLeft(line, " "))]
+	node := line[len(indent):]
+	switch {
+	case node == "":
+		return line
+	case strings.HasPrefix(node, "#"):
+		return indent + colorize(node, colMuted)
+	// A JSON brace or bracket alone on its line is pure syntax.
+	case isManifestPunctuation(node):
+		return indent + colorize(node, colMuted)
+	case node == "-":
+		return indent + colorize(node, colMuted)
+	case strings.HasPrefix(node, "- "):
+		// Dim the marker, then treat what follows as its own node: it may be a
+		// scalar or the first key of a mapping in a sequence.
+		return indent + colorize("- ", colMuted) + highlightManifestLine(node[2:])
+	}
+	if key, sep, value, ok := splitManifestKey(node); ok {
+		out := boldColor(key, colHighlight) + colorize(sep, colMuted)
+		if value != "" {
+			out += highlightManifestValue(value)
+		}
+		return indent + out
+	}
+	return indent + highlightManifestValue(node)
+}
+
+// splitManifestKey finds the mapping key a line opens with, if any. Only a
+// colon at end of line or before a space separates a key from its value, which
+// is what keeps the one inside `https://…` from splitting a URL in half.
+func splitManifestKey(node string) (key, sep, value string, ok bool) {
+	quoted := false
+	for i := 0; i < len(node); i++ {
+		switch node[i] {
+		case '"':
+			quoted = !quoted
+		case ':':
+			if quoted {
+				continue
+			}
+			if i+1 == len(node) {
+				return node[:i], ":", "", true
+			}
+			if node[i+1] == ' ' {
+				return node[:i], ": ", node[i+2:], true
+			}
+		}
+	}
+	return "", "", "", false
+}
+
+// highlightManifestValue leaves scalars in the terminal's own foreground so
+// they read against the colored keys, and picks out the ${VAR} placeholders —
+// the one part of a generated manifest that still needs the user to do
+// something, and what the closing "export" hint refers to.
+func highlightManifestValue(value string) string {
+	// A JSON container opening in value position is syntax, same as the brace
+	// that closes it further down.
+	if value == "{" || value == "[" {
+		return colorize(value, colMuted)
+	}
+	suffix := ""
+	if strings.HasSuffix(value, ",") {
+		suffix = colorize(",", colMuted)
+		value = value[:len(value)-1]
+	}
+	return manifestEnvRef.ReplaceAllStringFunc(value, func(ref string) string {
+		return colorize(ref, colWarning)
+	}) + suffix
+}
+
+func isManifestPunctuation(node string) bool {
+	switch node {
+	case "{", "}", "[", "]", "},", "],", "{}", "[]":
+		return true
+	}
+	return false
+}
+
+// printGenerateNextSteps closes every run with what to do with the manifest.
+// The commands are complete and pasteable, so the path from "generated" to
+// "running" is copy, paste, enter.
+//
+// The manifest declares credentials as ${VAR} placeholders, and the commands
+// that consume it expand those from the environment before anything else — so
+// the exports come first. (Notably `config create --secret` cannot substitute
+// for them: expansion happens while the file is read, before that flag is
+// applied.) On a terminal those commands prompt instead, but a printed export
+// line is what makes the sequence work in a script too.
+func printGenerateNextSteps(w io.Writer, a *generateAnswers, m *generatedManifest, path string) {
+	stylingEnabled = detectStyling()
+
+	ref := path
+	if ref == "" {
+		// Nothing was written, so the follow-ups can only name a file the user
+		// still has to create; say so rather than printing a broken command.
+		fmt.Fprintf(w, "\n%s\n", colorize("Save this manifest, then:", colMuted))
+		ref = "agents.yaml"
+	} else {
+		fmt.Fprintf(w, "\n%s\n", colorize("Next steps", colMuted))
+	}
+
+	var needExport []string
+	for _, slot := range a.Secrets {
+		// A brokered slot is filled by the platform, and an inlined one is
+		// already in the file.
+		if slot.Inline || strings.HasPrefix(slot.Value, "oauth/") {
+			continue
+		}
+		if strings.TrimSpace(os.Getenv(slot.Name)) == "" {
+			needExport = append(needExport, slot.Name+"=…")
+		}
+	}
+	if len(needExport) > 0 {
+		fmt.Fprint(w, cardRow("set", "export "+strings.Join(needExport, " ")))
+	}
+
+	name := strings.TrimSpace(m.Name)
+	if name == "" {
+		name = "my-config"
+	}
+	fmt.Fprint(w, cardRow("reuse", fmt.Sprintf("%s config create --%s %s --%s %s", agentCLI, doctl.ArgAgentSpec, ref, doctl.ArgAgentName, name)))
+	fmt.Fprint(w, cardRow("run", fmt.Sprintf("%s launch --%s %s", agentCLI, doctl.ArgAgentSpec, ref)))
+}

--- a/commands/agent_config_generate_manifest.go
+++ b/commands/agent_config_generate_manifest.go
@@ -1,0 +1,1210 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/digitalocean/doctl"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// The flat agent manifest, as authored for `harness-runtime config generate`.
+//
+// Field order follows the canonical annotated contract (harness-api
+// contracts/agent.flat.yaml) section by section — identity, agent, workspace,
+// environment, secrets, model, sizing, egress, tools, permissions, execution
+// environment, skills, memory/budget, mode — so a generated file reads like
+// the documented example rather than like a Go struct dump. Nested blocks are
+// typed rather than map[string]any for the same reason: a map would emit its
+// keys alphabetically (`auth` before `name`), which reads backwards.
+//
+// Only fields the command can populate are modeled. `mounts` is deliberately
+// absent: it is accepted-but-unenforced server-side and requires `env: false`
+// secret slots, which is beyond what a generator should guess at.
+type generatedManifest struct {
+	Name        string            `yaml:"name,omitempty" json:"name,omitempty"`
+	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
+
+	Agent      string         `yaml:"agent" json:"agent"`
+	Image      string         `yaml:"image,omitempty" json:"image,omitempty"`
+	Entrypoint []string       `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
+	Config     map[string]any `yaml:"config,omitempty" json:"config,omitempty"`
+
+	Repos []string `yaml:"repos,omitempty" json:"repos,omitempty"`
+
+	Env     map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+	Secrets map[string]string `yaml:"secrets,omitempty" json:"secrets,omitempty"`
+
+	Model any `yaml:"model,omitempty" json:"model,omitempty"`
+
+	Size        string `yaml:"size,omitempty" json:"size,omitempty"`
+	IdleTimeout string `yaml:"idle_timeout,omitempty" json:"idle_timeout,omitempty"`
+	MaxLifetime string `yaml:"max_lifetime,omitempty" json:"max_lifetime,omitempty"`
+
+	Egress []string `yaml:"egress,omitempty" json:"egress,omitempty"`
+
+	Tools       []any                 `yaml:"tools,omitempty" json:"tools,omitempty"`
+	Permissions *generatedPermissions `yaml:"permissions,omitempty" json:"permissions,omitempty"`
+
+	Template            string `yaml:"template,omitempty" json:"template,omitempty"`
+	PersistentWorkspace *bool  `yaml:"persistent_workspace,omitempty" json:"persistent_workspace,omitempty"`
+
+	Skills []generatedSkill `yaml:"skills,omitempty" json:"skills,omitempty"`
+
+	Mode    string            `yaml:"mode,omitempty" json:"mode,omitempty"`
+	Serving *generatedServing `yaml:"serving,omitempty" json:"serving,omitempty"`
+}
+
+// generatedModel is the object form of `model`. The string shorthand is used
+// whenever only a default model is set.
+type generatedModel struct {
+	Default string `yaml:"default" json:"default"`
+	Routing string `yaml:"routing,omitempty" json:"routing,omitempty"`
+}
+
+// generatedMCPServer is an inline (non-DO) MCP server attachment.
+type generatedMCPServer struct {
+	Name  string            `yaml:"name" json:"name"`
+	URL   string            `yaml:"url" json:"url"`
+	Tools []string          `yaml:"tools,omitempty" json:"tools,omitempty"`
+	Auth  *generatedMCPAuth `yaml:"auth,omitempty" json:"auth,omitempty"`
+}
+
+// generatedMCPAuth points an inline MCP server at a declared secrets slot. The
+// contract has no plaintext token field by design, so neither does this.
+type generatedMCPAuth struct {
+	Secret string `yaml:"secret" json:"secret"`
+}
+
+type generatedPermissions struct {
+	Default string                    `yaml:"default,omitempty" json:"default,omitempty"`
+	Rules   []generatedPermissionRule `yaml:"rules,omitempty" json:"rules,omitempty"`
+}
+
+type generatedPermissionRule struct {
+	Tool   string            `yaml:"tool" json:"tool"`
+	Match  map[string]string `yaml:"match,omitempty" json:"match,omitempty"`
+	Action string            `yaml:"action" json:"action"`
+}
+
+type generatedSkill struct {
+	Name         string `yaml:"name" json:"name"`
+	Description  string `yaml:"description" json:"description"`
+	Instructions string `yaml:"instructions" json:"instructions"`
+}
+
+type generatedServing struct {
+	Min               *int                  `yaml:"min,omitempty" json:"min,omitempty"`
+	Max               *int                  `yaml:"max,omitempty" json:"max,omitempty"`
+	TargetConcurrency *int                  `yaml:"target_concurrency,omitempty" json:"target_concurrency,omitempty"`
+	ScaleToZero       *generatedScaleToZero `yaml:"scale_to_zero,omitempty" json:"scale_to_zero,omitempty"`
+}
+
+type generatedScaleToZero struct {
+	Idle string `yaml:"idle" json:"idle"`
+}
+
+// --- harness catalog --------------------------------------------------------
+
+// generateHarness describes one selectable harness: its manifest id, the name
+// shown in the picker, the sandbox template the server derives when `template`
+// is omitted, how it gets inference, and any credential slots it needs beyond
+// that.
+type generateHarness struct {
+	ID        string
+	Label     string
+	Template  string
+	Inference *harnessInference
+	// Secrets are credential slots unrelated to inference. Only the
+	// OpenAI-hosted loop has one, since OpenAI runs the agent rather than the
+	// sandbox calling a model endpoint itself.
+	Secrets []string
+}
+
+// Where a harness gets its model. This is not a manifest field: the platform
+// has no inference section, so the choice materializes as guest environment
+// plus one credential slot. Two mutually exclusive groups exist, and the
+// in-VM runtime prefers the native one whenever its key is present — so a
+// manifest must commit to one group or the other, never mix them.
+const (
+	// inferenceProviderNative uses the agent's own upstream API (Anthropic for
+	// claude-code, OpenAI for codex/opencode, Cursor for cursor) with that
+	// vendor's own environment variables, and lets the agent pick its default
+	// model. It is the default when nothing is prompted, being the only option
+	// that needs no further answers.
+	inferenceProviderNative = "native"
+	// inferenceProviderDO routes inference through DigitalOcean Serverless
+	// Inference, and is what the wizard recommends: one model access key, and
+	// the platform already allows its host. It has no default model, so it
+	// costs one more answer — which is why it leads the picker but not the
+	// non-prompting path.
+	inferenceProviderDO = "do"
+	// inferenceProviderCustom points the harness at any other
+	// OpenAI-compatible endpoint. Requires a URL, a model, and egress for the
+	// host, none of which can be guessed.
+	inferenceProviderCustom = "custom"
+)
+
+// The harness-owned inference wiring. The manifest is the only source of these
+// values — nothing is injected control-plane side — and setting the key here is
+// what activates endpoint routing at all.
+const (
+	harnessInferenceBaseURLEnv = "HARNESS_INFERENCE_BASE_URL"
+	harnessInferenceAPIKeyEnv  = "HARNESS_INFERENCE_API_KEY"
+	harnessInferenceModelEnv   = "HARNESS_INFERENCE_MODEL"
+
+	// doInferenceBaseURL is the DigitalOcean Serverless Inference endpoint. The
+	// /v1 suffix is part of the documented base URL; adapters that need it
+	// stripped (claude-code, whose SDK appends its own resource path) strip it
+	// themselves in the guest.
+	doInferenceBaseURL = "https://inference.do-ai.run/v1"
+	// doInferenceModelsCmd lists the model ids that endpoint accepts. They are
+	// gateway slugs (anthropic-claude-4.5-sonnet), not upstream vendor ids
+	// (claude-sonnet-4-5), which is the single easiest thing to get wrong here.
+	doInferenceModelsCmd = "doctl serverless-inference models list"
+)
+
+// harnessInference records the environment a harness reads for inference, so
+// the generator can write the right variable names for the chosen provider
+// instead of a field the platform does not read.
+type harnessInference struct {
+	// NativeKeyEnv is the credential the agent binary looks for on its own.
+	NativeKeyEnv string
+	// NativeBaseURLEnv is that binary's own endpoint override. Empty when the
+	// agent talks to a fixed backend.
+	NativeBaseURLEnv string
+	// NativeModelEnv is that binary's own model selector. Empty when the agent
+	// has none and a model can only be pinned through HARNESS_INFERENCE_MODEL.
+	NativeModelEnv string
+	// ExtraModelEnv is a second model variable the agent binary itself reads
+	// (claude-code's ANTHROPIC_MODEL). It is set for every provider, which also
+	// keeps the manifest clear of doctl's own model-consistency warnings.
+	ExtraModelEnv string
+
+	// ProviderLabel names the upstream vendor in the picker.
+	ProviderLabel string
+	// NativeModelHint and DOModelHint are example ids in each id space.
+	NativeModelHint string
+	DOModelHint     string
+
+	// NativeOnly marks an agent whose backend cannot be redirected, so
+	// offering it an endpoint choice would be a lie.
+	NativeOnly bool
+}
+
+// modelEnvNames lists the environment variables a model id should be written
+// to for the given provider. Endpoint routing pins the model through the
+// harness variable; the native path prefers the agent's own.
+func (h *harnessInference) modelEnvNames(provider string) []string {
+	if h == nil {
+		return nil
+	}
+	var names []string
+	if provider == inferenceProviderNative && h.NativeModelEnv != "" {
+		names = append(names, h.NativeModelEnv)
+	} else {
+		names = append(names, harnessInferenceModelEnv)
+	}
+	if h.ExtraModelEnv != "" {
+		names = append(names, h.ExtraModelEnv)
+	}
+	return names
+}
+
+// keyEnvName is the credential slot the provider needs.
+func (h *harnessInference) keyEnvName(provider string) string {
+	if h == nil {
+		return ""
+	}
+	if provider == inferenceProviderNative {
+		return h.NativeKeyEnv
+	}
+	return harnessInferenceAPIKeyEnv
+}
+
+// generateHarnessCatalog is the set offered interactively: the canonical
+// supported adapter ids from the agent-manifest contract. Adapters outside this
+// list (hermes, the deprecated aliases, the declared-but-unsupported
+// frameworks) remain reachable through --harness, which validates against the
+// same accept-list `validate` uses, so there is one source of truth for what a
+// manifest may name.
+var generateHarnessCatalog = []generateHarness{
+	{
+		ID:       "claude-code",
+		Label:    "Claude Code",
+		Template: "coding-claude-code",
+		Inference: &harnessInference{
+			NativeKeyEnv:     "ANTHROPIC_API_KEY",
+			NativeBaseURLEnv: "ANTHROPIC_BASE_URL",
+			// claude-code has no model env of its own; the runtime pins its
+			// --model from HARNESS_INFERENCE_MODEL. ANTHROPIC_MODEL is read by
+			// the CLI itself, so both are set.
+			ExtraModelEnv:   "ANTHROPIC_MODEL",
+			ProviderLabel:   "Anthropic",
+			NativeModelHint: "claude-sonnet-4-5",
+			DOModelHint:     "anthropic-claude-4.5-sonnet",
+		},
+	},
+	{
+		ID:       "opencode",
+		Label:    "OpenCode",
+		Template: "coding-opencode",
+		Inference: &harnessInference{
+			NativeKeyEnv:     "OPENAI_API_KEY",
+			NativeBaseURLEnv: "OPENAI_BASE_URL",
+			NativeModelEnv:   "MODEL",
+			ProviderLabel:    "OpenAI",
+			NativeModelHint:  "gpt-5-codex",
+			DOModelHint:      "deepseek-v4-pro",
+		},
+	},
+	{
+		ID:       "codex",
+		Label:    "Codex",
+		Template: "coding-codex",
+		Inference: &harnessInference{
+			NativeKeyEnv:     "OPENAI_API_KEY",
+			NativeBaseURLEnv: "OPENAI_BASE_URL",
+			NativeModelEnv:   "MODEL",
+			ProviderLabel:    "OpenAI",
+			NativeModelHint:  "gpt-5-codex",
+			DOModelHint:      "openai-gpt-5.3-codex",
+		},
+	},
+	{
+		ID:       "cursor",
+		Label:    "Cursor CLI",
+		Template: "coding-cursor",
+		Inference: &harnessInference{
+			NativeKeyEnv:  "CURSOR_API_KEY",
+			ProviderLabel: "Cursor",
+			// Cursor's agent talks to Cursor's own backend, which no endpoint
+			// override can redirect.
+			NativeOnly: true,
+		},
+	},
+	{
+		ID:       "codex-agentapi",
+		Label:    "Codex (OpenAI-hosted loop)",
+		Template: "coding-codex",
+		// No inference wiring at all: the loop runs at OpenAI, so the sandbox
+		// never calls a model endpoint and the harness variables are ignored.
+		Secrets: []string{"OPENAI_API_KEY"},
+	},
+	{
+		ID:       "custom",
+		Label:    "Custom container",
+		Template: "",
+	},
+}
+
+// generateHarnessAliases are the spellings accepted in addition to the
+// canonical ids, mirroring the courtesy `create --harness` extends.
+var generateHarnessAliases = map[string]string{
+	"claude":         "claude-code",
+	"claude-code":    "claude-code",
+	"open-code":      "opencode",
+	"opencode":       "opencode",
+	"codex":          "codex",
+	"cursor":         "cursor",
+	"cursor-agent":   "cursor",
+	"openai-codex":   "codex-agentapi",
+	"codex-agentapi": "codex-agentapi",
+	"custom":         "custom",
+}
+
+// generateFallbackSizes is used when the live size catalog is unreachable —
+// `config generate` must work offline and unauthenticated, so a failed lookup
+// degrades to the documented slugs instead of erroring.
+var generateFallbackSizes = []string{
+	"mv-1vcpu-2gb",
+	"mv-2vcpu-4gb",
+	"mv-8vcpu-16gb",
+	"mv-16vcpu-32gb",
+}
+
+// generateDefaultToolsPreset is the `--tools-preset default` bundle: the DO
+// Action Gateway with a small, safe selection rather than its whole catalog.
+var generateDefaultToolsPreset = []string{"web_search", "execute_code", "toolbelt:read-only"}
+
+const (
+	generateToolsPresetNone    = "none"
+	generateToolsPresetDefault = "default"
+
+	// generateDefaultPermission is the recommended disposition for an unmatched
+	// tool call: pause and ask rather than run or refuse silently.
+	generateDefaultPermission = "ask"
+
+	// generateGitHubOAuthSlot is the brokered GitHub credential slot added by
+	// --github-access.
+	generateGitHubOAuthSlot  = "GITHUB_TOKEN"
+	generateGitHubOAuthValue = "oauth/github"
+
+	// doCatalogToolPrefix is the reserved DO-owned tool namespace.
+	doCatalogToolPrefix = "do."
+	doActionsCatalogRef = "do.actions"
+)
+
+// generateGitHubEgress are the hosts a repo-attached session needs to reach.
+var generateGitHubEgress = []string{"github.com", "api.github.com"}
+
+func lookupGenerateHarness(id string) (generateHarness, bool) {
+	for _, h := range generateHarnessCatalog {
+		if h.ID == id {
+			return h, true
+		}
+	}
+	return generateHarness{}, false
+}
+
+// resolveGenerateHarness canonicalizes a --harness value and checks it against
+// the same adapter accept-list `validate` enforces, so `generate` can never
+// emit an `agent:` value that doctl itself would reject.
+//
+// It is deliberately separate from resolveHarnessAgent, which serves
+// `create`/`launch` and intentionally covers only the three adapters those
+// commands build manifests for.
+func resolveGenerateHarness(harness string) (string, error) {
+	key := strings.ToLower(strings.TrimSpace(harness))
+	if key == "" {
+		return "", fmt.Errorf("--%s is required (one of %s)", doctl.ArgAgentHarness, generateHarnessIDList())
+	}
+	if canonical, ok := generateHarnessAliases[key]; ok {
+		return canonical, nil
+	}
+	if _, known := knownAgentAdapters[key]; known {
+		return key, nil
+	}
+	return "", fmt.Errorf("unsupported --%s %q; supported values: %s", doctl.ArgAgentHarness, harness, generateHarnessIDList())
+}
+
+func generateHarnessIDList() string {
+	ids := make([]string, 0, len(generateHarnessCatalog))
+	for _, h := range generateHarnessCatalog {
+		ids = append(ids, h.ID)
+	}
+	return strings.Join(ids, ", ")
+}
+
+// derivedTemplateFor reports the template the server picks when `template` is
+// omitted. Shown in the review card so "auto" is never a mystery.
+func derivedTemplateFor(agent string) string {
+	if h, ok := lookupGenerateHarness(agent); ok {
+		return h.Template
+	}
+	return ""
+}
+
+// --- answers --------------------------------------------------------------
+
+// generateSecretSlot is one declared credential slot. Value carries what the
+// manifest will say: a ${VAR} placeholder, an `oauth/<provider>` reference, or
+// (only via --inline-secret) a literal.
+type generateSecretSlot struct {
+	Name   string
+	Value  string
+	Inline bool
+}
+
+// generateAnswers is the fully-resolved intent behind one `config generate`
+// run, whether it arrived from flags, from wizard prompts, or from a mix of the
+// two. Both paths converge here, so the manifest builder has exactly one input
+// shape and the two front ends cannot drift.
+type generateAnswers struct {
+	Name        string
+	Description string
+	Labels      map[string]string
+
+	Harness    string
+	Image      string
+	Entrypoint []string
+	Prompt     string
+
+	Repos        []string
+	GitHubAccess bool
+
+	Env     map[string]string
+	Secrets []generateSecretSlot
+
+	// InferenceProvider is one of the inferenceProvider* constants, and
+	// InferenceURL is the endpoint when it is inferenceProviderCustom.
+	InferenceProvider string
+	InferenceURL      string
+
+	Model        string
+	ModelRouting string
+
+	Size                string
+	Template            string
+	PersistentWorkspace *bool
+	IdleTimeout         string
+	MaxLifetime         string
+
+	Egress []string
+
+	ToolsPreset string
+	Tools       []string
+	MCPServers  []generatedMCPServer
+
+	PermissionDefault string
+	PermissionRules   []generatedPermissionRule
+
+	Skills []generatedSkill
+
+	Mode    string
+	Serving *generatedServing
+}
+
+// secretNames lists declared slot names in declaration order, for the review
+// card and the next-step hints.
+func (a *generateAnswers) secretNames() []string {
+	names := make([]string, 0, len(a.Secrets))
+	for _, s := range a.Secrets {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+func (a *generateAnswers) hasSecret(name string) bool {
+	for _, s := range a.Secrets {
+		if strings.EqualFold(s.Name, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// addSecretSlot appends a slot, ignoring a duplicate declaration so the
+// convenience flags (--github-access) and explicit ones (--secret) can overlap
+// without producing a doubled key.
+func (a *generateAnswers) addSecretSlot(slot generateSecretSlot) {
+	if a.hasSecret(slot.Name) {
+		return
+	}
+	a.Secrets = append(a.Secrets, slot)
+}
+
+func (a *generateAnswers) addEgress(hosts ...string) {
+	for _, host := range hosts {
+		host = strings.TrimSpace(host)
+		if host == "" {
+			continue
+		}
+		found := false
+		for _, existing := range a.Egress {
+			if strings.EqualFold(existing, host) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			a.Egress = append(a.Egress, host)
+		}
+	}
+}
+
+// --- manifest construction --------------------------------------------------
+
+// buildGeneratedManifest turns resolved answers into the manifest document.
+// It applies only the derivations a generator can make safely: credential slots
+// implied by a chosen harness, egress implied by an attached repo or inline MCP
+// host, and the opaque Codex config block. Everything else is written exactly
+// as answered, and anything unanswered is omitted so the server's own defaults
+// apply.
+func buildGeneratedManifest(a *generateAnswers) (*generatedManifest, error) {
+	if a == nil {
+		return nil, fmt.Errorf("no answers to build a manifest from")
+	}
+	agent, err := resolveGenerateHarness(a.Harness)
+	if err != nil {
+		return nil, err
+	}
+
+	m := &generatedManifest{
+		Agent:               agent,
+		Name:                strings.TrimSpace(a.Name),
+		Description:         strings.TrimSpace(a.Description),
+		Labels:              nonEmptyStringMap(a.Labels),
+		Repos:               a.Repos,
+		Env:                 nonEmptyStringMap(a.Env),
+		Size:                strings.TrimSpace(a.Size),
+		IdleTimeout:         strings.TrimSpace(a.IdleTimeout),
+		MaxLifetime:         strings.TrimSpace(a.MaxLifetime),
+		Template:            strings.TrimSpace(a.Template),
+		PersistentWorkspace: a.PersistentWorkspace,
+		Skills:              a.Skills,
+	}
+
+	if m.Name != "" {
+		if err := validateHostedAgentIdentifier(m.Name); err != nil {
+			return nil, err
+		}
+	}
+
+	if agent == "custom" {
+		if strings.TrimSpace(a.Image) == "" {
+			return nil, fmt.Errorf("--%s is required with --%s custom (a digest-pinned container image)", doctl.ArgAgentImage, doctl.ArgAgentHarness)
+		}
+		m.Image = strings.TrimSpace(a.Image)
+		m.Entrypoint = a.Entrypoint
+	} else if strings.TrimSpace(a.Image) != "" || len(a.Entrypoint) > 0 {
+		return nil, fmt.Errorf("--%s and --%s are only valid with --%s custom", doctl.ArgAgentImage, doctl.ArgAgentEntrypoint, doctl.ArgAgentHarness)
+	}
+
+	// The OpenAI-hosted Codex loop is the one adapter with a required opaque
+	// config block; reuse the same builder `create --harness codex` uses so the
+	// two commands cannot describe the same runtime differently.
+	if isOpenAISandboxAdapter(agent) {
+		m.Config = defaultCodexRunConfig(a.Prompt)
+	} else if strings.TrimSpace(a.Prompt) != "" {
+		return nil, fmt.Errorf("--%s only applies to --%s codex-agentapi; send a first prompt with `%s create --%s` instead", doctl.ArgAgentTriggerPrompt, doctl.ArgAgentHarness, agentCLI, doctl.ArgAgentTriggerPrompt)
+	}
+
+	if err := validateGeneratedDurations(m); err != nil {
+		return nil, err
+	}
+
+	secrets := make(map[string]string, len(a.Secrets))
+	for _, slot := range a.Secrets {
+		name := strings.TrimSpace(slot.Name)
+		if name == "" {
+			continue
+		}
+		if err := validateSecretSlotName(name); err != nil {
+			return nil, err
+		}
+		secrets[name] = slot.Value
+	}
+	if len(secrets) > 0 {
+		m.Secrets = secrets
+	}
+
+	if model := strings.TrimSpace(a.Model); model != "" {
+		if routing := strings.TrimSpace(a.ModelRouting); routing != "" {
+			m.Model = generatedModel{Default: model, Routing: routing}
+		} else {
+			m.Model = model
+		}
+	} else if strings.TrimSpace(a.ModelRouting) != "" {
+		return nil, fmt.Errorf("--%s needs --%s (routing selects how a named model is served)", doctl.ArgAgentModelRouting, doctl.ArgAgentModel)
+	}
+
+	tools, err := buildGeneratedTools(a)
+	if err != nil {
+		return nil, err
+	}
+	m.Tools = tools
+
+	if perms := buildGeneratedPermissions(a); perms != nil {
+		m.Permissions = perms
+	}
+
+	// Egress is assembled last so hosts implied by other sections (repos, inline
+	// MCP servers) join the explicitly requested ones.
+	egress := append([]string{}, a.Egress...)
+	m.Egress = dedupeHosts(egress)
+	if len(m.Egress) == 0 {
+		m.Egress = nil
+	}
+
+	if mode := strings.TrimSpace(a.Mode); mode != "" {
+		if mode != "interactive" && mode != "served" {
+			return nil, fmt.Errorf("--%s must be interactive or served (got %q)", doctl.ArgAgentMode, mode)
+		}
+		m.Mode = mode
+	}
+	if a.Serving != nil {
+		if m.Mode != "served" {
+			return nil, fmt.Errorf("serving flags require --%s served", doctl.ArgAgentMode)
+		}
+		m.Serving = a.Serving
+	} else if m.Mode == "served" {
+		return nil, fmt.Errorf("--%s served requires the serving flags (--%s, --%s, --%s)", doctl.ArgAgentMode, doctl.ArgAgentServingMin, doctl.ArgAgentServingMax, doctl.ArgAgentServingConcurrency)
+	}
+
+	return m, nil
+}
+
+// applyGenerateEnterDefaults answers every still-unanswered question with the
+// value the wizard offers as its default.
+//
+// This is what keeps --no-interactive (and a redirected stdout) aligned with
+// walking the wizard and pressing Enter at every step, rather than a second,
+// barer set of defaults nobody documented. The wizard reads its defaults from
+// the same places, so the two paths cannot drift apart.
+//
+// Questions whose default is "nothing" — repos, MCP servers, skills, a model
+// override — are simply left unset here, exactly as Enter would leave them.
+// The one deliberate difference is that nothing here looks at the working
+// directory: the wizard offers the checked-out repo as a default, which would
+// make a scripted run depend on where it happened to be invoked.
+func applyGenerateEnterDefaults(a *generateAnswers) {
+	if a.Name == "" {
+		a.Name = suggestGenerateName(a.Harness)
+	}
+	// Native inference is the default precisely because it is the only provider
+	// that needs no follow-up answer: the agent uses its own vendor and its own
+	// default model. The credential slot it implies is added by
+	// applyGenerateDerivations, which runs for the wizard too.
+	if a.InferenceProvider == "" {
+		a.InferenceProvider = inferenceProviderNative
+	}
+	if a.ToolsPreset == "" && len(a.Tools) == 0 && len(a.MCPServers) == 0 {
+		a.ToolsPreset = generateToolsPresetDefault
+	}
+	if a.PermissionDefault == "" {
+		a.PermissionDefault = generateDefaultPermission
+	}
+	if len(a.Repos) > 0 && !a.GitHubAccess {
+		a.GitHubAccess = true
+	}
+}
+
+// applyGenerateInference turns the chosen provider into the guest environment,
+// credential slot, and egress it needs.
+//
+// The platform has no inference field, so this is the whole mechanism: which
+// variables get written decides which of the runtime's two credential groups
+// activates. The groups are never mixed — a native key present anywhere makes
+// the runtime ignore the endpoint variables entirely, which would silently send
+// traffic to the vendor instead of the endpoint the user asked for.
+func applyGenerateInference(a *generateAnswers) error {
+	harness, ok := lookupGenerateHarness(a.Harness)
+	if !ok || harness.Inference == nil {
+		// Nothing to wire: either an unlisted adapter, a custom image whose
+		// inference is its own business, or the OpenAI-hosted loop.
+		if strings.TrimSpace(a.InferenceProvider) != "" && strings.TrimSpace(a.InferenceProvider) != inferenceProviderNative {
+			return fmt.Errorf("--%s does not apply to --%s %s: it does not call a model endpoint from the sandbox", doctl.ArgAgentInference, doctl.ArgAgentHarness, a.Harness)
+		}
+		return nil
+	}
+	inf := harness.Inference
+
+	provider := strings.TrimSpace(a.InferenceProvider)
+	if provider == "" {
+		provider = inferenceProviderNative
+	}
+	switch provider {
+	case inferenceProviderNative, inferenceProviderDO, inferenceProviderCustom:
+	default:
+		return fmt.Errorf("--%s must be %s, %s, or %s (got %q)", doctl.ArgAgentInference, inferenceProviderNative, inferenceProviderDO, inferenceProviderCustom, provider)
+	}
+	if inf.NativeOnly && provider != inferenceProviderNative {
+		return fmt.Errorf("--%s %s only supports %s inference: its agent talks to %s's own backend, which an endpoint override cannot redirect", doctl.ArgAgentHarness, a.Harness, inferenceProviderNative, inf.ProviderLabel)
+	}
+	a.InferenceProvider = provider
+
+	if a.Env == nil {
+		a.Env = map[string]string{}
+	}
+
+	switch provider {
+	case inferenceProviderDO:
+		if a.Model == "" {
+			return fmt.Errorf("--%s %s needs --%s: Serverless Inference has no default model. List the ids it accepts with `%s`", doctl.ArgAgentInference, inferenceProviderDO, doctl.ArgAgentModel, doInferenceModelsCmd)
+		}
+		a.Env[harnessInferenceBaseURLEnv] = doInferenceBaseURL
+		a.addSecretSlot(generateSecretSlot{Name: harnessInferenceAPIKeyEnv, Value: secretPlaceholder(harnessInferenceAPIKeyEnv)})
+		// The platform allows the Serverless Inference host itself, so no
+		// egress entry is needed here.
+	case inferenceProviderCustom:
+		url := strings.TrimSpace(a.InferenceURL)
+		if url == "" {
+			// Error text avoids naming the vendor: doctl's error beautifier
+			// rewrites any message mentioning it into an unrelated
+			// "check your API key" card (agents_errors.go).
+			return fmt.Errorf("--%s %s needs --%s (the endpoint's base URL, usually ending in /v1)", doctl.ArgAgentInference, inferenceProviderCustom, doctl.ArgAgentInferenceURL)
+		}
+		if !strings.HasPrefix(url, "https://") {
+			return fmt.Errorf("--%s must be an https:// URL (got %q)", doctl.ArgAgentInferenceURL, url)
+		}
+		if a.Model == "" {
+			return fmt.Errorf("--%s %s needs --%s: doctl cannot know which models your endpoint serves", doctl.ArgAgentInference, inferenceProviderCustom, doctl.ArgAgentModel)
+		}
+		a.Env[harnessInferenceBaseURLEnv] = url
+		a.addSecretSlot(generateSecretSlot{Name: harnessInferenceAPIKeyEnv, Value: secretPlaceholder(harnessInferenceAPIKeyEnv)})
+		// Unlike the DO endpoint, an arbitrary host is not allowed by default.
+		if host := egressHostFor(url); host != "" {
+			a.addEgress(host)
+		}
+	case inferenceProviderNative:
+		if key := inf.NativeKeyEnv; key != "" {
+			a.addSecretSlot(generateSecretSlot{Name: key, Value: secretPlaceholder(key)})
+		}
+	}
+
+	// The model id goes to the variables this harness actually reads. The
+	// top-level `model:` field is written too (see buildGeneratedManifest), but
+	// it is accepted-not-enforced today and selects nothing on its own.
+	if a.Model != "" {
+		for _, name := range inf.modelEnvNames(provider) {
+			a.Env[name] = a.Model
+		}
+	}
+	if len(a.Env) == 0 {
+		a.Env = nil
+	}
+	return nil
+}
+
+// applyGenerateDerivations fills in what a chosen harness, provider, and
+// attached repo imply, before the manifest is built. It runs after both the
+// flag pass and the wizard, so a value the user set explicitly always wins, and
+// it is idempotent so running it twice — once to make the review card truthful,
+// once before writing — cannot double anything up.
+func applyGenerateDerivations(a *generateAnswers) error {
+	if err := applyGenerateInference(a); err != nil {
+		return err
+	}
+	// Credential slots a harness needs for something other than inference.
+	for _, name := range suggestedSecretsFor(a.Harness) {
+		a.addSecretSlot(generateSecretSlot{Name: name, Value: secretPlaceholder(name)})
+	}
+	if a.GitHubAccess {
+		a.addSecretSlot(generateSecretSlot{Name: generateGitHubOAuthSlot, Value: generateGitHubOAuthValue})
+		a.addEgress(generateGitHubEgress...)
+	}
+	// An inline MCP host is not auto-allowed by the platform; adding it here
+	// spares the user a create-time warning for a host they clearly intend to
+	// reach.
+	for _, srv := range a.MCPServers {
+		if host := egressHostFor(srv.URL); host != "" {
+			a.addEgress(host)
+		}
+	}
+	return nil
+}
+
+// suggestedSecretsFor lists the credential slots a harness needs for something
+// other than inference; inference slots come from applyGenerateInference.
+func suggestedSecretsFor(agent string) []string {
+	if h, ok := lookupGenerateHarness(agent); ok {
+		return h.Secrets
+	}
+	return nil
+}
+
+func buildGeneratedTools(a *generateAnswers) ([]any, error) {
+	var tools []any
+
+	catalog := append([]string{}, a.Tools...)
+	if strings.EqualFold(strings.TrimSpace(a.ToolsPreset), generateToolsPresetDefault) && len(catalog) == 0 {
+		catalog = append(catalog, doActionsCatalogRef+":"+strings.Join(generateDefaultToolsPreset, ","))
+	}
+
+	// Selections for the same catalog server merge into one entry: the contract
+	// allows a server once, and two entries for do.actions would be rejected.
+	order := make([]string, 0, len(catalog))
+	selections := make(map[string][]string, len(catalog))
+	for _, raw := range catalog {
+		ref, sel, err := parseCatalogToolRef(raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, seen := selections[ref]; !seen {
+			order = append(order, ref)
+		}
+		selections[ref] = append(selections[ref], sel...)
+	}
+	for _, ref := range order {
+		sel := dedupeStrings(selections[ref])
+		if len(sel) == 0 {
+			tools = append(tools, ref)
+			continue
+		}
+		tools = append(tools, map[string][]string{ref: sel})
+	}
+
+	for _, srv := range a.MCPServers {
+		if err := validateInlineMCPServer(srv, a); err != nil {
+			return nil, err
+		}
+		tools = append(tools, srv)
+	}
+
+	return tools, nil
+}
+
+// parseCatalogToolRef splits `do.actions` or `do.actions:tool1,tool2` into the
+// server ref and its selection.
+func parseCatalogToolRef(raw string) (string, []string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil, fmt.Errorf("--%s cannot be empty", doctl.ArgAgentTool)
+	}
+	ref, rest, hasSel := strings.Cut(raw, ":")
+	ref = strings.TrimSpace(ref)
+	if !strings.HasPrefix(ref, doCatalogToolPrefix) {
+		return "", nil, fmt.Errorf("--%s %q must name a DO catalog server in the reserved do.* namespace (e.g. %s); attach any other MCP server with --%s", doctl.ArgAgentTool, raw, doActionsCatalogRef, doctl.ArgAgentMCPServer)
+	}
+	if !hasSel {
+		return ref, nil, nil
+	}
+	// A toolbelt reference carries its own colon (toolbelt:read-only), so the
+	// selection is re-split on commas rather than assumed to be a single name.
+	var sel []string
+	for _, part := range strings.Split(rest, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			sel = append(sel, part)
+		}
+	}
+	if len(sel) == 0 {
+		return "", nil, fmt.Errorf("--%s %q has an empty selection; drop the colon to attach every tool the server advertises", doctl.ArgAgentTool, raw)
+	}
+	return ref, sel, nil
+}
+
+func validateInlineMCPServer(srv generatedMCPServer, a *generateAnswers) error {
+	name := strings.TrimSpace(srv.Name)
+	if name == "" {
+		return fmt.Errorf("--%s needs a server name (NAME=URL)", doctl.ArgAgentMCPServer)
+	}
+	if strings.HasPrefix(name, doCatalogToolPrefix) {
+		return fmt.Errorf("MCP server %q cannot start with %q: that namespace is reserved for DO catalog refs", name, doCatalogToolPrefix)
+	}
+	if !strings.HasPrefix(srv.URL, "https://") {
+		return fmt.Errorf("MCP server %q must have an https:// URL (got %q)", name, srv.URL)
+	}
+	if srv.Auth != nil {
+		if !a.hasSecret(srv.Auth.Secret) {
+			return fmt.Errorf("MCP server %q authenticates with secret slot %q, which is not declared; add --%s %s", name, srv.Auth.Secret, doctl.ArgAgentSecret, srv.Auth.Secret)
+		}
+	}
+	return nil
+}
+
+func buildGeneratedPermissions(a *generateAnswers) *generatedPermissions {
+	def := strings.TrimSpace(a.PermissionDefault)
+	if def == "" && len(a.PermissionRules) == 0 {
+		return nil
+	}
+	return &generatedPermissions{Default: def, Rules: a.PermissionRules}
+}
+
+// --- parsing helpers --------------------------------------------------------
+
+// generateDurationRE mirrors the manifest contract's duration grammar: integer
+// hour/minute/second components, never a bare second count.
+var generateDurationRE = regexp.MustCompile(`^([0-9]+h)?([0-9]+m)?([0-9]+s)?$`)
+
+func validateGenerateDuration(flag, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if !generateDurationRE.MatchString(value) || value == "" {
+		return fmt.Errorf("--%s %q must be a duration of integer hours/minutes/seconds (e.g. 10m, 90s, 1h30m, 8h)", flag, value)
+	}
+	return nil
+}
+
+func validateGeneratedDurations(m *generatedManifest) error {
+	if err := validateGenerateDuration(doctl.ArgAgentIdleTimeout, m.IdleTimeout); err != nil {
+		return err
+	}
+	return validateGenerateDuration(doctl.ArgAgentMaxLifetime, m.MaxLifetime)
+}
+
+// secretSlotNameRE mirrors the contract: a slot name is the guest env var the
+// credential materializes as.
+var secretSlotNameRE = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+func validateSecretSlotName(name string) error {
+	if !secretSlotNameRE.MatchString(name) {
+		return fmt.Errorf("secret slot %q must be an upper-case environment variable name (A-Z, digits, underscores)", name)
+	}
+	if _, reserved := reservedAgentEnvKeys[name]; reserved {
+		return fmt.Errorf("secret slot %q is a reserved platform key", name)
+	}
+	return nil
+}
+
+// secretPlaceholder is the value written for a declared slot: a ${VAR}
+// reference doctl expands at create time, so the generated file stays
+// committable and the credential never lands on disk here.
+func secretPlaceholder(name string) string {
+	return "${" + name + "}"
+}
+
+// parseGenerateKeyValues parses repeatable KEY=VALUE flags without resolving
+// @file / - indirection, for flags whose values are plain config rather than
+// credentials.
+func parseGenerateKeyValues(flag string, pairs []string) (map[string]string, error) {
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(pairs))
+	for _, pair := range pairs {
+		key, value, err := parseKeyValueLine(pair)
+		if err != nil {
+			return nil, fmt.Errorf("--%s: %w", flag, err)
+		}
+		key = strings.TrimSpace(key)
+		if _, dup := out[key]; dup {
+			return nil, fmt.Errorf("--%s: duplicate key %q", flag, key)
+		}
+		out[key] = value
+	}
+	return out, nil
+}
+
+// parseGeneratePermissionRules turns TOOL[:match] flag values into rules. The
+// optional match is the bash-style `command` matcher, the only matcher the
+// contract exemplifies.
+func parseGeneratePermissionRules(flag, action string, values []string) ([]generatedPermissionRule, error) {
+	var rules []generatedPermissionRule
+	for _, raw := range values {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		tool, match, hasMatch := strings.Cut(raw, ":")
+		tool = strings.TrimSpace(tool)
+		if tool == "" {
+			return nil, fmt.Errorf("--%s %q needs a tool name (e.g. bash, file.write, do.actions/web_search)", flag, raw)
+		}
+		rule := generatedPermissionRule{Tool: tool, Action: action}
+		// A server-qualified MCP target keeps its own colon (do.actions/toolbelt:read-only),
+		// so only treat the tail as a matcher when the head is not itself qualified.
+		if hasMatch && strings.TrimSpace(match) != "" && !strings.Contains(tool, "/") {
+			rule.Match = map[string]string{"command": strings.TrimSpace(match)}
+		} else if hasMatch && strings.Contains(tool, "/") {
+			rule.Tool = raw
+		}
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+// parseGenerateMCPServers assembles inline MCP servers from the three flags
+// that describe them, keyed by server name.
+func parseGenerateMCPServers(servers, toolSels, authSecrets []string) ([]generatedMCPServer, error) {
+	if len(servers) == 0 {
+		if len(toolSels) > 0 || len(authSecrets) > 0 {
+			return nil, fmt.Errorf("--%s and --%s need a matching --%s NAME=URL", doctl.ArgAgentMCPTools, doctl.ArgAgentMCPAuthSecret, doctl.ArgAgentMCPServer)
+		}
+		return nil, nil
+	}
+
+	order := make([]string, 0, len(servers))
+	byName := make(map[string]*generatedMCPServer, len(servers))
+	for _, raw := range servers {
+		name, url, err := parseKeyValueLine(raw)
+		if err != nil {
+			return nil, fmt.Errorf("--%s: %w (expected NAME=URL)", doctl.ArgAgentMCPServer, err)
+		}
+		name = strings.TrimSpace(name)
+		if _, dup := byName[name]; dup {
+			return nil, fmt.Errorf("--%s: duplicate server %q", doctl.ArgAgentMCPServer, name)
+		}
+		byName[name] = &generatedMCPServer{Name: name, URL: strings.TrimSpace(url)}
+		order = append(order, name)
+	}
+
+	for _, raw := range toolSels {
+		name, list, found := strings.Cut(strings.TrimSpace(raw), ":")
+		name = strings.TrimSpace(name)
+		srv, ok := byName[name]
+		if !found || !ok {
+			return nil, fmt.Errorf("--%s %q must be NAME:tool[,tool] naming a server declared with --%s", doctl.ArgAgentMCPTools, raw, doctl.ArgAgentMCPServer)
+		}
+		for _, tool := range strings.Split(list, ",") {
+			if tool = strings.TrimSpace(tool); tool != "" {
+				srv.Tools = append(srv.Tools, tool)
+			}
+		}
+	}
+
+	for _, raw := range authSecrets {
+		name, slot, err := parseKeyValueLine(raw)
+		if err != nil {
+			return nil, fmt.Errorf("--%s: %w (expected NAME=SECRET_SLOT)", doctl.ArgAgentMCPAuthSecret, err)
+		}
+		srv, ok := byName[strings.TrimSpace(name)]
+		if !ok {
+			return nil, fmt.Errorf("--%s %q names a server not declared with --%s", doctl.ArgAgentMCPAuthSecret, raw, doctl.ArgAgentMCPServer)
+		}
+		srv.Auth = &generatedMCPAuth{Secret: strings.TrimSpace(slot)}
+	}
+
+	out := make([]generatedMCPServer, 0, len(order))
+	for _, name := range order {
+		out = append(out, *byName[name])
+	}
+	return out, nil
+}
+
+// parseGenerateSkills reads each NAME=path skill file into an inline skill. The
+// description is the file's first non-blank line unless overridden, matching how
+// a SKILL.md leads with what it is for.
+func parseGenerateSkills(skills, descriptions []string) ([]generatedSkill, error) {
+	if len(skills) == 0 {
+		if len(descriptions) > 0 {
+			return nil, fmt.Errorf("--%s needs a matching --%s NAME=PATH", doctl.ArgAgentSkillDescription, doctl.ArgAgentSkill)
+		}
+		return nil, nil
+	}
+
+	overrides, err := parseGenerateKeyValues(doctl.ArgAgentSkillDescription, descriptions)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]generatedSkill, 0, len(skills))
+	seen := make(map[string]struct{}, len(skills))
+	for _, raw := range skills {
+		name, path, err := parseKeyValueLine(raw)
+		if err != nil {
+			return nil, fmt.Errorf("--%s: %w (expected NAME=PATH)", doctl.ArgAgentSkill, err)
+		}
+		name = strings.TrimSpace(name)
+		if !skillNameRE.MatchString(name) {
+			return nil, fmt.Errorf("--%s: skill name %q must be lowercase letters, digits, and single hyphens", doctl.ArgAgentSkill, name)
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("--%s: duplicate skill %q", doctl.ArgAgentSkill, name)
+		}
+		seen[name] = struct{}{}
+
+		body, err := os.ReadFile(filepath.Clean(strings.TrimSpace(path)))
+		if err != nil {
+			return nil, fmt.Errorf("--%s %s: %w", doctl.ArgAgentSkill, name, err)
+		}
+		instructions := strings.TrimSpace(string(body))
+		if instructions == "" {
+			return nil, fmt.Errorf("--%s %s: %s is empty", doctl.ArgAgentSkill, name, path)
+		}
+		description := overrides[name]
+		if strings.TrimSpace(description) == "" {
+			description = firstMeaningfulLine(instructions)
+		}
+		if strings.TrimSpace(description) == "" {
+			return nil, fmt.Errorf("--%s %s: no description found; add --%s %s=...", doctl.ArgAgentSkill, name, doctl.ArgAgentSkillDescription, name)
+		}
+		out = append(out, generatedSkill{Name: name, Description: description, Instructions: instructions})
+	}
+	return out, nil
+}
+
+// firstMeaningfulLine returns the first non-blank line with markdown heading
+// punctuation stripped, so `# Release checklist` becomes a usable description.
+func firstMeaningfulLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(line), "#"))
+		if line != "" {
+			return strings.TrimSpace(line)
+		}
+	}
+	return ""
+}
+
+// egressHostFor reduces a URL the manifest points at — an MCP server, an
+// inference endpoint — to the bare host an egress entry needs.
+func egressHostFor(rawURL string) string {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(rawURL), "https://")
+	host, _, _ := strings.Cut(trimmed, "/")
+	host, _, _ = strings.Cut(host, ":")
+	return strings.TrimSpace(host)
+}
+
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+func dedupeHosts(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, host := range in {
+		host = strings.TrimSpace(host)
+		if host == "" {
+			continue
+		}
+		key := strings.ToLower(host)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, host)
+	}
+	return out
+}
+
+func nonEmptyStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
+// sortedKeys is used where a stable presentation order is needed for display;
+// the encoders sort map keys themselves.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// --- encoding ---------------------------------------------------------------
+
+const (
+	generateFormatYAML = "yaml"
+	generateFormatJSON = "json"
+)
+
+// encodeGeneratedManifest renders the manifest in the requested format. YAML is
+// the default because that is what `config create --spec` and the contract's own
+// examples use; JSON is offered for programmatic consumers that would otherwise
+// need a YAML parser.
+func encodeGeneratedManifest(m *generatedManifest, format string) ([]byte, error) {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "", generateFormatYAML, "yml":
+		out, err := yaml.Marshal(m)
+		if err != nil {
+			return nil, fmt.Errorf("encoding manifest: %w", err)
+		}
+		return out, nil
+	case generateFormatJSON:
+		out, err := json.MarshalIndent(m, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("encoding manifest: %w", err)
+		}
+		return append(out, '\n'), nil
+	default:
+		return nil, fmt.Errorf("--%s must be %s or %s (got %q)", doctl.ArgAgentManifestFormat, generateFormatYAML, generateFormatJSON, format)
+	}
+}

--- a/commands/agent_config_generate_models_test.go
+++ b/commands/agent_config_generate_models_test.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The Serverless Inference catalog mixes agent-capable models with embedding,
+// reranking, and media-generation ones, and its list endpoint reports no type,
+// so the family is read off the id. This pins that heuristic against a real
+// snapshot of the catalog: a false negative hides a model people want, and a
+// false positive offers one whose first turn cannot work.
+func TestIsGenerateChatModel(t *testing.T) {
+	notChat := []string{
+		"all-mini-lm-l6-v2",
+		"bge-m3",
+		"bge-reranker-v2-m3",
+		"e5-large-v2",
+		"gte-large-en-v1.5",
+		"multi-qa-mpnet-base-dot-v1",
+		"qwen3-embedding-0.6b",
+		"openai-gpt-image-1",
+		"openai-gpt-image-1.5",
+		"openai-gpt-image-2",
+		"stable-diffusion-3.5-large",
+		"qwen3-tts-voicedesign",
+		"wan2-2-t2v-a14b",
+	}
+	for _, id := range notChat {
+		assert.False(t, isGenerateChatModel(id), "%s should be filtered out", id)
+	}
+
+	chat := []string{
+		"anthropic-claude-4.5-sonnet",
+		"anthropic-claude-opus-5",
+		"arcee-trinity-large-thinking",
+		"deepseek-v4-pro",
+		"gemma-4-31B-it",
+		"glm-5.3-flash",
+		"kimi-k3",
+		"llama-4-maverick",
+		"mistral-3-14B",
+		"nemotron-3-nano-omni",
+		"nemotron-nano-12b-v2-vl",
+		"nvidia-nemotron-3-super-120b",
+		"openai-gpt-5.3-codex",
+		"openai-gpt-oss-120b",
+		"openai-o3",
+		"qwen3.8-max",
+		// The smart routers are chat endpoints, and one of them is aimed at
+		// exactly this use case.
+		"router:software-engineering",
+	}
+	for _, id := range chat {
+		assert.True(t, isGenerateChatModel(id), "%s should be offered", id)
+	}
+}
+
+// Every harness's preferred DigitalOcean model must survive the filter, or the
+// picker would never be able to promote it to the Enter default.
+func TestGenerateDOModelHintsAreChatModels(t *testing.T) {
+	for _, h := range generateHarnessCatalog {
+		if h.Inference == nil || h.Inference.DOModelHint == "" {
+			continue
+		}
+		assert.True(t, isGenerateChatModel(h.Inference.DOModelHint), "%s: %s", h.ID, h.Inference.DOModelHint)
+	}
+}

--- a/commands/agent_config_generate_test.go
+++ b/commands/agent_config_generate_test.go
@@ -1,0 +1,403 @@
+/*
+Copyright 2018 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateFor runs the flag-only path — the same one --no-interactive and any
+// agent driving doctl take — and returns the encoded manifest.
+func generateFor(t *testing.T, a *generateAnswers) string {
+	t.Helper()
+	require.NoError(t, applyGenerateDerivations(a))
+	m, err := buildGeneratedManifest(a)
+	require.NoError(t, err)
+	out, err := encodeGeneratedManifest(m, generateFormatYAML)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func TestGenerate_FlagOnlyGolden(t *testing.T) {
+	a := &generateAnswers{
+		Harness:           "claude-code",
+		Name:              "payments-reviewer",
+		Repos:             []string{"acme/payments-service"},
+		GitHubAccess:      true,
+		ToolsPreset:       generateToolsPresetDefault,
+		PermissionDefault: generateDefaultPermission,
+	}
+
+	const want = `name: payments-reviewer
+agent: claude-code
+repos:
+- acme/payments-service
+secrets:
+  ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+  GITHUB_TOKEN: oauth/github
+egress:
+- github.com
+- api.github.com
+tools:
+- do.actions:
+  - web_search
+  - execute_code
+  - toolbelt:read-only
+permissions:
+  default: ask
+`
+	assert.Equal(t, want, generateFor(t, a))
+}
+
+// The generator's whole job is emitting a manifest the platform accepts, so
+// every harness must round-trip through the same validator `validate` uses
+// without a single warning. Warnings here are how a stale env mapping shows up.
+func TestGenerate_RoundTripsValidatorCleanly(t *testing.T) {
+	providers := []struct {
+		provider string
+		url      string
+		model    string
+	}{
+		{provider: inferenceProviderNative},
+		{provider: inferenceProviderNative, model: "some-model"},
+		{provider: inferenceProviderDO, model: "do-catalog-slug"},
+		{provider: inferenceProviderCustom, url: "https://llm.example.com/v1", model: "served-model"},
+	}
+
+	for _, h := range generateHarnessCatalog {
+		for _, p := range providers {
+			name := h.ID + "/" + p.provider
+			if p.model != "" && p.provider == inferenceProviderNative {
+				name += "-with-model"
+			}
+			t.Run(name, func(t *testing.T) {
+				a := &generateAnswers{
+					Harness:           h.ID,
+					Name:              "rt",
+					InferenceProvider: p.provider,
+					InferenceURL:      p.url,
+					Model:             p.model,
+					ToolsPreset:       generateToolsPresetDefault,
+					PermissionDefault: generateDefaultPermission,
+				}
+				if h.ID == "custom" {
+					a.Image = "registry.example.com/agent@sha256:" + strings.Repeat("a", 64)
+					a.Entrypoint = []string{"/bin/agent"}
+				}
+				if h.Inference == nil && p.provider != inferenceProviderNative {
+					// Harnesses that never call a model endpoint reject the
+					// choice outright; that path is asserted separately.
+					require.Error(t, applyGenerateDerivations(a))
+					return
+				}
+				if h.Inference != nil && h.Inference.NativeOnly && p.provider != inferenceProviderNative {
+					require.Error(t, applyGenerateDerivations(a))
+					return
+				}
+
+				v := validateAgentManifest([]byte(generateFor(t, a)))
+				assert.True(t, v.ok(), "errors=%v", v.Errors)
+				assert.Empty(t, v.Warnings)
+			})
+		}
+	}
+}
+
+func TestGenerate_InferenceWiring(t *testing.T) {
+	tests := []struct {
+		name     string
+		answers  generateAnswers
+		wantEnv  map[string]string
+		wantKey  string
+		wantHost string
+	}{
+		{
+			// Native with no model is the Enter-through default: one vendor key
+			// and nothing else, so the agent uses the model it ships with.
+			name:    "native declares only the vendor key",
+			answers: generateAnswers{Harness: "claude-code", InferenceProvider: inferenceProviderNative},
+			wantEnv: nil,
+			wantKey: "ANTHROPIC_API_KEY",
+		},
+		{
+			// claude-code has no model env of its own, so a pinned model has to
+			// travel as HARNESS_INFERENCE_MODEL; ANTHROPIC_MODEL is what the
+			// CLI itself reads.
+			name:    "native claude-code pins a model through both vars",
+			answers: generateAnswers{Harness: "claude-code", InferenceProvider: inferenceProviderNative, Model: "claude-sonnet-4-5"},
+			wantEnv: map[string]string{
+				"ANTHROPIC_MODEL":        "claude-sonnet-4-5",
+				harnessInferenceModelEnv: "claude-sonnet-4-5",
+			},
+			wantKey: "ANTHROPIC_API_KEY",
+		},
+		{
+			// codex reads MODEL, so the native path uses it rather than the
+			// harness var.
+			name:    "native codex uses its own model var",
+			answers: generateAnswers{Harness: "codex", InferenceProvider: inferenceProviderNative, Model: "gpt-5-codex"},
+			wantEnv: map[string]string{"MODEL": "gpt-5-codex"},
+			wantKey: "OPENAI_API_KEY",
+		},
+		{
+			// Endpoint routing must not declare the vendor key: the runtime
+			// prefers it and would ignore the endpoint entirely.
+			name:    "do inference swaps the key and sets the endpoint",
+			answers: generateAnswers{Harness: "opencode", InferenceProvider: inferenceProviderDO, Model: "deepseek-v4-pro"},
+			wantEnv: map[string]string{
+				harnessInferenceBaseURLEnv: doInferenceBaseURL,
+				harnessInferenceModelEnv:   "deepseek-v4-pro",
+			},
+			wantKey: harnessInferenceAPIKeyEnv,
+		},
+		{
+			name:    "custom endpoint also opens egress for its host",
+			answers: generateAnswers{Harness: "codex", InferenceProvider: inferenceProviderCustom, InferenceURL: "https://llm.internal.example.com/v1", Model: "served"},
+			wantEnv: map[string]string{
+				harnessInferenceBaseURLEnv: "https://llm.internal.example.com/v1",
+				harnessInferenceModelEnv:   "served",
+			},
+			wantKey:  harnessInferenceAPIKeyEnv,
+			wantHost: "llm.internal.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := tt.answers
+			require.NoError(t, applyGenerateDerivations(&a))
+
+			assert.Equal(t, tt.wantEnv, a.Env)
+			assert.Equal(t, []string{tt.wantKey}, a.secretNames())
+			if tt.wantHost != "" {
+				assert.Contains(t, a.Egress, tt.wantHost)
+			} else {
+				assert.Empty(t, a.Egress)
+			}
+			// The vendor key and the endpoint key are never both declared.
+			if tt.wantKey == harnessInferenceAPIKeyEnv {
+				harness, _ := lookupGenerateHarness(a.Harness)
+				assert.False(t, a.hasSecret(harness.Inference.NativeKeyEnv))
+			}
+		})
+	}
+}
+
+// DigitalOcean's endpoint publishes no default model, and an arbitrary endpoint
+// tells doctl nothing, so both must refuse rather than emit a manifest whose
+// first turn fails.
+func TestGenerate_InferenceRejectsUnusableCombinations(t *testing.T) {
+	tests := []struct {
+		name    string
+		answers generateAnswers
+		wantErr string
+	}{
+		{
+			name:    "do inference without a model",
+			answers: generateAnswers{Harness: "opencode", InferenceProvider: inferenceProviderDO},
+			wantErr: "needs --model",
+		},
+		{
+			name:    "custom endpoint without a url",
+			answers: generateAnswers{Harness: "opencode", InferenceProvider: inferenceProviderCustom, Model: "m"},
+			wantErr: "needs --inference-url",
+		},
+		{
+			name:    "custom endpoint without a model",
+			answers: generateAnswers{Harness: "opencode", InferenceProvider: inferenceProviderCustom, InferenceURL: "https://llm.example.com/v1"},
+			wantErr: "needs --model",
+		},
+		{
+			name:    "plaintext endpoint",
+			answers: generateAnswers{Harness: "opencode", InferenceProvider: inferenceProviderCustom, InferenceURL: "http://llm.example.com/v1", Model: "m"},
+			wantErr: "must be an https:// URL",
+		},
+		{
+			name:    "unknown provider",
+			answers: generateAnswers{Harness: "opencode", InferenceProvider: "bogus"},
+			wantErr: "must be native, do, or custom",
+		},
+		{
+			// Cursor's agent talks to Cursor, so an endpoint override would be
+			// silently ignored rather than honored.
+			name:    "endpoint override on a fixed-backend harness",
+			answers: generateAnswers{Harness: "cursor", InferenceProvider: inferenceProviderDO, Model: "m"},
+			wantErr: "only supports native inference",
+		},
+		{
+			// The loop runs at OpenAI, so the sandbox never calls a model.
+			name:    "endpoint override on an externally-hosted loop",
+			answers: generateAnswers{Harness: "codex-agentapi", InferenceProvider: inferenceProviderDO, Model: "m"},
+			wantErr: "does not apply",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := tt.answers
+			err := applyGenerateDerivations(&a)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			// doctl's error beautifier rewrites any message naming the vendor
+			// into an unrelated "check your API key" card, so these must not.
+			assert.NotContains(t, strings.ToLower(err.Error()), "openai")
+		})
+	}
+}
+
+// --no-interactive exists to be the wizard's Enter key, so its defaults have to
+// come from the same place rather than a second, barer set.
+func TestGenerate_EnterDefaultsMatchWizardDefaults(t *testing.T) {
+	restore := creationClock
+	creationClock = func() time.Time { return time.Date(2026, 9, 2, 11, 48, 0, 0, time.UTC) }
+	defer func() { creationClock = restore }()
+
+	a := &generateAnswers{Harness: "claude-code"}
+	applyGenerateEnterDefaults(a)
+
+	assert.Equal(t, "claude-code-0902-1148", a.Name)
+	assert.Equal(t, inferenceProviderNative, a.InferenceProvider)
+	assert.Equal(t, generateToolsPresetDefault, a.ToolsPreset)
+	assert.Equal(t, generateDefaultPermission, a.PermissionDefault)
+	// Questions whose default is "nothing" stay unset, and nothing is inferred
+	// from the working directory.
+	assert.Empty(t, a.Repos)
+	assert.Empty(t, a.Model)
+	assert.Empty(t, a.MCPServers)
+	assert.Empty(t, a.Skills)
+}
+
+// Running derivations twice is what lets the wizard show a truthful review card
+// and then write the file, so it must not double up slots or hosts.
+func TestGenerate_DerivationsAreIdempotent(t *testing.T) {
+	a := &generateAnswers{
+		Harness:           "codex",
+		Name:              "twice",
+		Repos:             []string{"acme/api"},
+		GitHubAccess:      true,
+		InferenceProvider: inferenceProviderCustom,
+		InferenceURL:      "https://llm.example.com/v1",
+		Model:             "m",
+	}
+	require.NoError(t, applyGenerateDerivations(a))
+	first := generateFor(t, a)
+	assert.Equal(t, first, generateFor(t, a))
+}
+
+// Highlighting must never reach a pipe: `generate > agents.yaml` and
+// `generate | config create --spec -` have to receive the bytes that were
+// validated, not a decorated copy of them.
+func TestHighlightManifest_PassesBytesThroughUnstyled(t *testing.T) {
+	restore := stylingEnabled
+	stylingEnabled = false
+	defer func() { stylingEnabled = restore }()
+
+	const manifest = `name: reviewer
+agent: claude-code
+secrets:
+  ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+`
+	assert.Equal(t, manifest, highlightManifest([]byte(manifest)))
+}
+
+// With styling on, the added bytes must be ANSI and nothing else: the document
+// has to survive being copied out of the terminal, which keeps plain text only.
+func TestHighlightManifest_AddsOnlyANSI(t *testing.T) {
+	restore := stylingEnabled
+	stylingEnabled = true
+	// lipgloss decides separately whether to emit escapes, and under `go test`
+	// it sees no terminal (and honors NO_COLOR), so the profile is forced or
+	// this asserts nothing.
+	restoreProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer func() {
+		stylingEnabled = restore
+		lipgloss.SetColorProfile(restoreProfile)
+	}()
+
+	const manifest = `name: reviewer
+agent: claude-code
+repos:
+- acme/api
+env:
+  HARNESS_INFERENCE_BASE_URL: https://inference.do-ai.run/v1
+secrets:
+  ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+tools:
+- name: linear
+  url: https://mcp.linear.app/sse
+`
+	styled := highlightManifest([]byte(manifest))
+	require.NotEqual(t, manifest, styled, "expected styling to be applied")
+
+	ansi := regexp.MustCompile("\x1b\\[[0-9;]*m")
+	assert.Equal(t, manifest, ansi.ReplaceAllString(styled, ""))
+}
+
+func TestSplitManifestKey(t *testing.T) {
+	tests := []struct {
+		node  string
+		key   string
+		value string
+		ok    bool
+	}{
+		{node: "name: reviewer", key: "name", value: "reviewer", ok: true},
+		{node: "secrets:", key: "secrets", ok: true},
+		// The colon in a URL must not be mistaken for the key separator, or
+		// half the scheme would be colored as a key.
+		{node: "url: https://mcp.linear.app/sse", key: "url", value: "https://mcp.linear.app/sse", ok: true},
+		{node: `"name": "as-json",`, key: `"name"`, value: `"as-json",`, ok: true},
+		// A colon inside a quoted scalar is not a separator either.
+		{node: `"toolbelt:read-only",`, ok: false},
+		{node: "web_search", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.node, func(t *testing.T) {
+			key, _, value, ok := splitManifestKey(tt.node)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.key, key)
+			assert.Equal(t, tt.value, value)
+		})
+	}
+}
+
+func TestGenerate_JSONFormat(t *testing.T) {
+	a := &generateAnswers{Harness: "opencode", Name: "as-json"}
+	require.NoError(t, applyGenerateDerivations(a))
+	m, err := buildGeneratedManifest(a)
+	require.NoError(t, err)
+
+	out, err := encodeGeneratedManifest(m, generateFormatJSON)
+	require.NoError(t, err)
+	assert.Equal(t, `{
+  "name": "as-json",
+  "agent": "opencode",
+  "secrets": {
+    "OPENAI_API_KEY": "${OPENAI_API_KEY}"
+  }
+}
+`, string(out))
+
+	_, err = encodeGeneratedManifest(m, "toml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be yaml or json")
+}

--- a/commands/agent_config_generate_wizard.go
+++ b/commands/agent_config_generate_wizard.go
@@ -1,0 +1,910 @@
+/*
+Copyright 2026 The Doctl Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/digitalocean/doctl"
+	"github.com/digitalocean/doctl/commands/charm/confirm"
+	"github.com/digitalocean/doctl/commands/charm/input"
+	"github.com/digitalocean/doctl/commands/charm/selection"
+	"github.com/erikgeiser/promptkit"
+	"golang.org/x/term"
+)
+
+// The interactive half of `config generate`.
+//
+// Two rules shape every step. First, a step that a flag already answered is
+// skipped, so the wizard is a gap-filler rather than a mode: `--harness codex`
+// on a terminal asks everything except the harness. Second, every question is
+// answerable with Enter — its default is shown in the prompt rather than
+// applied silently afterwards — so the fast path through a fresh manifest is
+// naming it and pressing Enter through the rest.
+//
+// Prompts render inline (never an alternate screen) so the finished Q&A stays
+// in scrollback next to the manifest it produced.
+
+// The prompt seam. Each is a package var so tests can drive the whole wizard
+// without a terminal, the same way promptEnvVarValue is replaced in env tests.
+var (
+	generatePromptText    = defaultGeneratePromptText
+	generatePromptSelect  = defaultGeneratePromptSelect
+	generatePromptConfirm = defaultGeneratePromptConfirm
+)
+
+// generateSelectPageSize is where a picker starts scrolling rather than
+// printing every option. Sized so the question and the list still fit a short
+// terminal together.
+const generateSelectPageSize = 10
+
+// generateChoice is one option in a picker: the value written to the manifest,
+// what the user reads, and an optional trailing hint.
+//
+// Hints are for options whose name does not speak for itself — a size's specs,
+// what `ask` means. Named products (harnesses, models, providers) carry no
+// hint: a sentence each turns a glanceable list into a wall of text.
+type generateChoice struct {
+	ID    string
+	Label string
+	Hint  string
+}
+
+func (c generateChoice) display() string {
+	if c.Hint == "" {
+		return c.Label
+	}
+	return c.Label + " — " + c.Hint
+}
+
+func defaultGeneratePromptText(question, placeholder string, secret bool) (string, error) {
+	opts := []input.Option{}
+	if placeholder != "" {
+		opts = append(opts, input.WithPlaceholder(placeholder))
+	}
+	if secret {
+		opts = append(opts, input.WithHidden())
+	}
+	answer, err := input.New(question+" ", opts...).Prompt()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(answer), nil
+}
+
+func defaultGeneratePromptSelect(question string, choices []generateChoice) (string, error) {
+	labels := make([]string, 0, len(choices))
+	for _, ch := range choices {
+		labels = append(labels, ch.display())
+	}
+	// Filtering is off: typing should never be swallowed by a filter the user
+	// did not know was there. Long lists scroll instead, so a service catalog
+	// cannot push the question itself off screen.
+	opts := []selection.Option{
+		selection.WithPrompt(question),
+		selection.WithFiltering(false),
+	}
+	if len(labels) > generateSelectPageSize {
+		opts = append(opts, selection.WithPageSize(generateSelectPageSize))
+	}
+	picked, err := selection.New(labels, opts...).Select()
+	if err != nil {
+		return "", err
+	}
+	for _, ch := range choices {
+		if ch.display() == picked {
+			return ch.ID, nil
+		}
+	}
+	return "", fmt.Errorf("unrecognized selection %q", picked)
+}
+
+func defaultGeneratePromptConfirm(question string, defaultYes bool) (bool, error) {
+	def := confirm.No
+	if defaultYes {
+		def = confirm.Yes
+	}
+	choice, err := confirm.New(question, confirm.WithDefaultChoice(def)).Prompt()
+	if err != nil {
+		return false, err
+	}
+	return choice == confirm.Yes, nil
+}
+
+// agentGenerateCanPrompt reports whether the wizard may run: the user has not
+// opted out with --no-interactive, and both ends of the terminal are real. The
+// stdout check is what makes `generate > agents.yaml` silently non-interactive
+// instead of writing prompts into the file.
+func agentGenerateCanPrompt() bool {
+	if !Interactive {
+		return false
+	}
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// isPromptCanceled reports whether an error is a user cancel (Ctrl+C, Esc)
+// rather than a failure. Cancel is a normal outcome for a wizard, so it exits
+// quietly with nothing written instead of printing a Go error.
+func isPromptCanceled(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, promptkit.ErrAborted) {
+		return true
+	}
+	msg := err.Error()
+	return msg == "no decision was made" || strings.Contains(msg, "canceled")
+}
+
+// runAgentGenerateWizard fills in whatever the flags left unanswered.
+func runAgentGenerateWizard(c *CmdConfig, a *generateAnswers, dest *generateDestination, notes io.Writer) error {
+	stylingEnabled = detectStyling()
+	printGenerateHeader(notes)
+
+	// The harness comes first: it is the one decision with no default, and it
+	// shapes the defaults of everything after it (suggested name, credential
+	// slots, template, model).
+	steps := []func(*CmdConfig, *generateAnswers, io.Writer) error{
+		askGenerateHarness,
+		askGenerateName,
+		askGenerateCustomImage,
+		askGenerateRepos,
+		askGenerateGitHubAccess,
+		askGenerateInference,
+		askGenerateSize,
+		askGenerateTools,
+		askGeneratePermissions,
+		askGenerateSkills,
+	}
+	for _, step := range steps {
+		if err := step(c, a, notes); err != nil {
+			return err
+		}
+	}
+
+	// Derive now rather than after confirming, so the review card names the
+	// credential slots and egress hosts the answers imply — the parts a user
+	// most needs to see before agreeing to them.
+	if err := applyGenerateDerivations(a); err != nil {
+		return err
+	}
+
+	// The review is the last chance to back out, so it runs before the
+	// destination is chosen and before anything touches the filesystem.
+	printGenerateReview(notes, a)
+	ok, err := generatePromptConfirm("Generate this manifest?", true)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errGenerateCanceled
+	}
+
+	return askGenerateDestination(a, dest, notes)
+}
+
+// errGenerateCanceled declines at the review step. It is reported through the
+// same quiet path as a Ctrl+C so a decline never looks like a failure.
+var errGenerateCanceled = errors.New("canceled")
+
+func printGenerateHeader(w io.Writer) {
+	fmt.Fprintf(w, "\n%s %s\n", boldColor("Generate an agent manifest", colHighlight), colorize("· nothing is created until you run it", colMuted))
+	fmt.Fprintf(w, "%s\n\n", colorize("Enter accepts the shown default at every step.", colMuted))
+}
+
+// --- steps ------------------------------------------------------------------
+
+func askGenerateName(c *CmdConfig, a *generateAnswers, w io.Writer) error {
+	if a.Name != "" {
+		return nil
+	}
+	suggestion := suggestGenerateName(a.Harness)
+	name, err := generatePromptText(fmt.Sprintf("Name? (Enter for %s)", suggestion), suggestion, false)
+	if err != nil {
+		return err
+	}
+	if name == "" {
+		name = suggestion
+	}
+	if err := validateHostedAgentIdentifier(name); err != nil {
+		return err
+	}
+	a.Name = name
+	return nil
+}
+
+// suggestGenerateName offers a name that is readable and unlikely to collide
+// with a live session, so the very first question can be answered with Enter.
+// It reads the same injectable clock the create-progress code uses, so
+// generated output is assertable in tests.
+func suggestGenerateName(harness string) string {
+	base := strings.TrimSpace(harness)
+	if base == "" {
+		base = "agent"
+	}
+	return fmt.Sprintf("%s-%s", base, creationClock().Format("0102-1504"))
+}
+
+func askGenerateHarness(c *CmdConfig, a *generateAnswers, w io.Writer) error {
+	if a.Harness != "" {
+		return nil
+	}
+	// Names only. These are products the user already came here to pick
+	// between, so a sentence about each one is length without information.
+	choices := make([]generateChoice, 0, len(generateHarnessCatalog))
+	for _, h := range generateHarnessCatalog {
+		choices = append(choices, generateChoice{ID: h.ID, Label: h.Label})
+	}
+	harness, err := generatePromptSelect("Which harness?", choices)
+	if err != nil {
+		return err
+	}
+	a.Harness = harness
+	return nil
+}
+
+func askGenerateCustomImage(c *CmdConfig, a *generateAnswers, w io.Writer) error {
+	if a.Harness != "custom" || a.Image != "" {
+		return nil
+	}
+	fmt.Fprintf(w, "%s\n", colorize("  A custom agent runs your image; pin it by digest so the run is reproducible.", colMuted))
+	image, err := generatePromptText("Container image?", "registry.digitalocean.com/team/agent@sha256:…", false)
+	if err != nil {
+		return err
+	}
+	if image == "" {
+		return fmt.Errorf("a custom agent needs an image; re-run with --%s", doctl.ArgAgentImage)
+	}
+	a.Image = image
+
+	if len(a.Entrypoint) > 0 {
+		return nil
+	}
+	entrypoint, err := generatePromptText("Entrypoint? (Enter to use the image's own)", "/usr/local/bin/agent --serve", false)
+	if err != nil {
+		return err
+	}
+	if entrypoint != "" {
+		a.Entrypoint = strings.Fields(entrypoint)
+	}
+	return nil
+}
+
+func askGenerateRepos(c *CmdConfig, a *generateAnswers, w io.Writer) error {
+	if len(a.Repos) > 0 {
+		return nil
+	}
+	attach, err := generatePromptConfirm("Attach a GitHub repository?", true)
+	if err != nil {
+		return err
+	}
+	if !attach {
+		return nil
+	}
+	for {
+		repo, err := generatePromptText("Repository? (owner/repo)", "digitalocean/doctl", false)
+		if err != nil {
+			return err
+		}
+		if repo == "" {
+			return nil
+		}
+		ref, err := normalizeHarnessRepoRef(repo)
+		if err != nil {
+			// A typo should cost one retry, not the whole wizard.
+			fmt.Fprintf(w, "  %s %s\n", colorize("✗", colError), colorize(err.Error(), colMuted))
+			continue
+		}
+		a.Repos = append(a.Repos, ref)
+
+		more, err := generatePromptConfirm("Attach another?", false)
+		if err != nil {
+			return err
+		}
+		if !more {
+			return nil
+		}
+	}
+}
+
+func askGenerateGitHubAccess(c *CmdConfig, a *generateAnswers, w io.Writer) error {
+	if len(a.Repos) == 0 || a.GitHubAccess || a.hasSecret(generateGitHubOAuthSlot) {
+		return nil
+	}
+	fmt.Fprintf(w, "%s\n", colorize("  Lets the agent clone, push, and open pull requests as you.", colMuted))
+	grant, err := generatePromptConfirm("Grant GitHub access?", true)
+	if err != nil {
+		return err
+	}
+	a.GitHubAccess = grant
+	return nil
+}
+
+// askGenerateInference asks where the model comes from, then which model.
+//
+// The two questions belong together: the provider decides which environment
+// variables the manifest writes, whether a model id is required at all, and —
+// because DigitalOcean's gateway uses its own slugs — which id space the answer
+// has to be in. Asking for a model without asking for a provider is what makes
+// a model answer unattachable.
+func askGenerateInference(c *CmdConfig, a *generateAnswers, w io.Writer) error {
+	harness, ok := lookupGenerateHarness(a.Harness)
+	if !ok || harness.Inference == nil {
+		// A custom image, or the OpenAI-hosted loop: the sandbox never calls a
+		// model endpoint, so there is nothing to choose.
+		return nil
+	}
+	inf := harness.Inference
+
+	if a.InferenceProvider == "" {
+		if inf.NativeOnly {
+			a.InferenceProvider = inferenceProviderNative
+		} else {
+			choices := []generateChoice{
+				{ID: inferenceProviderDO, Label: "DigitalOcean Serverless Inference (recommended)"},
+				{ID: inferenceProviderNative, Label: inf.ProviderLabel},
+				{ID: inferenceProviderCustom, Label: "Custom endpoint"},
+			}
+			provider, err := generatePromptSelect("Where should inference come from?", choices)
+			if err != nil {
+				return err
+			}
+			a.InferenceProvider = provider
+		}
+	}
+
+	if a.InferenceProvider == inferenceProviderCustom && a.InferenceURL == "" {
+		url, err := generatePromptText("Endpoint base URL?", "https://llm.internal.example.com/v1", false)
+		if err != nil {
+			return err
+		}
+		if url == "" {
+			return fmt.Errorf("a custom inference endpoint needs a base URL")
+		}
+		a.InferenceURL = url
+	}
+
+	if a.Model != "" {
+		return nil
+	}
+	switch a.InferenceProvider {
+	case inferenceProviderDO:
+		return askGenerateDOModel(c, a, w, inf)
+	case inferenceProviderCustom:
+		model, err := generatePromptText("Model?", inf.NativeModelHint, false)
+		if err != nil {
+			return err
+		}
+		if model == "" {
+			return fmt.Errorf("a custom inference endpoint needs a model id")
+		}
+		a.Model = model
+	default:
+		// Optional: leaving it blank keeps whatever the agent ships with, which
+		// is why this is the Enter-through path.
+		model, err := generatePromptText("Model? (Enter for the agent's default)", inf.NativeModelHint, false)
+		if err != nil {
+			return err
+		}
+		a.Model = model
+	}
+	return nil
+}
+
+// generateModelOtherID is the picker entry that drops to typing an id. It
+// cannot collide with a model id, since ids come from a URL path segment.
+const generateModelOtherID = "/other"
+
+// askGenerateDOModel picks the model for Serverless Inference. A model is
+// required here — the gateway has no default — and the ids are gateway slugs
+// rather than the vendor ids people know, so this is one question the user
+// cannot reasonably answer from memory. Hence the live catalog.
+func askGenerateDOModel(c *CmdConfig, a *generateAnswers, w io.Writer, inf *harnessInference) error {
+	if choices := generateDOModelChoices(c, w, inf); len(choices) > 0 {
+		picked, err := generatePromptSelect("Model?", choices)
+		if err != nil {
+			return err
+		}
+		if picked != generateModelOtherID {
+			a.Model = picked
+			return nil
+		}
+	} else {
+		fmt.Fprintf(w, "%s\n", colorize("  Couldn't reach the model catalog. List it with "+doInferenceModelsCmd+".", colMuted))
+	}
+
+	model, err := generatePromptText("Model?", inf.DOModelHint, false)
+	if err != nil {
+		return err
+	}
+	if model == "" {
+		return fmt.Errorf("Serverless Inference has no default model; pass a model id (see %s) or pick %s inference instead", doInferenceModelsCmd, inf.ProviderLabel)
+	}
+	a.Model = model
+	return nil
+}
+
+// generateNonChatModelFamilies are id fragments of catalog entries that cannot
+// drive an agent: embedding, reranking, and image, speech, and video
+// generation models. The catalog carries no type field, so the family has to be
+// read off the id — and offering one of these would produce a manifest that
+// validates and then fails on its first turn.
+//
+// Being a heuristic, it is paired with the picker's escape hatch: anything
+// wrongly hidden can still be typed in.
+var generateNonChatModelFamilies = []string{
+	"embedding", "mini-lm", "mpnet", "e5-large", "gte-large", "bge-",
+	"rerank", "-image-", "stable-diffusion", "-tts-", "-t2v-",
+}
+
+func isGenerateChatModel(id string) bool {
+	lower := strings.ToLower(id)
+	for _, family := range generateNonChatModelFamilies {
+		if strings.Contains(lower, family) {
+			return false
+		}
+	}
+	return true
+}
+
+// generateDOModelChoices offers the live Serverless Inference catalog, or
+// nothing if it cannot be reached.
+//
+// Fetching beats a built-in list because these ids are gateway slugs that come
+// and go; a stale constant would produce a manifest that validates and then
+// fails on its first turn. It also means the harness's preferred model is only
+// ever offered when the catalog confirms it still exists.
+//
+// The call needs a model access key or a full-access token, so an unauthorized
+// or offline user is expected, not exceptional: they fall through to typing an
+// id, the same as with sandbox sizes.
+func generateDOModelChoices(c *CmdConfig, w io.Writer, inf *harnessInference) []generateChoice {
+	if c == nil || c.Inference == nil {
+		return nil
+	}
+	ctx := context.Background()
+	if c.Command != nil && c.Command.Context() != nil {
+		ctx = c.Command.Context()
+	}
+
+	prog := newCreationProgress(w)
+	prog.wait("Fetching models…")
+	list, err := c.Inference().ListModels(ctx)
+	if err != nil || list == nil || len(list.Data) == 0 {
+		prog.stop()
+		return nil
+	}
+	prog.ok("Models loaded")
+
+	ids := make([]string, 0, len(list.Data))
+	for _, m := range list.Data {
+		if id := strings.TrimSpace(m.ID); id != "" && isGenerateChatModel(id) {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	sort.Strings(ids)
+
+	// The catalog arrives in no particular order, so surface the model this
+	// harness is built around first and let Enter take it.
+	preferred := ""
+	if inf != nil {
+		for _, id := range ids {
+			if strings.EqualFold(id, inf.DOModelHint) {
+				preferred = id
+				break
+			}
+		}
+	}
+	choices := make([]generateChoice, 0, len(ids))
+	if preferred != "" {
+		choices = append(choices, generateChoice{ID: preferred, Label: preferred})
+	}
+	for _, id := range ids {
+		if id != preferred {
+			choices = append(choices, generateChoice{ID: id, Label: id})
+		}
+	}
+	return append(choices, generateChoice{ID: generateModelOtherID, Label: "Enter an id"})
+}
+
+// askGenerateSize asks only for the sandbox size.
+//
+// The template is not asked about at all: every harness maps to one, the server
+// derives it from the harness whenever the manifest omits it, and the review
+// card shows which one that will be. Offering a picker whose recommended
+// answer is already the answer just costs a keystroke. Pinning a different
+// template — a browser or Python image under a coding harness — stays possible
+// with --template.
+func askGenerateSize(c *CmdConfig, a *generateAnswers, w io.Writer) error {
+	if a.Size == "" {
+		choices := []generateChoice{{ID: "", Label: "Auto (recommended)", Hint: "the service default for this template"}}
+		for _, size := range generateSandboxSizeChoices(c, w) {
+			choices = append(choices, size)
+		}
+		size, err := generatePromptSelect("Sandbox size?", choices)
+		if err != nil {
+			return err
+		}
+		a.Size = size
+	}
+	return nil
+}
+
+// generateSandboxSizeChoices offers the live size catalog when it is reachable.
+// This is the one step that can block on the network, so it shows the same
+// spinner session creation uses and falls back to the documented slugs on any
+// failure — an unauthenticated or offline user still gets a usable picker
+// rather than an error from a command that makes no API writes.
+func generateSandboxSizeChoices(c *CmdConfig, w io.Writer) []generateChoice {
+	fallback := make([]generateChoice, 0, len(generateFallbackSizes))
+	for _, slug := range generateFallbackSizes {
+		fallback = append(fallback, generateChoice{ID: slug, Label: slug})
+	}
+	if c == nil || c.HostedAgents == nil {
+		return fallback
+	}
+
+	prog := newCreationProgress(w)
+	prog.wait("Fetching sandbox sizes…")
+	sizes, err := c.HostedAgents().ListSandboxSizes()
+	if err != nil || len(sizes) == 0 {
+		prog.stop()
+		return fallback
+	}
+	prog.ok("Sizes loaded")
+
+	out := make([]generateChoice, 0, len(sizes))
+	for _, size := range sizes {
+		if strings.TrimSpace(size.Slug) == "" {
+			continue
+		}
+		hint := ""
+		if size.VCPUs > 0 && size.MemoryMB > 0 {
+			hint = fmt.Sprintf("%d vCPU · %d GB", size.VCPUs, size.MemoryMB/1024)
+		}
+		out = append(out, generateChoice{ID: size.Slug, Label: size.Slug, Hint: hint})
+	}
+	if len(out) == 0 {
+		return fallback
+	}
+	return out
+}
+
+func askGenerateTools(c *CmdConfig, a *generateAnswers, w io.Writer) error {
+	if a.ToolsPreset == "" || strings.EqualFold(a.ToolsPreset, generateToolsPresetNone) {
+		if len(a.Tools) == 0 && len(a.MCPServers) == 0 {
+			fmt.Fprintf(w, "%s\n", colorize("  DO tools: "+strings.Join(generateDefaultToolsPreset, ", ")+".", colMuted))
+			attach, err := generatePromptConfirm("Attach the default DO tools?", true)
+			if err != nil {
+				return err
+			}
+			if attach {
+				a.ToolsPreset = generateToolsPresetDefault
+			}
+		}
+	}
+
+	if len(a.MCPServers) > 0 {
+		return nil
+	}
+	add, err := generatePromptConfirm("Add an MCP server?", false)
+	if err != nil {
+		return err
+	}
+	for add {
+		srv, err := askGenerateMCPServer(a)
+		if err != nil {
+			return err
+		}
+		if srv == nil {
+			return nil
+		}
+		a.MCPServers = append(a.MCPServers, *srv)
+		if add, err = generatePromptConfirm("Add another MCP server?", false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func askGenerateMCPServer(a *generateAnswers) (*generatedMCPServer, error) {
+	name, err := generatePromptText("Server name?", "linear", false)
+	if err != nil {
+		return nil, err
+	}
+	if name == "" {
+		return nil, nil
+	}
+	url, err := generatePromptText("Server URL?", "https://mcp.linear.app/mcp", false)
+	if err != nil {
+		return nil, err
+	}
+	if url == "" {
+		return nil, fmt.Errorf("MCP server %q needs an https:// URL", name)
+	}
+	srv := &generatedMCPServer{Name: name, URL: url}
+
+	tools, err := generatePromptText("Tools? (comma-separated, Enter for all)", "create_issue,list_issues", false)
+	if err != nil {
+		return nil, err
+	}
+	for _, tool := range strings.Split(tools, ",") {
+		if tool = strings.TrimSpace(tool); tool != "" {
+			srv.Tools = append(srv.Tools, tool)
+		}
+	}
+
+	slot, err := generatePromptText("Auth secret slot? (Enter for none)", "LINEAR_API_KEY", false)
+	if err != nil {
+		return nil, err
+	}
+	if slot != "" {
+		// The slot has to exist for the manifest to validate, so declaring the
+		// server declares its credential too.
+		a.addSecretSlot(generateSecretSlot{Name: slot, Value: secretPlaceholder(slot)})
+		srv.Auth = &generatedMCPAuth{Secret: slot}
+	}
+	return srv, nil
+}
+
+func askGeneratePermissions(c *CmdConfig, a *generateAnswers, w io.Writer) error {
+	if a.PermissionDefault != "" {
+		return nil
+	}
+	// The recommended value leads the list so Enter selects it, and it is the
+	// same constant the non-interactive path applies.
+	choices := []generateChoice{
+		{ID: generateDefaultPermission, Label: generateDefaultPermission + " (recommended)", Hint: "pause for approval on anything unmatched"},
+		{ID: "allow", Label: "allow", Hint: "run unmatched tool calls without asking"},
+		{ID: "deny", Label: "deny", Hint: "refuse anything not explicitly allowed"},
+	}
+	def, err := generatePromptSelect("Default for tool calls no rule matches?", choices)
+	if err != nil {
+		return err
+	}
+	a.PermissionDefault = def
+	return nil
+}
+
+func askGenerateSkills(c *CmdConfig, a *generateAnswers, w io.Writer) error {
+	if len(a.Skills) > 0 {
+		return nil
+	}
+	add, err := generatePromptConfirm("Add a skill?", false)
+	if err != nil {
+		return err
+	}
+	for add {
+		skill, err := askGenerateSkill()
+		if err != nil {
+			return err
+		}
+		if skill == nil {
+			return nil
+		}
+		a.Skills = append(a.Skills, *skill)
+		if add, err = generatePromptConfirm("Add another skill?", false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func askGenerateSkill() (*generatedSkill, error) {
+	name, err := generatePromptText("Skill name? (lowercase-with-hyphens)", "release-checklist", false)
+	if err != nil {
+		return nil, err
+	}
+	if name == "" {
+		return nil, nil
+	}
+	if !skillNameRE.MatchString(name) {
+		return nil, fmt.Errorf("skill name %q must be lowercase letters, digits, and single hyphens", name)
+	}
+	path, err := generatePromptText("Markdown file?", "./skills/release-checklist.md", false)
+	if err != nil {
+		return nil, err
+	}
+	if path == "" {
+		return nil, fmt.Errorf("skill %q needs a markdown file", name)
+	}
+	skills, err := parseGenerateSkills([]string{name + "=" + path}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &skills[0], nil
+}
+
+// askGenerateDestination asks where the manifest should land. Printing is the
+// default because the command's contract is "hand me the config" — saving is
+// one keypress away for anyone who wants a file.
+func askGenerateDestination(a *generateAnswers, dest *generateDestination, notes io.Writer) error {
+	if dest.path != "" {
+		return nil
+	}
+	suggested := generateDefaultFilename(a)
+	choices := []generateChoice{
+		{ID: "print", Label: "Print it here", Hint: "copy it, or re-run with --" + doctl.ArgAgentOut},
+		{ID: "save", Label: "Save to a file", Hint: suggested},
+	}
+	where, err := generatePromptSelect("Where should it go?", choices)
+	if err != nil {
+		return err
+	}
+	if where == "print" {
+		return nil
+	}
+
+	path, err := generatePromptText(fmt.Sprintf("Path? (Enter for %s)", suggested), suggested, false)
+	if err != nil {
+		return err
+	}
+	if path == "" {
+		path = suggested
+	}
+	if _, err := os.Stat(path); err == nil {
+		replace, err := generatePromptConfirm(fmt.Sprintf("%s exists — replace it?", path), false)
+		if err != nil {
+			return err
+		}
+		if !replace {
+			return errGenerateCanceled
+		}
+		dest.overwrite = true
+	}
+	dest.path = path
+
+	// `create`/`launch` discover ./agents.yaml with no --spec at all, so saving
+	// under that name is a feature worth naming rather than a coincidence.
+	if strings.EqualFold(strings.TrimSpace(path), "agents.yaml") {
+		fmt.Fprintf(notes, "%s\n", colorize("  agents.yaml is auto-discovered, so `"+agentCLI+" launch` will pick this up with no --"+doctl.ArgAgentSpec+".", colMuted))
+	}
+	return nil
+}
+
+func generateDefaultFilename(a *generateAnswers) string {
+	base := strings.TrimSpace(a.Name)
+	if base == "" {
+		base = strings.TrimSpace(a.Harness)
+	}
+	if base == "" {
+		base = "agents"
+	}
+	return base + ".yaml"
+}
+
+// --- review -----------------------------------------------------------------
+
+// printGenerateReview summarizes what is about to be written. It is a card of
+// decisions, not the manifest itself: the point is to confirm intent at a
+// glance, and the file follows immediately after.
+func printGenerateReview(w io.Writer, a *generateAnswers) {
+	var body strings.Builder
+	fmt.Fprintf(&body, "%s\n\n", boldColor("Review", colHighlight))
+
+	if a.Name != "" {
+		body.WriteString(cardRow("Name", a.Name))
+	}
+	body.WriteString(cardRow("Harness", a.Harness))
+	if a.Image != "" {
+		body.WriteString(cardRow("Image", colorize(a.Image, colMuted)))
+	}
+	if len(a.Repos) > 0 {
+		body.WriteString(cardRow("Repos", strings.Join(a.Repos, ", ")))
+	}
+	if provider := describeGenerateInference(a); provider != "" {
+		body.WriteString(cardRow("Model", provider))
+	}
+
+	template := a.Template
+	if template == "" {
+		if derived := derivedTemplateFor(a.Harness); derived != "" {
+			template = colorize("auto ("+derived+")", colMuted)
+		} else {
+			template = colorize("auto", colMuted)
+		}
+	}
+	body.WriteString(cardRow("Template", template))
+
+	size := a.Size
+	if size == "" {
+		size = colorize("auto", colMuted)
+	}
+	body.WriteString(cardRow("Size", size))
+
+	if names := a.secretNames(); len(names) > 0 {
+		// Names only — a review card is exactly the wrong place for a value.
+		labeled := make([]string, 0, len(names))
+		for _, slot := range a.Secrets {
+			label := slot.Name
+			switch {
+			case slot.Inline:
+				label += colorize(" (inlined)", colWarning)
+			case strings.HasPrefix(slot.Value, "oauth/"):
+				label += colorize(" (brokered)", colMuted)
+			}
+			labeled = append(labeled, label)
+		}
+		body.WriteString(cardRow("Secrets", strings.Join(labeled, ", ")))
+	}
+
+	if tools := describeGenerateTools(a); tools != "" {
+		body.WriteString(cardRow("Tools", tools))
+	}
+	if a.PermissionDefault != "" {
+		perms := a.PermissionDefault
+		if n := len(a.PermissionRules); n > 0 {
+			perms += colorize(fmt.Sprintf(" · %d rule(s)", n), colMuted)
+		}
+		body.WriteString(cardRow("Perms", perms))
+	}
+	if len(a.Skills) > 0 {
+		names := make([]string, 0, len(a.Skills))
+		for _, skill := range a.Skills {
+			names = append(names, skill.Name)
+		}
+		body.WriteString(cardRow("Skills", strings.Join(names, ", ")))
+	}
+	if len(a.Egress) > 0 || a.GitHubAccess {
+		hosts := append([]string{}, a.Egress...)
+		if a.GitHubAccess {
+			hosts = append(hosts, generateGitHubEgress...)
+		}
+		body.WriteString(cardRow("Egress", strings.Join(dedupeHosts(hosts), ", ")))
+	}
+
+	renderAgentCard(w, body.String())
+}
+
+// describeGenerateInference renders the model and where it is served from as
+// one line, since neither is meaningful without the other.
+func describeGenerateInference(a *generateAnswers) string {
+	model := a.Model
+	harness, ok := lookupGenerateHarness(a.Harness)
+	if !ok || harness.Inference == nil {
+		return model
+	}
+	if model == "" {
+		model = colorize(harness.Inference.ProviderLabel+" default", colMuted)
+	}
+	switch a.InferenceProvider {
+	case inferenceProviderDO:
+		return model + colorize(" · DigitalOcean Serverless Inference", colMuted)
+	case inferenceProviderCustom:
+		return model + colorize(" · "+a.InferenceURL, colMuted)
+	default:
+		return model + colorize(" · "+harness.Inference.ProviderLabel, colMuted)
+	}
+}
+
+func describeGenerateTools(a *generateAnswers) string {
+	var parts []string
+	if strings.EqualFold(a.ToolsPreset, generateToolsPresetDefault) && len(a.Tools) == 0 {
+		parts = append(parts, strings.Join(generateDefaultToolsPreset, ", "))
+	}
+	parts = append(parts, a.Tools...)
+	for _, srv := range a.MCPServers {
+		parts = append(parts, srv.Name+colorize(" (mcp)", colMuted))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/commands/agent_configs.go
+++ b/commands/agent_configs.go
@@ -59,6 +59,15 @@ func AgentConfigs() *Command {
 	AddStringSliceFlag(cmdCreate, doctl.ArgAgentSecret, "", nil, agentSecretFlagDesc)
 	cmdCreate.Example = agentCLI + ` config create --spec agent-spec.yaml --name my-config; ` + agentCLI + ` config create --spec agent-spec.yaml --name my-config --secret ANTHROPIC_API_KEY=@~/.secrets/anthropic.key`
 
+	// `generate` sits next to `create` because it authors the very manifest
+	// `create` consumes — but it is local-only and makes no API call at all.
+	cmdGenerate := CmdBuilder(cmd, RunAgentsConfigGenerate, "generate",
+		"Generate an agent manifest locally",
+		agentsConfigGenerateHelpMD,
+		Writer, append(ns, aliasOpt("gen"))...)
+	addAgentConfigGenerateFlags(cmdGenerate)
+	cmdGenerate.Example = agentCLI + ` config generate; ` + agentCLI + ` config generate --harness claude-code --name payments-reviewer --gh-repo acme/payments-service --github-access --out agents.yaml; ` + agentCLI + ` config generate --harness opencode --inference do --model deepseek-v4-pro`
+
 	cmdList := CmdBuilder(cmd, RunAgentsConfigList, "list",
 		"List agent configs",
 		agentsConfigListHelpMD,
@@ -138,16 +147,14 @@ func RunAgentsConfigCreate(c *CmdConfig) error {
 		return err
 	}
 	if Output == "json" {
-		if err := c.Display(&displayers.HostedAgentConfig{Configs: []godo.HostedAgentConfig{*cfg}, Single: true}); err != nil {
-			return err
-		}
-	} else {
-		stylingEnabled = detectStyling()
-		printAgentConfigCard(c.Out, cfg, true)
+		// The payload carries its own "warnings" field, so JSON callers are
+		// already told. Appending the prose form here would have left the
+		// document unparseable for the scripts that asked for JSON.
+		return c.Display(&displayers.HostedAgentConfig{Configs: []godo.HostedAgentConfig{*cfg}, Single: true})
 	}
-	for _, w := range cfg.Warnings {
-		fmt.Fprintf(c.Out, "%s %s\n", colorize("Warning:", colWarning), w)
-	}
+	stylingEnabled = detectStyling()
+	printAgentConfigCard(c.Out, cfg, true)
+	printAgentManifestWarnings(os.Stderr, cfg.Warnings)
 	return nil
 }
 

--- a/commands/agent_configs_test.go
+++ b/commands/agent_configs_test.go
@@ -15,6 +15,7 @@ package commands
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -33,7 +34,7 @@ import (
 func TestAgentConfigsCommand(t *testing.T) {
 	cmd := AgentConfigs()
 	assert.NotNil(t, cmd)
-	assertCommandNames(t, cmd, "create", "list", "get", "delete", "list-sessions", "start-session")
+	assertCommandNames(t, cmd, "generate", "create", "list", "get", "delete", "list-sessions", "start-session")
 }
 
 func TestAgentConfigCreate(t *testing.T) {
@@ -242,5 +243,82 @@ func TestAgentConfigStartSession(t *testing.T) {
 		config.Args = append(config.Args, "cfg_1")
 		config.Doit.Set(config.NS, doctl.ArgAgentName, "my-session")
 		require.NoError(t, RunAgentsConfigStartSession(config))
+	})
+}
+
+// Server-side warnings are advisory, so they must not be allowed to append
+// prose to the document that -o json callers are parsing.
+func TestAgentConfigCreate_WarningsKeepJSONParseable(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		dir := t.TempDir()
+		specPath := filepath.Join(dir, "agent.yaml")
+		require.NoError(t, os.WriteFile(specPath, []byte("agent: opencode\n"), 0o600))
+
+		tm.hostedAgents.EXPECT().
+			CreateAgentConfig(gomock.Any()).
+			Return(&godo.HostedAgentConfig{
+				ID:       "cfg_warned",
+				Name:     "my-config",
+				Warnings: []string{"adapter opencode is not yet supported for session create"},
+			}, nil)
+
+		config.Doit.Set(config.NS, doctl.ArgAgentSpec, specPath)
+		config.Doit.Set(config.NS, doctl.ArgAgentName, "my-config")
+
+		var stdout bytes.Buffer
+		config.Out = &stdout
+
+		prev := Output
+		Output = "json"
+		defer func() { Output = prev }()
+
+		stderr := captureProcessStderr(t, func() {
+			require.NoError(t, RunAgentsConfigCreate(config))
+		})
+
+		raw := stdout.String()
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(raw), &parsed), "stdout must be valid JSON in -o json mode, got: %q", raw)
+		assert.Equal(t, "cfg_warned", parsed["id"])
+
+		// The warning is reported as data in the payload rather than as prose
+		// appended after it, which is what made the document unparseable.
+		assert.Equal(t,
+			[]any{"adapter opencode is not yet supported for session create"},
+			parsed["warnings"],
+			"warnings must be carried in the JSON payload")
+
+		assert.Empty(t, stderr, "nothing may be written to stderr in -o json mode")
+	})
+}
+
+// In text mode there is no payload to carry the warning, so it is printed —
+// and to stderr, keeping the card on stdout pipeable on its own.
+func TestAgentConfigCreate_WarningsPrintedToStderrInTextMode(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		dir := t.TempDir()
+		specPath := filepath.Join(dir, "agent.yaml")
+		require.NoError(t, os.WriteFile(specPath, []byte("agent: opencode\n"), 0o600))
+
+		tm.hostedAgents.EXPECT().
+			CreateAgentConfig(gomock.Any()).
+			Return(&godo.HostedAgentConfig{
+				ID:       "cfg_warned",
+				Name:     "my-config",
+				Warnings: []string{"adapter opencode is not yet supported for session create"},
+			}, nil)
+
+		config.Doit.Set(config.NS, doctl.ArgAgentSpec, specPath)
+		config.Doit.Set(config.NS, doctl.ArgAgentName, "my-config")
+
+		var stdout bytes.Buffer
+		config.Out = &stdout
+
+		stderr := captureProcessStderr(t, func() {
+			require.NoError(t, RunAgentsConfigCreate(config))
+		})
+
+		assert.Contains(t, stderr, "not yet supported", "warning must reach the operator")
+		assert.NotContains(t, stdout.String(), "not yet supported", "warning must not be mixed into the card on stdout")
 	})
 }

--- a/commands/agent_triggers.go
+++ b/commands/agent_triggers.go
@@ -64,7 +64,7 @@ func AgentTriggers() *Command {
 	AddStringFlag(cmdCreate, doctl.ArgAgentSpec, "", "", "Path to agents.yaml manifest for session-mode=fresh (\"-\" reads stdin). ${VAR} references are resolved from the local environment at create time and stored expanded.")
 	AddStringFlag(cmdCreate, doctl.ArgAgentFromConfig, "", "", "Name or ID of an existing Agent Config to use as the session template for session-mode=fresh, instead of --spec. Its manifest is copied into this trigger at create time.")
 	AddStringSliceFlag(cmdCreate, doctl.ArgAgentSecret, "", nil, agentSecretFlagDesc)
-	AddStringFlag(cmdCreate, doctl.ArgAgentTriggerBoundSessionID, "", "", "Paused session ID for session-mode=reuse")
+	AddStringFlag(cmdCreate, doctl.ArgAgentTriggerBoundSessionID, "", "", "Paused session ID or name for session-mode=reuse")
 	cmdCreate.MarkFlagsMutuallyExclusive(doctl.ArgAgentSpec, doctl.ArgAgentFromConfig)
 	AddStringFlag(cmdCreate, doctl.ArgAgentTriggerProvider, "", "", "Webhook provider (github|gitlab|custom); default custom")
 	AddStringFlag(cmdCreate, doctl.ArgAgentTriggerCronExpr, "", "", "Cron expression when kind=cron")
@@ -91,7 +91,7 @@ func AgentTriggers() *Command {
 	AddStringFlag(cmdUpdate, doctl.ArgAgentSpec, "", "", "Updated agents.yaml manifest for fresh triggers (\"-\" reads stdin). ${VAR} references are resolved from the local environment at update time and stored expanded.")
 	AddStringFlag(cmdUpdate, doctl.ArgAgentFromConfig, "", "", "Name or ID of an existing Agent Config whose manifest becomes this trigger's session template, instead of --spec.")
 	AddStringSliceFlag(cmdUpdate, doctl.ArgAgentSecret, "", nil, agentSecretFlagDesc)
-	AddStringFlag(cmdUpdate, doctl.ArgAgentTriggerBoundSessionID, "", "", "Updated bound session ID for reuse triggers")
+	AddStringFlag(cmdUpdate, doctl.ArgAgentTriggerBoundSessionID, "", "", "Updated bound session ID or name for reuse triggers")
 	cmdUpdate.MarkFlagsMutuallyExclusive(doctl.ArgAgentSpec, doctl.ArgAgentFromConfig)
 	AddStringFlag(cmdUpdate, doctl.ArgAgentTriggerCronExpr, "", "", "Updated cron expression")
 	AddStringFlag(cmdUpdate, doctl.ArgAgentTriggerTimezone, "", "", "Updated IANA timezone")
@@ -609,7 +609,14 @@ func agentTriggerCreateRequest(c *CmdConfig) (*godo.HostedAgentTriggerCreateRequ
 		if bound == "" {
 			return nil, fmt.Errorf("--%s is required when --%s=reuse", doctl.ArgAgentTriggerBoundSessionID, doctl.ArgAgentTriggerSessionMode)
 		}
-		req.BoundSessionID = bound
+		// Accept a name as well as an ID, like every other command that takes a
+		// session. `list-reusable-sessions` shows both, so the name is often
+		// what gets copied.
+		boundID, err := resolveSessionRef(c.HostedAgents(), bound)
+		if err != nil {
+			return nil, err
+		}
+		req.BoundSessionID = boundID
 	default:
 		return nil, fmt.Errorf("invalid --%s %q; want fresh or reuse", doctl.ArgAgentTriggerSessionMode, sessionMode)
 	}
@@ -752,13 +759,28 @@ func agentTriggerUpdateRequest(c *CmdConfig) (*godo.HostedAgentTriggerUpdateRequ
 	if err != nil {
 		return nil, err
 	}
-	if outputMode != "" {
+	outputEmail, err := c.Doit.GetString(c.NS, doctl.ArgAgentTriggerOutputEmail)
+	if err != nil {
+		return nil, err
+	}
+	outputSlack, err := c.Doit.GetString(c.NS, doctl.ArgAgentTriggerOutputSlackWebhook)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case outputMode != "":
 		output, err := agentTriggerOutputWrite(c, true)
 		if err != nil {
 			return nil, err
 		}
 		update.Output = output
 		changed = true
+	case outputEmail != "" || outputSlack != "":
+		// An update replaces the whole output block rather than merging into
+		// it, so a destination on its own has no mode to attach to. Say so
+		// instead of exiting 0 having changed nothing.
+		return nil, fmt.Errorf("--%s is required to change where run results go; pass it alongside --%s or --%s",
+			doctl.ArgAgentTriggerOutputMode, doctl.ArgAgentTriggerOutputEmail, doctl.ArgAgentTriggerOutputSlackWebhook)
 	}
 
 	manifest, err := agentTriggerSessionTemplate(c)
@@ -775,7 +797,11 @@ func agentTriggerUpdateRequest(c *CmdConfig) (*godo.HostedAgentTriggerUpdateRequ
 		return nil, err
 	}
 	if bound != "" {
-		update.BoundSessionID = bound
+		boundID, err := resolveSessionRef(c.HostedAgents(), bound)
+		if err != nil {
+			return nil, err
+		}
+		update.BoundSessionID = boundID
 		changed = true
 	}
 

--- a/commands/agent_triggers_test.go
+++ b/commands/agent_triggers_test.go
@@ -696,3 +696,113 @@ func TestAgentTriggersGetExecution_TextMode(t *testing.T) {
 		assert.Contains(t, stdout.String(), "output truncated", "truncation notice must appear on stdout in text mode")
 	})
 }
+
+// A reuse trigger binds to a paused session, and `list-reusable-sessions`
+// prints names next to IDs — so the name is what gets copied. Every other
+// session-taking command accepts either, and this one has to as well.
+func TestAgentTriggersCreate_BoundSessionByName(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().
+			ListSessions(&godo.HostedAgentSessionListOptions{Name: "nightly-reviewer"}).
+			Return([]do.HostedAgentSession{{
+				HostedAgentSession: &godo.HostedAgentSession{
+					SessionID: "sess_paused",
+					Name:      "nightly-reviewer",
+					Status:    godo.HostedAgentSessionStatusPaused,
+				},
+			}}, "", nil)
+
+		tm.hostedAgentTriggers.EXPECT().
+			Create(&godo.HostedAgentTriggerCreateRequest{
+				Kind:        godo.HostedAgentTriggerKindWebhook,
+				Name:        "on-push",
+				SessionMode: godo.HostedAgentTriggerSessionModeReuse,
+				Output:      godo.HostedAgentTriggerOutputWrite{Mode: godo.HostedAgentTriggerOutputModeNone},
+				// The name resolved to this ID rather than being sent as-is.
+				BoundSessionID: "sess_paused",
+				Webhook:        &godo.HostedAgentCreateWebhookConfig{},
+			}).
+			Return(&do.HostedAgentTriggerCreateResult{
+				Trigger: &do.HostedAgentTrigger{
+					HostedAgentTrigger: &godo.HostedAgentTrigger{TriggerID: "tr_1", Name: "on-push"},
+				},
+			}, nil)
+
+		config.Doit.Set(config.NS, doctl.ArgAgentTriggerKind, "webhook")
+		config.Doit.Set(config.NS, doctl.ArgAgentName, "on-push")
+		config.Doit.Set(config.NS, doctl.ArgAgentTriggerSessionMode, "reuse")
+		config.Doit.Set(config.NS, doctl.ArgAgentTriggerOutputMode, "none")
+		config.Doit.Set(config.NS, doctl.ArgAgentTriggerBoundSessionID, "nightly-reviewer")
+		require.NoError(t, RunAgentTriggersCreate(config))
+	})
+}
+
+func TestAgentTriggersUpdate_BoundSessionByName(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgents.EXPECT().
+			ListSessions(&godo.HostedAgentSessionListOptions{Name: "nightly-reviewer"}).
+			Return([]do.HostedAgentSession{{
+				HostedAgentSession: &godo.HostedAgentSession{
+					SessionID: "sess_paused",
+					Name:      "nightly-reviewer",
+					Status:    godo.HostedAgentSessionStatusPaused,
+				},
+			}}, "", nil)
+
+		tm.hostedAgentTriggers.EXPECT().
+			Update("tr_1", &godo.HostedAgentTriggerUpdateRequest{BoundSessionID: "sess_paused"}).
+			Return(&do.HostedAgentTrigger{
+				HostedAgentTrigger: &godo.HostedAgentTrigger{TriggerID: "tr_1"},
+			}, nil)
+
+		config.Args = []string{"tr_1"}
+		config.Doit.Set(config.NS, doctl.ArgAgentTriggerBoundSessionID, "nightly-reviewer")
+		require.NoError(t, RunAgentTriggersUpdate(config))
+	})
+}
+
+// An update replaces the whole output block, so a destination with no mode
+// cannot be applied. Exiting 0 having ignored it is the failure to avoid.
+func TestAgentTriggersUpdate_OutputDestinationNeedsMode(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		arg  string
+		val  string
+	}{
+		{name: "email", arg: doctl.ArgAgentTriggerOutputEmail, val: "oncall@example.com"},
+		{name: "slack", arg: doctl.ArgAgentTriggerOutputSlackWebhook, val: "https://hooks.slack.com/services/T/B/xxx"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+				// No Update expectation: the command must fail before calling.
+				config.Args = []string{"tr_1"}
+				config.Doit.Set(config.NS, tt.arg, tt.val)
+
+				err := RunAgentTriggersUpdate(config)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "--"+doctl.ArgAgentTriggerOutputMode+" is required")
+			})
+		})
+	}
+}
+
+// With the mode supplied, the destination applies as it always did.
+func TestAgentTriggersUpdate_OutputModeWithDestination(t *testing.T) {
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		tm.hostedAgentTriggers.EXPECT().
+			Update("tr_1", &godo.HostedAgentTriggerUpdateRequest{
+				Output: &godo.HostedAgentTriggerOutputWrite{
+					Mode:  godo.HostedAgentTriggerOutputModeEmail,
+					Email: "oncall@example.com",
+				},
+			}).
+			Return(&do.HostedAgentTrigger{
+				HostedAgentTrigger: &godo.HostedAgentTrigger{TriggerID: "tr_1"},
+			}, nil)
+
+		config.Args = []string{"tr_1"}
+		config.Doit.Set(config.NS, doctl.ArgAgentTriggerOutputMode, "email")
+		config.Doit.Set(config.NS, doctl.ArgAgentTriggerOutputEmail, "oncall@example.com")
+		require.NoError(t, RunAgentTriggersUpdate(config))
+	})
+}

--- a/commands/agents_help.go
+++ b/commands/agents_help.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/digitalocean/doctl"
 	"github.com/spf13/cobra"
 )
 
@@ -165,6 +166,43 @@ const agentsSizesListHelpMD = `Print the customer-selectable sandbox size catalo
 const agentsConfigCreateHelpMD = `Create an immutable config from an agents.yaml manifest (same format as ` + "`" + agentCLI + " create --spec`" + `). ` + "`--name`" + ` must be unique within your team.
 
 ` + "`--secret NAME=VALUE`" + ` (also ` + "`NAME=@path`" + ` / ` + "`NAME=-`" + `, repeatable) fills a secret slot the manifest declares. The value is captured server-side against this config and never returned, so sessions started from it need no secrets of their own.`
+
+const agentsConfigGenerateHelpMD = `Write an agent manifest — the ` + "`agents.yaml`" + ` that ` + "`" + agentCLI + " config create --spec`" + ` and ` + "`" + agentCLI + " create --spec`" + ` consume. This command only authors the file: nothing is created, started, or charged.
+
+Run it bare on a terminal and it walks you through the manifest one question at a time, each with a default you can accept with Enter:
+
+` + "```bash\n" + agentCLI + ` config generate
+` + "```\n\n" + `Every question has a flag, so any interactive run is reproducible as one command — useful in CI and for agents driving doctl:
+
+` + "```bash\n" + agentCLI + ` config generate \
+  --harness claude-code --name payments-reviewer \
+  --gh-repo acme/payments-service --github-access \
+  --tools-preset default --permission-default ask \
+  --out agents.yaml
+` + "```\n\n" + `Flags and prompts compose: a flag you pass is never asked about, and on a terminal anything you leave out is. Pass ` + "`--no-interactive`" + ` (or redirect stdout) to skip prompting entirely and take the default for every unanswered question.
+
+By default the manifest goes to stdout, so it pipes and copies:
+
+` + "```bash\n" + agentCLI + ` config generate --harness opencode > agents.yaml
+` + "```\n\n" + `## Inference
+
+` + "`--" + doctl.ArgAgentInference + "`" + ` picks where the agent gets its model, which decides the environment the manifest writes:
+
+- ` + "`do`" + ` — DigitalOcean Serverless Inference, and what the wizard recommends: one model access key, and its host is already allowed. Needs a ` + "`--" + doctl.ArgAgentModel + "`" + `, whose ids are DigitalOcean's own (` + "`anthropic-claude-4.5-sonnet`" + `, not ` + "`claude-sonnet-4-5`" + `); the wizard lists them for you, or see ` + "`" + doInferenceModelsCmd + "`" + `.
+- ` + "`native`" + ` — the agent's own vendor (Anthropic for claude-code, OpenAI for codex and opencode) and its own default model. This is the default when not prompting, because it is the only one that needs no model id.
+- ` + "`custom`" + ` — any other OpenAI-compatible endpoint, via ` + "`--" + doctl.ArgAgentInferenceURL + "`" + `. Adds its host to egress.
+
+So a manifest served by DigitalOcean is:
+
+` + "```bash\n" + agentCLI + ` config generate --harness opencode \
+  --` + doctl.ArgAgentInference + ` do --` + doctl.ArgAgentModel + ` deepseek-v4-pro
+` + "```\n\n" + `The two credential styles are mutually exclusive on purpose: an agent that finds its vendor's own key ignores the endpoint settings entirely, so a manifest declares one or the other, never both.
+
+## Secrets
+
+` + "`--secret NAME`" + ` declares a credential slot as a ` + "`${NAME}`" + ` placeholder and never writes the value, so the generated file is safe to commit — supply values later with ` + "`" + agentCLI + " config create --secret NAME=VALUE`" + `. Use ` + "`--secret NAME=oauth/github`" + ` for a brokered credential, or ` + "`--inline-secret NAME=VALUE`" + ` to deliberately embed a literal.
+
+The manifest is checked client-side before it is written; anything the server would reject is an error, and advisory notes are printed as warnings. Skip the check with ` + "`--skip-validate`" + `.`
 
 const agentsConfigListHelpMD = `List configs for your team. Paginate with ` + "`--page-size`" + ` and ` + "`--page-token`" + `.`
 

--- a/commands/agents_validate.go
+++ b/commands/agents_validate.go
@@ -35,6 +35,7 @@ var knownAgentAdapters = map[string]struct{}{
 	"claude-code":      {},
 	"opencode":         {},
 	"codex":            {},
+	"cursor":           {},
 	"codex-agentapi":   {},
 	"hermes":           {}, // runnable, but outside the default server-side agent-kind set
 	"custom":           {},
@@ -254,7 +255,7 @@ func validateEnvelopeManifest(doc map[string]any, out *agentManifestValidation) 
 
 func validateAdapter(adapter, path string, out *agentManifestValidation) {
 	if _, ok := knownAgentAdapters[adapter]; !ok {
-		out.Errors = append(out.Errors, fmt.Sprintf("%s %q is not a known adapter (want claude-code, opencode, codex, codex-agentapi, custom, …)", path, adapter))
+		out.Errors = append(out.Errors, fmt.Sprintf("%s %q is not a known adapter (want claude-code, opencode, codex, cursor, codex-agentapi, custom, …)", path, adapter))
 		return
 	}
 	switch adapter {

--- a/commands/agents_validate_test.go
+++ b/commands/agents_validate_test.go
@@ -61,7 +61,7 @@ func TestValidateAgentManifest_UnknownAdapter(t *testing.T) {
 }
 
 func TestValidateAgentManifest_RemovedAdaptersRejected(t *testing.T) {
-	for _, adapter := range []string{"cursor", "cursor-cli"} {
+	for _, adapter := range []string{"cursor-cli"} {
 		t.Run(adapter, func(t *testing.T) {
 			v := validateAgentManifest([]byte("agent: " + adapter + "\n"))
 			require.False(t, v.ok())
@@ -69,6 +69,16 @@ func TestValidateAgentManifest_RemovedAdaptersRejected(t *testing.T) {
 			assert.Contains(t, v.Errors[0], adapter)
 		})
 	}
+}
+
+// TestValidateAgentManifest_CursorAccepted pins the canonical adapter id back
+// to the server contract: harness-api agentspec lists cursor as a supported
+// adapter (AGENT_KIND_CURSOR_CLI), so rejecting it client-side turned a valid
+// manifest into a local error.
+func TestValidateAgentManifest_CursorAccepted(t *testing.T) {
+	v := validateAgentManifest([]byte("agent: cursor\n"))
+	assert.True(t, v.ok(), "errors=%v", v.Errors)
+	assert.Empty(t, v.Warnings)
 }
 
 func TestValidateAgentManifest_HermesAccepted(t *testing.T) {

--- a/commands/charm/selection/selection.go
+++ b/commands/charm/selection/selection.go
@@ -6,6 +6,7 @@ type Selection struct {
 	options   []string
 	prompt    string
 	filtering bool
+	pageSize  int
 }
 
 type Option func(*Selection)
@@ -34,10 +35,22 @@ func WithPrompt(prompt string) Option {
 	}
 }
 
+// WithPageSize scrolls the list instead of printing every option, which keeps
+// a long list (a service catalog, say) from pushing the question itself off
+// screen. Zero, the default, prints everything.
+func WithPageSize(n int) Option {
+	return func(s *Selection) {
+		s.pageSize = n
+	}
+}
+
 func (s *Selection) Select() (string, error) {
 	sp := selection.New(s.prompt, s.options)
 	if !s.filtering {
 		sp.Filter = nil
+	}
+	if s.pageSize > 0 {
+		sp.PageSize = s.pageSize
 	}
 	return sp.RunPrompt()
 }


### PR DESCRIPTION
## Summary

Writing an agent manifest by hand meant knowing the flat schema and which env vars wire up inference before you could start a single session. This adds `doctl harness-runtime config generate`, which authors one locally and makes no API call:

- **Flags for agents and CI, a wizard for people.** Every wizard question maps to a flag, so an interactive run is reproducible as a single non-interactive command. `--no-interactive` (and any non-TTY) answers each question with its default.
- **Inference is the part that's hard to guess**, so the wizard asks the one question that decides it — DigitalOcean Serverless Inference (recommended), the agent's own vendor, or another OpenAI-compatible endpoint — and derives the `env`, secret slots, and `egress` from the answer. The DO model catalog is pulled live rather than shipped as a list that goes stale, filtered to chat-capable models with a free-text escape hatch.
- **Secrets are declared, not embedded.** `--secret NAME` writes a `${NAME}` placeholder; `--inline-secret NAME=VALUE` is the explicit opt-in to a literal value.
- The manifest is syntax-highlighted when stdout is a terminal and byte-identical when piped or redirected, so it stays copy-pasteable.

Also fixes three defects found while reviewing the surrounding commands:

- `config create` appended warning prose to its own JSON document, leaving `-o json` unparseable exactly when the API had something to say. Warnings now ride in the payload's `warnings` field, and print to stderr in text mode.
- Trigger `--bound-session-id` passed its value through verbatim, so a session name reached the API as a bogus ID — and `list-reusable-sessions` prints names next to IDs, so the name is what gets copied. It now resolves names like every other session-taking command, on both create and update.
- `trigger update --output-email` on its own exited 0 having changed nothing, since the output block was only patched when `--output-mode` was also set. It now names the missing flag.

`cursor` is also restored to the known-adapter list, which had drifted from the canonical contract.

## Test plan

- [x] `go test ./commands/...` passes (`TestRegistryLogin`/`TestRegistryLogout` fail identically on a clean tree in this environment; they need a Docker config)
- [x] `go vet ./commands/` clean, `gofmt` clean
- [x] Golden tests for flag-only generation, inference wiring per provider, and `validateAgentManifest` round-trips on the generated output
- [x] Highlighting tests assert byte-exactness when unstyled and ANSI-only additions when styled
- [x] Regression tests for each of the three fixes above
- [x] Wizard driven end-to-end under a pty via `expect`
- [ ] Reviewer sanity check: `doctl harness-runtime config generate` in a git repo, then `config create --spec` the result