### PR TITLE
add --wait flag for database destroy calls

### DIFF
--- a/commands/databases.go
+++ b/commands/databases.go
@@ -16,6 +16,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -102,6 +103,7 @@ You can customize the configuration using the listed flags, all of which are opt
 To retrieve a list of your database clusters and their IDs, use `+"`"+`doctl databases list`+"`"+`.`, Writer,
 		aliasOpt("rm"))
 	AddBoolFlag(cmdDatabaseDelete, doctl.ArgForce, doctl.ArgShortForce, false, "Delete the database cluster without a confirmation prompt")
+	AddBoolFlag(cmdDatabaseDelete, doctl.ArgCommandWait, "", false, "A boolean value that specifies whether to wait for the database cluster to be deleted before returning control to the terminal.")
 	cmdDatabaseDelete.Example = `The following example deletes the database cluster with the ID ` + "`" + `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` + "`" + `: doctl databases delete f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
 
 	cmdDatabaseGetConn := CmdBuilder(cmd, RunDatabaseConnectionGet, "connection <database-cluster-id>", "Retrieve connection details for a database cluster", `Retrieves the following connection details for a database cluster:
@@ -452,7 +454,25 @@ func RunDatabaseDelete(c *CmdConfig) error {
 
 	if force || AskForConfirmDelete("database cluster", 1) == nil {
 		id := c.Args[0]
-		return c.Databases().Delete(id)
+		dbs := c.Databases()
+		if err := dbs.Delete(id); err != nil {
+			return err
+		}
+
+		wait, err := c.Doit.GetBool(c.NS, doctl.ArgCommandWait)
+		if err != nil {
+			return err
+		}
+
+		if wait {
+			notice("Database deletion is in progress, waiting for database to be deleted")
+			if err := waitForDatabaseDeleted(dbs, id); err != nil {
+				return fmt.Errorf("database couldn't be deleted: %v", err)
+			}
+			notice("Database is successfully deleted")
+		}
+
+		return nil
 	}
 
 	return errOperationAborted
@@ -2626,6 +2646,38 @@ func waitForDatabaseReady(dbs do.DatabasesService, dbID string) error {
 
 	return fmt.Errorf(
 		"timeout waiting for database (%s) to enter `online` state",
+		dbID,
+	)
+}
+
+func waitForDatabaseDeleted(dbs do.DatabasesService, dbID string) error {
+	const maxAttempts = 180
+	attempts := 0
+	printNewLineSet := false
+
+	for i := 0; i < maxAttempts; i++ {
+		if attempts != 0 {
+			fmt.Fprint(os.Stderr, ".")
+			if !printNewLineSet {
+				printNewLineSet = true
+				defer fmt.Fprintln(os.Stderr)
+			}
+		}
+
+		_, err := dbs.Get(dbID)
+		if err != nil {
+			if errResp, ok := err.(*godo.ErrorResponse); ok && errResp.Response.StatusCode == http.StatusNotFound {
+				return nil
+			}
+			return err
+		}
+
+		attempts++
+		time.Sleep(10 * time.Second)
+	}
+
+	return fmt.Errorf(
+		"timeout waiting for database (%s) to be deleted",
 		dbID,
 	)
 }

--- a/commands/databases_test.go
+++ b/commands/databases_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -617,6 +618,23 @@ func TestDatabasesDelete(t *testing.T) {
 
 		config.Args = append(config.Args, testDBCluster.ID)
 		config.Doit.Set(config.NS, doctl.ArgForce, "true")
+
+		err := RunDatabaseDelete(config)
+		assert.NoError(t, err)
+	})
+
+	// Successful with wait flag
+	withTestClient(t, func(config *CmdConfig, tm *tcMocks) {
+		notFound := &godo.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotFound},
+			Message:  "not found",
+		}
+		tm.databases.EXPECT().Delete(testDBCluster.ID).Return(nil)
+		tm.databases.EXPECT().Get(testDBCluster.ID).Return(nil, notFound)
+
+		config.Args = append(config.Args, testDBCluster.ID)
+		config.Doit.Set(config.NS, doctl.ArgForce, "true")
+		config.Doit.Set(config.NS, doctl.ArgCommandWait, true)
 
 		err := RunDatabaseDelete(config)
 		assert.NoError(t, err)


### PR DESCRIPTION
## Summary
1. Add --wait to doctl databases delete so the CLI polls until the cluster is gone before returning
2. Detect completion via HTTP 404 from Get, consistent with other wait-for-delete flows
3. Cover the wait path with a unit test
### usage

```
./doctl databases delete <CLUSTER_UUID> --wait --api-url=https://api.digitalocean.com --access-token <ACCESS_TOKEN>                                
❯ Are you sure you want to delete this database cluster? yes
Notice: Database deletion is in progress, waiting for database to be deleted
.......................
Notice: Database is successfully deleted
```

<img width="2104" height="844" alt="image" src="https://github.com/user-attachments/assets/401c2ebf-3f64-440c-889f-fb58c1579015" />
