### PR TITLE
agents proxy: opencode M2 — prompts bridge to the hosted session, answers stream back

### DIFF
--- a/internal/agentproxy/opencode/bridge.go
+++ b/internal/agentproxy/opencode/bridge.go
@@ -1,0 +1,463 @@
+package opencode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/digitalocean/godo"
+)
+
+func timeNowMs() int64 { return time.Now().UnixMilli() }
+
+// M2: the harness bridge. Client prompts go to SendInput; the hosted
+// session's canonical event stream comes back as opencode-native SSE frames.
+// The translation tables are the inverse of plano's opencode adapter
+// (crates/agent_adapters/src/opencode/raw.rs) — when unsure how a canonical
+// event should look in opencode terms, that adapter is the answer key.
+
+// turnState tracks one in-flight hosted run and the opencode ids synthesized
+// for it. Created when SendInput returns the run id; deleted on
+// run.completed/run.failed. Events for runs this facade isn't tracking are
+// skipped, same as the codex facade — they belong to another client's turn
+// or predate this connection (M3's history endpoint covers the latter).
+type turnState struct {
+	// userMsgID/promptText echo the user's message back on the stream when
+	// the turn starts — the real server does this (message.updated role
+	// "user" + a text part carrying the prompt), and the TUI renders the
+	// user's side of the conversation from those frames, not optimistically.
+	// userMsgID is the client-minted id from the prompt body when present.
+	userMsgID  string
+	promptText string
+	// startedSent: the turn-start frames (user echo, busy, assistant
+	// message.updated) went out. Normally set by run.started, but set lazily
+	// by the first delta too — a turn whose run.started this stream never
+	// saw (mid-turn connect) must not emit deltas for a message the TUI was
+	// never told about.
+	startedSent bool
+	// textPartStarted / reasoningPartStarted: the empty-text
+	// message.part.updated announcing each part went out. Load-bearing
+	// order (confirmed by the ground-truth capture): the TUI applies a
+	// message.part.delta only to a part a message.part.updated already
+	// created — a delta for an unannounced part renders nothing, silently.
+	textPartStarted      bool
+	reasoningPartStarted bool
+	// sawText: at least one non-reasoning delta was emitted, so the
+	// finalizing message.part.updated has content to carry.
+	sawText bool
+	// text accumulates the answer for the finalizing part update. The real
+	// server re-carries the full text in the finalized part (plano's adapter
+	// drops it as a duplicate for exactly that reason) — the TUI expects the
+	// part's final state, not only the delta trail.
+	text strings.Builder
+	// startMs stamps part time.start; the finalizer adds time.end.
+	startMs int64
+}
+
+// ocID strips the dashes from a harness UUID so synthesized ids match the
+// dash-less shape opencode mints (ses_..., msg_..., prt_...), in case any
+// client pattern-matches id prefixes or separators.
+func ocID(prefix, uuid string) string {
+	return prefix + strings.ReplaceAll(uuid, "-", "")
+}
+
+// ocSessionID is the opencode-side id this facade advertises for the one
+// hosted session it bridges. Stable across reconnects on purpose: the TUI's
+// own scrollback and session picker key off it.
+func (f *Facade) ocSessionID() string { return ocID("ses_", f.SessionID) }
+
+// sessionObject is the opencode session Info shape the TUI consumes from
+// POST /session, GET /session/{id}, and the session list.
+func (f *Facade) sessionObject() map[string]any {
+	return map[string]any{
+		"id":        f.ocSessionID(),
+		"projectID": "global",
+		"directory": f.Dir,
+		"title":     "Hosted session " + f.SessionID,
+		"version":   TestedVersion,
+		"time":      map[string]any{"created": 0, "updated": 0},
+	}
+}
+
+// handleSessionCreate answers POST /session. The facade bridges exactly one
+// hosted session, so every create maps to it — the TUI creating "a new
+// session" gets the same hosted session back. Model choice, workspace, and
+// policy were all fixed when the hosted session was created; there is
+// nothing a second session could bind to.
+func (f *Facade) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	f.sessionCreated = true
+	f.mu.Unlock()
+	f.writeJSON(w, f.sessionObject())
+}
+
+// handleSessionList answers GET /session: empty until the client has
+// created/used the session, then a single-entry list. An empty list is the
+// "fresh server" state the TUI expects on first attach (verified in the M0
+// capture); returning the session unconditionally would make every attach
+// look like a resume.
+func (f *Facade) handleSessionList(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	created := f.sessionCreated
+	f.mu.Unlock()
+	if !created {
+		f.writeJSON(w, []any{})
+		return
+	}
+	f.writeJSON(w, []any{f.sessionObject()})
+}
+
+// promptInput is the POST /session/{id}/prompt_async body (opencode's
+// PromptInput, minus fields this facade has no use for). Only text parts
+// are bridged in M2; file/agent/subtask parts are logged and dropped.
+type promptInput struct {
+	MessageID string `json:"messageID"`
+	Parts     []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"parts"`
+	// Model is accepted and ignored: the hosted session's model was pinned
+	// at create time. The synthetic catalog only advertises one model, so a
+	// well-behaved client can't ask for anything else anyway.
+	Model json.RawMessage `json:"model"`
+}
+
+// handlePromptAsync bridges a prompt to the hosted session: concatenate the
+// text parts, SendInput, track the returned per-turn run id so the event
+// loop can translate that run's events back. 204 on success — the real
+// server answers prompt_async with 204 NO_CONTENT and results ride the
+// event stream.
+func (f *Facade) handlePromptAsync(w http.ResponseWriter, r *http.Request) {
+	var body promptInput
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, fmt.Sprintf("malformed prompt body: %v", err), http.StatusBadRequest)
+		return
+	}
+	var texts []string
+	for _, p := range body.Parts {
+		switch p.Type {
+		case "text":
+			if p.Text != "" {
+				texts = append(texts, p.Text)
+			}
+		default:
+			log.Printf("agentproxy/opencode: dropping unsupported prompt part type %q", p.Type)
+		}
+	}
+	text := strings.Join(texts, "\n\n")
+	if text == "" {
+		http.Error(w, "prompt has no text parts", http.StatusBadRequest)
+		return
+	}
+
+	resp, err := f.Sessions.SendInput(f.SessionID, &godo.HostedAgentSendInputRequest{Text: text})
+	if err != nil {
+		// 502, not 500: the facade is fine, the harness leg failed. The TUI
+		// surfaces the body text.
+		http.Error(w, fmt.Sprintf("sending input to the hosted session failed: %v", err), http.StatusBadGateway)
+		return
+	}
+
+	userMsgID := body.MessageID
+	if userMsgID == "" {
+		userMsgID = ocID("msg_", resp.RunID) + "u"
+	}
+	f.mu.Lock()
+	if f.turns == nil {
+		f.turns = make(map[string]*turnState)
+	}
+	f.turns[resp.RunID] = &turnState{userMsgID: userMsgID, promptText: text}
+	f.sessionCreated = true
+	f.mu.Unlock()
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (f *Facade) lookupTurn(runID string) (*turnState, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ts, ok := f.turns[runID]
+	return ts, ok
+}
+
+func (f *Facade) dropTurn(runID string) {
+	f.mu.Lock()
+	delete(f.turns, runID)
+	f.mu.Unlock()
+}
+
+// runEventLoop is the live StreamSession drain for one connected event
+// stream. It runs inside the /global/event handler goroutine — the SSE
+// response writer has exactly one writer by construction, so no notifier
+// mutex is needed the way the WS transport's wsNotifier is.
+//
+// M2 scope: no reconnect. A dropped harness stream ends the SSE response,
+// and the TUI's own re-attach opens a fresh one (which re-runs this loop).
+// M6 adds replay_from-cursor reconnects inside a single SSE response.
+func (f *Facade) runEventLoop(ctx context.Context, ew *eventWriter) {
+	stream, err := f.Sessions.StreamSession(ctx, f.SessionID, nil)
+	if err != nil {
+		log.Printf("agentproxy/opencode: StreamSession failed: %v", err)
+		return
+	}
+	defer stream.Close()
+
+	for stream.Next() {
+		ev := stream.Current()
+		// Control frames (stream.state) and anything else without a run id
+		// belong to no turn.
+		if ev.RunID == "" {
+			continue
+		}
+		ts, ok := f.lookupTurn(ev.RunID)
+		if !ok {
+			continue
+		}
+		if err := f.translateEvent(ev, ts, ew); err != nil {
+			log.Printf("agentproxy/opencode: client write failed, closing stream: %v", err)
+			return
+		}
+	}
+	if err := stream.Err(); err != nil && ctx.Err() == nil {
+		log.Printf("agentproxy/opencode: harness stream ended: %v", err)
+	}
+}
+
+// translateEvent maps one canonical event to opencode frames on the
+// connected stream, following the ground-truth sequence captured from a real
+// `opencode serve` turn (see the M0/M2 capture doc): user echo → busy →
+// assistant message.updated → empty part.updated → deltas → finalized
+// part.updated → status idle → session.idle. Returns a write error when the
+// client is gone.
+func (f *Facade) translateEvent(ev godo.HostedAgentEvent, ts *turnState, ew *eventWriter) error {
+	sid := f.ocSessionID()
+	msgID := ocID("msg_", ev.RunID)
+	at := eventTimeMs(ev)
+
+	switch ev.Kind {
+	case godo.HostedAgentEventKindRunStarted:
+		return f.announceTurn(ev.RunID, ts, ew, at)
+
+	case godo.HostedAgentEventKindTokenChunk:
+		var payload struct {
+			Text        string `json:"text"`
+			IsReasoning bool   `json:"is_reasoning"`
+		}
+		if err := json.Unmarshal(ev.Payload, &payload); err != nil || payload.Text == "" {
+			return nil
+		}
+		// A delta for a message the TUI hasn't been told about yet (stream
+		// connected mid-turn, or run.started was lost) — announce it first.
+		if !ts.startedSent {
+			if err := f.announceTurn(ev.RunID, ts, ew, at); err != nil {
+				return err
+			}
+		}
+		// Unlike codex's protocol, opencode has a first-class reasoning
+		// channel: same flat delta frame, field "reasoning", its own part.
+		field, part := "text", ocID("prt_", ev.RunID)+"t"
+		started := &ts.textPartStarted
+		if payload.IsReasoning {
+			field, part = "reasoning", ocID("prt_", ev.RunID)+"r"
+			started = &ts.reasoningPartStarted
+		} else {
+			ts.sawText = true
+			ts.text.WriteString(payload.Text)
+		}
+		// The part must exist before its first delta: the TUI applies
+		// deltas only to parts a message.part.updated already created —
+		// verified live, a delta for an unannounced part renders nothing.
+		if !*started {
+			if err := ew.session("message.part.updated", map[string]any{
+				"sessionID": sid,
+				"part": map[string]any{
+					"id": part, "messageID": msgID, "sessionID": sid,
+					"type": field, "text": "",
+					"time": map[string]any{"start": at},
+				},
+			}); err != nil {
+				return err
+			}
+			*started = true
+		}
+		return ew.session("message.part.delta", map[string]any{
+			"sessionID": sid,
+			"messageID": msgID,
+			"partID":    part,
+			"field":     field,
+			"delta":     payload.Text,
+		})
+
+	case godo.HostedAgentEventKindRunCompleted:
+		defer f.dropTurn(ev.RunID)
+		// Finalize the text part with its full content before idling — the
+		// real server does (deltas stream, then the part's final state
+		// re-carries the whole text; plano's adapter must drop that as a
+		// duplicate for exactly this reason).
+		if ts.sawText {
+			if err := ew.session("message.part.updated", map[string]any{
+				"sessionID": sid,
+				"part": map[string]any{
+					"id": ocID("prt_", ev.RunID) + "t", "messageID": msgID, "sessionID": sid,
+					"type": "text", "text": ts.text.String(),
+					"time": map[string]any{"start": ts.startMs, "end": at},
+				},
+			}); err != nil {
+				return err
+			}
+		}
+		// Close the assistant message with time.completed — without it the
+		// TUI leaves the turn looking in-flight (a lingering QUEUED tag on
+		// the user message, found live).
+		if err := f.finishAssistantMessage(ev.RunID, ts, ew, at); err != nil {
+			return err
+		}
+		return f.emitIdle(sid, ew)
+
+	case godo.HostedAgentEventKindRunFailed:
+		defer f.dropTurn(ev.RunID)
+		var payload struct {
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(ev.Payload, &payload)
+		if payload.Message == "" {
+			payload.Message = "hosted session run failed"
+		}
+		if err := ew.session("session.error", map[string]any{
+			"sessionID": sid,
+			"error": map[string]any{
+				"name": "UnknownError",
+				"data": map[string]any{"message": payload.Message},
+			},
+		}); err != nil {
+			return err
+		}
+		return f.emitIdle(sid, ew)
+
+	default:
+		// Tool calls, usage, HITL: M4/M5. The log is the backlog, exactly
+		// like the codex facade's unhandled-method log was.
+		log.Printf("unhandled event kind: %s", ev.Kind)
+		return nil
+	}
+}
+
+// announceTurn emits the turn-start frames in the real server's order: the
+// user message echo (message.updated role "user" + a text part carrying the
+// prompt — the TUI renders the user's side of the conversation from these),
+// then session.status busy, then the assistant message.updated every later
+// part delta hangs off. Idempotent per turn via ts.startedSent.
+func (f *Facade) announceTurn(runID string, ts *turnState, ew *eventWriter, at int64) error {
+	if ts.startedSent {
+		return nil
+	}
+	ts.startedSent = true
+	ts.startMs = at
+	sid := f.ocSessionID()
+
+	if ts.userMsgID != "" {
+		if err := ew.session("message.updated", map[string]any{
+			"sessionID": sid,
+			"info": map[string]any{
+				"id": ts.userMsgID, "sessionID": sid,
+				"role":    "user",
+				"time":    map[string]any{"created": at},
+				"agent":   "build",
+				"model":   map[string]any{"providerID": providerID, "modelID": modelID},
+				"summary": map[string]any{"diffs": []any{}},
+			},
+		}); err != nil {
+			return err
+		}
+		if err := ew.session("message.part.updated", map[string]any{
+			"sessionID": sid,
+			"part": map[string]any{
+				"id": ocID("prt_", runID) + "u", "messageID": ts.userMsgID, "sessionID": sid,
+				"type": "text", "text": ts.promptText,
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	if err := ew.session("session.status", map[string]any{
+		"sessionID": sid,
+		"status":    map[string]any{"type": "busy"},
+	}); err != nil {
+		return err
+	}
+	// The assistant info's cost/tokens are not optional decoration: the TUI
+	// crashes rendering a message list whose assistant entries lack
+	// `tokens.output` ("undefined is not an object", found live). Zeros are
+	// fine; absent is fatal. Field set mirrors the ground-truth capture.
+	info := map[string]any{
+		"id": ocID("msg_", runID), "sessionID": sid,
+		"role":  "assistant",
+		"time":  map[string]any{"created": at},
+		"mode":  "build",
+		"agent": "build",
+		"model": map[string]any{"providerID": providerID, "modelID": modelID},
+		"path":  map[string]any{"cwd": f.Dir, "root": f.Dir},
+		"cost":  0,
+		"tokens": map[string]any{
+			"input": 0, "output": 0, "reasoning": 0,
+			"cache": map[string]any{"read": 0, "write": 0},
+		},
+	}
+	if ts.userMsgID != "" {
+		info["parentID"] = ts.userMsgID
+	}
+	return ew.session("message.updated", map[string]any{
+		"sessionID": sid,
+		"info":      info,
+	})
+}
+
+// finishAssistantMessage re-sends the assistant message.updated with
+// time.completed stamped, mirroring the real server's end-of-turn frame.
+func (f *Facade) finishAssistantMessage(runID string, ts *turnState, ew *eventWriter, at int64) error {
+	sid := f.ocSessionID()
+	info := map[string]any{
+		"id": ocID("msg_", runID), "sessionID": sid,
+		"role":  "assistant",
+		"time":  map[string]any{"created": ts.startMs, "completed": at},
+		"mode":  "build",
+		"agent": "build",
+		"model": map[string]any{"providerID": providerID, "modelID": modelID},
+		"path":  map[string]any{"cwd": f.Dir, "root": f.Dir},
+		"cost":  0,
+		"tokens": map[string]any{
+			"input": 0, "output": 0, "reasoning": 0,
+			"cache": map[string]any{"read": 0, "write": 0},
+		},
+	}
+	if ts.userMsgID != "" {
+		info["parentID"] = ts.userMsgID
+	}
+	return ew.session("message.updated", map[string]any{"sessionID": sid, "info": info})
+}
+
+// emitIdle ends a turn on the stream the way the real server does: a
+// session.status idle followed by the dedicated session.idle event (both
+// exist on the wire; the TUI's spinner keys off them).
+func (f *Facade) emitIdle(sid string, ew *eventWriter) error {
+	if err := ew.session("session.status", map[string]any{
+		"sessionID": sid,
+		"status":    map[string]any{"type": "idle"},
+	}); err != nil {
+		return err
+	}
+	return ew.session("session.idle", map[string]any{"sessionID": sid})
+}
+
+// eventTimeMs is the event's timestamp in Unix milliseconds, falling back to
+// now — opencode part/message times are millisecond epochs.
+func eventTimeMs(ev godo.HostedAgentEvent) int64 {
+	if !ev.At.IsZero() {
+		return ev.At.UnixMilli()
+	}
+	return timeNowMs()
+}

--- a/internal/agentproxy/opencode/bridge.go
+++ b/internal/agentproxy/opencode/bridge.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,6 +34,13 @@ type turnState struct {
 	// userMsgID is the client-minted id from the prompt body when present.
 	userMsgID  string
 	promptText string
+	// asstMsgID and the part ids are minted time-ordered (ocTimeID) at
+	// announce time so the conversation sorts correctly; stored here so
+	// every later frame references the same ids.
+	asstMsgID       string
+	userPartID      string
+	textPartID      string
+	reasoningPartID string
 	// startedSent: the turn-start frames (user echo, busy, assistant
 	// message.updated) went out. Normally set by run.started, but set lazily
 	// by the first delta too — a turn whose run.started this stream never
@@ -63,6 +71,58 @@ type turnState struct {
 // client pattern-matches id prefixes or separators.
 func ocID(prefix, uuid string) string {
 	return prefix + strings.ReplaceAll(uuid, "-", "")
+}
+
+// opencode ids embed a 48-bit time value: T = ((unix_ms << 12) | counter)
+// truncated to 48 bits, rendered as 12 hex chars after the prefix (sessions
+// use the bitwise NOT of T, which is why ses_ ids sort newest-first). The
+// encoding was decoded from a real server's ids and verified to the bit.
+//
+// This matters because the TUI orders messages lexicographically by id — the
+// time prefix is what makes id order chronological order. The first M2 cut
+// derived message ids from the run UUID (random), and the TUI rendered the
+// assistant's answer ABOVE the user's prompt (found live).
+const ocTimeMask = uint64(1)<<48 - 1
+
+// ocTimeVal is the 48-bit T for a millisecond timestamp (counter zero). All
+// ordering comparisons must happen on T values, never on raw milliseconds —
+// T is truncated mod 2^48, so a T recovered from an id and a fresh untruncated
+// ms are not comparable (that mismatch shipped once: the clock-skew guard
+// below silently never fired and the conversation stayed inverted).
+func ocTimeVal(ms int64) uint64 { return (uint64(ms) << 12) & ocTimeMask }
+
+// ocIDWithT mints an opencode-shaped ascending id from an explicit T.
+func ocIDWithT(prefix string, t uint64, counter uint16, tail string) string {
+	return fmt.Sprintf("%s%012x%s", prefix, (t|uint64(counter&0xfff))&ocTimeMask, tail)
+}
+
+// ocTimeID is ocIDWithT for callers that start from a timestamp.
+func ocTimeID(prefix string, ms int64, counter uint16, tail string) string {
+	return ocIDWithT(prefix, ocTimeVal(ms), counter, tail)
+}
+
+// tFromOCID recovers T (counter bits cleared) from an id's 12-hex-char time
+// prefix. ok=false for ids that don't parse (foreign format, too short).
+func tFromOCID(id string) (uint64, bool) {
+	i := strings.IndexByte(id, '_')
+	if i < 0 || len(id) < i+13 {
+		return 0, false
+	}
+	t, err := strconv.ParseUint(id[i+1:i+13], 16, 64)
+	if err != nil {
+		return 0, false
+	}
+	return t &^ 0xfff, true
+}
+
+// runTail is the id tail: a fragment of the run UUID for debuggability plus
+// a role marker, standing in for the real server's random base62 tail.
+func runTail(runID, marker string) string {
+	s := strings.ReplaceAll(runID, "-", "")
+	if len(s) > 10 {
+		s = s[:10]
+	}
+	return s + marker
 }
 
 // ocSessionID is the opencode-side id this facade advertises for the one
@@ -164,7 +224,7 @@ func (f *Facade) handlePromptAsync(w http.ResponseWriter, r *http.Request) {
 
 	userMsgID := body.MessageID
 	if userMsgID == "" {
-		userMsgID = ocID("msg_", resp.RunID) + "u"
+		userMsgID = ocTimeID("msg_", timeNowMs(), 0, runTail(resp.RunID, "us"))
 	}
 	f.mu.Lock()
 	if f.turns == nil {
@@ -235,7 +295,6 @@ func (f *Facade) runEventLoop(ctx context.Context, ew *eventWriter) {
 // client is gone.
 func (f *Facade) translateEvent(ev godo.HostedAgentEvent, ts *turnState, ew *eventWriter) error {
 	sid := f.ocSessionID()
-	msgID := ocID("msg_", ev.RunID)
 	at := eventTimeMs(ev)
 
 	switch ev.Kind {
@@ -259,11 +318,12 @@ func (f *Facade) translateEvent(ev godo.HostedAgentEvent, ts *turnState, ew *eve
 		}
 		// Unlike codex's protocol, opencode has a first-class reasoning
 		// channel: same flat delta frame, field "reasoning", its own part.
-		field, part := "text", ocID("prt_", ev.RunID)+"t"
+		field := "text"
+		part := &ts.textPartID
 		started := &ts.textPartStarted
+		marker := "tx"
 		if payload.IsReasoning {
-			field, part = "reasoning", ocID("prt_", ev.RunID)+"r"
-			started = &ts.reasoningPartStarted
+			field, part, started, marker = "reasoning", &ts.reasoningPartID, &ts.reasoningPartStarted, "re"
 		} else {
 			ts.sawText = true
 			ts.text.WriteString(payload.Text)
@@ -272,10 +332,11 @@ func (f *Facade) translateEvent(ev godo.HostedAgentEvent, ts *turnState, ew *eve
 		// deltas only to parts a message.part.updated already created —
 		// verified live, a delta for an unannounced part renders nothing.
 		if !*started {
+			*part = ocTimeID("prt_", at, 2, runTail(ev.RunID, marker))
 			if err := ew.session("message.part.updated", map[string]any{
 				"sessionID": sid,
 				"part": map[string]any{
-					"id": part, "messageID": msgID, "sessionID": sid,
+					"id": *part, "messageID": ts.asstMsgID, "sessionID": sid,
 					"type": field, "text": "",
 					"time": map[string]any{"start": at},
 				},
@@ -286,8 +347,8 @@ func (f *Facade) translateEvent(ev godo.HostedAgentEvent, ts *turnState, ew *eve
 		}
 		return ew.session("message.part.delta", map[string]any{
 			"sessionID": sid,
-			"messageID": msgID,
-			"partID":    part,
+			"messageID": ts.asstMsgID,
+			"partID":    *part,
 			"field":     field,
 			"delta":     payload.Text,
 		})
@@ -302,7 +363,7 @@ func (f *Facade) translateEvent(ev godo.HostedAgentEvent, ts *turnState, ew *eve
 			if err := ew.session("message.part.updated", map[string]any{
 				"sessionID": sid,
 				"part": map[string]any{
-					"id": ocID("prt_", ev.RunID) + "t", "messageID": msgID, "sessionID": sid,
+					"id": ts.textPartID, "messageID": ts.asstMsgID, "sessionID": sid,
 					"type": "text", "text": ts.text.String(),
 					"time": map[string]any{"start": ts.startMs, "end": at},
 				},
@@ -359,6 +420,19 @@ func (f *Facade) announceTurn(runID string, ts *turnState, ew *eventWriter, at i
 	ts.startMs = at
 	sid := f.ocSessionID()
 
+	// The assistant id must sort strictly after the user id (the TUI orders
+	// by id string). The user id's time prefix comes from a different clock
+	// — the client's when client-minted, the proxy's on the fallback — while
+	// `at` is the harness event time (the dev stack's container clock runs
+	// ~half a second behind the host, observed live). Mint the assistant id
+	// off whichever is later so skew can't invert the conversation.
+	asstT := ocTimeVal(at)
+	if userT, ok := tFromOCID(ts.userMsgID); ok && userT >= asstT {
+		asstT = userT + 0x1000 // +1ms in T-space
+	}
+	ts.asstMsgID = ocIDWithT("msg_", asstT, 1, runTail(runID, "as"))
+	ts.userPartID = ocIDWithT("prt_", asstT, 0, runTail(runID, "up"))
+
 	if ts.userMsgID != "" {
 		if err := ew.session("message.updated", map[string]any{
 			"sessionID": sid,
@@ -376,7 +450,7 @@ func (f *Facade) announceTurn(runID string, ts *turnState, ew *eventWriter, at i
 		if err := ew.session("message.part.updated", map[string]any{
 			"sessionID": sid,
 			"part": map[string]any{
-				"id": ocID("prt_", runID) + "u", "messageID": ts.userMsgID, "sessionID": sid,
+				"id": ts.userPartID, "messageID": ts.userMsgID, "sessionID": sid,
 				"type": "text", "text": ts.promptText,
 			},
 		}); err != nil {
@@ -394,7 +468,7 @@ func (f *Facade) announceTurn(runID string, ts *turnState, ew *eventWriter, at i
 	// `tokens.output` ("undefined is not an object", found live). Zeros are
 	// fine; absent is fatal. Field set mirrors the ground-truth capture.
 	info := map[string]any{
-		"id": ocID("msg_", runID), "sessionID": sid,
+		"id": ts.asstMsgID, "sessionID": sid,
 		"role":  "assistant",
 		"time":  map[string]any{"created": at},
 		"mode":  "build",
@@ -419,9 +493,14 @@ func (f *Facade) announceTurn(runID string, ts *turnState, ew *eventWriter, at i
 // finishAssistantMessage re-sends the assistant message.updated with
 // time.completed stamped, mirroring the real server's end-of-turn frame.
 func (f *Facade) finishAssistantMessage(runID string, ts *turnState, ew *eventWriter, at int64) error {
+	if ts.asstMsgID == "" {
+		// The turn was never announced (no run.started or delta seen) —
+		// there is no assistant message to close.
+		return nil
+	}
 	sid := f.ocSessionID()
 	info := map[string]any{
-		"id": ocID("msg_", runID), "sessionID": sid,
+		"id": ts.asstMsgID, "sessionID": sid,
 		"role":  "assistant",
 		"time":  map[string]any{"created": ts.startMs, "completed": at},
 		"mode":  "build",

--- a/internal/agentproxy/opencode/bridge_test.go
+++ b/internal/agentproxy/opencode/bridge_test.go
@@ -1,0 +1,317 @@
+package opencode
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/digitalocean/doctl/do"
+	"github.com/digitalocean/doctl/internal/agentproxy/agentproxytest"
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSessionID = "11111111-2222-3333-4444-555555555555"
+
+// newBridgedFacade wires a Facade against a fresh agentproxytest.Harness (a
+// real do.HostedAgentsService over httptest), plus an httptest server for
+// the facade's own client-facing surface.
+func newBridgedFacade(t *testing.T) (*httptest.Server, *agentproxytest.Harness) {
+	t.Helper()
+	h := agentproxytest.New(t, testSessionID)
+	client, err := godo.New(nil, godo.SetBaseURL(h.Server.URL+"/"))
+	require.NoError(t, err)
+	f := &Facade{SessionID: testSessionID, Sessions: do.NewHostedAgentsService(client), Dir: "/tmp/ws"}
+	srv := httptest.NewServer(f)
+	t.Cleanup(srv.Close)
+	return srv, h
+}
+
+func postPrompt(t *testing.T, srv *httptest.Server, text string) *http.Response {
+	t.Helper()
+	body := `{"parts":[{"type":"text","text":` + string(mustJSON(t, text)) + `}]}`
+	resp, err := http.Post(srv.URL+"/session/ses_x/prompt_async", "application/json", strings.NewReader(body))
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+// frame is one decoded global-stream SSE envelope.
+type frame struct {
+	Directory string `json:"directory"`
+	Project   string `json:"project"`
+	Payload   struct {
+		ID         string          `json:"id"`
+		Type       string          `json:"type"`
+		Properties json.RawMessage `json:"properties"`
+	} `json:"payload"`
+}
+
+// drainFrames reads SSE frames until the stream closes (the harness closes
+// its stream after serving the queued events, which ends the facade's SSE
+// response) and returns them decoded.
+func drainFrames(t *testing.T, body io.Reader) []frame {
+	t.Helper()
+	var frames []frame
+	sc := bufio.NewScanner(body)
+	sc.Buffer(make([]byte, 1<<20), 1<<20)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if !bytes.HasPrefix(line, []byte("data: ")) {
+			continue
+		}
+		var fr frame
+		require.NoError(t, json.Unmarshal(bytes.TrimPrefix(line, []byte("data: ")), &fr))
+		frames = append(frames, fr)
+	}
+	return frames
+}
+
+func propsOf(t *testing.T, fr frame) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(fr.Payload.Properties, &m))
+	return m
+}
+
+func TestPromptAsyncBridgesToSendInput(t *testing.T) {
+	srv, h := newBridgedFacade(t)
+	h.QueueRun("run-1")
+
+	resp := postPrompt(t, srv, "hello hosted agent")
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	input := h.LastInput()
+	require.NotNil(t, input)
+	assert.Equal(t, "hello hosted agent", input.Text)
+}
+
+func TestPromptWithoutTextIs400(t *testing.T) {
+	srv, h := newBridgedFacade(t)
+	h.QueueRun("run-1")
+
+	body := `{"parts":[{"type":"file","text":""}]}`
+	resp, err := http.Post(srv.URL+"/session/ses_x/prompt_async", "application/json", strings.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Nil(t, h.LastInput())
+}
+
+// The M2 acceptance path: a prompt's turn streams back as the opencode
+// frame sequence message.updated → part deltas → finalized text part →
+// session.status idle, with ids stamped consistently.
+func TestTurnStreamsAsOpencodeFrames(t *testing.T) {
+	srv, h := newBridgedFacade(t)
+	h.QueueRun("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindRunStarted)},
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindTokenChunk), Data: json.RawMessage(`{"text":"thinking...","is_reasoning":true}`)},
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindTokenChunk), Data: json.RawMessage(`{"text":"Par","is_reasoning":false}`)},
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindTokenChunk), Data: json.RawMessage(`{"text":"is","is_reasoning":false}`)},
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindRunCompleted)},
+	)
+
+	resp := postPrompt(t, srv, "capital of France?")
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	stream, err := http.Get(srv.URL + "/global/event")
+	require.NoError(t, err)
+	defer stream.Body.Close()
+	frames := drainFrames(t, stream.Body)
+
+	var types []string
+	for _, fr := range frames {
+		types = append(types, fr.Payload.Type)
+	}
+	// The ground-truth sequence from a real `opencode serve` turn: user echo
+	// (message + part), busy, assistant message, part-create before each
+	// part's first delta, finalized text part, then idle status + idle event.
+	require.Equal(t, []string{
+		"server.connected",
+		"message.updated",      // user echo
+		"message.part.updated", // user prompt part
+		"session.status",       // busy
+		"message.updated",      // assistant
+		"message.part.updated", // reasoning part created
+		"message.part.delta",   // reasoning
+		"message.part.updated", // text part created
+		"message.part.delta",   // "Par"
+		"message.part.delta",   // "is"
+		"message.part.updated", // text part finalized
+		"message.updated",      // assistant finalized (time.completed)
+		"session.status",       // idle
+		"session.idle",
+	}, types)
+
+	wantSession := "ses_" + strings.ReplaceAll(testSessionID, "-", "")
+	wantMsg := "msg_aaaaaaaabbbbccccddddeeeeeeeeeeee"
+
+	// server.connected is server-scoped; session frames carry directory and
+	// a top-level properties.sessionID.
+	assert.Empty(t, frames[0].Directory)
+	for _, fr := range frames[1:] {
+		assert.Equal(t, "/tmp/ws", fr.Directory, fr.Payload.Type)
+		assert.Equal(t, wantSession, propsOf(t, fr)["sessionID"], fr.Payload.Type)
+	}
+
+	userMsg := propsOf(t, frames[1])
+	userInfo, ok := userMsg["info"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "user", userInfo["role"])
+
+	userPart := propsOf(t, frames[2])
+	upart, ok := userPart["part"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "capital of France?", upart["text"])
+	assert.Equal(t, userInfo["id"], upart["messageID"])
+
+	busy := propsOf(t, frames[3])
+	assert.Equal(t, map[string]any{"type": "busy"}, busy["status"])
+
+	msg := propsOf(t, frames[4])
+	info, ok := msg["info"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, wantMsg, info["id"])
+	assert.Equal(t, "assistant", info["role"])
+	assert.Equal(t, userInfo["id"], info["parentID"])
+
+	reasoningCreate := propsOf(t, frames[5])
+	rpart, ok := reasoningCreate["part"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "reasoning", rpart["type"])
+	assert.Equal(t, "", rpart["text"])
+
+	reasoning := propsOf(t, frames[6])
+	assert.Equal(t, "reasoning", reasoning["field"])
+	assert.Equal(t, "thinking...", reasoning["delta"])
+	assert.Equal(t, rpart["id"], reasoning["partID"])
+
+	textCreate := propsOf(t, frames[7])
+	tpart, ok := textCreate["part"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "text", tpart["type"])
+	assert.Equal(t, "", tpart["text"])
+
+	textDelta := propsOf(t, frames[8])
+	assert.Equal(t, "text", textDelta["field"])
+	assert.Equal(t, "Par", textDelta["delta"])
+	assert.Equal(t, wantMsg, textDelta["messageID"])
+	assert.Equal(t, tpart["id"], textDelta["partID"])
+	// Reasoning and text stream as distinct parts.
+	assert.NotEqual(t, reasoning["partID"], textDelta["partID"])
+
+	finalized := propsOf(t, frames[10])
+	part, ok := finalized["part"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "text", part["type"])
+	assert.Equal(t, "Paris", part["text"])
+	assert.Equal(t, textDelta["partID"], part["id"])
+
+	finalMsg := propsOf(t, frames[11])
+	finalInfo, ok := finalMsg["info"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, wantMsg, finalInfo["id"])
+	tm, ok := finalInfo["time"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, tm, "completed")
+
+	status := propsOf(t, frames[12])
+	assert.Equal(t, map[string]any{"type": "idle"}, status["status"])
+}
+
+func TestRunFailedEmitsSessionErrorThenIdle(t *testing.T) {
+	srv, h := newBridgedFacade(t)
+	h.QueueRun("run-f",
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindRunStarted)},
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindRunFailed), Data: json.RawMessage(`{"message":"provider exploded"}`)},
+	)
+
+	resp := postPrompt(t, srv, "boom")
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	stream, err := http.Get(srv.URL + "/global/event")
+	require.NoError(t, err)
+	defer stream.Body.Close()
+	frames := drainFrames(t, stream.Body)
+
+	var types []string
+	for _, fr := range frames {
+		types = append(types, fr.Payload.Type)
+	}
+	require.Equal(t, []string{
+		"server.connected",
+		"message.updated",      // user echo
+		"message.part.updated", // user prompt part
+		"session.status",       // busy
+		"message.updated",      // assistant
+		"session.error",
+		"session.status", // idle
+		"session.idle",
+	}, types)
+
+	errProps := propsOf(t, frames[5])
+	errObj, ok := errProps["error"].(map[string]any)
+	require.True(t, ok)
+	data, ok := errObj["data"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "provider exploded", data["message"])
+}
+
+// Events for runs this facade didn't start (another device's turns) are not
+// translated onto the client stream.
+func TestUntrackedRunsAreSkipped(t *testing.T) {
+	srv, h := newBridgedFacade(t)
+	h.QueueRun("run-foreign",
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindRunStarted)},
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindTokenChunk), Data: json.RawMessage(`{"text":"not yours"}`)},
+	)
+	// No prompt sent — nothing tracked.
+
+	stream, err := http.Get(srv.URL + "/global/event")
+	require.NoError(t, err)
+	defer stream.Body.Close()
+	frames := drainFrames(t, stream.Body)
+
+	require.Len(t, frames, 1)
+	assert.Equal(t, "server.connected", frames[0].Payload.Type)
+}
+
+// Session lifecycle: list is empty until create/prompt, then single-entry;
+// create always returns the one bridged session.
+func TestSessionListGrowsAfterCreate(t *testing.T) {
+	srv, _ := newBridgedFacade(t)
+
+	resp, err := http.Get(srv.URL + "/session")
+	require.NoError(t, err)
+	var list []map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&list))
+	resp.Body.Close()
+	assert.Empty(t, list)
+
+	created, err := http.Post(srv.URL+"/session", "application/json", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	var sess map[string]any
+	require.NoError(t, json.NewDecoder(created.Body).Decode(&sess))
+	created.Body.Close()
+	assert.Equal(t, "ses_"+strings.ReplaceAll(testSessionID, "-", ""), sess["id"])
+
+	resp, err = http.Get(srv.URL + "/session")
+	require.NoError(t, err)
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&list))
+	resp.Body.Close()
+	require.Len(t, list, 1)
+	assert.Equal(t, sess["id"], list[0]["id"])
+}

--- a/internal/agentproxy/opencode/bridge_test.go
+++ b/internal/agentproxy/opencode/bridge_test.go
@@ -157,7 +157,6 @@ func TestTurnStreamsAsOpencodeFrames(t *testing.T) {
 	}, types)
 
 	wantSession := "ses_" + strings.ReplaceAll(testSessionID, "-", "")
-	wantMsg := "msg_aaaaaaaabbbbccccddddeeeeeeeeeeee"
 
 	// server.connected is server-scoped; session frames carry directory and
 	// a top-level properties.sessionID.
@@ -184,9 +183,17 @@ func TestTurnStreamsAsOpencodeFrames(t *testing.T) {
 	msg := propsOf(t, frames[4])
 	info, ok := msg["info"].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, wantMsg, info["id"])
+	wantMsg, ok := info["id"].(string)
+	require.True(t, ok)
 	assert.Equal(t, "assistant", info["role"])
 	assert.Equal(t, userInfo["id"], info["parentID"])
+	// Ids must sort chronologically as strings — the TUI orders messages by
+	// id, and a random-prefixed assistant id rendered the answer ABOVE the
+	// user's prompt (found live). User id strictly before assistant id.
+	userID, ok := userInfo["id"].(string)
+	require.True(t, ok)
+	assert.Regexp(t, `^msg_[0-9a-f]{12}`, wantMsg)
+	assert.Less(t, userID, wantMsg, "user message id must sort before the assistant's")
 
 	reasoningCreate := propsOf(t, frames[5])
 	rpart, ok := reasoningCreate["part"].(map[string]any)
@@ -230,6 +237,55 @@ func TestTurnStreamsAsOpencodeFrames(t *testing.T) {
 
 	status := propsOf(t, frames[12])
 	assert.Equal(t, map[string]any{"type": "idle"}, status["status"])
+}
+
+// The assistant id must sort after the user id even when the event clock
+// runs behind the clock that minted the user id (client-minted ids, or
+// container-vs-host skew on the dev stack — both observed live). The
+// comparison must happen on 48-bit T values: comparing a truncated T against
+// an untruncated millisecond count silently never fires (shipped once).
+func TestAssistantIDSortsAfterUserIDDespiteClockSkew(t *testing.T) {
+	srv, h := newBridgedFacade(t)
+	// Harness events are stamped 2026-01-01, far behind the wall clock that
+	// mints the fallback user id — exactly the inversion scenario.
+	h.QueueRun("run-skew",
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindRunStarted)},
+		agentproxytest.Event{Type: string(godo.HostedAgentEventKindRunCompleted)},
+	)
+
+	// Client-minted user id far in the future of the event clock.
+	futureID := ocTimeID("msg_", timeNowMs()+3_600_000, 0, "clientmint")
+	body := `{"messageID":` + string(mustJSON(t, futureID)) + `,"parts":[{"type":"text","text":"skew test"}]}`
+	resp, err := http.Post(srv.URL+"/session/ses_x/prompt_async", "application/json", strings.NewReader(body))
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	stream, err := http.Get(srv.URL + "/global/event")
+	require.NoError(t, err)
+	defer stream.Body.Close()
+	frames := drainFrames(t, stream.Body)
+
+	var userID, asstID string
+	for _, fr := range frames {
+		if fr.Payload.Type != "message.updated" {
+			continue
+		}
+		info, ok := propsOf(t, fr)["info"].(map[string]any)
+		require.True(t, ok)
+		switch info["role"] {
+		case "user":
+			userID = info["id"].(string)
+		case "assistant":
+			if asstID == "" {
+				asstID = info["id"].(string)
+			}
+		}
+	}
+	require.NotEmpty(t, userID)
+	require.NotEmpty(t, asstID)
+	assert.Equal(t, futureID, userID)
+	assert.Less(t, userID, asstID, "assistant id must sort after the user id")
 }
 
 func TestRunFailedEmitsSessionErrorThenIdle(t *testing.T) {

--- a/internal/agentproxy/opencode/facade.go
+++ b/internal/agentproxy/opencode/facade.go
@@ -60,6 +60,16 @@ type Facade struct {
 	eventInUse  bool
 	handlerOnce sync.Once
 	mux         *http.ServeMux
+
+	// mu guards turns and sessionCreated: turns is written by prompt
+	// handlers (request goroutines) and read by the event loop (the SSE
+	// handler goroutine).
+	mu    sync.Mutex
+	turns map[string]*turnState
+	// sessionCreated flips once the client has created/prompted the bridged
+	// session, so the session list grows its single entry (see
+	// handleSessionList).
+	sessionCreated bool
 }
 
 // ServeHTTP implements http.Handler.
@@ -151,10 +161,25 @@ func (f *Facade) buildMux() {
 	mux.HandleFunc("GET /experimental/workspace", f.json([]any{}))
 	mux.HandleFunc("GET /experimental/workspace/status", f.json([]any{}))
 
-	// Session listing: empty until M3 serves history. The TUI treats an
-	// empty list as "fresh session, create lazily on first prompt" — exactly
-	// the M1 empty-ready-conversation state.
-	mux.HandleFunc("GET /session", f.json([]any{}))
+	// The bridged session: list/create/get plus the prompt bridge (M2).
+	// History (GET .../message) returns empty until M3 serves it from a
+	// replay_only stream pass.
+	mux.HandleFunc("GET /session", f.handleSessionList)
+	mux.HandleFunc("POST /session", f.handleSessionCreate)
+	mux.HandleFunc("GET /session/{id}", func(w http.ResponseWriter, r *http.Request) {
+		f.writeJSON(w, f.sessionObject())
+	})
+	mux.HandleFunc("GET /session/{id}/message", f.json([]any{}))
+	mux.HandleFunc("POST /session/{id}/prompt_async", f.handlePromptAsync)
+	// The synchronous variant officially awaits the reply; bridging that
+	// faithfully would block a request goroutine for a whole turn. Current
+	// TUIs use prompt_async (M0 capture); if a client POSTs /message, treat
+	// it as fire-and-forget and let the reply ride the stream — log it so a
+	// client that genuinely blocks on the response is diagnosable.
+	mux.HandleFunc("POST /session/{id}/message", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("agentproxy/opencode: POST message treated as prompt_async (reply rides the stream)")
+		f.handlePromptAsync(w, r)
+	})
 
 	// The /api/* surface (new in recent opencode versions; sits alongside
 	// the older paths above — the TUI queries both). Wrapped responses:
@@ -193,8 +218,8 @@ func (f *Facade) buildMux() {
 }
 
 // handleGlobalEvent serves the SSE event stream: server.connected first (the
-// TUI's liveness signal), then blocks until the client disconnects or the
-// server shuts down. M2 wires the harness event loop in here.
+// TUI's liveness signal), then the live harness event loop until the client
+// disconnects, the harness stream ends, or the server shuts down.
 func (f *Facade) handleGlobalEvent(w http.ResponseWriter, r *http.Request) {
 	f.eventSlot.Lock()
 	if f.eventInUse {
@@ -219,32 +244,67 @@ func (f *Facade) handleGlobalEvent(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.WriteHeader(http.StatusOK)
 
-	if err := f.sendEvent(w, "server.connected", map[string]any{}); err != nil {
+	ew := &eventWriter{f: f, w: w, fl: fl}
+	if err := ew.global("server.connected", map[string]any{}); err != nil {
 		return
 	}
-	fl.Flush()
 
 	// r.Context() is rooted in the transport's ctx (ServeHTTPListener's
-	// BaseContext), so both a client disconnect and a proxy shutdown land
-	// here — no separate signal plumbing needed.
-	<-r.Context().Done()
+	// BaseContext), so both a client disconnect and a proxy shutdown cancel
+	// the harness stream — no separate signal plumbing needed.
+	f.runEventLoop(r.Context(), ew)
 }
 
-// sendEvent writes one global-stream SSE frame. Envelope shape per the
-// capture: data: {"payload":{"id":"evt_<n>","type":T,"properties":P}}
-func (f *Facade) sendEvent(w http.ResponseWriter, eventType string, properties any) error {
-	frame, err := json.Marshal(map[string]any{
-		"payload": map[string]any{
-			"id":         fmt.Sprintf("evt_%d", f.eventSeq.Add(1)),
-			"type":       eventType,
-			"properties": properties,
-		},
-	})
+// eventWriter frames global-stream SSE events. Envelope shape per the M0
+// capture: data: {"payload":{"id":"evt_<n>","type":T,"properties":P}}, with
+// top-level directory/project keys on directory-scoped (session) events —
+// mirroring how the real global stream tags them (project.updated carries
+// them; server.connected doesn't).
+//
+// Only the /global/event handler goroutine writes, by construction — the
+// prompt handlers never touch the stream — so unlike the WS transport's
+// wsNotifier there is no write mutex here. That changes the moment anything
+// else needs to emit (M5's HITL resolution is the candidate); add the mutex
+// then, not never.
+type eventWriter struct {
+	f  *Facade
+	w  http.ResponseWriter
+	fl http.Flusher
+}
+
+func (ew *eventWriter) send(envelope map[string]any) error {
+	frame, err := json.Marshal(envelope)
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(w, "data: %s\n\n", frame)
-	return err
+	if _, err := fmt.Fprintf(ew.w, "data: %s\n\n", frame); err != nil {
+		return err
+	}
+	ew.fl.Flush()
+	return nil
+}
+
+func (ew *eventWriter) payload(eventType string, properties any) map[string]any {
+	return map[string]any{
+		"id":         fmt.Sprintf("evt_%d", ew.f.eventSeq.Add(1)),
+		"type":       eventType,
+		"properties": properties,
+	}
+}
+
+// global emits a server-scoped frame (server.connected).
+func (ew *eventWriter) global(eventType string, properties any) error {
+	return ew.send(map[string]any{"payload": ew.payload(eventType, properties)})
+}
+
+// session emits a directory-scoped frame (everything about the bridged
+// session).
+func (ew *eventWriter) session(eventType string, properties any) error {
+	return ew.send(map[string]any{
+		"directory": ew.f.Dir,
+		"project":   "global",
+		"payload":   ew.payload(eventType, properties),
+	})
 }
 
 // json returns a handler that writes a fixed JSON body. For bodies that

--- a/internal/agentproxy/opencode/facade_test.go
+++ b/internal/agentproxy/opencode/facade_test.go
@@ -83,8 +83,11 @@ func TestHealthReportsTestedVersion(t *testing.T) {
 // The global stream's first frame must be server.connected in the wrapped
 // payload envelope — the TUI treats it as the liveness signal.
 func TestGlobalEventStreamsServerConnectedFirst(t *testing.T) {
-	srv := httptest.NewServer(newTestFacade())
-	defer srv.Close()
+	// A wired harness with a hanging stream: the SSE handler now runs the
+	// live event loop after server.connected, so it needs a real (fake)
+	// harness to stream from.
+	srv, h := newBridgedFacade(t)
+	h.HangStreamAfterEvents(true)
 
 	resp, err := http.Get(srv.URL + "/global/event")
 	require.NoError(t, err)
@@ -111,8 +114,8 @@ func TestGlobalEventStreamsServerConnectedFirst(t *testing.T) {
 // transport's single-client slot, enforced on the stream rather than the
 // listener since plain REST requests may overlap freely.
 func TestSecondEventStreamConsumerConflicts(t *testing.T) {
-	srv := httptest.NewServer(newTestFacade())
-	defer srv.Close()
+	srv, h := newBridgedFacade(t)
+	h.HangStreamAfterEvents(true)
 
 	first, err := http.Get(srv.URL + "/global/event")
 	require.NoError(t, err)


### PR DESCRIPTION
Follows #1942 (M0/M1, merged). Second slice of the opencode facade: the first demo checkpoint — a prompt typed in a real, unmodified `opencode` TUI streams the hosted agent's answer back into the TUI. This also delivers exactly what @SSharma-10's M1 verification flagged: `POST /session` and prompt bridging.

## What's here

- **Prompt bridge**: `POST /session/{id}/prompt_async` concatenates the body's text parts into `SendInput` and tracks the returned per-turn `run_id`. The synchronous `POST /session/{id}/message` variant is accepted as fire-and-forget (logged; current TUIs use `prompt_async`). Non-text parts are logged and dropped.
- **Event loop**: the `/global/event` handler drains `StreamSession` and translates canonical events into the opencode frame sequence. Single writer by construction (the SSE handler goroutine), so no notifier mutex — a comment marks M5's HITL work as the point where that changes.
- **Session synthesis**: `POST /session` / `GET /session` / `GET /session/{id}` map every client-side session onto the one bridged hosted session.

## The translation was captured, not guessed — and the capture mattered

A first version built only from the OHR adapter's inverse mapping tables bridged the turn correctly (the hosted run executed and completed) but rendered **nothing** in the TUI. Ground truth from a real `opencode serve` turn (logging relay + `curl -N /global/event`) surfaced three load-bearing requirements, each confirmed against the real client:

1. **A part must be created before its first delta** — `message.part.updated` with empty text, then deltas. A delta for an unannounced part silently renders nothing.
2. **Assistant `message.updated` info must carry `cost` and `tokens{...}`** — without `tokens.output` the 1.18.25 TUI crashes (`undefined is not an object`). Zeros are fine; absent is fatal.
3. **The turn must close with an assistant `message.updated` carrying `time.completed`** — otherwise the TUI leaves the turn looking in-flight.

Full verified sequence: user echo (message + prompt part) → `session.status busy` → assistant message → part-create → delta trail → finalized part → completed message → `session.status idle` → `session.idle`. Reasoning tokens stream as their own part with `field:"reasoning"`.

## Testing

- Unit: the full frame sequence (order + ids + per-frame fields) against the shared `agentproxytest` harness; failure path (`run.failed` → `session.error` → idle); untracked-run skipping; prompt validation; session list lifecycle.
- Live: against the local dev stack, a real `opencode attach` + typed prompt rendered the hosted agent's streamed answer (verified by replaying the pty capture through a terminal emulator), with no unhandled routes during the turn.

## Not in this PR

History on re-attach (M3), tool-call parts and real usage/cost in `step-finish` (M4), permission round-trips (M5), stream reconnect (M6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)